### PR TITLE
feat: Recognize UI macros in the single-pass inline builder (inline-ast Phase 4, step 4b(i))

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -867,6 +867,32 @@ Each phase is a reviewable unit with a clear exit gate.
   wired into the parse path. The remaining macro families (`Ref`, `Footnote`, `Ui`,
   `IndexTerm`, `Stem`, `Anchor`) are later sub-steps.
 
+  *Step 4b(i) landed as (`Macros` → `Ui`, the UI-macro family):*
+  [`apply_macros`](../../parser/src/content/inline_builder.rs) now also recognizes the **UI
+  macros** – keyboard (`kbd:[…]`), button (`btn:[…]`), and menu (`menu:…[…]`) – replacing each
+  with a [`Ui`](../../parser/src/inlines/ui.rs) node that carries the split keys / normalized
+  label / menu path the string replacer computes. It reuses the string pipeline's *exact*
+  recognition and splitting, now shared `pub(crate)`
+  ([`INLINE_KBD_BTN_MACRO`](../../parser/src/content/macros.rs),
+  [`INLINE_MENU_MACRO`](../../parser/src/content/macros.rs), `split_kbd_keys`,
+  `normalize_index_text`), so only the *sink* differs (§4.1). Like the string step it runs the
+  families **in order** – keyboard/button, then menu, then image/icon – and recognizes the UI
+  macros only under the `experimental` document attribute, mirroring the gate exactly (with it
+  off a `kbd:[…]` stays literal, in the tree as in the string). The
+  [`fold_html`](../../parser/src/content/inline_builder.rs) fold reconstructs the render
+  parameters from the node and calls the same `render_keyboard`/`render_button`/`render_menu`
+  the string step calls (a menu reads the document's `icons` attribute for its caret), so its
+  output is byte-identical (a differential corpus pins it under `experimental`, and a companion
+  test pins that the macros stay literal *without* it). The image increment's match/rebuild
+  plumbing is generalized into a shared `MacroMatch`/`rebuild_macro_level` seam the families
+  now share. The one intended divergence is the `&gt;`-submenu form
+  (`menu:View[Zoom > Reset]`): its `>` is always an escaped `CharRef` by the time macros run, so
+  it fails the verbatim boundary and is left **unrecognized** for a later increment – documented
+  and pinned by a test, exactly as step 4a defers a macro over a special character (the
+  comma-delimited and bare/single-item menu forms *are* verbatim and covered). This step is
+  **additive**: nothing is wired into the parse path. The remaining macro families (`Ref`,
+  `Footnote`, `IndexTerm`, `Stem`, `Anchor`) are later sub-steps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -875,8 +901,9 @@ Each phase is a reviewable unit with a clear exit gate.
      the step that makes nodes **self-describing** (and the one that finally unblocks
      `render_with`):
      - ✅ **4a.** `Image` / icon (`image:` / `icon:`).
-     - **4b.** the remaining families – `Ref` (links / cross-references), `Footnote`, `Ui`
-       (`kbd:` / `btn:` / `menu:`), `IndexTerm`, `Stem`, `Anchor`.
+     - **4b.** the remaining families, each its own sub-step:
+       - ✅ **4b(i).** `Ui` (`kbd:` / `btn:` / `menu:`).
+       - **4b(ii).** `Ref` (links / cross-references), `Footnote`, `IndexTerm`, `Stem`, `Anchor`.
   5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
      `Callouts` – completing the vocabulary the recorder covers.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -38,12 +38,18 @@
 //!   step, matches over the *escaped* text so an arrow (`-&gt;`) or entity
 //!   (`&amp;copy;`) can straddle a `Text`/`CharRef` boundary.
 //! - [`apply_macros`] recognizes **image and icon macros** (`image:target[…]`,
-//!   `icon:target[…]`), replacing each with an [`Image`](InlineNode::Image)
-//!   node that captures its own owned [`Attrlist`] – the step that makes a
-//!   macro node *self-describing*. It reuses the shared [`INLINE_IMAGE_MACRO`]
-//!   pattern and builds `'src`-borrowing nodes for verbatim macros only (see
-//!   [`apply_macros`] for the boundary the escaped-content case defers). The
-//!   other macro families are later increments.
+//!   `icon:target[…]`) and the **UI macros** (`kbd:[…]`, `btn:[…]`,
+//!   `menu:…[…]`), replacing each with an [`Image`](InlineNode::Image) or
+//!   [`Ui`](InlineNode::Ui) node. An image node captures its own owned
+//!   [`Attrlist`] – the step that makes a macro node *self-describing*. Each
+//!   family reuses the shared pattern the string step matches with
+//!   ([`INLINE_IMAGE_MACRO`], [`INLINE_KBD_BTN_MACRO`], [`INLINE_MENU_MACRO`]),
+//!   builds `'src`-borrowing nodes for verbatim macros only (see
+//!   [`apply_macros`] for the boundary the escaped-content case defers), and –
+//!   for the UI macros – is recognized only under the `experimental` document
+//!   attribute, exactly as the string step gates them. The remaining macro
+//!   families (links, cross-references, footnotes, index terms, anchors, STEM)
+//!   are later increments.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -89,14 +95,15 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, INLINE_IMAGE_MACRO, QuoteSub, basename, character_replacements,
-        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements,
-        normalize_text_lf_escaped_bracket, quote_subs,
+        CharacterReplacement, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
+        QuoteSub, basename, character_replacements, hard_line_break_pattern, maybe_has_quotes,
+        maybe_has_replacements, normalize_index_text, normalize_text_lf_escaped_bracket,
+        quote_subs, split_kbd_keys,
     },
-    inlines::{CharRef, Image, InlineNode, SpanForm, StyleVariant, Styled},
+    inlines::{CharRef, Image, InlineNode, SpanForm, StyleVariant, Styled, Ui, UiKind},
     parser::{
         CharacterReplacementType, IconRenderParams, ImageRenderParams, InlineSubstitutionRenderer,
-        QuoteScope, QuoteType, SpecialCharacter,
+        MenuRenderParams, QuoteScope, QuoteType, SpecialCharacter,
     },
     strings::CowStr,
 };
@@ -1137,20 +1144,33 @@ fn rebuild_replacements<'src>(
 
 /// The macros substitution, as a node transducer.
 ///
-/// This increment recognizes **image and icon macros** only
-/// (`image:target[…]`, `icon:target[…]`), replacing each with an
-/// [`Image`](InlineNode::Image) node that carries its own owned
-/// [`Attrlist`] – the step that makes a macro node *self-describing*,
-/// so the fold reconstructs the render parameters and calls the same
-/// `render_image`/`render_icon` the string step calls. The remaining macro
-/// families (links, cross-references, footnotes, UI macros, index terms,
-/// anchors, STEM) are later increments.
+/// This increment recognizes **image and icon macros** (`image:target[…]`,
+/// `icon:target[…]`) and the **UI macros** (`kbd:[…]`, `btn:[…]`,
+/// `menu:…[…]`), replacing each with an [`Image`](InlineNode::Image) or
+/// [`Ui`](InlineNode::Ui) node. An image node carries its own owned
+/// [`Attrlist`] – the step that makes a macro node *self-describing*, so the
+/// fold reconstructs the render parameters and calls the same
+/// `render_image`/`render_icon` the string step calls; a UI node carries the
+/// keys / label / menu path the string replacer computed, so its fold calls the
+/// same `render_keyboard`/`render_button`/`render_menu`. The remaining macro
+/// families (links, cross-references, footnotes, index terms, anchors, STEM)
+/// are later increments.
 ///
-/// Like the other steps it descends into the
-/// [`Styled`]/[`Ref`](InlineNode::Ref) children earlier steps created – a macro
-/// can appear inside a rendered span (`*image:x[]*`), just as the string
-/// pipeline matches one inside a rendered `<strong>` tag – then matches at each
-/// level.
+/// Each family is applied at each level in the **same order the string step
+/// applies them** – keyboard/button, then menu, then image/icon – so a level's
+/// overlapping constructs resolve identically. Like the other steps it descends
+/// into the [`Styled`]/[`Ref`](InlineNode::Ref) children earlier steps created
+/// – a macro can appear inside a rendered span (`*image:x[]*`), just as the
+/// string pipeline matches one inside a rendered `<strong>` tag – then matches
+/// at each level.
+///
+/// # The UI macros are gated on `experimental`
+///
+/// The string step recognizes `kbd:`/`btn:`/`menu:` only when the
+/// `experimental` document attribute is set (an optimization that skips the
+/// work in the common case); this transducer mirrors that gate exactly, so with
+/// `experimental` off a `kbd:[…]` stays literal here just as it does in the
+/// string output.
 ///
 /// # Scope: verbatim macros only
 ///
@@ -1163,8 +1183,11 @@ fn rebuild_replacements<'src>(
 /// text as an `'src` slice. Such a macro is therefore **left unrecognized**
 /// here for a later increment (the attribute-references step and the cutover),
 /// mirroring how the quotes step documents its own cross-span boundary (crossed
-/// delimiters). The differential corpus pins the verbatim cases this increment
-/// claims.
+/// delimiters). For a menu this notably defers the `&gt;`-submenu form
+/// (`menu:View[Zoom > Reset]`), whose `>` is always an escaped
+/// [`CharRef`](InlineNode::CharRef) by the time macros run; the comma-delimited
+/// and bare/single-item forms are verbatim and covered. The differential corpus
+/// pins the verbatim cases this increment claims.
 fn apply_macros<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -1189,27 +1212,38 @@ fn apply_macros<'src>(
         })
         .collect();
 
+    // The UI macros run before image/icon and only under `experimental`,
+    // mirroring the string step's order and gate.
+    let nodes = if parser.is_attribute_set("experimental") {
+        let nodes = kbd_btn_macros_level(nodes, root);
+        menu_macros_level(nodes, root)
+    } else {
+        nodes
+    };
+
     image_macros_level(nodes, root, parser)
 }
 
-/// One image/icon match at a level, in absolute match-string byte offsets.
-struct ImageMatch<'src> {
+/// One recognized macro match at a level, in absolute match-string byte
+/// offsets. Shared across the macro families (image/icon, UI, and later
+/// increments), which differ only in how they *build* a match's node.
+struct MacroMatch<'src> {
     /// The whole match, `[start, end)`.
     full: std::ops::Range<usize>,
 
     /// What to emit in place of `full`.
-    kind: ImageMatchKind<'src>,
+    kind: MacroMatchKind<'src>,
 }
 
-enum ImageMatchKind<'src> {
-    /// An escaped macro (`\image:…`): drop the leading backslash and keep the
-    /// rest as literal nodes, replacing nothing – mirroring the string
-    /// replacer's `caps[0][1..]`.
+enum MacroMatchKind<'src> {
+    /// An escaped macro (`\image:…`, `\kbd:[…]`): drop the leading backslash
+    /// and keep the rest as literal nodes, replacing nothing – mirroring
+    /// the string replacer's `caps[0][1..]`.
     Unescape,
 
-    /// A recognized macro, built into an [`Image`](InlineNode::Image) node.
-    /// Boxed to keep this enum small – the [`Image`](InlineNode::Image) node is
-    /// far larger than the empty [`Unescape`](Self::Unescape) variant.
+    /// A recognized macro, built into its node ([`Image`](InlineNode::Image),
+    /// [`Ui`](InlineNode::Ui), …). Boxed to keep this enum small – a macro node
+    /// is far larger than the empty [`Unescape`](Self::Unescape) variant.
     Node(Box<InlineNode<'src>>),
 }
 
@@ -1235,7 +1269,7 @@ fn image_macros_level<'src>(
         return nodes;
     }
 
-    rebuild_image_level(&nodes, &pieces, &s, matches)
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
 /// Finds every image/icon macro at this level, skipping any whose match is not
@@ -1245,7 +1279,7 @@ fn find_image_matches<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
-) -> Vec<ImageMatch<'src>> {
+) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
     for caps in INLINE_IMAGE_MACRO.captures_iter(s) {
@@ -1263,9 +1297,9 @@ fn find_image_matches<'src>(
         }
 
         if whole.as_str().starts_with('\\') {
-            matches.push(ImageMatch {
+            matches.push(MacroMatch {
                 full,
-                kind: ImageMatchKind::Unescape,
+                kind: MacroMatchKind::Unescape,
             });
 
             continue;
@@ -1273,9 +1307,9 @@ fn find_image_matches<'src>(
 
         let node = build_image_node(&caps, &full, pieces, root, parser);
 
-        matches.push(ImageMatch {
+        matches.push(MacroMatch {
             full,
-            kind: ImageMatchKind::Node(Box::new(node)),
+            kind: MacroMatchKind::Node(Box::new(node)),
         });
     }
 
@@ -1379,28 +1413,29 @@ fn build_image_node<'src>(
     })
 }
 
-/// Rebuilds a level's node list from its image/icon matches: each gap keeps its
+/// Rebuilds a level's node list from its macro matches: each gap keeps its
 /// original nodes; each match becomes either its literal text (an escape, with
-/// the leading backslash dropped) or the built [`Image`](InlineNode::Image)
-/// node.
-fn rebuild_image_level<'src>(
+/// the leading backslash dropped) or the built macro node. Shared across the
+/// macro families, which differ only in how they produce the [`MacroMatch`]
+/// list.
+fn rebuild_macro_level<'src>(
     nodes: &[InlineNode<'src>],
     pieces: &[Piece],
     s: &str,
-    matches: Vec<ImageMatch<'src>>,
+    matches: Vec<MacroMatch<'src>>,
 ) -> Vec<InlineNode<'src>> {
     let mut out = Vec::new();
     let mut cursor = 0usize;
 
     for m in matches {
         match m.kind {
-            ImageMatchKind::Unescape => {
+            MacroMatchKind::Unescape => {
                 // Keep the whole match with the single leading backslash dropped.
                 emit_range(nodes, pieces, cursor..m.full.start, &mut out);
                 emit_range(nodes, pieces, (m.full.start + 1)..m.full.end, &mut out);
             }
 
-            ImageMatchKind::Node(node) => {
+            MacroMatchKind::Node(node) => {
                 emit_range(nodes, pieces, cursor..m.full.start, &mut out);
                 out.push(*node);
             }
@@ -1414,6 +1449,247 @@ fn rebuild_image_level<'src>(
     }
 
     out
+}
+
+// ─── UI macros (kbd: / btn: / menu:) ──────────────────────────────────────
+
+/// The keyboard/button UI macro pass at a level: matches
+/// [`INLINE_KBD_BTN_MACRO`] over the level's escaped text and replaces each
+/// verbatim match with the [`Ui`](InlineNode::Ui) node it produces.
+///
+/// The caller runs this only under the `experimental` document attribute (see
+/// [`apply_macros`]); a cheap prefilter still skips the pattern sweep when no
+/// `kbd:`/`btn:` prefix with a `:[` is present, mirroring the string step's
+/// `found_macroish_short` guard.
+fn kbd_btn_macros_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    if !(s.contains(":[") && (s.contains("kbd:") || s.contains("btn:"))) {
+        return nodes;
+    }
+
+    let matches = find_kbd_btn_matches(&s, &pieces, root);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every keyboard/button macro at this level, skipping any whose match is
+/// not wholly verbatim source (see [`apply_macros`]).
+fn find_kbd_btn_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_KBD_BTN_MACRO.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        // Only a wholly-verbatim match maps its bracket content 1:1 onto source;
+        // a match crossing an escaped special or a rendered span is left for a
+        // later increment.
+        if !range_is_verbatim(pieces, &full) {
+            continue;
+        }
+
+        // Group 1 is the (optional) escape backslash.
+        if caps.get(1).is_some() {
+            matches.push(MacroMatch {
+                full,
+                kind: MacroMatchKind::Unescape,
+            });
+
+            continue;
+        }
+
+        let node = build_kbd_btn_node(&caps, &full, pieces, root);
+
+        matches.push(MacroMatch {
+            full,
+            kind: MacroMatchKind::Node(Box::new(node)),
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Ui`](InlineNode::Ui) node from a verbatim keyboard/button
+/// match, splitting the keys / normalizing the label exactly as the string
+/// replacer does so the fold reproduces the same bytes. On a verbatim match the
+/// bracket content is source text, so this splits/normalizes precisely what the
+/// string step splits/normalizes from the (identical, un-escaped) rendered
+/// text.
+fn build_kbd_btn_node<'src>(
+    caps: &regex::Captures<'_>,
+    full: &std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> InlineNode<'src> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    // Group 2 is the macro name; group 3 the bracketed content. Both always
+    // participate in a non-escaped match.
+    let content = caps.get(3).map_or("", |m| m.as_str());
+
+    let kind = if caps.get(2).map(|m| m.as_str()) == Some("kbd") {
+        let keys = split_kbd_keys(content)
+            .into_iter()
+            .map(CowStr::from)
+            .collect();
+
+        UiKind::Keyboard(keys)
+    } else {
+        UiKind::Button(CowStr::from(normalize_index_text(content, true)))
+    };
+
+    InlineNode::Ui(Ui { kind, location })
+}
+
+/// The menu UI macro pass at a level: matches [`INLINE_MENU_MACRO`] over the
+/// level's escaped text and replaces each verbatim match with the
+/// [`Ui`](InlineNode::Ui) node it produces.
+///
+/// The caller runs this only under the `experimental` document attribute (see
+/// [`apply_macros`]); a cheap prefilter still skips the pattern sweep when no
+/// `menu:` prefix with an opening bracket is present. The `&gt;`-submenu form
+/// is always non-verbatim (its `>` is an escaped
+/// [`CharRef`](InlineNode::CharRef) by the time macros run) and is therefore
+/// deferred; the comma-delimited and bare/single-item forms are verbatim and
+/// handled here.
+fn menu_macros_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    if !(s.contains("menu:") && s.contains('[')) {
+        return nodes;
+    }
+
+    let matches = find_menu_matches(&s, &pieces, root);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every menu macro at this level, skipping any whose match is not wholly
+/// verbatim source (see [`apply_macros`]).
+fn find_menu_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_MENU_MACRO.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        if !range_is_verbatim(pieces, &full) {
+            continue;
+        }
+
+        // The menu pattern's escape is an uncaptured leading `\?`.
+        if whole.as_str().starts_with('\\') {
+            matches.push(MacroMatch {
+                full,
+                kind: MacroMatchKind::Unescape,
+            });
+
+            continue;
+        }
+
+        let node = build_menu_node(&caps, &full, pieces, root);
+
+        matches.push(MacroMatch {
+            full,
+            kind: MacroMatchKind::Node(Box::new(node)),
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Ui`](InlineNode::Ui) menu node from a verbatim match. The menu
+/// name borrows from `'src`; the submenu path and trailing item are split
+/// exactly as the string replacer splits them (owned, because a split part is
+/// trimmed).
+fn build_menu_node<'src>(
+    caps: &regex::Captures<'_>,
+    full: &std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> InlineNode<'src> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    // Group 1 (the menu name) always participates; on a verbatim match it slices
+    // straight from `'src`, so it borrows.
+    let menu = caps.get(1).map_or_else(
+        || CowStr::from(""),
+        |m| CowStr::from(source_slice(pieces, m.start()..m.end(), root).data()),
+    );
+
+    // Group 2 (the items) is optional.
+    let (submenus, item) = split_menu_items(caps.get(2).map(|m| m.as_str()));
+
+    InlineNode::Ui(Ui {
+        kind: UiKind::Menu {
+            menu,
+            submenus,
+            item,
+        },
+        location,
+    })
+}
+
+/// Splits a menu macro's item list into its submenu path and trailing item,
+/// reproducing the string replacer's delimiter handling: a `&gt;` (from a
+/// source `>`) takes precedence over a comma, the last part is the menu item,
+/// and any earlier parts are submenus. With no delimiter the whole
+/// (right-trimmed) list is a single item, and an absent list (an empty `[]`) is
+/// a bare menu reference. Because a `&gt;` never survives into a *verbatim*
+/// match (see [`menu_macros_level`]), only the comma / single-item / bare
+/// branches run in practice; the `&gt;` branch is kept so the split stays
+/// faithful.
+fn split_menu_items<'src>(items: Option<&str>) -> (Vec<CowStr<'src>>, Option<CowStr<'src>>) {
+    let Some(items) = items else {
+        return (vec![], None);
+    };
+
+    let mut items = items.to_string();
+    if items.contains(']') {
+        items = items.replace("\\]", "]");
+    }
+
+    let delim = if items.contains("&gt;") {
+        Some("&gt;")
+    } else if items.contains(',') {
+        Some(",")
+    } else {
+        None
+    };
+
+    if let Some(delim) = delim {
+        let mut parts: Vec<String> = items.split(delim).map(|i| i.trim().to_string()).collect();
+        let item = parts.pop().map(CowStr::from);
+
+        (parts.into_iter().map(CowStr::from).collect(), item)
+    } else {
+        (vec![], Some(CowStr::from(items.trim_end().to_string())))
+    }
 }
 
 // ─── Post replacements (hard line breaks) ─────────────────────────────────
@@ -1613,6 +1889,10 @@ fn fold_into_html(
                 fold_image(image, renderer, parser, out);
             }
 
+            InlineNode::Ui(ui) => {
+                fold_ui(ui, renderer, parser, out);
+            }
+
             InlineNode::Styled(styled) => {
                 // Fold the children to the body, then wrap it exactly as the
                 // string pipeline's quotes step did: the same `QuoteType`,
@@ -1637,11 +1917,11 @@ fn fold_into_html(
 
             other => {
                 // The steps wired up so far produce only `Text`,
-                // `CharRef::Special`, `Styled`, `Image`, and `LineBreak` nodes,
-                // and this fold additionally emits the design-legal `Raw` leaf;
-                // no other node kind reaches the fold in this increment. A later
-                // increment fills in the arms above as the transducer grows new
-                // kinds.
+                // `CharRef::Special`, `Styled`, `Image`, `Ui`, and `LineBreak`
+                // nodes, and this fold additionally emits the design-legal `Raw`
+                // leaf; no other node kind reaches the fold in this increment. A
+                // later increment fills in the arms above as the transducer
+                // grows new kinds.
                 // Guard against a premature caller in debug builds and emit
                 // nothing in release, mirroring the safe defensive fallback in
                 // [`content`](super::content).
@@ -1734,6 +2014,47 @@ fn fold_image(
     }
 }
 
+/// Folds a [`Ui`](InlineNode::Ui) node through the same
+/// `render_keyboard`/`render_button`/`render_menu` the string pipeline's macros
+/// step calls, reconstructing the render parameters from the keys / label /
+/// menu path the macro step captured, so the output is byte-for-byte identical.
+/// `parser` is threaded through because rendering a menu reads the document's
+/// `icons` attribute to choose the caret between menu levels.
+fn fold_ui(
+    ui: &Ui<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+    out: &mut String,
+) {
+    match &ui.kind {
+        UiKind::Keyboard(keys) => {
+            let keys: Vec<String> = keys.iter().map(|k| k.to_string()).collect();
+            renderer.render_keyboard(&keys, out);
+        }
+
+        UiKind::Button(text) => {
+            renderer.render_button(text.as_ref(), out);
+        }
+
+        UiKind::Menu {
+            menu,
+            submenus,
+            item,
+        } => {
+            let submenus: Vec<String> = submenus.iter().map(|s| s.to_string()).collect();
+
+            let params = MenuRenderParams {
+                menu: menu.as_ref(),
+                submenus: &submenus,
+                menuitem: item.as_deref(),
+                parser,
+            };
+
+            renderer.render_menu(&params, out);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -1747,7 +2068,9 @@ mod tests {
     use crate::{
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
-        inlines::{CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled},
+        inlines::{
+            CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled, Ui, UiKind,
+        },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
@@ -3083,5 +3406,267 @@ mod tests {
     /// so a test can drive [`apply_macros`] directly.
     fn build_through_special_and_replacements(source: Span<'_>) -> Vec<InlineNode<'_>> {
         apply_character_replacements(build_through_quotes(source), source)
+    }
+
+    // ─── Macros (UI: kbd / btn / menu) ────────────────────────────────────
+
+    /// A parser with the `experimental` attribute set, so the UI macros are
+    /// recognized (the string step gates them on it, and the builder mirrors
+    /// that gate).
+    fn experimental_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default().with_intrinsic_attribute_bool(
+            "experimental",
+            true,
+            ModificationContext::Anywhere,
+        )
+    }
+
+    /// Builds the single-pass tree for `source` under [`experimental_parser`].
+    fn build_ui(source: Span<'_>) -> Vec<InlineNode<'_>> {
+        build(source, &experimental_parser())
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_ui_macros() {
+        // For each fixture, folding the single-pass tree (all five steps, under
+        // `experimental`) reproduces the string pipeline's output byte-for-byte.
+        // This is the differential corpus (design §5.3) that pins the UI-macro
+        // increment. Every fixture is deliberately *verbatim* (no `<`/`>`/`&`
+        // inside a macro), the boundary this increment claims.
+        let fixtures = [
+            // No UI macro despite macro-ish characters.
+            "kbd is a word, not a macro",
+            "a menu without a bracket menu:File stays literal",
+            // Keyboard: single key and sequences (both delimiters).
+            "kbd:[Enter]",
+            "press kbd:[F11] to go full screen",
+            "kbd:[Ctrl+T]",
+            "kbd:[Ctrl+Shift+N]",
+            "kbd:[Ctrl,T]",
+            // A key whose value is the delimiter, and an escaped bracket.
+            "kbd:[Ctrl + +]",
+            "kbd:[Ctrl+\\]]",
+            // Button: plain, embedded, and whitespace-normalized.
+            "btn:[Save]",
+            "click btn:[OK] to continue",
+            "btn:[ Trim Me ]",
+            // Menu: bare, single item, multi-word item, comma submenu path.
+            "menu:File[]",
+            "menu:File[Save]",
+            "menu:File[Save As]",
+            "menu:Tools[Project, Build]",
+            "menu:View[Tool Windows, Project, Structure]",
+            // Several UI macros together, and next to another macro family.
+            "See kbd:[F1] for help and btn:[Go] to run.",
+            "kbd:[A] then image:x.png[X]",
+            // A UI macro inside a rendered span.
+            "*press kbd:[Esc]*",
+            "_click btn:[OK] now_",
+            // Escapes: the macro stays literal, minus the backslash.
+            "\\kbd:[X]",
+            "\\btn:[Y]",
+            "\\menu:File[Save]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+        let parser = experimental_parser();
+
+        for fixture in fixtures {
+            let folded = super::fold_html(&build(Span::new(fixture), &parser), &renderer, &parser);
+
+            assert_eq!(
+                folded,
+                golden_macros_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ui_macros_are_literal_without_experimental() {
+        // Without `experimental`, the string step does not recognize the UI
+        // macros, and neither does the builder: the fold reproduces the literal
+        // (default-parser) output byte-for-byte.
+        let fixtures = ["kbd:[Ctrl+T]", "btn:[Save]", "menu:File[Save]"];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let nodes = build_src(Span::new(fixture));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ui(_))),
+                "no UI node without experimental: {nodes:?}"
+            );
+
+            assert_eq!(
+                fold_html(&nodes, &renderer),
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    /// Asserts that `node` is a [`Ui`], returning it for further inspection.
+    fn assert_ui<'a, 'src>(node: &'a InlineNode<'src>) -> &'a Ui<'src> {
+        match node {
+            InlineNode::Ui(ui) => ui,
+
+            other => panic!("expected Ui, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_kbd_macro_becomes_a_ui_node() {
+        let nodes = build_ui(Span::new("kbd:[Enter]"));
+
+        assert_eq!(nodes.len(), 1);
+        let ui = assert_ui(&nodes[0]);
+
+        match &ui.kind {
+            UiKind::Keyboard(keys) => assert_eq!(keys, &[CowStr::from("Enter")]),
+
+            other => panic!("expected Keyboard, got {other:?}"),
+        }
+
+        // Its location covers the whole macro, delimiters included.
+        assert_eq!(ui.location.data(), "kbd:[Enter]");
+        assert_eq!(ui.location.line(), 1);
+        assert_eq!(ui.location.col(), 1);
+    }
+
+    #[test]
+    fn a_kbd_sequence_splits_into_keys() {
+        // The `+`/`,` delimiter selects how the sequence is split into keys,
+        // exactly as the string replacer's `split_kbd_keys` does.
+        let nodes = build_ui(Span::new("kbd:[Ctrl+Shift+N]"));
+
+        match &assert_ui(&nodes[0]).kind {
+            UiKind::Keyboard(keys) => assert_eq!(
+                keys,
+                &[
+                    CowStr::from("Ctrl"),
+                    CowStr::from("Shift"),
+                    CowStr::from("N"),
+                ]
+            ),
+
+            other => panic!("expected Keyboard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_btn_macro_becomes_a_ui_node() {
+        // The label is normalized (surrounding whitespace folded) like the
+        // string replacer's `normalize_index_text`.
+        let nodes = build_ui(Span::new("btn:[ Save ]"));
+
+        match &assert_ui(&nodes[0]).kind {
+            UiKind::Button(text) => assert_eq!(text.as_ref(), "Save"),
+
+            other => panic!("expected Button, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_menu_with_a_comma_path_splits_submenu_and_item() {
+        // The last comma-separated part is the menu item; earlier parts are the
+        // submenu path. The menu name borrows from source.
+        let nodes = build_ui(Span::new("menu:View[Tool Windows, Project, Structure]"));
+
+        match &assert_ui(&nodes[0]).kind {
+            UiKind::Menu {
+                menu,
+                submenus,
+                item,
+            } => {
+                assert!(matches!(menu, CowStr::Borrowed(_)));
+                assert_eq!(menu.as_ref(), "View");
+                assert_eq!(
+                    submenus,
+                    &[CowStr::from("Tool Windows"), CowStr::from("Project")]
+                );
+                assert_eq!(item.as_deref(), Some("Structure"));
+            }
+
+            other => panic!("expected Menu, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_bare_menu_reference_has_no_item() {
+        // `menu:File[]` is a bare reference: no submenus and no item.
+        let nodes = build_ui(Span::new("menu:File[]"));
+
+        match &assert_ui(&nodes[0]).kind {
+            UiKind::Menu {
+                menu,
+                submenus,
+                item,
+            } => {
+                assert_eq!(menu.as_ref(), "File");
+                assert!(submenus.is_empty());
+                assert_eq!(item.as_deref(), None);
+            }
+
+            other => panic!("expected Menu, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_escaped_ui_macro_stays_literal() {
+        // `\kbd:[X]` drops the backslash and keeps the macro as literal text –
+        // no UI node.
+        let nodes = build_ui(Span::new("\\kbd:[X]"));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ui(_))),
+            "an escaped UI macro must not produce a UI node: {nodes:?}"
+        );
+
+        assert_eq!(
+            super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &experimental_parser()),
+            golden_macros_with("\\kbd:[X]", &experimental_parser())
+        );
+    }
+
+    #[test]
+    fn a_ui_macro_is_recognized_inside_a_span() {
+        // A UI macro can appear inside a rendered span; the transducer descends
+        // into the span body and builds the node there.
+        let nodes = build_ui(Span::new("*press kbd:[Esc]*"));
+
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+        assert_eq!(children.len(), 2);
+        assert_text(&children[0], "press ", 1, 2);
+
+        match &assert_ui(&children[1]).kind {
+            UiKind::Keyboard(keys) => assert_eq!(keys, &[CowStr::from("Esc")]),
+
+            other => panic!("expected Keyboard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_menu_with_a_submenu_caret_is_a_documented_divergence() {
+        // The submenu form `menu:View[Zoom > Reset]` uses `>` as the level
+        // delimiter, but by the time macros run the special-characters step has
+        // turned `>` into a `&gt;` `CharRef`. A self-describing node cannot carry
+        // that escaped text as an `'src` slice, so the single-pass builder leaves
+        // the macro *unrecognized* here (deferred to a later increment), exactly
+        // as the image increment defers a macro over a special character.
+        let source = "menu:View[Zoom > Reset]";
+        let nodes = build_ui(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ui(_))),
+            "a menu crossing an escaped `>` must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, *does* build a menuseq with a
+        // submenu here – the divergence this test documents.
+        assert!(golden_macros_with(source, &experimental_parser()).contains(r#"class="submenu""#));
     }
 }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -1635,12 +1635,13 @@ fn build_menu_node<'src>(
 ) -> InlineNode<'src> {
     let location = source_slice(pieces, full.clone(), root);
 
-    // Group 1 (the menu name) always participates; on a verbatim match it slices
-    // straight from `'src`, so it borrows.
-    let menu = caps.get(1).map_or_else(
-        || CowStr::from(""),
-        |m| CowStr::from(source_slice(pieces, m.start()..m.end(), root).data()),
-    );
+    // Group 1 (the menu name) is mandatory in the pattern, and on a verbatim
+    // match it slices straight from `'src`, so the name borrows.
+    // `unwrap` is safe: the pattern cannot match without group 1.
+    #[allow(clippy::unwrap_used)]
+    let name = caps.get(1).unwrap();
+
+    let menu = CowStr::from(source_slice(pieces, name.start()..name.end(), root).data());
 
     // Group 2 (the items) is optional.
     let (submenus, item) = split_menu_items(caps.get(2).map(|m| m.as_str()));
@@ -3439,6 +3440,9 @@ mod tests {
             // No UI macro despite macro-ish characters.
             "kbd is a word, not a macro",
             "a menu without a bracket menu:File stays literal",
+            // Passes the `kbd:`/`:[` prefilter but never forms a `kbd:[…]`, so
+            // the pattern sweep finds nothing and the level returns unchanged.
+            "note kbd: and a :[ bracket here",
             // Keyboard: single key and sequences (both delimiters).
             "kbd:[Enter]",
             "press kbd:[F11] to go full screen",
@@ -3668,5 +3672,70 @@ mod tests {
         // The string pipeline, by contrast, *does* build a menuseq with a
         // submenu here – the divergence this test documents.
         assert!(golden_macros_with(source, &experimental_parser()).contains(r#"class="submenu""#));
+    }
+
+    #[test]
+    fn a_kbd_macro_over_a_special_character_is_a_documented_divergence() {
+        // A `kbd:` whose bracket content contains a special character (`<`) is
+        // matched by the string pipeline over the *escaped* text (`kbd:[a&lt;b]`),
+        // but a self-describing node cannot carry that escaped text as an `'src`
+        // slice, so the single-pass builder leaves the macro *unrecognized* here
+        // (deferred to a later increment), exactly as it defers the `&gt;`-submenu
+        // menu form and the image increment defers a macro over a special.
+        let nodes = build_ui(Span::new("kbd:[a<b]"));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ui(_))),
+            "a kbd macro crossing an escaped special must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, *does* build a keyboard macro here.
+        assert!(golden_macros_with("kbd:[a<b]", &experimental_parser()).contains("<kbd>"));
+    }
+
+    #[test]
+    fn split_menu_items_reproduces_the_delimiter_handling() {
+        use super::split_menu_items;
+
+        // Helper to compare against owned expectations.
+        let go = |items: Option<&str>| {
+            let (submenus, item) = split_menu_items(items);
+
+            (
+                submenus.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                item.map(|i| i.to_string()),
+            )
+        };
+
+        // An absent list (an empty `[]`) is a bare menu reference.
+        assert_eq!(go(None), (vec![], None));
+
+        // No delimiter: the whole (right-trimmed) list is a single item.
+        assert_eq!(go(Some("Save As ")), (vec![], Some("Save As".to_string())));
+
+        // Comma: the last part is the item, earlier parts are submenus.
+        assert_eq!(
+            go(Some("Project, Build")),
+            (vec!["Project".to_string()], Some("Build".to_string()))
+        );
+
+        // An escaped `]` inside the list is unescaped before splitting.
+        assert_eq!(
+            go(Some("a\\]b, c")),
+            (vec!["a]b".to_string()], Some("c".to_string()))
+        );
+
+        // The `&gt;` submenu delimiter takes precedence over a comma. This form
+        // never reaches [`build_menu_node`] through the verbatim boundary (its
+        // source `>` is an escaped `CharRef` by macro time), so it is exercised
+        // directly here to keep [`split_menu_items`] a faithful reproduction of
+        // the string replacer's splitting.
+        assert_eq!(
+            go(Some("View &gt; Zoom &gt; Reset")),
+            (
+                vec!["View".to_string(), "Zoom".to_string()],
+                Some("Reset".to_string())
+            )
+        );
     }
 }

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -398,13 +398,18 @@ pub(crate) fn basename(path: &str) -> String {
 
 /// Matches a keyboard (`kbd:[…]`) or button (`btn:[…]`) UI macro.
 ///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) recognizes keyboard and
+/// button macros with the *exact* same pattern this string step matches with,
+/// changing only the recognition *sink* (a node instead of rendered markup).
+///
 /// ## Examples
 ///
 /// * `kbd:[F3]`
 /// * `kbd:[Ctrl+Shift+T]`
 /// * `kbd:[Ctrl+\]]`
 /// * `btn:[Save]`
-static INLINE_KBD_BTN_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_KBD_BTN_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)                    # extended mode; dot matches newline
@@ -451,7 +456,11 @@ impl Replacer for InlineKbdBtnMacroReplacer<'_> {
 /// (e.g. `kbd:[,te]` is the single key `,te`). If the argument ends with the
 /// delimiter, that trailing delimiter is preserved as the value of the final
 /// key (e.g. `kbd:[Ctrl + +]` yields `Ctrl` and `+`).
-fn split_kbd_keys(raw: &str) -> Vec<String> {
+///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) splits a keyboard macro's
+/// keys exactly as this string step does.
+pub(crate) fn split_kbd_keys(raw: &str) -> Vec<String> {
     let mut keys = raw.trim().to_string();
     if keys.contains(']') {
         keys = keys.replace("\\]", "]");
@@ -497,13 +506,18 @@ fn split_kbd_keys(raw: &str) -> Vec<String> {
 /// The shorthand form (`"File > Save"`) is intentionally not matched here; per
 /// the spec it is not on a standards track.
 ///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) recognizes menu macros
+/// with the *exact* same pattern this string step matches with, changing only
+/// the recognition *sink* (a node instead of rendered markup).
+///
 /// ## Examples
 ///
 /// * `menu:File[]`
 /// * `menu:File[Save]`
 /// * `menu:View[Zoom > Reset]`
 /// * `menu:Tools[Project, Build]`
-static INLINE_MENU_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_MENU_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)                        # extended mode; dot matches newline
@@ -745,7 +759,11 @@ impl LookaheadReplacer for InlineIndextermReplacer<'_> {
 /// collapses embedded newlines to spaces (Asciidoctor compacts a multi-line
 /// term onto a single line). When `unescape_brackets` is set (the macro forms),
 /// an escaped closing square bracket (`\]`) is also unescaped.
-fn normalize_index_text(text: &str, unescape_brackets: bool) -> String {
+///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) normalizes a button
+/// macro's label exactly as this string step does.
+pub(crate) fn normalize_index_text(text: &str, unescape_brackets: bool) -> String {
     let normalized = text.trim().replace('\n', " ");
     if unescape_brackets {
         normalized.replace("\\]", "]")

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -17,8 +17,9 @@ pub(crate) mod inline_tree;
 
 mod macros;
 pub(crate) use macros::{
-    INLINE_IMAGE_MACRO, apply_macros_with_leading_anchor_registered, basename,
-    normalize_text_lf_escaped_bracket,
+    INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
+    apply_macros_with_leading_anchor_registered, basename, normalize_index_text,
+    normalize_text_lf_escaped_bracket, split_kbd_keys,
 };
 
 mod xref_target;


### PR DESCRIPTION
## Summary

Extends the additive single-pass inline builder (Strategy B) to recognize the **UI macros** – keyboard (`kbd:[…]`), button (`btn:[…]`), and menu (`menu:…[…]`) – as **Phase 4, step 4b(i)**. Each is replaced with a `Ui` node carrying the split keys / normalized label / menu path the string replacer computes.

Step 4a carved out `Image`/icon on its own; this picks up the first of the remaining macro families. UI macros are the cleanest to land next: fully self-contained, with direct rendering and no deferred cross-reference resolution, footnote text extraction, or catalog side effects. The heavier families (`Ref` links/xrefs, `Footnote`, `IndexTerm`, `Stem`, `Anchor`) remain as step 4b(ii).

## What changed

- `apply_macros` now recognizes `kbd:`/`btn:`/`menu:`, reusing the string pipeline's **exact** recognition and splitting – now shared `pub(crate)` (`INLINE_KBD_BTN_MACRO`, `INLINE_MENU_MACRO`, `split_kbd_keys`, `normalize_index_text`) – so only the *sink* differs (§4.1).
- Families run in the **same order** the string step applies them (keyboard/button → menu → image/icon), and the UI macros are gated on the `experimental` document attribute exactly as the string step gates them.
- The `fold_html` fold reconstructs the render params from the node and calls the same `render_keyboard`/`render_button`/`render_menu` (a menu reads the document's `icons` attribute for its caret), so output is byte-identical.
- The image increment's match/rebuild plumbing is generalized into a shared `MacroMatch`/`rebuild_macro_level` seam the families now share.

## Documented boundary

As with step 4a, a macro whose match is not wholly verbatim source is left **unrecognized** for a later increment. For a menu this defers the `&gt;`-submenu form (`menu:View[Zoom > Reset]`), whose `>` is always an escaped `CharRef` by the time macros run. The comma-delimited and bare/single-item forms are verbatim and covered. Documented and pinned by a test.

## Additive & non-regressing

Nothing is wired into the parse path, so the ~277 golden `.rendered_html()` assertions are untouched.

## Testing

- Full suite: **4722 passed, 0 failed**.
- New `inline_builder` tests: an `experimental` differential corpus (byte-for-byte fold parity through all five steps), a companion pinning that the macros stay literal *without* `experimental`, structural node assertions (keys/label/menu path, borrowed menu name, precise spans), the escaped-macro case, and the `&gt;`-submenu documented divergence.
- `cargo +nightly fmt --all -- --check` clean; `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)