### PR TITLE
feat: Fold the inline tree through a caller-supplied renderer (inline-ast Phase 3, step 3)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -752,6 +752,39 @@ Each phase is a reviewable unit with a clear exit gate.
   deferred remainder of Phase 2 and Phase 4, unchanged by this step. The `render_with` /
   `render_to` fold is still the remaining Phase 3 piece.
 
+  *Step 3 landed as (the `render_with` fold):* the render-time counterpart of
+  `rendered_html()` — [`Content::render_with`](../../parser/src/content/content.rs) — folds a
+  block's inline tree through a **caller-supplied**
+  [`InlineSubstitutionRenderer`](../../parser/src/parser/inline_substitution_renderer.rs) and
+  returns an owned `String`, so a consumer can drive an alternate backend over an
+  already-parsed document without reparsing (§3.3). Passing the built-in HTML renderer
+  reproduces `rendered_html()` **byte-for-byte**, including resolved cross-references — a new
+  corpus-wide differential (`render_with_reproduces_rendered_html_byte_for_byte`) folds every
+  fixture through it and pins the same bytes the golden oracle pins. A cross-reference is the
+  one construct whose captured bytes are resolution-*dependent* (the recording pass runs
+  before resolution), so the fold re-renders it from its *resolved*
+  [`XrefSegment`](../../parser/src/content/content.rs) — pairing the tree's cross-reference
+  leaves, in document order, with the block-level segments the placeholder-ordered
+  [`block_tree_xref_segments`](../../parser/src/content/content.rs) yields, the same
+  positional correlation [`mirror_tree_xref_resolution`](../../parser/src/content/content.rs)
+  relies on. To re-fold after the parse, `Content` retains the recorder's marked string and
+  event log (a private, `inlines`-like derived artifact, behind
+  [`with_inline_tree`](../../parser/src/parser/parser.rs)); with the flag off there is nothing
+  to fold, so `render_with` returns the cached built-in rendering.
+
+  Because the Strategy A tree carries each construct's *built-in bytes* rather than the full
+  parameters some renderer methods need, `render_with` invokes the supplied renderer only for
+  the **self-contained** constructs it can drive faithfully — special characters, line breaks,
+  anchors, index terms, buttons, keyboards, and cross-references — so a custom backend
+  overrides those (a smoke test drives a renderer that re-skins the line break). A formatted
+  span, link, or STEM wrapper, and an image, menu, callout, or footnote marker, emit their
+  captured bytes; a span's or link's *children* are still folded, so a renderer-driven
+  construct nested inside one still reaches the renderer. Widening renderer control over the
+  captured constructs — and a document-level `render_to` — awaits the single-pass builder and
+  the reshaped renderer seam (Phases 4–5), the point at which nodes carry logical parameters
+  instead of pre-rendered bytes. With this step the substantive Phase 3 API surface
+  (`inlines()`, the HTML-specific accessor names, and the `render_with` fold) is in place.
+
 - **Phase 4 — precision spans + ASG output.** Land the single-pass builder (Strategy B) and
   `Document::to_asg()`; validate against the ASG schema; retire the `attribute-missing`
   per-line hack (#564).

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Span,
-    content::Passthrough,
+    content::{Passthrough, inline_tree, inline_tree::Event},
     inlines::{InlineNode, RefVariant},
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
@@ -101,6 +101,35 @@ pub struct Content<'src> {
     ///
     /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
     inlines: Vec<InlineNode<'src>>,
+
+    /// The recorder artifacts the inline tree was folded from, retained so
+    /// [`render_with`](Self::render_with) can re-fold the tree through a
+    /// caller-supplied renderer.
+    ///
+    /// Populated alongside [`inlines`](Self::inlines) only when inline-tree
+    /// building is enabled on the [`Parser`](crate::Parser)
+    /// ([`with_inline_tree`](crate::Parser::with_inline_tree)); `None`
+    /// otherwise, in which case [`render_with`](Self::render_with) falls back
+    /// to the cached built-in rendering. Like `inlines`, it is a **derived
+    /// artifact** and is deliberately excluded from
+    /// [`PartialEq`]/[`Eq`]/[`Hash`].
+    fold: Option<Box<InlineFold>>,
+}
+
+/// The recorder artifacts retained for [`Content::render_with`]: the marked
+/// string a [`RecordingRenderer`](inline_tree) produced and the event log it
+/// filled in, from which the inline tree was folded. This is a Strategy A
+/// carry-over that the Phase 4 single-pass builder retires along with the
+/// recording pass itself.
+#[derive(Clone)]
+struct InlineFold {
+    /// The recorder-marked string (the built-in rendering bracketed with inert
+    /// sentinels).
+    marked: String,
+
+    /// The recorded construct metadata, indexed by the marker each construct
+    /// carries.
+    events: Vec<Event>,
 }
 
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
@@ -240,6 +269,7 @@ impl<'src> Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            fold: None,
         }
     }
 
@@ -269,6 +299,7 @@ impl<'src> Content<'src> {
                 .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            fold: None,
         }
     }
 
@@ -307,6 +338,7 @@ impl<'src> Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            fold: None,
         }
     }
 
@@ -424,6 +456,95 @@ impl<'src> Content<'src> {
     /// (see [`inline_tree`](crate::content::inline_tree)).
     pub(crate) fn set_inlines(&mut self, inlines: Vec<InlineNode<'src>>) {
         self.inlines = inlines;
+    }
+
+    /// Retains the recorder artifacts (`marked` string and `events` log) the
+    /// inline tree was folded from, so [`render_with`](Self::render_with) can
+    /// re-fold it through a caller-supplied renderer.
+    pub(crate) fn set_inline_fold(&mut self, marked: String, events: Vec<Event>) {
+        self.fold = Some(Box::new(InlineFold { marked, events }));
+    }
+
+    /// Renders this content to a caller-supplied backend, as a fold over the
+    /// inline tree ([`inlines`](Self::inlines)), and returns the result.
+    ///
+    /// This is the render-time counterpart of
+    /// [`rendered_html`](Self::rendered_html): where that returns the cached
+    /// built-in HTML, this folds the same tree through `renderer`, so a caller
+    /// can drive an alternate backend over an already-parsed document without
+    /// reparsing. The result is owned and **not** cached.
+    ///
+    /// Passing the built-in
+    /// [`HtmlSubstitutionRenderer`](crate::parser::HtmlSubstitutionRenderer)
+    /// reproduces [`rendered_html`](Self::rendered_html) **byte-for-byte**,
+    /// including resolved cross-references (which are re-rendered from their
+    /// resolved state, not the tree's parse-time capture).
+    ///
+    /// # Which constructs `renderer` drives
+    ///
+    /// While the tree is built by the Strategy A recording pass (design §4.1),
+    /// it retains the built-in bytes of each construct rather than the full
+    /// parameters some renderer methods need. `renderer` is therefore invoked
+    /// for the **self-contained** kinds it can drive faithfully – special
+    /// characters, line breaks, anchors, index terms, buttons, keyboards, and
+    /// cross-references – so a custom backend overrides those. A formatted
+    /// span, link, or STEM wrapper, and an image, menu, callout, or
+    /// footnote marker, emit their captured built-in bytes (nested
+    /// renderer-driven constructs inside a span or link are still folded
+    /// through `renderer`). Full `renderer` control over every construct
+    /// arrives with the single-pass builder and the reshaped renderer seam
+    /// (design Phases 4–5).
+    ///
+    /// # Fallback
+    ///
+    /// When no inline tree was built – tree building was not enabled on the
+    /// [`Parser`](crate::Parser) (see
+    /// [`with_inline_tree`](crate::Parser::with_inline_tree)), or this content
+    /// carries none – there is nothing to fold through `renderer`, so this
+    /// returns the cached built-in rendering (the same bytes as
+    /// [`rendered_html`](Self::rendered_html)).
+    pub fn render_with(&self, renderer: &dyn InlineSubstitutionRenderer) -> String {
+        let Some(fold) = self.fold.as_deref() else {
+            return self.rendered.as_ref().to_string();
+        };
+
+        // The block-level cross-references, in the document order the tree's
+        // cross-reference leaves appear – each carrying the destination
+        // resolution filled in (the same segments the rendered string reflects).
+        // A footnote-embedded reference is re-homed out of the block template,
+        // so it is excluded here exactly as it is absent from the block tree.
+        let segments: Vec<&XrefSegment> = match self.deferred.as_deref() {
+            Some(deferred) => block_tree_xref_segments(&deferred.template, &deferred.xrefs),
+            None => Vec::new(),
+        };
+
+        let mut segments = segments.into_iter();
+
+        let mut render_xref = |out: &mut String| match segments.next() {
+            Some(xref) => renderer.render_xref(
+                &XrefRenderParams {
+                    target: &xref.target,
+                    provided_text: xref.provided_text.as_deref(),
+                    window: xref.window.as_deref(),
+                    roles: &xref.roles,
+                    xrefstyle: xref.xrefstyle,
+                    derived: xref.derived.as_ref(),
+                    resolved: xref.resolved.as_ref(),
+                },
+                out,
+            ),
+
+            // Each cross-reference leaf in the tree lines up with one block-level
+            // segment (the invariant `mirror_tree_xref_resolution` also relies
+            // on); running out means the recording pass and the authoritative
+            // pass enumerated references differently.
+            None => debug_assert!(
+                false,
+                "inline fold requested more cross-references than the content holds"
+            ),
+        };
+
+        inline_tree::fold_with(&fold.marked, &fold.events, renderer, &mut render_xref)
     }
 
     /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
@@ -735,6 +856,29 @@ pub(crate) fn block_tree_xrefs(
         .enumerate()
         .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)))
         .map(|(_, xref)| xref.resolved.clone())
+        .collect()
+}
+
+/// The block-level deferred cross-reference segments, in placeholder (document)
+/// order, that [`Content::render_with`] re-renders in place of the tree's
+/// cross-reference leaves.
+///
+/// This is the whole-segment counterpart of [`block_tree_xrefs`] (which
+/// projects each to just its resolved destination): it applies the same
+/// still-in-`template` filter – so a footnote-re-homed reference is excluded
+/// and the result lines up one-to-one with the block tree's cross-reference
+/// leaves – but keeps each [`XrefSegment`] so the fold can rebuild a full
+/// [`XrefRenderParams`] (target, provided text, window, roles, style, and
+/// resolution) and reproduce the rendered string's link exactly.
+pub(crate) fn block_tree_xref_segments<'a>(
+    template: &str,
+    xrefs: &'a [XrefSegment],
+) -> Vec<&'a XrefSegment> {
+    xrefs
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)))
+        .map(|(_, xref)| xref)
         .collect()
 }
 
@@ -1057,6 +1201,7 @@ impl<'src> From<Span<'src>> for Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            fold: None,
         }
     }
 }

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -67,7 +67,7 @@ use crate::{
     parser::{
         CalloutRenderParams, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
         IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
-        QuoteScope, QuoteType, XrefRenderParams,
+        QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -1071,6 +1071,144 @@ pub(crate) fn fold_marked(marked: &str, events: &[Event]) -> String {
 /// to cross-check the recovered tree against the recorder.
 pub(crate) fn open_marker_count(marked: &str) -> usize {
     marked.matches(MARK_OPEN).count()
+}
+
+/// Folds a recorder-marked string to output, driving a **caller-supplied**
+/// renderer where the tree carries a construct's parameters in full, and
+/// emitting the captured (built-in) bytes for the constructs whose faithful
+/// rendering needs live parser/attrlist context. This is the engine behind
+/// [`Content::render_with`](crate::content::Content::render_with).
+///
+/// The kinds that reach `renderer` are the self-contained ones – special
+/// characters, line breaks, anchors, index terms, buttons, keyboards, and
+/// cross-references – so a custom backend can override them. A cross-reference
+/// is re-rendered from its *resolved* state (not the recording pass's
+/// unresolved capture) through `render_xref`, which the caller supplies: the
+/// tree's cross-reference leaves, in document order, correspond one-to-one with
+/// the caller's resolved segments, so each call renders the next one.
+///
+/// A formatted span, link, or STEM wrapper (a container), and an image, menu,
+/// callout, or footnote marker (a leaf), reconstruct only from context the tree
+/// does not retain under Strategy A, so their captured bytes are emitted;
+/// container children are still folded, so a renderer-driven construct nested
+/// inside one still reaches `renderer`. Widening `renderer` control over the
+/// captured kinds lands with the Phase 5 node-taking seam.
+pub(crate) fn fold_with(
+    marked: &str,
+    events: &[Event],
+    renderer: &dyn InlineSubstitutionRenderer,
+    render_xref: &mut dyn FnMut(&mut String),
+) -> String {
+    let chars: Vec<char> = marked.chars().collect();
+    let recs = parse(&chars, events);
+    let mut out = String::new();
+    fold_with_into(&recs, renderer, render_xref, &mut out);
+    out
+}
+
+/// Recursive worker for [`fold_with`].
+fn fold_with_into(
+    recs: &[Rec],
+    renderer: &dyn InlineSubstitutionRenderer,
+    render_xref: &mut dyn FnMut(&mut String),
+    out: &mut String,
+) {
+    for rec in recs {
+        match rec {
+            Rec::Text(text) => out.push_str(text),
+
+            Rec::CharRef { html, kind } => fold_char_ref_with(kind, html, renderer, out),
+
+            Rec::Leaf { html, node } => fold_leaf_with(node, html, renderer, render_xref, out),
+
+            Rec::Container {
+                open,
+                close,
+                children,
+                ..
+            } => {
+                // A formatted span, link, or STEM wrapper is reconstructed only
+                // from live attrlist/parser context the tree does not retain, so
+                // its fixed open/close bytes are emitted as captured; its
+                // children are folded so a nested renderer-driven construct still
+                // reaches `renderer`.
+                out.push_str(open);
+                fold_with_into(children, renderer, render_xref, out);
+                out.push_str(close);
+            }
+        }
+    }
+}
+
+/// Folds one recovered character reference, routing a special character through
+/// `renderer` (so a custom backend can change how `<`, `>`, and `&` are
+/// escaped) and emitting the captured entity for a replacement or author entity
+/// – whose concrete
+/// [`CharacterReplacementType`](crate::parser::CharacterReplacementType)
+/// the tree does not retain.
+fn fold_char_ref_with(
+    kind: &CharRefKind,
+    html: &str,
+    renderer: &dyn InlineSubstitutionRenderer,
+    out: &mut String,
+) {
+    match kind {
+        CharRefKind::Special('<') => renderer.render_special_character(SpecialCharacter::Lt, out),
+        CharRefKind::Special('>') => renderer.render_special_character(SpecialCharacter::Gt, out),
+
+        CharRefKind::Special('&') => {
+            renderer.render_special_character(SpecialCharacter::Ampersand, out)
+        }
+
+        // `Special` only ever holds `<`, `>`, or `&`; a replacement or author
+        // entity carries only its logical value, not the concrete type the
+        // trait method needs, so its captured entity is emitted verbatim.
+        _ => out.push_str(html),
+    }
+}
+
+/// Folds one recovered leaf, routing the self-contained kinds through
+/// `renderer` and emitting the captured bytes for the kinds that need context
+/// the tree does not retain.
+fn fold_leaf_with(
+    node: &LeafNode,
+    html: &str,
+    renderer: &dyn InlineSubstitutionRenderer,
+    render_xref: &mut dyn FnMut(&mut String),
+    out: &mut String,
+) {
+    match node {
+        LeafNode::LineBreak => renderer.render_line_break(out),
+
+        LeafNode::Anchor { id } => renderer.render_anchor(id, None, out),
+
+        LeafNode::IndexTerm { terms, visible } => {
+            let params = IndexTermRenderParams {
+                visible_term: if *visible {
+                    terms.first().map(String::as_str)
+                } else {
+                    None
+                },
+            };
+
+            renderer.render_index_term(&params, out);
+        }
+
+        LeafNode::Ui(UiMeta::Button(text)) => renderer.render_button(text, out),
+
+        LeafNode::Ui(UiMeta::Keyboard(keys)) => renderer.render_keyboard(keys, out),
+
+        LeafNode::Reference {
+            variant: RefVariant::Xref,
+            ..
+        } => render_xref(out),
+
+        // Image/icon, menu, and callout need live parser/attrlist context; a
+        // footnote marker needs a param the tree does not retain; a link leaf
+        // (links are recorded as containers, so this does not arise in practice)
+        // likewise falls back. Each emits its captured (built-in) bytes.
+        _ => out.push_str(html),
+    }
 }
 
 #[cfg(test)]

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -356,6 +356,12 @@ impl SubstitutionGroup {
         );
 
         content.set_inlines(tree);
+
+        // Retain the marked string and event log so `Content::render_with` can
+        // re-fold the tree through a caller-supplied renderer. This is a
+        // Strategy A carry-over, retired with the recording pass by the Phase 4
+        // single-pass builder.
+        content.set_inline_fold(marked, events.to_vec());
     }
 
     /// Applies any block style masquerade and `subs` attribute override from

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -35,7 +35,7 @@ use crate::{
         },
     },
     inlines::{CharRef, InlineNode, RefVariant, SpanForm, StyleVariant, UiKind},
-    parser::{HtmlSubstitutionRenderer, ModificationContext},
+    parser::{HtmlSubstitutionRenderer, InlineSubstitutionRenderer, ModificationContext},
 };
 
 /// Rejects a fixture whose source uses a reserved recorder codepoint. Such a
@@ -569,6 +569,174 @@ fn inline_tree_flag_leaves_rendered_output_unchanged() {
     {
         check_inline_tree_flag_parity(source);
     }
+}
+
+// ─── Public API: `Content::render_with` ─────────────────────────────────────
+//
+// `render_with` folds the inline tree through a caller-supplied renderer
+// (design Phase 3). Passing the built-in HTML renderer must reproduce
+// `rendered_html()` byte-for-byte – including resolved cross-references, which
+// the fold re-renders from their resolved state rather than the tree's
+// parse-time capture – so the same golden oracle that pins `rendered_html()`
+// pins `render_with` too. A custom renderer overrides the self-contained
+// constructs.
+
+/// Parses `source` with tree building on, then asserts that folding every
+/// simple block's (and inline table cell's) tree with the built-in HTML
+/// renderer via [`Content::render_with`] reproduces its `rendered_html()`
+/// exactly.
+fn check_document_render_with(source: &str) {
+    use crate::{
+        blocks::{Block, TableCellContent, TableRow},
+        parser::HtmlSubstitutionRenderer,
+    };
+
+    assert_no_reserved_sentinels(source);
+
+    let mut parser = experimental(Parser::default()).with_inline_tree(true);
+    let doc = parser.parse(source);
+    let html = HtmlSubstitutionRenderer {};
+
+    fn check_content(content: &Content<'_>, html: &HtmlSubstitutionRenderer, checked: &mut usize) {
+        let rendered = content.rendered_html();
+
+        assert_eq!(
+            content.render_with(html),
+            rendered,
+            "render_with(&Html) diverged from rendered_html() for {content:?}"
+        );
+
+        *checked += 1;
+    }
+
+    fn cells(row: &TableRow<'_>, html: &HtmlSubstitutionRenderer, checked: &mut usize) {
+        for cell in row.cells() {
+            // Only inline (`Simple`) cells carry a single `Content`; an
+            // `AsciiDoc` cell is a nested standalone document, out of scope here.
+            if let TableCellContent::Simple(content) = cell.content() {
+                check_content(content, html, checked);
+            }
+        }
+    }
+
+    fn walk(block: &Block<'_>, html: &HtmlSubstitutionRenderer, checked: &mut usize) {
+        match block {
+            Block::Simple(simple) => check_content(simple.content(), html, checked),
+
+            Block::Table(table) => {
+                if let Some(header) = table.header_row() {
+                    cells(header, html, checked);
+                }
+
+                for row in table.body_rows() {
+                    cells(row, html, checked);
+                }
+
+                if let Some(footer) = table.footer_row() {
+                    cells(footer, html, checked);
+                }
+            }
+
+            _ => {}
+        }
+
+        for child in block.child_blocks() {
+            walk(child, html, checked);
+        }
+    }
+
+    let mut checked = 0;
+
+    for block in doc.child_blocks() {
+        walk(block, &html, &mut checked);
+    }
+
+    // A fixture that exercised no content location would pass vacuously; every
+    // corpus entry has at least one simple block or inline cell.
+    assert!(
+        checked > 0,
+        "render_with fixture exercised no content for {source:?}"
+    );
+}
+
+#[test]
+fn render_with_reproduces_rendered_html_byte_for_byte() {
+    // The document corpus reaches resolved cross-references; the normal corpus
+    // (each parsed as a one-paragraph document) reaches every inline construct.
+    // A blank fixture parses to no block, so it has no content to fold.
+    for source in DOCUMENT_CORPUS.iter().chain(NORMAL_CORPUS) {
+        if source.trim().is_empty() {
+            continue;
+        }
+
+        check_document_render_with(source);
+    }
+}
+
+#[test]
+fn render_with_reproduces_rendered_html_for_callouts() {
+    // A callout leaf renders from captured bytes (it needs the parser's `icons`
+    // attribute), so it must still reproduce `rendered_html()` under the fold.
+    check_document_render_with("[source]\n----\ncode line <1>\n----\n<1> a note");
+}
+
+#[test]
+fn render_with_falls_back_to_rendered_html_when_tree_is_off() {
+    // With tree building disabled there is nothing to fold, so `render_with`
+    // returns the built-in rendering and ignores the (here custom) renderer.
+    use crate::blocks::Block;
+
+    let mut parser = Parser::default();
+    let doc = parser.parse("a *bold* line +\nand <b>raw</b>? no.");
+
+    let Block::Simple(simple) = doc.child_blocks().next().expect("a block") else {
+        panic!("expected a simple block");
+    };
+
+    let content = simple.content();
+
+    assert_eq!(
+        content.render_with(&LineBreakMarkerRenderer),
+        content.rendered_html()
+    );
+}
+
+/// A custom renderer that emits a distinctive line break, so a test can observe
+/// that `render_with` genuinely drives the supplied renderer (rather than
+/// replaying the built-in bytes).
+#[derive(Debug)]
+struct LineBreakMarkerRenderer;
+
+impl InlineSubstitutionRenderer for LineBreakMarkerRenderer {
+    fn render_line_break(&self, dest: &mut String) {
+        dest.push_str("[BR]");
+    }
+}
+
+#[test]
+fn render_with_drives_a_custom_renderer() {
+    use crate::blocks::Block;
+
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("first line +\nsecond line");
+
+    let Block::Simple(simple) = doc.child_blocks().next().expect("a block") else {
+        panic!("expected a simple block");
+    };
+
+    let content = simple.content();
+
+    // The built-in rendering uses `<br>`; the custom renderer overrides the
+    // line break, and only `render_with` reflects it.
+    assert!(content.rendered_html().contains("<br>"));
+
+    let custom = content.render_with(&LineBreakMarkerRenderer);
+    assert!(custom.contains("[BR]"), "custom render was {custom:?}");
+    assert!(!custom.contains("<br>"), "custom render was {custom:?}");
+
+    // The surrounding text is untouched.
+    assert!(custom.starts_with("first line"));
+    assert!(custom.ends_with("second line"));
 }
 
 #[test]


### PR DESCRIPTION
Implements the **`render_with` fold** — the remaining Phase 3 piece of the [inline AST architecture](../blob/inline-ast/docs/design/inline-ast-architecture.md).

## What

Adds `Content::render_with(&dyn InlineSubstitutionRenderer) -> String`, the render-time counterpart of `rendered_html()`: it folds a block's inline tree through a **caller-supplied** backend and returns an owned string, so a consumer can drive an alternate renderer over an already-parsed document without reparsing.

Passing the built-in HTML renderer reproduces `rendered_html()` **byte-for-byte**, including resolved cross-references — pinned by a new corpus-wide differential (`render_with_reproduces_rendered_html_byte_for_byte`) that folds every fixture through it against the same golden oracle.

## How it stays byte-faithful

- **Cross-references** are the one construct whose captured bytes are resolution-*dependent* (the recording pass runs before resolution), so the fold re-renders each from its resolved `XrefSegment`, pairing the tree's xref leaves with the placeholder-ordered `block_tree_xref_segments` in document order — the same correlation `mirror_tree_xref_resolution` relies on.
- To re-fold after the parse, `Content` retains the recorder's marked string and event log as a private, `inlines`-like derived artifact behind `with_inline_tree` (excluded from `Eq`/`Hash`/`Debug`). With the flag off there is nothing to fold, so `render_with` returns the cached built-in rendering.

## Scope boundary (Strategy A)

Because the Strategy A tree carries each construct's built-in bytes rather than the full parameters some renderer methods need, `render_with` invokes the supplied renderer only for the **self-contained** constructs it can drive faithfully — special characters, line breaks, anchors, index terms, buttons, keyboards, and cross-references — so a custom backend overrides those (a smoke test re-skins the line break). Formatted spans, links, STEM, images, menus, callouts, and footnote markers emit captured bytes, while still folding a span's or link's children so nested renderer-driven constructs are reached.

Widening renderer control over the captured constructs — and a document-level `render_to` (the crate has no document-level HTML converter today) — awaits the single-pass builder and reshaped renderer seam (Phases 4–5).

## Tests

- `render_with_reproduces_rendered_html_byte_for_byte` — document + normal corpora, incl. resolved xrefs.
- `render_with_reproduces_rendered_html_for_callouts` — a captured-bytes construct under the fold.
- `render_with_falls_back_to_rendered_html_when_tree_is_off` — flag-off fallback.
- `render_with_drives_a_custom_renderer` — proves the renderer is genuinely driven.

`cargo +nightly fmt --check`, `cargo clippy --all-targets`, the full workspace suite (4668 tests), and `cargo doc -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)