### PR TITLE
fix: Honor a cell-body sectnumlevels assignment in an AsciiDoc table cell

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -53,15 +53,29 @@ fn absolute_cell_directive_origin(
     }
 }
 
-/// Attributes that an AsciiDoc table cell may modify even when they are set in
-/// the parent document.
+/// Attributes that an AsciiDoc table cell may modify even when they hold a
+/// value inherited from the parent document.
 ///
 /// An AsciiDoc cell inherits the parent's attributes and cannot modify them,
 /// but the AsciiDoc specification carves out a handful of exceptions:
 /// `doctype`, `toc`, `notitle` (and its complement, `showtitle`), and
 /// `compat-mode`.
-const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
-    &["doctype", "toc", "notitle", "showtitle", "compat-mode"];
+///
+/// `sectnumlevels` is also listed here. It is header-settable (its built-in
+/// default carries a value of `3`) and an AsciiDoc cell is a nested, standalone
+/// document whose leading attribute lines form its own header, so the cell may
+/// set its own `sectnumlevels` – matching Asciidoctor, where a cell that
+/// assigns `:sectnumlevels:` is honored rather than pinned to the inherited
+/// default. Without this exception the built-in default value would lock the
+/// attribute for the cell, silently ignoring the cell-body assignment.
+const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] = &[
+    "doctype",
+    "toc",
+    "notitle",
+    "showtitle",
+    "compat-mode",
+    "sectnumlevels",
+];
 
 /// A table is a delimited block that arranges content into a grid of rows and
 /// columns.

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1702,6 +1702,13 @@ fn process_content<'src>(
         // which a static lock could not do anyway once the cell changes its own
         // doctype.
         let saved_locks = parser.locked_attribute_names.clone();
+
+        // The cached section-numbering depth is frozen at the end of the
+        // enclosing document's header, so it holds the parent's value throughout
+        // the cell. A cell that assigns its own `sectnumlevels` refreshes it (see
+        // `Parser::set_attribute_from_body`); snapshot and restore it here so that
+        // refresh cannot leak back into the parent's numbering.
+        let saved_sectnumlevels = parser.sectnumlevels;
         {
             // Whether `name` (holding `value` in the inherited set) must be
             // locked for the cell. Kept separate from the insert so each source
@@ -1943,6 +1950,7 @@ fn process_content<'src>(
 
         parser.locked_attribute_names = saved_locks;
         parser.attribute_values = saved_attributes;
+        parser.sectnumlevels = saved_sectnumlevels;
         TableCellContent::AsciiDoc(cell)
     } else {
         let mut content = match replacement {

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -1022,6 +1022,28 @@ fn asciidoc_cell_may_set_sectnumlevels() {
         crate::document::InterpretedValue::Value("all".to_string())
     );
 
+    // Section numbering within the cell honors the cell-local depth, not just the
+    // resolved attribute: `Alpha` (level 1) is numbered, while `Beta` (level 2)
+    // falls beyond the cell's `sectnumlevels` of 1 and is left unnumbered.
+    let alpha = cell
+        .blocks()
+        .iter()
+        .find_map(|b| match b {
+            Block::Section(section) => Some(section),
+            _ => None,
+        })
+        .unwrap();
+    assert!(alpha.section_number().is_some());
+
+    let beta = alpha
+        .child_blocks()
+        .find_map(|b| match b {
+            Block::Section(section) => Some(section),
+            _ => None,
+        })
+        .unwrap();
+    assert!(beta.section_number().is_none());
+
     // The parent document is unaffected: its `sectnumlevels` stays at the default.
     assert_eq!(
         doc.attribute_value("sectnumlevels"),

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -987,6 +987,49 @@ fn asciidoc_cell_may_set_an_attribute_unset_in_the_parent() {
 }
 
 #[test]
+fn asciidoc_cell_may_set_sectnumlevels() {
+    // `sectnumlevels` has a built-in default value (`3`), but the parent did not
+    // set it, so the built-in default must not lock it inside the cell. An
+    // AsciiDoc cell is a nested, standalone document whose leading attribute lines
+    // are its own header, and `sectnumlevels` is header-settable, so a cell-body
+    // assignment is honored: the cell's resolved `sectnumlevels` reflects the
+    // value the cell set (`1`), not the inherited default (`3`), matching
+    // Asciidoctor.
+    let doc = Parser::default()
+        .parse("|===\na|\n:toc:\n:sectnums:\n:sectnumlevels: 1\n\n== Alpha\n\n=== Beta\n\nx\n|===");
+
+    let table = doc
+        .child_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    assert_eq!(
+        cell.attribute_value("sectnumlevels"),
+        crate::document::InterpretedValue::Value("1".to_string())
+    );
+
+    // The other attributes the cell set are likewise honored (a bare `:sectnums:`
+    // resolves to its `all` default).
+    assert_eq!(
+        cell.attribute_value("sectnums"),
+        crate::document::InterpretedValue::Value("all".to_string())
+    );
+
+    // The parent document is unaffected: its `sectnumlevels` stays at the default.
+    assert_eq!(
+        doc.attribute_value("sectnumlevels"),
+        crate::document::InterpretedValue::Value("3".to_string())
+    );
+}
+
+#[test]
 fn asciidoc_cell_may_modify_an_exempt_attribute() {
     // A handful of attributes are exempt from the cell lock; `compat-mode` is one
     // of them, so a cell may modify it even though the parent set it, while a

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2669,6 +2669,18 @@ impl Parser {
             value,
         };
 
+        // Inside an AsciiDoc table cell (a nested document) the leading attribute
+        // lines act as the cell's own header, so a `sectnumlevels` assignment
+        // there must refresh the cached depth that section numbering reads. The
+        // top-level document freezes that value at the end of its header (see
+        // [`Document::parse`](crate::Document)) and a cell has no separate header
+        // pass, so without this a cell that lowered `sectnumlevels` would still
+        // number its deeper sections at the inherited depth. The enclosing cell
+        // parse saves and restores the field, keeping the change scoped to the
+        // cell.
+        let refresh_cell_sectnumlevels =
+            attr_name == "sectnumlevels" && self.nested_document_depth > 0;
+
         // An explicit assignment supersedes (and resets) any counter of the same
         // name. This is what lets `:!name:` reset a counter.
         self.counter_values.borrow_mut().remove(&attr_name);
@@ -2676,6 +2688,14 @@ impl Parser {
         // The derived `backend-html5-doctype-*` attribute tracks `doctype`
         // automatically (it is synthesized on lookup), so no refresh is needed.
         Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
+
+        if refresh_cell_sectnumlevels {
+            self.sectnumlevels = self
+                .attribute_value("sectnumlevels")
+                .as_maybe_str()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(3);
+        }
     }
 
     /// Unlocks each *flexible* document attribute ([`FLEXIBLE_ATTRIBUTES`],


### PR DESCRIPTION
## Summary

Fixes #1092.

`AsciiDocCell::attribute_value("sectnumlevels")` returned the intrinsic default (`3`) instead of the value the cell set in its body (e.g. `:sectnumlevels: 1`).

### Root cause

An AsciiDoc table cell locks every attribute it *inherits with a value* from the parent, so a cell-body assignment to one is silently ignored (this mirrors Asciidoctor's `@attribute_overrides = parent.attributes.dup`). `sectnumlevels` is registered with a built-in **default value** of `3`, so the lock loop treated that default as an inherited value and locked the attribute for the cell — even though the parent never set it. A cell-body `:sectnumlevels:` was therefore dropped.

Other numbering attributes were unaffected: `sectnums` defaults to *unset* (so it isn't locked), and `toclevels` isn't materialized as a built-in at all (its default is applied at read time), so neither is pinned in a cell.

### Fix

Add `sectnumlevels` to `ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES`. A cell is a nested, standalone document whose leading attribute lines form its own header, and `sectnumlevels` is header-settable, so the cell may set its own value. This both excludes it from the cell lock and relaxes its modification context for the duration of the cell parse, so the cell-body assignment is honored — matching Asciidoctor 2.0.26. The parent document and normal (non-cell) body-assignment behavior are unchanged.

## Testing

- New test `asciidoc_cell_may_set_sectnumlevels` reproduces the issue example and asserts the cell resolves `sectnumlevels` to `1` while the parent stays at `3`.
- Full parser suite passes (`cargo test -p asciidoc-parser`), `cargo clippy` clean, `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)