### PR TITLE
fix: Hide AsciiDoc table cell doctitle by default (embedded semantics)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2043,7 +2043,12 @@ fn parse_asciidoc_cell_body<'src>(
         InterpretedValue::Value(ref v) if v == "inline"
     );
 
-    let title = if parser.resolve_show_title(true) {
+    // An AsciiDoc table cell's inner document is embedded output (like
+    // `convert_string_to_embedded`), so its doctitle defaults to hidden when
+    // neither `showtitle` nor `notitle` is set – matching Asciidoctor, which
+    // renders a nested cell document without an `<h1>` unless `showtitle` is
+    // enabled.
+    let title = if parser.resolve_show_title(false) {
         title_source.map(|span| {
             let mut content = Content::from(span);
             SubstitutionGroup::Header.apply(&mut content, parser, None);

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1368,8 +1368,9 @@ impl Parser {
     /// `showtitle` takes precedence: if present, the title shows precisely when
     /// it is set. Otherwise `notitle`, if present, hides the title when set.
     /// When neither attribute is present, `default_shown` decides – a
-    /// standalone document (such as a nested AsciiDoc table cell) shows its
-    /// title, while an embedded document does not.
+    /// standalone document shows its title, while embedded output does not.
+    /// A nested AsciiDoc table cell is embedded output, so it passes
+    /// `default_shown = false`.
     pub(crate) fn resolve_show_title(&self, default_shown: bool) -> bool {
         if self.has_attribute("showtitle") {
             self.is_attribute_set("showtitle")

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -3430,6 +3430,27 @@ mod psv {
     }
 
     #[test]
+    fn asciidoc_table_cell_hides_its_title_by_default() {
+        // An AsciiDoc table cell that opens with a level-0 title but sets neither
+        // `showtitle` nor `notitle` behaves like embedded output: its doctitle is
+        // hidden. Asciidoctor 2.0.26 emits no `<h1>` for such a cell (the "neither
+        // set" default), whereas enabling `showtitle` in the cell renders it.
+        let default_doc = Parser::default()
+            .parse("= Document Title\n\n|===\na|\n= Nested Document Title\n\ncontent\n|===");
+
+        // Neither attribute set: the cell hides its title.
+        assert_css(&default_doc, ".tableblock h1", 0);
+
+        // With `showtitle` enabled in the cell, the same title renders – proving
+        // only the "neither set" default changed.
+        let shown_doc = Parser::default().parse(
+            "= Document Title\n\n|===\na|\n= Nested Document Title\n:showtitle:\n\ncontent\n|===",
+        );
+
+        assert_css(&shown_doc, ".tableblock h1", 1);
+    }
+
+    #[test]
     fn asciidoc_content() {
         verifies!(
             r#"


### PR DESCRIPTION
## Summary

Fixes an AsciiDoc parity gap: an AsciiDoc (`a`) table cell that opens with a level-0 title (`= Title`) but sets **neither** `showtitle` nor `notitle` was resolving its title as *shown*, so `AsciiDocCell::title()` returned `Some(...)` and a renderer emitted an `<h1>` inside the cell.

Asciidoctor 2.0.26 treats a nested cell document as **embedded** output, which hides the doctitle unless `showtitle` is enabled:

```
$ printf '= Doc\n\n|===\na|\n= Nested Title\n\ncontent\n|===\n' | asciidoctor -e -o - - | grep -c '<h1'
0
```

## Change

- `parser/src/blocks/table.rs`: gate the cell title with `resolve_show_title(false)` instead of `true`, so the "neither set" default hides the title. The explicit `showtitle`/`notitle` toggle cases (in-cell, inherited from parent, or set by API) are unaffected — those all pass already.
- `parser/src/parser/parser.rs`: correct the now-misleading `resolve_show_title` doc comment (a nested cell is embedded output, so it passes `default_shown = false`).
- Added a focused regression test in `tables_test.rs` asserting no `.tableblock h1` by default, and one when the cell enables `showtitle`.

## Testing

- `cargo test -p asciidoc-parser --lib` — 4636 passed, 0 failed.
- `cargo +nightly fmt --all -- --check` — clean.

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)