### PR TITLE
feat: Recognize character replacements and line breaks in the single-pass inline builder (inline-ast Phase 4, step 3)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -808,10 +808,40 @@ Each phase is a reviewable unit with a clear exit gate.
   builder seals the inner delimiter inside its opaque span and stays well-formed. This step is
   **additive**: nothing is wired into the parse path.
 
+  *Step 3 landed as (`CharacterReplacements` → `CharRef`, `PostReplacement` → `LineBreak`):*
+  two more transducer steps.
+  [`apply_character_replacements`](../../parser/src/content/inline_builder.rs) recognizes the
+  typographic replacements – `(C)`/`(R)`/`(TM)`, em dashes, ellipsis, apostrophes, arrows, and
+  restored entities – replacing each with a
+  [`CharRef::Replacement`](../../parser/src/inlines/char_ref.rs) (logical character(s)) or
+  [`CharRef::Entity`](../../parser/src/inlines/char_ref.rs) (a named/numeric entity as written)
+  leaf, and [`apply_post_replacements`](../../parser/src/content/inline_builder.rs) turns a
+  trailing ` +` at the end of a line into a
+  [`LineBreak`](../../parser/src/inlines/inline_node.rs) leaf. Both reuse the string pipeline's
+  *exact* recognition, now shared `pub(crate)`
+  ([`character_replacements`](../../parser/src/content/substitution_step.rs) and
+  [`hard_line_break_pattern`](../../parser/src/content/substitution_step.rs)), so only the
+  *sink* differs (§4.1). Like the string step, they match over the level's **escaped** working
+  string (reusing the quotes step's leaf-to-string machinery), which is precisely why an arrow
+  (`-&gt;`, `&lt;-`) or a restored entity (`&amp;copy;`) can straddle a `Text`/`CharRef`
+  boundary and still be recognized as one construct; a word character the pattern anchors on
+  (the `w` in `w--`, the letters around a `w'w` apostrophe) stays outside the consumed range and
+  is kept by the surrounding gaps, and an escape (`\(C)`) drops its backslash and wraps nothing.
+  Each leaf is sliced back to a precise `'src` span. The fold reconstructs the replacement's
+  [`CharacterReplacementType`](../../parser/src/parser/inline_substitution_renderer.rs) from its
+  logical value (a bijection) and renders through the same `render_character_replacement` /
+  `render_line_break` the string step calls, so its output is byte-identical. A broad
+  differential corpus pins symbols, dashes, ellipsis, apostrophes, boundary-straddling arrows
+  and entities, escapes, replacements inside spans, and hard line breaks (including their
+  interaction with spans and replacements), alongside structural precise-span assertions the
+  Strategy-A tree cannot make. This step is **additive**: nothing is wired into the parse path.
+  The block-wide `hardbreaks` option (which needs the block's attribute list, not yet threaded
+  into the builder) is deferred to the cutover (step 6).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
-  3. `CharacterReplacements` → `CharRef::Replacement`, and `PostReplacement` → `LineBreak`.
+  3. ✅ `CharacterReplacements` → `CharRef::Replacement`, and `PostReplacement` → `LineBreak`.
   4. `Macros` → `Ref` / `Image` / `Footnote` / `Ui` / `IndexTerm` / `Stem` / `Anchor`,
      capturing the owned `Attrlist<'src>` each construct carries – the step that makes nodes
      **self-describing** (and the one that finally unblocks `render_with`).

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -888,9 +888,10 @@ fn apply_character_replacements<'src>(
 }
 
 /// Applies one [`CharacterReplacement`] rule to `nodes`, first descending into
-/// the [`Styled`]/[`Ref`] children earlier steps created (a replacement inside
-/// a span is recognized just as the string pipeline recognizes one inside a
-/// rendered tag), then matching and replacing at this level.
+/// the [`Styled`]/[`Ref`](InlineNode::Ref) children earlier steps created (a
+/// replacement inside a span is recognized just as the string pipeline
+/// recognizes one inside a rendered tag), then matching and replacing at this
+/// level.
 fn apply_one_replacement<'src>(
     repl: &CharacterReplacement,
     nodes: Vec<InlineNode<'src>>,
@@ -978,9 +979,9 @@ fn find_replacement_matches(repl: &CharacterReplacement, s: &str) -> Vec<Replace
     let mut matches = Vec::new();
 
     for caps in repl.pattern.captures_iter(s) {
-        let Some(whole) = caps.get(0) else {
-            continue;
-        };
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
 
         let full = whole.start()..whole.end();
 
@@ -1165,13 +1166,18 @@ fn apply_post_replacements<'src>(
     }
 
     // Each match's `[content.end, whole.end)` is the trailing ` +` the break
-    // replaces; the line content before it is kept.
+    // replaces; the line content before it is kept. Group 0 (the whole match)
+    // and group 1 (the `(.*)` line content) always participate in this pattern.
     let breaks: Vec<std::ops::Range<usize>> = hard_line_break_pattern()
         .captures_iter(&s)
-        .filter_map(|caps| {
-            let whole = caps.get(0)?;
-            let content = caps.get(1)?;
-            Some(content.end()..whole.end())
+        .map(|caps| {
+            #[allow(clippy::unwrap_used)]
+            let whole = caps.get(0).unwrap();
+
+            #[allow(clippy::unwrap_used)]
+            let content = caps.get(1).unwrap();
+
+            content.end()..whole.end()
         })
         .collect();
 
@@ -1273,18 +1279,15 @@ fn fold_into_html(
                 value: CharRef::Replacement(value),
                 ..
             } => match replacement_type_of(value) {
+                // A replacement the builder produced routes through the renderer,
+                // so a custom backend can override the entity it emits.
                 Some(type_) => renderer.render_character_replacement(type_, out),
 
+                // A value the builder never produces (only a hand-built node can
+                // reach here) still folds losslessly: the general rule every
+                // known replacement follows is one decimal numeric entity per
+                // logical character.
                 None => {
-                    // Every replacement the builder produces has a known type,
-                    // so this is defensive. The general rule the known
-                    // replacements all follow is one decimal numeric entity per
-                    // logical character; fall back to it in release builds.
-                    debug_assert!(
-                        false,
-                        "inline_builder::fold_html reached an unknown replacement value: {value:?}"
-                    );
-
                     for ch in value.chars() {
                         out.push_str(&format!("&#{};", ch as u32));
                     }
@@ -1368,7 +1371,10 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::{apply_quotes, apply_special_characters, build, fold_html};
+    use super::{
+        apply_character_replacements, apply_post_replacements, apply_quotes,
+        apply_special_characters, build, fold_html,
+    };
     use crate::{
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
@@ -2164,6 +2170,12 @@ mod tests {
             "no break here\nsecond line",
             "line one +\nline two\nline three +\nline four",
             "trailing space but no plus \nnext",
+            // A `+` and a newline are both present, but no line ends in ` +`, so
+            // no break is recognized.
+            "a + b\nc",
+            // The content ends exactly in a break, so nothing trails the last
+            // one.
+            "a\nfoo +",
             // Line breaks interacting with replacements and spans.
             "Acme (C) +\nnext line",
             "*bold* +\nplain",
@@ -2332,6 +2344,91 @@ mod tests {
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
             "foo<br>\nbar"
         );
+    }
+
+    #[test]
+    fn character_replacements_recurse_into_ref_children() {
+        // A reference's display text is subject to replacements, just as the
+        // string pipeline processes it inside the rendered anchor. (No macros
+        // step yet builds `Ref` nodes, so this drives the recursion directly.)
+        let loc = Span::new("(C)");
+
+        let reference = InlineNode::Ref(Ref {
+            variant: RefVariant::Link,
+            target: CowStr::from("https://example.com"),
+            children: vec![InlineNode::Text {
+                value: CowStr::from(loc.data()),
+                location: loc,
+            }],
+            roles: vec![],
+            window: None,
+            resolved: None,
+            location: loc,
+        });
+
+        let out = apply_character_replacements(vec![reference], loc);
+
+        assert_eq!(out.len(), 1);
+
+        match &out[0] {
+            InlineNode::Ref(reference) => {
+                assert_eq!(reference.children.len(), 1);
+                assert_replacement(&reference.children[0], "\u{a9}", "(C)");
+            }
+
+            other => panic!("expected Ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_replacements_recurse_into_ref_children() {
+        // A hard line break inside a reference's display text is likewise
+        // recognized (driven directly, as above).
+        let loc = Span::new("x +\ny");
+
+        let reference = InlineNode::Ref(Ref {
+            variant: RefVariant::Link,
+            target: CowStr::from("https://example.com"),
+            children: vec![InlineNode::Text {
+                value: CowStr::from(loc.data()),
+                location: loc,
+            }],
+            roles: vec![],
+            window: None,
+            resolved: None,
+            location: loc,
+        });
+
+        let out = apply_post_replacements(vec![reference], loc);
+
+        match &out[0] {
+            InlineNode::Ref(reference) => {
+                assert_eq!(reference.children.len(), 3);
+                assert_text(&reference.children[0], "x", 1, 1);
+                assert!(matches!(
+                    reference.children[1],
+                    InlineNode::LineBreak { .. }
+                ));
+                assert_text(&reference.children[2], "\ny", 1, 4);
+            }
+
+            other => panic!("expected Ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_encodes_an_unknown_replacement_value_per_character() {
+        // A `CharRef::Replacement` value the builder never produces (only a
+        // hand-built node can carry one) still folds losslessly: one decimal
+        // numeric entity per logical character. Here `z` is U+007A.
+        let location = Span::new("z");
+
+        let node = InlineNode::CharRef {
+            value: CharRef::Replacement("z"),
+            location,
+        };
+
+        assert_eq!(fold_html(&[node], &HtmlSubstitutionRenderer {}), "&#122;");
     }
 
     #[test]

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -19,7 +19,7 @@
 //!
 //! Strategy B "touches every step," so it lands incrementally under the
 //! golden-HTML oracle. This module currently implements the **foundation** plus
-//! the first two refinements:
+//! these refinements:
 //!
 //! - [`build`] seeds a single borrowed whole-source [`Text`](InlineNode::Text)
 //!   node and threads it through the steps.
@@ -31,18 +31,28 @@
 //!   a flat run. It reuses the *exact* [`quote_subs`] the string pipeline
 //!   matches with (changing the recognition *sink*, not the recognition), so
 //!   its fold is byte-identical to the string step.
+//! - [`apply_character_replacements`] recognizes [character replacements] –
+//!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities – replacing
+//!   each with a [`CharRef::Replacement`] or [`CharRef::Entity`] leaf. It
+//!   reuses the shared [`character_replacements`] rules and, like the string
+//!   step, matches over the *escaped* text so an arrow (`-&gt;`) or entity
+//!   (`&amp;copy;`) can straddle a `Text`/`CharRef` boundary.
+//! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
+//!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
 //!   through an [`InlineSubstitutionRenderer`] – the first fold over the
 //!   *public* [`InlineNode`] tree (the recorder's [`fold_into`] folds an
 //!   intermediate representation, not the public tree).
 //!
 //! [quoted text]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
+//! [character replacements]:
+//!     https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
 //!
 //! It is **additive and non-regressing**: nothing here is wired into the parse
 //! path yet, so the authoritative string pipeline and the Strategy-A
 //! [`Content::inlines`](crate::content::Content::inlines) tree are untouched.
-//! Later increments extend the transducer to replacements, macros, attribute
-//! expansion, and passthroughs, at which point it can replace the recorder,
+//! Later increments extend the transducer to macros, attribute expansion, and
+//! passthroughs, at which point it can replace the recorder,
 //! make `rendered_html()` a fold, and retire the sentinel systems.
 //!
 //! # A note on quote nesting
@@ -71,9 +81,15 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{QuoteSub, maybe_has_quotes, quote_subs},
+    content::{
+        CharacterReplacement, QuoteSub, character_replacements, hard_line_break_pattern,
+        maybe_has_quotes, maybe_has_replacements, quote_subs,
+    },
     inlines::{CharRef, InlineNode, SpanForm, StyleVariant, Styled},
-    parser::{InlineSubstitutionRenderer, QuoteScope, QuoteType, SpecialCharacter},
+    parser::{
+        CharacterReplacementType, InlineSubstitutionRenderer, QuoteScope, QuoteType,
+        SpecialCharacter,
+    },
     strings::CowStr,
 };
 
@@ -94,8 +110,10 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     }];
 
     let nodes = apply_special_characters(seed);
+    let nodes = apply_quotes(nodes, source, parser);
+    let nodes = apply_character_replacements(nodes, source);
 
-    apply_quotes(nodes, source, parser)
+    apply_post_replacements(nodes, source)
 }
 
 /// Reports whether `c` is one of the three characters the special-characters
@@ -841,6 +859,372 @@ fn quote_type_of(variant: StyleVariant) -> QuoteType {
     }
 }
 
+// ─── Character replacements ───────────────────────────────────────────────
+
+/// The character-replacements substitution, as a node transducer: each shared
+/// [`character_replacements`] rule is applied to the tree in order (its order
+/// encodes Asciidoctor's precedence), replacing every matched construct with a
+/// [`CharRef::Replacement`] (a typographic replacement such as `(C)` → `©`) or
+/// a [`CharRef::Entity`] (a restored named/numeric entity such as `&amp;copy;`
+/// → `&copy;`) leaf.
+///
+/// Like the string pipeline's step, the rules match over the level's
+/// **escaped** text (built by [`build_match_string`], where a
+/// [`CharRef::Special`] contributes its canonical entity) – which is exactly
+/// why the arrow (`-&gt;`, `&lt;-`) and entity (`&amp;copy;`) rules can
+/// straddle a `Text`/`CharRef` boundary. `root` is the whole-content source
+/// span; every leaf's precise `location` is sliced from it.
+fn apply_character_replacements<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let mut nodes = nodes;
+
+    for repl in character_replacements() {
+        nodes = apply_one_replacement(repl, nodes, root);
+    }
+
+    nodes
+}
+
+/// Applies one [`CharacterReplacement`] rule to `nodes`, first descending into
+/// the [`Styled`]/[`Ref`] children earlier steps created (a replacement inside
+/// a span is recognized just as the string pipeline recognizes one inside a
+/// rendered tag), then matching and replacing at this level.
+fn apply_one_replacement<'src>(
+    repl: &CharacterReplacement,
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let nodes: Vec<InlineNode<'src>> = nodes
+        .into_iter()
+        .map(|node| match node {
+            InlineNode::Styled(mut styled) => {
+                styled.children = apply_one_replacement(repl, styled.children, root);
+                InlineNode::Styled(styled)
+            }
+
+            InlineNode::Ref(mut reference) => {
+                reference.children = apply_one_replacement(repl, reference.children, root);
+                InlineNode::Ref(reference)
+            }
+
+            other => other,
+        })
+        .collect();
+
+    replace_level(repl, nodes, root)
+}
+
+/// One character-replacement match at a level, in absolute match-string byte
+/// offsets.
+struct ReplacementMatch {
+    /// The whole match, `[start, end)`.
+    full: std::ops::Range<usize>,
+
+    /// What to emit in place of `full`.
+    kind: ReplacementKind,
+}
+
+enum ReplacementKind {
+    /// An escaped construct (`\(C)`, `\-&gt;`, …): drop the single backslash at
+    /// this offset and keep the rest of the match as literal nodes, replacing
+    /// nothing – mirroring the string replacer's `caps[0].replace("\\", "")`.
+    Unescape { backslash: usize },
+
+    /// A recognized typographic replacement. Only the `consumed` sub-range
+    /// becomes a [`CharRef::Replacement`] leaf carrying `value` (the logical
+    /// character(s)); any word character the pattern anchors on (the `w` in
+    /// `w--`, or the letters around a `w'w` apostrophe) lies outside `consumed`
+    /// and is kept as literal text by the surrounding gaps.
+    Replace {
+        consumed: std::ops::Range<usize>,
+        value: &'static str,
+    },
+
+    /// A restored character reference (`&amp;copy;`): the whole match becomes a
+    /// [`CharRef::Entity`] leaf whose value is the named/numeric entity `name`
+    /// wrapped as `&name;`.
+    Entity { name: std::ops::Range<usize> },
+}
+
+/// Matches `repl` over this level's escaped text, replacing each match with the
+/// leaf node(s) it produces and leaving everything else in place.
+fn replace_level<'src>(
+    repl: &CharacterReplacement,
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter: skip the pattern sweep when nothing replaceable is
+    // present at this level.
+    if !maybe_has_replacements(&s) {
+        return nodes;
+    }
+
+    let matches = find_replacement_matches(repl, &s);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_replacements(&nodes, &pieces, &s, &matches, root)
+}
+
+/// Finds every non-overlapping match of `repl` in the escaped match string `s`,
+/// left to right, exactly as the string pipeline's `replace_all` does.
+fn find_replacement_matches(repl: &CharacterReplacement, s: &str) -> Vec<ReplacementMatch> {
+    let mut matches = Vec::new();
+
+    for caps in repl.pattern.captures_iter(s) {
+        let Some(whole) = caps.get(0) else {
+            continue;
+        };
+
+        let full = whole.start()..whole.end();
+
+        // An escaped construct keeps its literal text with the single backslash
+        // dropped, and replaces nothing.
+        if let Some(rel) = whole.as_str().find('\\') {
+            matches.push(ReplacementMatch {
+                full,
+                kind: ReplacementKind::Unescape {
+                    backslash: whole.start() + rel,
+                },
+            });
+
+            continue;
+        }
+
+        matches.push(ReplacementMatch {
+            full: full.clone(),
+            kind: classify_replacement(repl, &caps, full),
+        });
+    }
+
+    matches
+}
+
+/// Classifies one non-escaped capture into the leaf it produces. Group presence
+/// distinguishes the two rules that share [`CharacterReplacementType`]: a bare
+/// `` `' `` apostrophe (no groups) versus a word-internal `w'w` one (two).
+fn classify_replacement(
+    repl: &CharacterReplacement,
+    caps: &regex::Captures<'_>,
+    full: std::ops::Range<usize>,
+) -> ReplacementKind {
+    let group = |i: usize| caps.get(i).map(|m| m.range());
+
+    // The whole match becomes a single replacement leaf with nothing kept.
+    let whole = |value| ReplacementKind::Replace {
+        consumed: full.clone(),
+        value,
+    };
+
+    match repl.type_ {
+        CharacterReplacementType::Copyright => whole("\u{a9}"),
+        CharacterReplacementType::Registered => whole("\u{ae}"),
+        CharacterReplacementType::Trademark => whole("\u{2122}"),
+        CharacterReplacementType::EmDashSurroundedBySpaces => whole("\u{2009}\u{2014}\u{2009}"),
+        CharacterReplacementType::Ellipsis => whole("\u{2026}\u{200b}"),
+        CharacterReplacementType::SingleLeftArrow => whole("\u{2190}"),
+        CharacterReplacementType::DoubleLeftArrow => whole("\u{21d0}"),
+        CharacterReplacementType::SingleRightArrow => whole("\u{2192}"),
+        CharacterReplacementType::DoubleRightArrow => whole("\u{21d2}"),
+
+        CharacterReplacementType::EmDashWithoutSpace => {
+            // `(\w)--`: the leading word character (group 1) stays; only the
+            // `--` after it is consumed.
+            let before = group(1).unwrap_or(full.start..full.start);
+
+            ReplacementKind::Replace {
+                consumed: before.end..full.end,
+                value: "\u{2014}\u{200b}",
+            }
+        }
+
+        CharacterReplacementType::TypographicApostrophe => match (group(1), group(2)) {
+            // `w'w`: the surrounding letters stay; only the apostrophe between
+            // them is consumed.
+            (Some(before), Some(after)) => ReplacementKind::Replace {
+                consumed: before.end..after.start,
+                value: "\u{2019}",
+            },
+
+            // `` `' ``: the whole match is the apostrophe.
+            _ => whole("\u{2019}"),
+        },
+
+        CharacterReplacementType::CharacterReference(_) => ReplacementKind::Entity {
+            name: group(1).unwrap_or(full),
+        },
+    }
+}
+
+/// Rebuilds a level's node list from its character-replacement matches: each
+/// gap keeps its original nodes; each match becomes its kept literal text plus
+/// the replacement leaf.
+fn rebuild_replacements<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    s: &str,
+    matches: &[ReplacementMatch],
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+
+    for m in matches {
+        match &m.kind {
+            ReplacementKind::Unescape { backslash } => {
+                // Keep the whole match with the single backslash dropped.
+                emit_range(nodes, pieces, cursor..*backslash, &mut out);
+                emit_range(nodes, pieces, (*backslash + 1)..m.full.end, &mut out);
+                cursor = m.full.end;
+            }
+
+            ReplacementKind::Replace { consumed, value } => {
+                // The gap runs up to `consumed`, absorbing any kept leading word
+                // character; the cursor stops at `consumed.end`, so a kept
+                // trailing letter (the second letter of a `w'w` apostrophe) is
+                // absorbed by the next gap.
+                emit_range(nodes, pieces, cursor..consumed.start, &mut out);
+
+                out.push(InlineNode::CharRef {
+                    value: CharRef::Replacement(value),
+                    location: source_slice(pieces, consumed.clone(), root),
+                });
+
+                cursor = consumed.end;
+            }
+
+            ReplacementKind::Entity { name } => {
+                // The entity is emitted as written (`&copy;`); its `&`/`;` come
+                // from the pattern, its name from the level's escaped text.
+                emit_range(nodes, pieces, cursor..m.full.start, &mut out);
+
+                let entity = format!("&{};", &s[name.clone()]);
+
+                out.push(InlineNode::CharRef {
+                    value: CharRef::Entity(CowStr::from(entity)),
+                    location: source_slice(pieces, m.full.clone(), root),
+                });
+
+                cursor = m.full.end;
+            }
+        }
+    }
+
+    if cursor < s.len() {
+        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+    }
+
+    out
+}
+
+// ─── Post replacements (hard line breaks) ─────────────────────────────────
+
+/// The post-replacement substitution, as a node transducer: a line ending in
+/// ` +` has that ` +` replaced by a [`LineBreak`](InlineNode::LineBreak) leaf,
+/// the line content before it staying in place.
+///
+/// Only the default hard-line-break form is handled here. The block-wide
+/// `hardbreaks` option – which turns *every* line ending into a break – needs
+/// the block's attribute list and the document's `hardbreaks-option` attribute,
+/// neither yet threaded into the builder, so it is deferred to the cutover
+/// (design §5.2 Phase 4, step 6).
+fn apply_post_replacements<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    // Descend into spans/refs first, matching the string pipeline's
+    // whole-string pass.
+    let nodes: Vec<InlineNode<'src>> = nodes
+        .into_iter()
+        .map(|node| match node {
+            InlineNode::Styled(mut styled) => {
+                styled.children = apply_post_replacements(styled.children, root);
+                InlineNode::Styled(styled)
+            }
+
+            InlineNode::Ref(mut reference) => {
+                reference.children = apply_post_replacements(reference.children, root);
+                InlineNode::Ref(reference)
+            }
+
+            other => other,
+        })
+        .collect();
+
+    let (s, pieces) = build_match_string(&nodes);
+
+    // The string pipeline guards on both a `+` and a newline being present.
+    if !(s.contains('+') && s.contains('\n')) {
+        return nodes;
+    }
+
+    // Each match's `[content.end, whole.end)` is the trailing ` +` the break
+    // replaces; the line content before it is kept.
+    let breaks: Vec<std::ops::Range<usize>> = hard_line_break_pattern()
+        .captures_iter(&s)
+        .filter_map(|caps| {
+            let whole = caps.get(0)?;
+            let content = caps.get(1)?;
+            Some(content.end()..whole.end())
+        })
+        .collect();
+
+    if breaks.is_empty() {
+        return nodes;
+    }
+
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+
+    for br in breaks {
+        emit_range(&nodes, &pieces, cursor..br.start, &mut out);
+
+        out.push(InlineNode::LineBreak {
+            location: source_slice(&pieces, br.clone(), root),
+        });
+
+        cursor = br.end;
+    }
+
+    if cursor < s.len() {
+        emit_range(&nodes, &pieces, cursor..s.len(), &mut out);
+    }
+
+    out
+}
+
+/// The inverse of the classifier's value assignment: the
+/// [`CharacterReplacementType`] the fold renders a [`CharRef::Replacement`]
+/// value with. The mapping is a bijection – each replacement type produces a
+/// distinct logical string – so the fold reproduces the string pipeline's bytes
+/// through the same [`render_character_replacement`] the step calls.
+///
+/// [`render_character_replacement`]:
+///     crate::parser::InlineSubstitutionRenderer::render_character_replacement
+fn replacement_type_of(value: &str) -> Option<CharacterReplacementType> {
+    Some(match value {
+        "\u{a9}" => CharacterReplacementType::Copyright,
+        "\u{ae}" => CharacterReplacementType::Registered,
+        "\u{2122}" => CharacterReplacementType::Trademark,
+        "\u{2009}\u{2014}\u{2009}" => CharacterReplacementType::EmDashSurroundedBySpaces,
+        "\u{2014}\u{200b}" => CharacterReplacementType::EmDashWithoutSpace,
+        "\u{2026}\u{200b}" => CharacterReplacementType::Ellipsis,
+        "\u{2019}" => CharacterReplacementType::TypographicApostrophe,
+        "\u{2190}" => CharacterReplacementType::SingleLeftArrow,
+        "\u{21d0}" => CharacterReplacementType::DoubleLeftArrow,
+        "\u{2192}" => CharacterReplacementType::SingleRightArrow,
+        "\u{21d2}" => CharacterReplacementType::DoubleRightArrow,
+
+        _ => return None,
+    })
+}
+
 /// Folds an inline node tree to output bytes through `renderer`.
 ///
 /// This is the first fold over the *public* [`InlineNode`] tree. It currently
@@ -883,6 +1267,41 @@ fn fold_into_html(
                 ..
             } => {
                 render_char(*ch, renderer, out);
+            }
+
+            InlineNode::CharRef {
+                value: CharRef::Replacement(value),
+                ..
+            } => match replacement_type_of(value) {
+                Some(type_) => renderer.render_character_replacement(type_, out),
+
+                None => {
+                    // Every replacement the builder produces has a known type,
+                    // so this is defensive. The general rule the known
+                    // replacements all follow is one decimal numeric entity per
+                    // logical character; fall back to it in release builds.
+                    debug_assert!(
+                        false,
+                        "inline_builder::fold_html reached an unknown replacement value: {value:?}"
+                    );
+
+                    for ch in value.chars() {
+                        out.push_str(&format!("&#{};", ch as u32));
+                    }
+                }
+            },
+
+            InlineNode::CharRef {
+                value: CharRef::Entity(entity),
+                ..
+            } => {
+                // `Entity` carries the character reference exactly as written
+                // (`&copy;`); it is already a valid entity, emitted verbatim.
+                out.push_str(entity);
+            }
+
+            InlineNode::LineBreak { .. } => {
+                renderer.render_line_break(out);
             }
 
             InlineNode::Styled(styled) => {
@@ -949,7 +1368,7 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::{apply_special_characters, build, fold_html};
+    use super::{apply_quotes, apply_special_characters, build, fold_html};
     use crate::{
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
@@ -962,6 +1381,28 @@ mod tests {
     /// parser is consulted only for attributed-quote attribute lists).
     fn build_src(source: Span<'_>) -> Vec<InlineNode<'_>> {
         build(source, &Parser::default())
+    }
+
+    /// Seeds the whole-source [`Text`](InlineNode::Text) node the transducer
+    /// steps refine, exactly as [`build`] does before running them.
+    fn seed(source: Span<'_>) -> Vec<InlineNode<'_>> {
+        vec![InlineNode::Text {
+            value: CowStr::from(source.data()),
+            location: source,
+        }]
+    }
+
+    /// Builds the tree **through the special-characters step only**, so a
+    /// staged differential test compares against the matching partial golden
+    /// (the full [`build`] runs later steps that would perturb it).
+    fn build_through_special(source: Span<'_>) -> Vec<InlineNode<'_>> {
+        apply_special_characters(seed(source))
+    }
+
+    /// Builds the tree **through the quotes step**, for the quotes-stage
+    /// differential (see [`build_through_special`]).
+    fn build_through_quotes(source: Span<'_>) -> Vec<InlineNode<'_>> {
+        apply_quotes(build_through_special(source), source, &Parser::default())
     }
 
     /// Asserts that `node` is a [`Text`](InlineNode::Text) whose `value`
@@ -1254,7 +1695,7 @@ mod tests {
         let renderer = HtmlSubstitutionRenderer {};
 
         for fixture in fixtures {
-            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+            let folded = fold_html(&build_through_special(Span::new(fixture)), &renderer);
 
             assert_eq!(
                 folded,
@@ -1356,7 +1797,7 @@ mod tests {
         let renderer = HtmlSubstitutionRenderer {};
 
         for fixture in fixtures {
-            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+            let folded = fold_html(&build_through_quotes(Span::new(fixture)), &renderer);
 
             assert_eq!(
                 folded,
@@ -1454,7 +1895,10 @@ mod tests {
         // docs): for pathological cross-span input the two intentionally differ.
         let source = "`a *b` c*";
 
-        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+        let folded = fold_html(
+            &build_through_quotes(Span::new(source)),
+            &HtmlSubstitutionRenderer {},
+        );
         let golden = golden_quotes(source);
 
         // The string pipeline's crossed tags: monospace matched *through* the
@@ -1634,5 +2078,288 @@ mod tests {
 
             other => panic!("expected Styled, got {other:?}"),
         }
+    }
+
+    /// The string pipeline's output through the **post-replacement** step for
+    /// `source`, used as the golden oracle: the four steps [`build`] runs, in
+    /// order (special characters, quotes, character replacements, post
+    /// replacement). Attribute references and macros are skipped – exactly as
+    /// the additive builder skips them – so the fixtures deliberately contain
+    /// neither.
+    fn golden_replacements(source: &str) -> String {
+        let parser = crate::Parser::default();
+        let mut content = Content::from(Span::new(source));
+        SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
+        SubstitutionStep::Quotes.apply(&mut content, &parser, None);
+        SubstitutionStep::CharacterReplacements.apply(&mut content, &parser, None);
+        SubstitutionStep::PostReplacement.apply(&mut content, &parser, None);
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_replacements() {
+        // For each fixture, folding the single-pass tree (special characters +
+        // quotes + character replacements + post replacement) reproduces the
+        // string pipeline's output byte-for-byte. This is the differential
+        // corpus (design §5.3) that pins this increment.
+        let fixtures = [
+            // No replacements.
+            "plain text",
+            "a < b & c > d",
+            "*bold* and _italic_",
+            // Symbols.
+            "(C)",
+            "(R)",
+            "(TM)",
+            "Copyright (C) 2026, Acme (R), Widget (TM)",
+            // Em dashes.
+            "a -- b",
+            "one--two",
+            "start -- of a thought",
+            "-- leading",
+            "trailing --",
+            "a--b--c",
+            // Ellipsis.
+            "wait...",
+            "a...b...c",
+            "...",
+            // Apostrophes.
+            "Sam's book",
+            "it's a girls' school",
+            "He said `'hello",
+            // Arrows (they straddle a Text/CharRef boundary once escaped).
+            "a -> b",
+            "a => b",
+            "a <- b",
+            "a <= b",
+            "if x -> y then z",
+            "->",
+            "<-",
+            // Entity restoration.
+            "&copy; 2026",
+            "&#8217;",
+            "&#x2019;",
+            "&hellip; and &mdash;",
+            // Escapes suppress the replacement.
+            "\\(C)",
+            "\\--",
+            "a\\--b",
+            "\\...",
+            "\\-> arrow",
+            "\\&copy;",
+            "It\\'s",
+            // Replacements inside spans.
+            "*Acme (C)*",
+            "_wait..._",
+            "`a -> b`",
+            "*a -- b* and _x...y_",
+            // Nesting with replacements.
+            "*a _b (C) c_ d*",
+            // Specials adjacent to replacement triggers.
+            "a<b (C) c>d",
+            "&amp; then (R)",
+            // Hard line breaks.
+            "foo +\nbar",
+            "a +\nb +\nc",
+            "no break here\nsecond line",
+            "line one +\nline two\nline three +\nline four",
+            "trailing space but no plus \nnext",
+            // Line breaks interacting with replacements and spans.
+            "Acme (C) +\nnext line",
+            "*bold* +\nplain",
+            "a -> b +\nc <- d",
+            // Combinations.
+            "(C) 2026 -- Acme's widgets... see x -> y",
+            // Quote-like / replacement-like characters that do not match.
+            "1 -- 2 * 3",
+            "a_b_c",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_replacements(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    /// Asserts that `node` is a [`CharRef::Replacement`] carrying `value`,
+    /// located over source `data`.
+    fn assert_replacement(node: &InlineNode<'_>, value: &str, data: &str) {
+        match node {
+            InlineNode::CharRef {
+                value: CharRef::Replacement(got),
+                location,
+            } => {
+                assert_eq!(*got, value, "replacement value");
+                assert_eq!(location.data(), data, "replacement location");
+            }
+
+            other => panic!("expected CharRef::Replacement({value:?}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copyright_becomes_a_replacement_leaf() {
+        let nodes = build_src(Span::new("(C)"));
+
+        assert_eq!(nodes.len(), 1);
+        // The logical value is the copyright character; the fold encodes it as
+        // the numeric entity the string pipeline emits.
+        assert_replacement(&nodes[0], "\u{a9}", "(C)");
+
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "&#169;");
+    }
+
+    #[test]
+    fn an_arrow_replacement_spans_a_text_and_charref_boundary() {
+        // `->` is `-` (text) followed by `&gt;` (a `CharRef::Special` from the
+        // special-characters step), so the arrow rule must match across the two.
+        let nodes = build_src(Span::new("a -> b"));
+
+        // "a " kept, the arrow leaf over "->", then " b".
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "a ", 1, 1);
+        assert_replacement(&nodes[1], "\u{2192}", "->");
+        assert_text(&nodes[2], " b", 1, 5);
+    }
+
+    #[test]
+    fn an_em_dash_without_space_keeps_the_leading_word_char() {
+        // `(\w)--`: the leading word character is kept, the `--` consumed.
+        let nodes = build_src(Span::new("one--two"));
+
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "one", 1, 1);
+        assert_replacement(&nodes[1], "\u{2014}\u{200b}", "--");
+        assert_text(&nodes[2], "two", 1, 6);
+    }
+
+    #[test]
+    fn a_word_apostrophe_keeps_both_letters() {
+        // `w'w`: the surrounding letters are kept, the apostrophe consumed.
+        let nodes = build_src(Span::new("Sam's"));
+
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "Sam", 1, 1);
+        assert_replacement(&nodes[1], "\u{2019}", "'");
+        assert_text(&nodes[2], "s", 1, 5);
+    }
+
+    #[test]
+    fn a_restored_entity_becomes_an_entity_leaf() {
+        let nodes = build_src(Span::new("&copy; 2026"));
+
+        assert_eq!(nodes.len(), 2);
+
+        match &nodes[0] {
+            InlineNode::CharRef {
+                value: CharRef::Entity(entity),
+                location,
+            } => {
+                assert_eq!(entity.as_ref(), "&copy;");
+                // The location covers the source the entity derives from.
+                assert_eq!(location.data(), "&copy;");
+            }
+
+            other => panic!("expected CharRef::Entity, got {other:?}"),
+        }
+
+        assert_text(&nodes[1], " 2026", 1, 7);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            "&copy; 2026"
+        );
+    }
+
+    #[test]
+    fn an_escaped_replacement_stays_literal() {
+        // `\(C)` drops the backslash and keeps `(C)` as literal text – no
+        // replacement leaf.
+        let nodes = build_src(Span::new("\\(C)"));
+
+        assert!(
+            nodes
+                .iter()
+                .all(|n| !matches!(n, InlineNode::CharRef { .. })),
+            "an escaped replacement must not produce a char-ref leaf: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_replacements("\\(C)")
+        );
+    }
+
+    #[test]
+    fn a_replacement_inside_a_span_is_recognized() {
+        // A `(C)` inside a strong span is replaced just as the string pipeline
+        // replaces one inside a rendered `<strong>` tag.
+        let nodes = build_src(Span::new("*Acme (C)*"));
+
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+        assert_eq!(children.len(), 2);
+        assert_text(&children[0], "Acme ", 1, 2);
+        assert_replacement(&children[1], "\u{a9}", "(C)");
+    }
+
+    #[test]
+    fn a_hard_line_break_becomes_a_line_break_leaf() {
+        // A line ending in ` +` yields a `LineBreak` leaf in place of the ` +`;
+        // the newline and following line stay as text.
+        let nodes = build_src(Span::new("foo +\nbar"));
+
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "foo", 1, 1);
+
+        match &nodes[1] {
+            InlineNode::LineBreak { location } => {
+                assert_eq!(location.data(), " +");
+            }
+
+            other => panic!("expected LineBreak, got {other:?}"),
+        }
+
+        assert_text(&nodes[2], "\nbar", 1, 6);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            "foo<br>\nbar"
+        );
+    }
+
+    #[test]
+    fn replacement_type_of_round_trips_every_variant() {
+        use super::replacement_type_of;
+
+        // Every replacement value the classifier assigns maps back to a type, so
+        // the fold always routes through the renderer. An unknown value is the
+        // defensive `None`.
+        for value in [
+            "\u{a9}",
+            "\u{ae}",
+            "\u{2122}",
+            "\u{2009}\u{2014}\u{2009}",
+            "\u{2014}\u{200b}",
+            "\u{2026}\u{200b}",
+            "\u{2019}",
+            "\u{2190}",
+            "\u{21d0}",
+            "\u{2192}",
+            "\u{21d2}",
+        ] {
+            assert!(
+                replacement_type_of(value).is_some(),
+                "no type for replacement value {value:?}"
+            );
+        }
+
+        assert!(replacement_type_of("not a replacement").is_none());
     }
 }

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -30,7 +30,8 @@ pub use substitution_group::SubstitutionGroup;
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
-    AttributeMissing, QuoteSub, maybe_has_quotes, quote_subs,
+    AttributeMissing, CharacterReplacement, QuoteSub, character_replacements,
+    hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, quote_subs,
     substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
     substitute_attributes_in_text,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1093,9 +1093,38 @@ fn apply_character_replacements(
     }
 }
 
-struct CharacterReplacement {
-    type_: CharacterReplacementType,
-    pattern: Regex,
+/// One character-replacement recognition rule: a
+/// [`CharacterReplacementType`] and the [`Regex`] that recognizes it.
+///
+/// The rules are `pub(crate)` (via [`character_replacements`]) so the
+/// single-pass [`inline_builder`](crate::content::inline_builder) reuses the
+/// *exact* same patterns the string pipeline matches with – the design's core
+/// principle of changing the recognition *sink*, not the recognition itself
+/// (§4.1). This mirrors how [`quote_subs`] is shared.
+pub(crate) struct CharacterReplacement {
+    pub(crate) type_: CharacterReplacementType,
+    pub(crate) pattern: Regex,
+}
+
+/// The ordered character-replacement recognition rules, shared with the
+/// single-pass [`inline_builder`](crate::content::inline_builder). The order is
+/// significant: it encodes Asciidoctor's precedence (see [`REPLACEMENTS`]).
+pub(crate) fn character_replacements() -> &'static [CharacterReplacement] {
+    &REPLACEMENTS
+}
+
+/// Reports whether `text` contains any character that could open a
+/// character-replacement construct. A cheap pre-filter (shared with the
+/// single-pass builder) that lets a caller skip the full pattern sweep when
+/// nothing replaceable is present.
+pub(crate) fn maybe_has_replacements(text: &str) -> bool {
+    REPLACEABLE_TEXT_SNIFF.is_match(text)
+}
+
+/// The hard-line-break recognition pattern (a line ending in ` +`), shared with
+/// the single-pass [`inline_builder`](crate::content::inline_builder).
+pub(crate) fn hard_line_break_pattern() -> &'static Regex {
+    &HARD_LINE_BREAK
 }
 
 static REPLACEABLE_TEXT_SNIFF: LazyLock<Regex> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary

Phase 4, step 3 of the [inline-ast architecture](docs/design/inline-ast-architecture.md): two more transducer steps for the single-pass inline builder, both **additive** (nothing is wired into the parse path yet) and gated by the golden-HTML differential oracle.

- **`apply_character_replacements`** recognizes the typographic replacements — `(C)`/`(R)`/`(TM)`, em dashes, ellipsis, apostrophes, arrows, and restored entities — emitting a `CharRef::Replacement` (logical character(s)) or `CharRef::Entity` (entity as written) leaf for each.
- **`apply_post_replacements`** turns a trailing ` +` at the end of a line into a `LineBreak` leaf.

## How it works

Both reuse the string pipeline's *exact* recognition data, now shared `pub(crate)` (`character_replacements`, `maybe_has_replacements`, `hard_line_break_pattern`), so only the recognition **sink** differs (§4.1) — the recognition itself is unchanged.

Like the string step, they match over the level's **escaped** working string (reusing the quotes step's leaf-to-string machinery). That is precisely why an arrow (`-&gt;`, `&lt;-`) or a restored entity (`&amp;copy;`) can straddle a `Text`/`CharRef` boundary and still be recognized as one construct. A word character the pattern anchors on (the `w` in `w--`, the letters around a `w'w` apostrophe) stays outside the consumed range and is kept by the surrounding gaps; an escape (`\(C)`) drops its backslash and wraps nothing. Each leaf is sliced back to a precise `'src` span.

The fold reconstructs a replacement's `CharacterReplacementType` from its logical value (a bijection) and renders through the same `render_character_replacement` / `render_line_break` the string step calls, so its output is **byte-identical**.

## Testing

- A broad **differential corpus** (~55 fixtures) asserts the fold reproduces the string pipeline's output byte-for-byte: symbols, dashes, ellipsis, apostrophes, boundary-straddling arrows and entities, escapes, replacements inside spans, and hard line breaks (including their interaction with spans and replacements).
- Structural precise-span assertions the Strategy-A tree cannot make.
- The earlier staged differential tests (special-chars/quotes) now build only through their own stage, since `build` runs the full pipeline.
- All 4700 parser tests pass; `cargo +nightly fmt --check` and clippy clean.

## Deferred

The block-wide `hardbreaks` option (which needs the block's attribute list, not yet threaded into the builder) is deferred to the cutover (step 6), and documented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)