### PR TITLE
fix: Reject block-image macro when target has leading or trailing whitespace

### DIFF
--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -135,6 +135,22 @@ impl<'src> MediaBlock<'src> {
             };
         }
 
+        // Asciidoctor's block-macro regex requires the target to begin and end
+        // with a non-space character. A target with leading or trailing
+        // whitespace is not recognized as a block macro at all; the line falls
+        // through to be parsed as a description list or paragraph instead. Reject
+        // it here (with no warning) so it is not mistaken for a media block.
+        let target_data = target.item.data();
+
+        if target_data.starts_with(char::is_whitespace)
+            || target_data.ends_with(char::is_whitespace)
+        {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        }
+
         let Some(open_brace) = target.after.take_prefix("[") else {
             return MatchAndWarnings {
                 item: None,

--- a/parser/src/blocks/tests/media.rs
+++ b/parser/src/blocks/tests/media.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::{
-    blocks::{ContentModel, IsBlock, MediaType},
+    blocks::{ContentModel, IsBlock, ListType, MediaType},
     tests::prelude::*,
 };
 
@@ -608,6 +608,156 @@ fn has_title() {
             line: 3,
             col: 1,
             offset: 26
+        }
+    );
+}
+
+// Asciidoctor's block-macro regex requires the target to begin and end with a
+// non-space character, so a block-image macro whose target has leading or
+// trailing whitespace is not recognized as a media block. A leading space turns
+// the line into a description list (`image` becomes the term); a trailing space
+// before the `[` turns it into a paragraph.
+
+#[test]
+fn rejects_image_with_leading_space_in_target() {
+    let mut parser = Parser::default();
+
+    let mi = crate::blocks::Block::parse(crate::Span::new("image:: tiger.png[Tiger]"), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    assert_eq!(
+        mi.item,
+        Block::List(ListBlock {
+            type_: ListType::Description,
+            items: &[Block::ListItem(ListItem {
+                marker: ListItemMarker::DefinedTerm {
+                    term: Content {
+                        original: Span {
+                            data: "image",
+                            line: 1,
+                            col: 1,
+                            offset: 0,
+                        },
+                        rendered: "image",
+                    },
+                    marker: Span {
+                        data: "::",
+                        line: 1,
+                        col: 6,
+                        offset: 5,
+                    },
+                    source: Span {
+                        data: "image::",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                },
+                blocks: &[Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "tiger.png[Tiger]",
+                            line: 1,
+                            col: 9,
+                            offset: 8,
+                        },
+                        rendered: "tiger.png[Tiger]",
+                    },
+                    source: Span {
+                        data: "tiger.png[Tiger]",
+                        line: 1,
+                        col: 9,
+                        offset: 8,
+                    },
+                    style: SimpleBlockStyle::Paragraph,
+                    title_source: None,
+                    title: None,
+                    caption: None,
+                    number: None,
+                    anchor: None,
+                    anchor_reftext: None,
+                    attrlist: None,
+                })],
+                source: Span {
+                    data: "image:: tiger.png[Tiger]",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            })],
+            source: Span {
+                data: "image:: tiger.png[Tiger]",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            title_source: None,
+            title: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: None,
+        }),
+    );
+}
+
+#[test]
+fn rejects_image_with_trailing_space_in_target() {
+    let mut parser = Parser::default();
+
+    let mi = crate::blocks::Block::parse(crate::Span::new("image::tiger.png [Tiger]"), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    assert_eq!(
+        mi.item,
+        Block::Simple(SimpleBlock {
+            content: Content {
+                original: Span {
+                    data: "image::tiger.png [Tiger]",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                rendered: "image::tiger.png [Tiger]",
+            },
+            source: Span {
+                data: "image::tiger.png [Tiger]",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            style: SimpleBlockStyle::Paragraph,
+            title_source: None,
+            title: None,
+            caption: None,
+            number: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: None,
+        }),
+    );
+
+    assert_eq!(
+        mi.item.span(),
+        Span {
+            data: "image::tiger.png [Tiger]",
+            line: 1,
+            col: 1,
+            offset: 0,
+        }
+    );
+
+    assert_eq!(
+        mi.after,
+        Span {
+            data: "",
+            line: 1,
+            col: 25,
+            offset: 24
         }
     );
 }


### PR DESCRIPTION
## Summary

Fixes #1093.

`asciidoc-parser` recognized the block-image macro even when the target carried leading or trailing whitespace, but Asciidoctor 2.0.26 does not. Asciidoctor's block-macro regex requires the target to begin and end with a non-space character.

- `image:: tiger.png[Tiger]` (leading space) → Asciidoctor renders a **description list** (`image` becomes the dlist term), no `<img>`.
- `image::tiger.png [Tiger]` (trailing space before `[`) → Asciidoctor renders a **paragraph**, no `<img>`.

Previously the crate produced `<img src="%20tiger.png" …>` / `<img src="tiger.png%20" …>` respectively.

## Fix

In `MediaBlock::parse`, after extracting the target (everything between `::` and `[`), reject it — with no warning — when its first or last character is whitespace. The line then falls through to be parsed as a description list or paragraph, exactly matching Asciidoctor. Whitespace *within* the target is still permitted, mirroring Asciidoctor's `\S.*?\S` target group.

## Tests

Added two unit tests in `parser/src/blocks/tests/media.rs`:

- `rejects_image_with_leading_space_in_target` — asserts `image:: tiger.png[Tiger]` parses as a `Description` list.
- `rejects_image_with_trailing_space_in_target` — asserts `image::tiger.png [Tiger]` parses as a paragraph `SimpleBlock`.

Full suite green (`cargo test -p asciidoc-parser`: 4631 passed), plus `cargo +nightly fmt --all -- --check` and `cargo clippy -p asciidoc-parser --tests` clean.

## Follow-up (separate repo)

Once released, the `non_normative!` marker on `should not recognize block image if target has leading or trailing spaces` in `asciidoc-html5`'s `blocks_test.rs` can be flipped back to a verified `#[test]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)