### PR TITLE
chore: Port Asciidoctor syntax-highlighting docs module for SDD coverage

### DIFF
--- a/parser/src/tests/asciidoctor_docs/mod.rs
+++ b/parser/src/tests/asciidoctor_docs/mod.rs
@@ -1,0 +1,24 @@
+//! This module quotes from the Asciidoctor *processor* documentation with the
+//! intent of verifying, line-by-line, compliance with that documentation.
+//!
+//! Unlike the AsciiDoc language documentation ported under
+//! [`super::asciidoc_lang`], these pages describe behavior specific to the
+//! Asciidoctor processor (e.g. how it renders a source block through a syntax
+//! highlighter). This crate implements the parsing half of AsciiDoc and
+//! performs no rendering, so much of this material is non-normative here; it is
+//! reproduced so the `sdd` coverage tool can account for every line.
+//!
+//! The quoted documentation can be found in rendered form here:
+//! https://docs.asciidoctor.org/asciidoctor/latest/
+//!
+//! and in source form here:
+//! https://github.com/asciidoctor/asciidoctor/tree/v2.0.26/docs/modules
+//!
+//! The vendored copies under `ref/asciidoctor/docs` are unmodified and taken
+//! from Asciidoctor v2.0.26, matching the reference test suite vendored under
+//! `ref/asciidoctor/test` (see `ref/asciidoctor/README.md`).
+//!
+//! Asciidoctor is distributed under the MIT License; see
+//! `ref/asciidoctor/LICENSE`.
+
+mod syntax_highlighting;

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/coderay.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/coderay.rs
@@ -2,10 +2,10 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/coderay.adoc");
 
-// This page documents how an AsciiDoc processor applies syntax highlighting
-// when rendering source blocks. Because asciidoc-parser performs no rendering –
-// neither client-side nor build-time (server-side) highlighting is a goal of
-// this crate – the whole page is non-normative here.
+// This page documents a build-time (server-side) syntax highlighter, which an
+// AsciiDoc processor invokes while rendering a source block. Build-time
+// highlighting is a non-goal of this project, and this crate performs no
+// rendering in any case, so the whole page is non-normative here.
 non_normative!(
     r##"
 = CodeRay

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/coderay.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/coderay.rs
@@ -1,0 +1,117 @@
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/coderay.adoc");
+
+// This page documents how an AsciiDoc processor applies syntax highlighting
+// when rendering source blocks. Because asciidoc-parser performs no rendering –
+// neither client-side nor build-time (server-side) highlighting is a goal of
+// this crate – the whole page is non-normative here.
+non_normative!(
+    r##"
+= CodeRay
+:url-coderay: http://coderay.rubychan.de/
+:url-coderay-gem: https://rubygems.org/gems/coderay
+
+{url-coderay}[CodeRay^] is an encoding-aware, syntax highlighter that supports the languages listed below.
+
+[%autowidth,cols="4*",grid=none,frame=none]
+|===
+| C
+| C++
+| Clojure
+| CSS
+
+| Delphi
+| diff
+| ERB
+| Go
+
+| Groovy
+| HAML
+| HTML
+| Java
+
+| JavaScript
+| JSON
+| Lua
+| PHP
+
+| Python
+| Ruby
+| Sass
+| SQL
+
+| Taskpaper
+| XML
+| YAML
+|
+|===
+
+== Install CodeRay
+
+To use CodeRay with Asciidoctor, you need the {url-coderay-gem}[coderay gem^].
+You can use one of the following methods to install CodeRay.
+
+Install using gem (all systems)::
++
+ $ gem install coderay
+
+Install using apt-get (Debian-based systems)::
++
+ $ sudo apt-get install ruby-coderay
+
+Install using dnf (Fedora-based systems)::
++
+ $ sudo dnf install rubygem-coderay
+
+== Activate CodeRay
+
+Once you've installed the gem, assign the `coderay` value to the `source-highlighter` attribute in the document header to activate it.
+
+[,asciidoc]
+----
+:source-highlighter: coderay
+----
+
+== CodeRay attributes
+
+You can further customize the source block output with additional CodeRay attributes.
+
+coderay-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` or `style`.
+Default: `class`.
+
+coderay-linenums-mode::
+Controls how line numbers are laid out.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+.Customizing a source block with CodeRay line numbers
+[source,asciidoc]
+....
+:source-highlighter: coderay
+:coderay-linenums-mode: inline
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+See the xref:html-backend:source-highlighting-stylesheets.adoc#coderay[CodeRay stylesheet section] to learn about the `coderay-css` attribute.
+
+////
+Note: I'm not getting this to work. Need to come back and do some quality assurance.
+////
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/custom.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/custom.rs
@@ -2,10 +2,10 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/custom.adoc");
 
-// This page documents how an AsciiDoc processor applies syntax highlighting
-// when rendering source blocks. Because asciidoc-parser performs no rendering –
-// neither client-side nor build-time (server-side) highlighting is a goal of
-// this crate – the whole page is non-normative here.
+// This page documents how to implement and register a syntax highlighter
+// adapter in Asciidoctor (in Ruby). This crate neither resolves nor registers
+// syntax highlighters and performs no rendering, so the whole page is
+// non-normative here.
 non_normative!(
     r##"
 = Custom Syntax Highlighter Adapter

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/custom.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/custom.rs
@@ -1,0 +1,118 @@
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/custom.adoc");
+
+// This page documents how an AsciiDoc processor applies syntax highlighting
+// when rendering source blocks. Because asciidoc-parser performs no rendering –
+// neither client-side nor build-time (server-side) highlighting is a goal of
+// this crate – the whole page is non-normative here.
+non_normative!(
+    r##"
+= Custom Syntax Highlighter Adapter
+:navtitle: Custom Adapter
+:apidoc-base: {url-api-gems}/asciidoctor/{release-version}/Asciidoctor
+:apidoc-syntax-highlighter: {apidoc-base}/SyntaxHighlighter
+:apidoc-syntax-highlighter-base: {apidoc-syntax-highlighter}/Base
+:apidoc-syntax-highlighter-for: {apidoc-syntax-highlighter}/Factory#for-instance_method
+
+You can integrate additional syntax highlighters into Asciidoctor by implementing and registering a syntax highlighter adapter.
+You can either write a new adapter from scratch or you can extend and even replace one of the built-in adapters.
+
+[#new]
+== Create a new adapter
+
+To implement a new adapter, you must create a class that extends the {apidoc-syntax-highlighter-base}[Asciidoctor::SyntaxHighlighter::Base] class, register the adapter for a value of the `source-highlighter` attribute, and implement the required methods.
+Which methods are required depends on whether the adapter is for a client-side (runs in the browser) or build-time (runs when the document is converted) syntax highlighter.
+
+Here's an example of how to write and register a syntax highlighter adapter for the Prism.js syntax highlighting library.
+Prism.js is a client-side syntax highlighter, meaning it runs in the browser.
+That means the adapter only has to implement methods that pertain to client-side syntax highlighting, which include `format`, `docinfo?`, and `docinfo`.
+
+.Syntax highlighter adapter for Prism.js
+[,ruby]
+----
+include::example$prism-syntax-highlighter.rb[]
+----
+
+Save this code to a file named [.path]_prism-syntax-highlighter.rb_.
+Then, require this file when invoking Asciidoctor and set `source-highlighter=prism` to activate it:
+
+ $ asciidoctor -r ./prism-syntax-highlighter -a source-highlighter=prism document.adoc
+
+You can also define an adapter for a syntax highlighter that runs during conversion.
+We'll look at doing that while also extending a built-in adapter.
+
+[#extend]
+== Extend an existing adapter
+
+Instead of creating a new adapter, you can customize a built-in adapter by extending it, overriding its behavior, and optionally replacing it.
+
+To extend an adapter, you need to look up a reference to the built-in adapter by name using the {apidoc-syntax-highlighter-for}[Asciidoctor::SyntaxHighlighter.for] method, create a class that extends it, register the adapter with a unique name (or the same name, if you want to replace it), and override any methods that provide the behavior you want to modify.
+
+Here's the basic template for customizing an existing adapter:
+
+[,ruby]
+----
+class CustomAdapter < (Asciidoctor::SyntaxHighlighter.for 'rouge')
+  register_for 'rouge'
+
+  # override methods go here
+end
+----
+
+Let's look at some examples of how to customize a built-in adapter.
+
+=== docinfo
+
+Let's override the adapter for Pygments to prevent it from adding a stylesheet to the HTML (presumably because the styles will be provided by a different stylesheet).
+
+.Extended syntax highlighter adapter for Pygments
+[,ruby]
+----
+include::example$extended-pygments-syntax-highlighter.rb[]
+----
+
+Save this code to a file named [.path]_extended-pygments-syntax-highlighter.rb_.
+Then, require this file when invoking Asciidoctor, setting `source-highlighter=pygments` to activate it, as you would normally do:
+
+ $ asciidoctor -r ./extended-pygments-syntax-highlighter.rb -a source-highlighter=pygments document.adoc
+
+If, instead, you wanted to modify the built-in adapter to honor the location of a custom stylesheet specified by the `pygments-stylesheet` attribute, you can do so by extending the adapter and overriding the `docinfo` method.
+
+[,ruby]
+----
+include::example$pygments-syntax-highlighter-with-custom-stylesheet.rb[]
+----
+
+If you want to decorate built-in behavior, you can invoke the `super` method anywhere inside the method to delegate to the behavior provided by the built-in adapter.
+
+=== highlight
+
+Let's say you always want lines to be numbered, regardless of the setting in the document.
+You can do so by overriding the `highlight` method, setting the `:number_lines` key on the `opts` argument, then delegating back to the built-in adapter using `super`.
+
+[,ruby]
+----
+include::example$always-number-lines.rb[]
+----
+
+=== create_formatter (Rouge)
+
+When using Rouge as the syntax highlighter, you can customize the formatter by overriding the `create_formatter` method.
+This allows you to add custom logic for handling certain tokens in the source language.
+
+Let's assume that you want to look for bare URLs in code comments and translate them into links (i.e., autolinks), just like in AsciiDoc.
+You can do that by weaving extra logic into the formatter that looks for tokens in the `Comment` category and applies a substitution to the value.
+
+[,ruby]
+----
+include::example$autolink-urls-in-comments.rb[]
+----
+
+Since the formatter has access to all the tokens in the code identified by the syntax highlighter, this technique opens up a lot of possibilities.
+For example, you could look for the `Type` token in the `Keyword` category in Java code and create a link to the API docs.
+The `lang` argument to the `create_formatter` method lets you know the source language (e.g., `java`) to which the tokens belong.
+
+To study the logic you may be interesting in overriding, browse the code for the https://github.com/asciidoctor/asciidoctor/tree/{page-origin-refname}/lib/asciidoctor/syntax_highlighter[built-in syntax highlighter adapters].
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
@@ -2,12 +2,13 @@ use crate::{document::InterpretedValue, tests::prelude::*};
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/highlightjs.adoc");
 
-// Highlight.js is a client-side syntax highlighter. asciidoc-parser performs no
+// Highlight.js is a client-side syntax highlighter. This crate performs no
 // rendering, so the activation, CDN-loading, language-bundle, and
-// custom-library mechanics on this page are non-normative here. The one
-// exception is the documented default value of the `highlightjs-theme` document
-// attribute, which the parser knows as a built-in default value (see
-// `built_in_attrs.rs`); that is verified below.
+// custom-library mechanics on this page are the responsibility of a downstream
+// renderer crate and are non-normative here. The one exception is the
+// documented default value of the `highlightjs-theme` document attribute, which
+// the parser knows as a built-in default value (see `built_in_attrs.rs`); that
+// is verified below.
 non_normative!(
     r##"
 = Highlight.js

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
@@ -2,13 +2,13 @@ use crate::{document::InterpretedValue, tests::prelude::*};
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/highlightjs.adoc");
 
-// Highlight.js is a client-side syntax highlighter. This crate performs no
-// rendering, so the activation, CDN-loading, language-bundle, and
-// custom-library mechanics on this page are the responsibility of a downstream
-// renderer crate and are non-normative here. The one exception is the
-// documented default value of the `highlightjs-theme` document attribute, which
-// the parser knows as a built-in default value (see `built_in_attrs.rs`); that
-// is verified below.
+// Highlight.js is a client-side syntax highlighter, and one this crate models:
+// when `source-highlighter` is `highlight.js`, a source block renders with the
+// highlight.js markup its browser-side loader expects (verified below). The
+// remaining CDN-loading, language-bundle, and custom-library mechanics concern
+// the standalone HTML document (its `<head>` and footer scripts), which this
+// block-level virtual DOM does not model, so those parts stay non-normative
+// here.
 non_normative!(
     r##"
 = Highlight.js
@@ -18,6 +18,13 @@ non_normative!(
 
 {url-highlightjs}[Highlight.js^] is a popular client-side syntax highlighter that supports a broad range of {url-highlightjs-lang}[languages^].
 
+"##
+);
+
+#[test]
+fn activate_highlightjs() {
+    verifies!(
+        r##"
 == Activate highlight.js
 
 To activate highlight.js, add the following attribute entry to the header of your AsciiDoc file:
@@ -26,6 +33,27 @@ To activate highlight.js, add the following attribute entry to the header of you
 ----
 :source-highlighter: highlight.js
 ----
+"##
+    );
+
+    // Setting `source-highlighter: highlight.js` renders a source block with the
+    // highlight.js markup: a `pre.highlightjs.highlight` wrapping a
+    // `code.language-<lang>.hljs` that carries `data-lang`.
+    let doc = Parser::default().parse(
+        ":source-highlighter: highlight.js\n\n[source,ruby]\n----\nputs 'Hello, World!'\n----\n",
+    );
+
+    assert_css(&doc, "pre.highlightjs.highlight", 1);
+
+    assert_css(
+        &doc,
+        "pre.highlightjs.highlight > code.language-ruby.hljs[data-lang=\"ruby\"]",
+        1,
+    );
+}
+
+non_normative!(
+    r##"
 
 By default, Asciidoctor will link to the highlight.js library and stylesheet hosted on {url-highlightjs-cdn}[cdnjs^].
 The version of the highlight.js library Asciidoctor loads from the CDN only includes support for languages in the common language bundle (apache, bash, coffeescript, cpp, cs, css, diff, http, ini, java, javascript, json, makefile, markdown, nginx, objectivec, perl, php, properties, python, ruby, shell, sql, xml, and yaml).
@@ -46,8 +74,7 @@ By default, highlight.js is configured to use the github theme.
 
     // `github` is the parser's built-in default value for `highlightjs-theme`:
     // setting the attribute with an empty value (a bare `:highlightjs-theme:`)
-    // resolves to `github`. The parser does no rendering, so this is the extent
-    // to which it models the documented default theme.
+    // resolves to `github`.
     let doc = Parser::default().parse(":highlightjs-theme:\n");
 
     assert_eq!(

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/highlightjs.rs
@@ -1,0 +1,103 @@
+use crate::{document::InterpretedValue, tests::prelude::*};
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/highlightjs.adoc");
+
+// Highlight.js is a client-side syntax highlighter. asciidoc-parser performs no
+// rendering, so the activation, CDN-loading, language-bundle, and
+// custom-library mechanics on this page are non-normative here. The one
+// exception is the documented default value of the `highlightjs-theme` document
+// attribute, which the parser knows as a built-in default value (see
+// `built_in_attrs.rs`); that is verified below.
+non_normative!(
+    r##"
+= Highlight.js
+:url-highlightjs: https://highlightjs.org/
+:url-highlightjs-lang: https://highlightjs.org/download/
+:url-highlightjs-cdn: https://cdnjs.com/libraries/highlight.js
+
+{url-highlightjs}[Highlight.js^] is a popular client-side syntax highlighter that supports a broad range of {url-highlightjs-lang}[languages^].
+
+== Activate highlight.js
+
+To activate highlight.js, add the following attribute entry to the header of your AsciiDoc file:
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+----
+
+By default, Asciidoctor will link to the highlight.js library and stylesheet hosted on {url-highlightjs-cdn}[cdnjs^].
+The version of the highlight.js library Asciidoctor loads from the CDN only includes support for languages in the common language bundle (apache, bash, coffeescript, cpp, cs, css, diff, http, ini, java, javascript, json, makefile, markdown, nginx, objectivec, perl, php, properties, python, ruby, shell, sql, xml, and yaml).
+
+== Change the theme
+
+The theme controls the colors that are used for the tokens (keywords, strings, methods, etc.) in the highlighted code.
+"##
+);
+
+#[test]
+fn highlightjs_theme_defaults_to_github() {
+    verifies!(
+        r##"
+By default, highlight.js is configured to use the github theme.
+"##
+    );
+
+    // `github` is the parser's built-in default value for `highlightjs-theme`:
+    // setting the attribute with an empty value (a bare `:highlightjs-theme:`)
+    // resolves to `github`. The parser does no rendering, so this is the extent
+    // to which it models the documented default theme.
+    let doc = Parser::default().parse(":highlightjs-theme:\n");
+
+    assert_eq!(
+        doc.attribute_value("highlightjs-theme"),
+        InterpretedValue::Value("github".to_string()),
+    );
+}
+
+non_normative!(
+    r##"
+You can change the theme used by highlight.js by setting the `highlightjs-theme` attribute.
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+:highlightjs-theme: monokai
+----
+
+The theme is loaded from the CDN, so any theme supported by the version of highlight.js that Asciidoctor uses is supported.
+Refer to https://cdnjs.com/libraries/highlight.js/9.18.3 for a list of themes (filter by *Asset Type: Styling*).
+The value of the `highlightjs-theme` attribute is the basename of the file minus the _.min.css_ file extension.
+
+== Load support for additional languages
+
+To load additional languages supported by highlight.js, list them in the value of the `highlightjs-languages` document attribute.
+Separate each language by a comma followed by an optional space.
+
+The common highlight.js bundle does not include support for Rust and Swift.
+Let's set the `highlightjs-languages` attribute so the HTML converter loads support for them into the HTML page.
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+:highlightjs-languages: rust, swift
+----
+
+The `highlightjs-languages` attribute only applies when generating a standalone HTML document (i.e., backend: html, standalone: true).
+It does not work when generating embedded HTML, which is used by site generator integrations such as Antora.
+
+== Use a custom highlight.js library
+
+If you'd rather use a personal copy of highlight.js instead of the one hosted on the CDN, follow these steps:
+
+. Create your custom bundle on the {url-highlightjs-lang}[download page^].
+. Download and unpack the zip into a folder called [.path]_highlight_ adjacent to your AsciiDoc file (or in the output directory, if different)
+. Rename [.path]_highlight/highlight.pack.js_ to [.path]_highlight/highlight.min.js_
+. Rename [.path]_highlight/styles/github.css_ to [.path]_highlight/styles/github.min.css_
+** Replace `github` with the name of the `highlightjs-theme` you are using, if different.
+. Add the attribute entry `:highlightjsdir: highlight` to the header of your AsciiDoc file.
+** Alternatively, you can pass the `-a highlightjsdir=highlight` flag when invoking the Asciidoctor CLI.
+
+The output file will use your personal copy of the highlight.js library and stylesheet instead of the one hosted on cdnjs.
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/index.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/index.rs
@@ -1,0 +1,154 @@
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/index.adoc");
+
+// This page documents how an AsciiDoc processor applies syntax highlighting
+// when rendering source blocks. Because asciidoc-parser performs no rendering –
+// neither client-side nor build-time (server-side) highlighting is a goal of
+// this crate – the whole page is non-normative here.
+non_normative!(
+    r##"
+= Syntax Highlighting
+
+AsciiDoc defines a style of listing block known as a xref:asciidoc:verbatim:source-blocks.adoc[source block] for adding source code snippets intended to be colorized by a syntax highlighter to a document.
+Here's a simple example of a source block:
+
+[source,asciidoc]
+....
+[source,ruby]
+----
+puts "Hello, World!"
+----
+....
+
+If a language is specified on a listing block, the source style is implied.
+Therefore, it can be excluded in this case.
+
+[source,asciidoc]
+....
+[,ruby]
+----
+puts "Hello, World!"
+----
+....
+
+Here's how we expect it to appear:
+
+[,ruby]
+----
+puts "Hello, World!"
+----
+
+It's up to an AsciiDoc processor such as Asciidoctor to apply the syntax highlighting to this source block, a process referred to as xref:asciidoc:verbatim:source-highlighter.adoc[source highlighting].
+Asciidoctor provides adapters that integrate with several popular syntax highlighter libraries to perform this task.
+It also provides an interface for implementing a custom syntax highlighter adapter.
+
+== Syntax highlighter types
+
+Asciidoctor supports two types of syntax highlighters: client-side and build-time.
+Let's explore each type and how they work.
+
+A [.term]*client-side syntax highlighter* performs syntax highlighting in the browser as the page is loading.
+Asciidoctor does not invoke the syntax highlighter itself.
+Instead, it focuses on adding the assets to the generated HTML so the browser can load the syntax highlighter and run it.
+For this type of syntax highlighter, Asciidoctor passes the contents of the source block through to the output as is.
+It also adds metadata to the element so that the syntax highlighter knows to highlight it and which language it is.
+Unfortunately, Asciidoctor does not process callout numbers in the source block in this case, so they may cause the syntax highlighter to get tripped up.
+
+A [.term]*build-time syntax highlighter* performs syntax highlighting during AsciiDoc conversion.
+Asciidoctor does invoke the syntax highlighter in this case.
+It also takes care of hiding the callout numbers from the syntax highlighter, ensuring they are put back in the proper place afterwards.
+What Asciidoctor emits into the output is the result produced by the syntax highlighter, which are the tokens enclosed in `<span>` elements to apply color and other formatting (either inline or via CSS classes).
+These syntax highlighters tend to support more features because Asciidoctor has greater control over the process.
+
+=== Client-side vs build-time
+
+There are benefits and drawbacks of each type.
+The benefit of a client-side syntax highlighter is that does not require installing any additional libraries.
+It also makes conversion faster and makes it produce smaller output since the syntax highlighting is deferred until page load.
+The main drawback is that callouts in the source block can be mangled by the syntax highlighter or confuse it.
+The benefits of a build-time syntax highlighter are that you have more control over syntax highlighting and can enable additional features such as line numbers and line highlighting.
+The main drawback is that it requires installing an extra library, it slows down conversion, and causes the output to be larger.
+
+You should try each syntax highlighter and find the one that works best for you.
+
+== Built-in syntax highlighter adapters
+
+[%autowidth]
+|===
+|Type |Syntax Highlighter |Required Gem |Compatible Converters
+
+h|Client-side
+
+|Highlight.js
+|_n/a_
+|HTML, Reveal.js
+
+.3+h|Build-time
+
+|CodeRay
+|coderay (>= 1.1)
+|HTML, PDF, EPUB3, Reveal.js
+
+|Pygments
+|pygments.rb (>= 1.2)
+|HTML, PDF, EPUB3, Reveal.js
+
+|Rouge
+|rouge (>= 2)
+|HTML, PDF, EPUB3, Reveal.js
+|===
+
+Asciidoctor does not apply syntax highlighting when generating DocBook.
+The assumption is that this is a task the DocBook toolchain can handle.
+The DocBook converter generates a `<programlisting>` element for the source block and passes through the source language as specified in the AsciiDoc.
+It's then up to the DocBook toolchain to apply syntax highlighting to the contents of that tag.
+
+You can explore these integrations in depth on the xref:highlightjs.adoc[], xref:rouge.adoc[], xref:pygments.adoc[], and xref:coderay.adoc[] pages.
+
+You can also create your own integration by making a xref:custom.adoc[].
+
+== Custom subs on source blocks
+
+You should not mix syntax highlighting with AsciiDoc text formatting (i.e., the `quotes` and `macros` substitutions).
+In many converters, these two operations are mutually exclusive.
+
+.Improper use of custom substitutions on a source block
+[source,asciidoc]
+....
+[,java,subs=+quotes]
+----
+interface OrderRepository extends CrudRepository<Order,Long> {
+
+  *List<Order>* findByCategory(String category);
+
+  Order findById(long id);
+}
+----
+....
+
+The additional markup introduced by AsciiDoc text formatting may confuse the syntax highlighter and lead to unexpected results.
+While it may work in some syntax highlighters in the HTML backend (which perhaps know how to work around the formatting tags), it will most certainly fail when converting to other formats such as PDF.
+
+If you're going to customize the substitutions on a source block using the `subs` attribute, you should limit those substitutions to attribute replacements (`attributes`).
+
+.Valid use of custom substitutions on a source block
+[source,asciidoc]
+....
+[,java,subs=attributes+]
+----
+interface {model}Repository extends CrudRepository<{model},Long> {
+
+  {model} findById(long id);
+}
+----
+....
+
+If you still need to emphasize certain tokens in the block of code, you should do so by creating a custom lexer or formatter for the syntax highlighting library that understands these additional semantics and perhaps even hints.
+In other words, work through the syntax highlighter so it's added during the highlighting process, giving the syntax highlighter full knowledge as to what's going on.
+Another option is to use a xref:custom.adoc[custom syntax highlighter adapter].
+
+Before trying to get the syntax highlighter to recognize new tokens, make sure it doesn't already recognize them.
+If it does, it may just be a matter of customizing the syntax highlighter theme to apply different formatting to those tokens.
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/index.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/index.rs
@@ -2,10 +2,11 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/index.adoc");
 
-// This page documents how an AsciiDoc processor applies syntax highlighting
-// when rendering source blocks. Because asciidoc-parser performs no rendering –
-// neither client-side nor build-time (server-side) highlighting is a goal of
-// this crate – the whole page is non-normative here.
+// This page is an overview of Asciidoctor's syntax highlighting: how a
+// processor applies a highlighter (client-side or build-time) to a source block
+// while rendering. Applying the highlighter is the responsibility of a
+// downstream renderer crate, not this parser, so the whole page is
+// non-normative here.
 non_normative!(
     r##"
 = Syntax Highlighting

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/mod.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/mod.rs
@@ -1,0 +1,9 @@
+//! Ports of the pages in Asciidoctor's `syntax-highlighting` documentation
+//! module (`ref/asciidoctor/docs/modules/syntax-highlighting/pages`).
+
+mod coderay;
+mod custom;
+mod highlightjs;
+mod index;
+mod pygments;
+mod rouge;

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/pygments.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/pygments.rs
@@ -2,10 +2,10 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/pygments.adoc");
 
-// This page documents how an AsciiDoc processor applies syntax highlighting
-// when rendering source blocks. Because asciidoc-parser performs no rendering –
-// neither client-side nor build-time (server-side) highlighting is a goal of
-// this crate – the whole page is non-normative here.
+// This page documents a build-time (server-side) syntax highlighter, which an
+// AsciiDoc processor invokes while rendering a source block. Build-time
+// highlighting is a non-goal of this project, and this crate performs no
+// rendering in any case, so the whole page is non-normative here.
 non_normative!(
     r##"
 = Pygments

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/pygments.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/pygments.rs
@@ -1,0 +1,179 @@
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/pygments.adoc");
+
+// This page documents how an AsciiDoc processor applies syntax highlighting
+// when rendering source blocks. Because asciidoc-parser performs no rendering –
+// neither client-side nor build-time (server-side) highlighting is a goal of
+// this crate – the whole page is non-normative here.
+non_normative!(
+    r##"
+= Pygments
+:url-pygments: https://pygments.org
+:url-pygments-lang: https://pygments.org/languages/
+:url-python: https://www.python.org
+:url-pygments-gem: https://rubygems.org/gems/pygments.rb
+
+{url-pygments}[Pygments^] is a popular syntax highlighter that supports a broad range of {url-pygments-lang}[programming and template languages^].
+
+== Install Pygments
+
+In order to use Pygments with Asciidoctor, you need {url-python}[Python] and the {url-pygments-gem}[pygments.rb gem^].
+The pygments.rb gem manages calls to Pygments, which is an external program that runs using Python.
+
+TIP: You do not need to install Pygments itself.
+It comes bundled with the pygments.rb gem.
+
+IMPORTANT: You must have Python installed to use pygments.rb.
+
+The version of Python required depends on which pygments.rb release you're using:
+
+* pygments.rb 1.x requires Python 2.
+Check that you have a `python2` (Linux), `python` (macOS), or `py -2` (Windows) executable on your PATH.
+(On macOS, verify that the `python` executable uses Python 2 by running `python -V`).
+* pygments.rb 2.x requires Python 3.
+Check that you have a `python3` (Linux/macOS) or `py -3` (Windows) executable on your PATH.
+
+.Installing Python and the pygments.rb gem via the CLI (cross platform)
+[,console]
+----
+$ "`\which apt-get || \which dnf || \which yum || \which brew`" install python # <.>
+$ gem install pygments.rb # <.>
+----
+<.> Install Python using your package manager
+<.> Install the pygments.rb gem
+
+== Activate Pygments
+
+Once you've installed these libraries, assign `pygments` to the `source-highlighter` attribute in your document's header.
+
+[,asciidoc]
+----
+:source-highlighter: pygments
+----
+
+== Pygments attributes
+
+You can further customize the source block output with additional Pygments attributes.
+
+pygments-style::
+Sets the name of the color theme Pygments uses.
+To see the list of available style names, see <<listing-pygments-style-names>>.
+Default: `pastie`.
+
+pygments-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` (CSS classes) or `style` (inline styles).
+See the xref:html-backend:source-highlighting-stylesheets.adoc#pygments[Pygments stylesheet section] to learn more about how the value `class` is handled.
+Default: `class`.
+
+pygments-linenums-mode::
+Controls how line numbers are arranged when line numbers are enabled on the source block.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+.Customizing a source block with Pygments attributes
+[source,asciidoc]
+....
+:source-highlighter: pygments
+:pygments-style: manni
+:pygments-linenums-mode: inline
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+////
+.Result: Source block using inline line numbers and the manni theme
+====
+image::custom-pygments.png[Line numbers and a custom Pygments theme for a source block.]
+====
+////
+
+[#listing-pygments-style-names]
+=== Available Pygments style names
+
+To list the available Pygments styles, run the following command in a terminal:
+
+ $ $(dirname $(gem which pygments.rb))/../vendor/pygments-main/pygmentize -L styles
+
+The pygments.rb gem uses a bundled version of Pygments (often ahead of the latest release).
+This command ensures that you are invoking the `pygmentize` command from the Pygments used by that gem.
+
+[#pygments-timeout]
+== Pygments timeout (pygments.rb 1.x only)
+
+If you're using pygments.rb 1.x, you may need to adjust the timeout.
+This configuration step is not necessary if you're using pygments.rb 2.x with Python 3.
+
+Since Pygments is an external program, the call to that command in pygments.rb 1.x is managed by a timeout to safeguard against a hanging process.
+By default, this timeout is 8 seconds.
+If you discover that the call is failing to complete within this timeout period, you can increase the timeout (in seconds) by setting the `MENTOS_TIMEOUT` environment variable.
+
+ export MENTOS_TIMEOUT=30
+
+Now the call to Pygments (via pygments.rb 1.x) will be allocated up to 30 seconds to complete.
+
+== Use a custom Pygments installation
+
+If you already have Pygments installed on your system, you want to use your own fork, or you want to customize how Pygments is configured, you can get Asciidoctor to use a custom version of Pygments instead of the one bundled with the pygments.rb gem.
+
+First, install your own version of Pygments.
+You can do this, for instance, by cloning the upstream Pygments repository:
+
+ $ hg clone https://bitbucket.org/birkenfeld/pygments-main pygments
+
+Find the directory that contains the file [.path]_pygmentize_ or the [.path]_Makefile_.
+That's your Pygments installation path.
+Make note of it.
+
+Next, create a script to run _before_ invoking Asciidoctor for the first time.
+Let's call it [.path]_pygments_init.rb_.
+Populate the script with the following content:
+
+.pygments_init.rb
+[,ruby]
+----
+require 'pygments'
+
+# use a custom Pygments installation (directory that contains pygmentize)
+Pygments.start '/path/to/pygments'
+
+# example of registering a missing or additional lexer
+#Pygments::Lexer.create name: 'Turtle', aliases: ['turtle'],
+#    filenames: ['*.ttl'], mimetypes: ['text/turtle', 'application/x-turtle']
+----
+
+TIP: You could enhance this script to read the Pygments installation path from an environment variable (or configuration file).
+
+Now just require this script before your invoke Asciidoctor the first time.
+When using the `asciidoctor` command, pass the script using the `-r` flag:
+
+ $ asciidoctor -r ./pygments_init.rb document.adoc
+
+When using the Asciidoctor API, require the script using `require` or `require_relative`:
+
+[,ruby]
+----
+require 'asciidoctor'
+require_relative './pygments_init.rb'
+
+Asciidoctor.convert_file 'document.adoc', safe: :safe
+----
+
+Now Asciidoctor is using your custom installation of Pygments instead of the one bundled with the pygments.rb gem.
+
+Alternately, you can xref:custom.adoc#extend[extend the adapter for Pygments] and put this logic inside that adapter.
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/rouge.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/rouge.rs
@@ -1,0 +1,105 @@
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/rouge.adoc");
+
+// This page documents how an AsciiDoc processor applies syntax highlighting
+// when rendering source blocks. Because asciidoc-parser performs no rendering –
+// neither client-side nor build-time (server-side) highlighting is a goal of
+// this crate – the whole page is non-normative here.
+non_normative!(
+    r##"
+= Rouge
+:url-rouge: http://rouge.jneen.net
+:url-rouge-gem: https://rubygems.org/gems/rouge
+:url-rouge-repo: https://github.com/rouge-ruby/rouge/tree/HEAD/lib/rouge/themes
+
+{url-rouge}[Rouge^] is an extendable code highlighter written in Ruby that supports a vast array of languages.
+
+== Install Rouge
+
+To use Rouge with Asciidoctor, you need the {url-rouge-gem}[rouge gem^].
+You can use one of the following methods to install Rouge.
+
+Install using `gem` (all systems)::
++
+ $ gem install rouge
+
+Install using `apt-get` (Debian-based systems)::
++
+ $ sudo apt-get install ruby-rouge
+
+Install using `dnf` (Fedora-based systems)::
++
+ $ sudo dnf install rubygem-rouge
+
+Install using `pacman` (Arch Linux-based systems)::
++
+ $ sudo pacman -S ruby-rouge
+
+== Assign rouge to source-highlighter
+
+Once you've installed the gem, assign the `rouge` value to the `source-highlighter` attribute in the document header to activate it.
+
+[,asciidoc]
+----
+:source-highlighter: rouge
+----
+
+== Rouge attributes
+
+You can further customize the source block output with additional Rouge attributes.
+
+rouge-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` or `style`.
+Default: `class`.
+
+[.line-through]#rouge-linenums-mode# (not currently implemented, see https://github.com/asciidoctor/asciidoctor/issues/3641[#3641])::
+Controls how line numbers are laid out.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+rouge-style::
+Controls the color theme used to for highlighting.
+You can find the list of themes in the {url-rouge-repo}[Rouge code repository^].
+
+Typically, you set these attributes using the CLI or API (e.g., `-a source-highlighter=rouge -a rouge-style=colorful`) so you don't have to define them in each document.
+However, you can define them per document as shown in the following example.
+
+.Activating the Rouge syntax highlighter and applying a different style
+[source,asciidoc]
+....
+:source-highlighter: rouge
+:rouge-style: monokai
+
+[,ruby]
+----
+puts "Hello, Rouge!"
+----
+....
+
+You can enable line numbering using the linenums option on the block.
+
+.Customizing a source block with Rouge line numbers
+[source,asciidoc]
+....
+:source-highlighter: rouge
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+It's also possible to enable linenums for all source blocks by setting the `source-linenums-option` attribute on the document.
+"##
+);

--- a/parser/src/tests/asciidoctor_docs/syntax_highlighting/rouge.rs
+++ b/parser/src/tests/asciidoctor_docs/syntax_highlighting/rouge.rs
@@ -2,10 +2,10 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoctor/docs/modules/syntax-highlighting/pages/rouge.adoc");
 
-// This page documents how an AsciiDoc processor applies syntax highlighting
-// when rendering source blocks. Because asciidoc-parser performs no rendering –
-// neither client-side nor build-time (server-side) highlighting is a goal of
-// this crate – the whole page is non-normative here.
+// This page documents a build-time (server-side) syntax highlighter, which an
+// AsciiDoc processor invokes while rendering a source block. Build-time
+// highlighting is a non-goal of this project, and this crate performs no
+// rendering in any case, so the whole page is non-normative here.
 non_normative!(
     r##"
 = Rouge

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -47,6 +47,27 @@ thread_local! {
     static ICONS_MODE: Cell<IconsMode> = const { Cell::new(IconsMode::None) };
 }
 
+/// The document-wide `source-highlighter`, captured so a source block (rendered
+/// without any document context) can emit the markup its highlighter requires.
+/// Only `highlight.js` – the built-in client-side highlighter – changes the
+/// block markup here; a build-time (server-side) highlighter runs during
+/// conversion and is out of scope, so every other value leaves the source block
+/// unchanged.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum SourceHighlighter {
+    /// No `source-highlighter`, or one whose output this virtual DOM does not
+    /// model.
+    Other,
+
+    /// `source-highlighter: highlight.js`.
+    HighlightJs,
+}
+
+thread_local! {
+    static SOURCE_HIGHLIGHTER: Cell<SourceHighlighter> =
+        const { Cell::new(SourceHighlighter::Other) };
+}
+
 /// A fully resolved table of contents, ready to render: the prebuilt section
 /// list (already pruned to the configured `toclevels`), the title text (from
 /// `toc-title`), and the container CSS class (from `toc-class`).
@@ -214,6 +235,16 @@ fn icons_mode_from_document(doc: &Document) -> IconsMode {
         }
     }
     IconsMode::None
+}
+
+/// Reads the document-wide `source-highlighter` mode for the virtual DOM. Only
+/// `highlight.js` is modeled; every other value (including unset) is treated as
+/// [`SourceHighlighter::Other`].
+fn source_highlighter_from_document(doc: &Document) -> SourceHighlighter {
+    match doc.attribute_value("source-highlighter") {
+        InterpretedValue::Value(v) if v == "highlight.js" => SourceHighlighter::HighlightJs,
+        _ => SourceHighlighter::Other,
+    }
 }
 
 /// Decodes common HTML entities to their character equivalents.
@@ -542,6 +573,11 @@ impl ToVirtualDom for Document<'_> {
         // Capture the document-wide icons mode so callout lists (built without
         // any document context) can render an icon table when appropriate.
         ICONS_MODE.with(|m| m.set(icons_mode_from_document(self)));
+
+        // Capture the document-wide `source-highlighter` so a source block can
+        // emit highlight.js markup when it is active (see
+        // [`raw_delimited_to_node`]).
+        SOURCE_HIGHLIGHTER.with(|m| m.set(source_highlighter_from_document(self)));
 
         let mut node = VirtualNode::new("div").with_class("document");
 
@@ -1592,23 +1628,47 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
             .unwrap_or(false);
 
         if is_source_block {
+            let highlighter = SOURCE_HIGHLIGHTER.with(|m| m.get());
+
+            // The source language is the second positional attribute (the first
+            // is `style="source"`).
+            let language = raw.attrlist().and_then(|attrlist| {
+                let mut attrs = attrlist.attributes();
+                attrs.next();
+                attrs.next().map(|lang_attr| lang_attr.value().to_string())
+            });
+
             // For source blocks, create pre > code structure.
             let mut code = VirtualNode::new("code");
 
-            // Add data-lang attribute if language is specified (second positional
-            // attribute).
-            if let Some(attrlist) = raw.attrlist() {
-                let mut attrs = attrlist.attributes();
+            match highlighter {
+                SourceHighlighter::HighlightJs => {
+                    // Highlight.js is a client-side highlighter: Asciidoctor
+                    // passes the source through unchanged and tags the element
+                    // for the browser-side library. The `<code>` carries a
+                    // `language-<lang>` class (falling back to `language-none`
+                    // when no language is set) plus the `hljs` marker class, and
+                    // `data-lang` is emitted only when a language is present.
+                    let lang_class = match language.as_deref() {
+                        Some(lang) => format!("language-{lang}"),
+                        None => "language-none".to_string(),
+                    };
 
-                // Skip first attribute (style="source").
-                attrs.next();
+                    code = code.with_class(lang_class).with_class("hljs");
 
-                // Second attribute is the language, which yields both a
-                // `language-<lang>` class and a `data-lang` attribute.
-                if let Some(lang_attr) = attrs.next() {
-                    code = code
-                        .with_class(format!("language-{}", lang_attr.value()))
-                        .with_attribute("data-lang", lang_attr.value());
+                    if let Some(lang) = language.as_deref() {
+                        code = code.with_attribute("data-lang", lang);
+                    }
+                }
+
+                SourceHighlighter::Other => {
+                    // A language yields both a `language-<lang>` class and a
+                    // `data-lang` attribute.
+                    if let Some(lang) = language.as_deref() {
+                        code = code
+                            .with_class(format!("language-{lang}"))
+                            .with_attribute("data-lang", lang);
+                    }
                 }
             }
 
@@ -1618,7 +1678,15 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
                 code = code.with_html_content(content);
             }
 
-            let pre = VirtualNode::new("pre").with_child(code);
+            let mut pre = VirtualNode::new("pre");
+
+            // Highlight.js marks the enclosing `<pre>` with `highlightjs
+            // highlight` so its loader can find the block.
+            if highlighter == SourceHighlighter::HighlightJs {
+                pre = pre.with_class("highlightjs").with_class("highlight");
+            }
+
+            pre = pre.with_child(code);
             node.children.push(pre);
         } else {
             let mut pre = VirtualNode::new("pre");

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::unwrap_used)]
 
 mod asciidoc_lang;
+mod asciidoctor_docs;
 mod asciidoctor_rb;
 pub(crate) mod assert_dom;
 mod block_nesting_depth;

--- a/ref/asciidoctor/README.md
+++ b/ref/asciidoctor/README.md
@@ -1,10 +1,17 @@
-# Asciidoctor reference test suite (in progress)
+# Asciidoctor reference material (in progress)
 
-This directory vendors test files from
+This directory vendors material from
 [Asciidoctor](https://github.com/asciidoctor/asciidoctor), the reference
 Ruby implementation of the AsciiDoc language, so that `asciidoc-parser` can be
-validated against Asciidoctor's own behavior using this repository's
-spec-driven-development coverage tooling (see `sdd/`).
+validated against Asciidoctor's own behavior and documentation using this
+repository's spec-driven-development coverage tooling (see `sdd/`).
+
+Two kinds of material are vendored:
+
+- **`test/`** — the Asciidoctor test suite.
+- **`docs/`** — the Asciidoctor processor documentation (Antora modules).
+
+## Test suite (`test/`)
 
 We're porting the Asciidoctor test suite **one file at a time**. Each file is
 vendored here verbatim and covered line-by-line by a matching Rust test module
@@ -15,6 +22,19 @@ building toward covering the suite in full.
 `test/attribute_list_test.rb` is where this started. (Some Asciidoctor tests
 were hand-ported into `parser/src/tests/asciidoctor_rb/` before this
 line-by-line approach; those will be migrated to it over time.)
+
+## Processor documentation (`docs/`)
+
+We're porting the Asciidoctor processor documentation **one module at a time**,
+mirrored line-by-line by Rust test modules under
+`parser/src/tests/asciidoctor_docs/`. Because these pages largely describe
+rendering behavior that `asciidoc-parser` does not implement (it parses AsciiDoc
+but performs no output rendering), most of the ported prose is marked
+non-normative.
+
+`docs/modules/syntax-highlighting` is the first module ported.
+
+## Provenance
 
 The vendored files are unmodified copies of their upstream originals, taken from
 Asciidoctor **v2.0.26**.

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/coderay.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/coderay.adoc
@@ -1,0 +1,105 @@
+= CodeRay
+:url-coderay: http://coderay.rubychan.de/
+:url-coderay-gem: https://rubygems.org/gems/coderay
+
+{url-coderay}[CodeRay^] is an encoding-aware, syntax highlighter that supports the languages listed below.
+
+[%autowidth,cols="4*",grid=none,frame=none]
+|===
+| C
+| C++
+| Clojure
+| CSS
+
+| Delphi
+| diff
+| ERB
+| Go
+
+| Groovy
+| HAML
+| HTML
+| Java
+
+| JavaScript
+| JSON
+| Lua
+| PHP
+
+| Python
+| Ruby
+| Sass
+| SQL
+
+| Taskpaper
+| XML
+| YAML
+|
+|===
+
+== Install CodeRay
+
+To use CodeRay with Asciidoctor, you need the {url-coderay-gem}[coderay gem^].
+You can use one of the following methods to install CodeRay.
+
+Install using gem (all systems)::
++
+ $ gem install coderay
+
+Install using apt-get (Debian-based systems)::
++
+ $ sudo apt-get install ruby-coderay
+
+Install using dnf (Fedora-based systems)::
++
+ $ sudo dnf install rubygem-coderay
+
+== Activate CodeRay
+
+Once you've installed the gem, assign the `coderay` value to the `source-highlighter` attribute in the document header to activate it.
+
+[,asciidoc]
+----
+:source-highlighter: coderay
+----
+
+== CodeRay attributes
+
+You can further customize the source block output with additional CodeRay attributes.
+
+coderay-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` or `style`.
+Default: `class`.
+
+coderay-linenums-mode::
+Controls how line numbers are laid out.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+.Customizing a source block with CodeRay line numbers
+[source,asciidoc]
+....
+:source-highlighter: coderay
+:coderay-linenums-mode: inline
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+See the xref:html-backend:source-highlighting-stylesheets.adoc#coderay[CodeRay stylesheet section] to learn about the `coderay-css` attribute.
+
+////
+Note: I'm not getting this to work. Need to come back and do some quality assurance.
+////

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/custom.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/custom.adoc
@@ -1,0 +1,106 @@
+= Custom Syntax Highlighter Adapter
+:navtitle: Custom Adapter
+:apidoc-base: {url-api-gems}/asciidoctor/{release-version}/Asciidoctor
+:apidoc-syntax-highlighter: {apidoc-base}/SyntaxHighlighter
+:apidoc-syntax-highlighter-base: {apidoc-syntax-highlighter}/Base
+:apidoc-syntax-highlighter-for: {apidoc-syntax-highlighter}/Factory#for-instance_method
+
+You can integrate additional syntax highlighters into Asciidoctor by implementing and registering a syntax highlighter adapter.
+You can either write a new adapter from scratch or you can extend and even replace one of the built-in adapters.
+
+[#new]
+== Create a new adapter
+
+To implement a new adapter, you must create a class that extends the {apidoc-syntax-highlighter-base}[Asciidoctor::SyntaxHighlighter::Base] class, register the adapter for a value of the `source-highlighter` attribute, and implement the required methods.
+Which methods are required depends on whether the adapter is for a client-side (runs in the browser) or build-time (runs when the document is converted) syntax highlighter.
+
+Here's an example of how to write and register a syntax highlighter adapter for the Prism.js syntax highlighting library.
+Prism.js is a client-side syntax highlighter, meaning it runs in the browser.
+That means the adapter only has to implement methods that pertain to client-side syntax highlighting, which include `format`, `docinfo?`, and `docinfo`.
+
+.Syntax highlighter adapter for Prism.js
+[,ruby]
+----
+include::example$prism-syntax-highlighter.rb[]
+----
+
+Save this code to a file named [.path]_prism-syntax-highlighter.rb_.
+Then, require this file when invoking Asciidoctor and set `source-highlighter=prism` to activate it:
+
+ $ asciidoctor -r ./prism-syntax-highlighter -a source-highlighter=prism document.adoc
+
+You can also define an adapter for a syntax highlighter that runs during conversion.
+We'll look at doing that while also extending a built-in adapter.
+
+[#extend]
+== Extend an existing adapter
+
+Instead of creating a new adapter, you can customize a built-in adapter by extending it, overriding its behavior, and optionally replacing it.
+
+To extend an adapter, you need to look up a reference to the built-in adapter by name using the {apidoc-syntax-highlighter-for}[Asciidoctor::SyntaxHighlighter.for] method, create a class that extends it, register the adapter with a unique name (or the same name, if you want to replace it), and override any methods that provide the behavior you want to modify.
+
+Here's the basic template for customizing an existing adapter:
+
+[,ruby]
+----
+class CustomAdapter < (Asciidoctor::SyntaxHighlighter.for 'rouge')
+  register_for 'rouge'
+
+  # override methods go here
+end
+----
+
+Let's look at some examples of how to customize a built-in adapter.
+
+=== docinfo
+
+Let's override the adapter for Pygments to prevent it from adding a stylesheet to the HTML (presumably because the styles will be provided by a different stylesheet).
+
+.Extended syntax highlighter adapter for Pygments
+[,ruby]
+----
+include::example$extended-pygments-syntax-highlighter.rb[]
+----
+
+Save this code to a file named [.path]_extended-pygments-syntax-highlighter.rb_.
+Then, require this file when invoking Asciidoctor, setting `source-highlighter=pygments` to activate it, as you would normally do:
+
+ $ asciidoctor -r ./extended-pygments-syntax-highlighter.rb -a source-highlighter=pygments document.adoc
+
+If, instead, you wanted to modify the built-in adapter to honor the location of a custom stylesheet specified by the `pygments-stylesheet` attribute, you can do so by extending the adapter and overriding the `docinfo` method.
+
+[,ruby]
+----
+include::example$pygments-syntax-highlighter-with-custom-stylesheet.rb[]
+----
+
+If you want to decorate built-in behavior, you can invoke the `super` method anywhere inside the method to delegate to the behavior provided by the built-in adapter.
+
+=== highlight
+
+Let's say you always want lines to be numbered, regardless of the setting in the document.
+You can do so by overriding the `highlight` method, setting the `:number_lines` key on the `opts` argument, then delegating back to the built-in adapter using `super`.
+
+[,ruby]
+----
+include::example$always-number-lines.rb[]
+----
+
+=== create_formatter (Rouge)
+
+When using Rouge as the syntax highlighter, you can customize the formatter by overriding the `create_formatter` method.
+This allows you to add custom logic for handling certain tokens in the source language.
+
+Let's assume that you want to look for bare URLs in code comments and translate them into links (i.e., autolinks), just like in AsciiDoc.
+You can do that by weaving extra logic into the formatter that looks for tokens in the `Comment` category and applies a substitution to the value.
+
+[,ruby]
+----
+include::example$autolink-urls-in-comments.rb[]
+----
+
+Since the formatter has access to all the tokens in the code identified by the syntax highlighter, this technique opens up a lot of possibilities.
+For example, you could look for the `Type` token in the `Keyword` category in Java code and create a link to the API docs.
+The `lang` argument to the `create_formatter` method lets you know the source language (e.g., `java`) to which the tokens belong.
+
+To study the logic you may be interesting in overriding, browse the code for the https://github.com/asciidoctor/asciidoctor/tree/{page-origin-refname}/lib/asciidoctor/syntax_highlighter[built-in syntax highlighter adapters].

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/highlightjs.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/highlightjs.adoc
@@ -1,0 +1,65 @@
+= Highlight.js
+:url-highlightjs: https://highlightjs.org/
+:url-highlightjs-lang: https://highlightjs.org/download/
+:url-highlightjs-cdn: https://cdnjs.com/libraries/highlight.js
+
+{url-highlightjs}[Highlight.js^] is a popular client-side syntax highlighter that supports a broad range of {url-highlightjs-lang}[languages^].
+
+== Activate highlight.js
+
+To activate highlight.js, add the following attribute entry to the header of your AsciiDoc file:
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+----
+
+By default, Asciidoctor will link to the highlight.js library and stylesheet hosted on {url-highlightjs-cdn}[cdnjs^].
+The version of the highlight.js library Asciidoctor loads from the CDN only includes support for languages in the common language bundle (apache, bash, coffeescript, cpp, cs, css, diff, http, ini, java, javascript, json, makefile, markdown, nginx, objectivec, perl, php, properties, python, ruby, shell, sql, xml, and yaml).
+
+== Change the theme
+
+The theme controls the colors that are used for the tokens (keywords, strings, methods, etc.) in the highlighted code.
+By default, highlight.js is configured to use the github theme.
+You can change the theme used by highlight.js by setting the `highlightjs-theme` attribute.
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+:highlightjs-theme: monokai
+----
+
+The theme is loaded from the CDN, so any theme supported by the version of highlight.js that Asciidoctor uses is supported.
+Refer to https://cdnjs.com/libraries/highlight.js/9.18.3 for a list of themes (filter by *Asset Type: Styling*).
+The value of the `highlightjs-theme` attribute is the basename of the file minus the _.min.css_ file extension.
+
+== Load support for additional languages
+
+To load additional languages supported by highlight.js, list them in the value of the `highlightjs-languages` document attribute.
+Separate each language by a comma followed by an optional space.
+
+The common highlight.js bundle does not include support for Rust and Swift.
+Let's set the `highlightjs-languages` attribute so the HTML converter loads support for them into the HTML page.
+
+[,asciidoc]
+----
+:source-highlighter: highlight.js
+:highlightjs-languages: rust, swift
+----
+
+The `highlightjs-languages` attribute only applies when generating a standalone HTML document (i.e., backend: html, standalone: true).
+It does not work when generating embedded HTML, which is used by site generator integrations such as Antora.
+
+== Use a custom highlight.js library
+
+If you'd rather use a personal copy of highlight.js instead of the one hosted on the CDN, follow these steps:
+
+. Create your custom bundle on the {url-highlightjs-lang}[download page^].
+. Download and unpack the zip into a folder called [.path]_highlight_ adjacent to your AsciiDoc file (or in the output directory, if different)
+. Rename [.path]_highlight/highlight.pack.js_ to [.path]_highlight/highlight.min.js_
+. Rename [.path]_highlight/styles/github.css_ to [.path]_highlight/styles/github.min.css_
+** Replace `github` with the name of the `highlightjs-theme` you are using, if different.
+. Add the attribute entry `:highlightjsdir: highlight` to the header of your AsciiDoc file.
+** Alternatively, you can pass the `-a highlightjsdir=highlight` flag when invoking the Asciidoctor CLI.
+
+The output file will use your personal copy of the highlight.js library and stylesheet instead of the one hosted on cdnjs.

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/index.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/index.adoc
@@ -1,0 +1,142 @@
+= Syntax Highlighting
+
+AsciiDoc defines a style of listing block known as a xref:asciidoc:verbatim:source-blocks.adoc[source block] for adding source code snippets intended to be colorized by a syntax highlighter to a document.
+Here's a simple example of a source block:
+
+[source,asciidoc]
+....
+[source,ruby]
+----
+puts "Hello, World!"
+----
+....
+
+If a language is specified on a listing block, the source style is implied.
+Therefore, it can be excluded in this case.
+
+[source,asciidoc]
+....
+[,ruby]
+----
+puts "Hello, World!"
+----
+....
+
+Here's how we expect it to appear:
+
+[,ruby]
+----
+puts "Hello, World!"
+----
+
+It's up to an AsciiDoc processor such as Asciidoctor to apply the syntax highlighting to this source block, a process referred to as xref:asciidoc:verbatim:source-highlighter.adoc[source highlighting].
+Asciidoctor provides adapters that integrate with several popular syntax highlighter libraries to perform this task.
+It also provides an interface for implementing a custom syntax highlighter adapter.
+
+== Syntax highlighter types
+
+Asciidoctor supports two types of syntax highlighters: client-side and build-time.
+Let's explore each type and how they work.
+
+A [.term]*client-side syntax highlighter* performs syntax highlighting in the browser as the page is loading.
+Asciidoctor does not invoke the syntax highlighter itself.
+Instead, it focuses on adding the assets to the generated HTML so the browser can load the syntax highlighter and run it.
+For this type of syntax highlighter, Asciidoctor passes the contents of the source block through to the output as is.
+It also adds metadata to the element so that the syntax highlighter knows to highlight it and which language it is.
+Unfortunately, Asciidoctor does not process callout numbers in the source block in this case, so they may cause the syntax highlighter to get tripped up.
+
+A [.term]*build-time syntax highlighter* performs syntax highlighting during AsciiDoc conversion.
+Asciidoctor does invoke the syntax highlighter in this case.
+It also takes care of hiding the callout numbers from the syntax highlighter, ensuring they are put back in the proper place afterwards.
+What Asciidoctor emits into the output is the result produced by the syntax highlighter, which are the tokens enclosed in `<span>` elements to apply color and other formatting (either inline or via CSS classes).
+These syntax highlighters tend to support more features because Asciidoctor has greater control over the process.
+
+=== Client-side vs build-time
+
+There are benefits and drawbacks of each type.
+The benefit of a client-side syntax highlighter is that does not require installing any additional libraries.
+It also makes conversion faster and makes it produce smaller output since the syntax highlighting is deferred until page load.
+The main drawback is that callouts in the source block can be mangled by the syntax highlighter or confuse it.
+The benefits of a build-time syntax highlighter are that you have more control over syntax highlighting and can enable additional features such as line numbers and line highlighting.
+The main drawback is that it requires installing an extra library, it slows down conversion, and causes the output to be larger.
+
+You should try each syntax highlighter and find the one that works best for you.
+
+== Built-in syntax highlighter adapters
+
+[%autowidth]
+|===
+|Type |Syntax Highlighter |Required Gem |Compatible Converters
+
+h|Client-side
+
+|Highlight.js
+|_n/a_
+|HTML, Reveal.js
+
+.3+h|Build-time
+
+|CodeRay
+|coderay (>= 1.1)
+|HTML, PDF, EPUB3, Reveal.js
+
+|Pygments
+|pygments.rb (>= 1.2)
+|HTML, PDF, EPUB3, Reveal.js
+
+|Rouge
+|rouge (>= 2)
+|HTML, PDF, EPUB3, Reveal.js
+|===
+
+Asciidoctor does not apply syntax highlighting when generating DocBook.
+The assumption is that this is a task the DocBook toolchain can handle.
+The DocBook converter generates a `<programlisting>` element for the source block and passes through the source language as specified in the AsciiDoc.
+It's then up to the DocBook toolchain to apply syntax highlighting to the contents of that tag.
+
+You can explore these integrations in depth on the xref:highlightjs.adoc[], xref:rouge.adoc[], xref:pygments.adoc[], and xref:coderay.adoc[] pages.
+
+You can also create your own integration by making a xref:custom.adoc[].
+
+== Custom subs on source blocks
+
+You should not mix syntax highlighting with AsciiDoc text formatting (i.e., the `quotes` and `macros` substitutions).
+In many converters, these two operations are mutually exclusive.
+
+.Improper use of custom substitutions on a source block
+[source,asciidoc]
+....
+[,java,subs=+quotes]
+----
+interface OrderRepository extends CrudRepository<Order,Long> {
+
+  *List<Order>* findByCategory(String category);
+
+  Order findById(long id);
+}
+----
+....
+
+The additional markup introduced by AsciiDoc text formatting may confuse the syntax highlighter and lead to unexpected results.
+While it may work in some syntax highlighters in the HTML backend (which perhaps know how to work around the formatting tags), it will most certainly fail when converting to other formats such as PDF.
+
+If you're going to customize the substitutions on a source block using the `subs` attribute, you should limit those substitutions to attribute replacements (`attributes`).
+
+.Valid use of custom substitutions on a source block
+[source,asciidoc]
+....
+[,java,subs=attributes+]
+----
+interface {model}Repository extends CrudRepository<{model},Long> {
+
+  {model} findById(long id);
+}
+----
+....
+
+If you still need to emphasize certain tokens in the block of code, you should do so by creating a custom lexer or formatter for the syntax highlighting library that understands these additional semantics and perhaps even hints.
+In other words, work through the syntax highlighter so it's added during the highlighting process, giving the syntax highlighter full knowledge as to what's going on.
+Another option is to use a xref:custom.adoc[custom syntax highlighter adapter].
+
+Before trying to get the syntax highlighter to recognize new tokens, make sure it doesn't already recognize them.
+If it does, it may just be a matter of customizing the syntax highlighter theme to apply different formatting to those tokens.

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/pygments.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/pygments.adoc
@@ -1,0 +1,167 @@
+= Pygments
+:url-pygments: https://pygments.org
+:url-pygments-lang: https://pygments.org/languages/
+:url-python: https://www.python.org
+:url-pygments-gem: https://rubygems.org/gems/pygments.rb
+
+{url-pygments}[Pygments^] is a popular syntax highlighter that supports a broad range of {url-pygments-lang}[programming and template languages^].
+
+== Install Pygments
+
+In order to use Pygments with Asciidoctor, you need {url-python}[Python] and the {url-pygments-gem}[pygments.rb gem^].
+The pygments.rb gem manages calls to Pygments, which is an external program that runs using Python.
+
+TIP: You do not need to install Pygments itself.
+It comes bundled with the pygments.rb gem.
+
+IMPORTANT: You must have Python installed to use pygments.rb.
+
+The version of Python required depends on which pygments.rb release you're using:
+
+* pygments.rb 1.x requires Python 2.
+Check that you have a `python2` (Linux), `python` (macOS), or `py -2` (Windows) executable on your PATH.
+(On macOS, verify that the `python` executable uses Python 2 by running `python -V`).
+* pygments.rb 2.x requires Python 3.
+Check that you have a `python3` (Linux/macOS) or `py -3` (Windows) executable on your PATH.
+
+.Installing Python and the pygments.rb gem via the CLI (cross platform)
+[,console]
+----
+$ "`\which apt-get || \which dnf || \which yum || \which brew`" install python # <.>
+$ gem install pygments.rb # <.>
+----
+<.> Install Python using your package manager
+<.> Install the pygments.rb gem
+
+== Activate Pygments
+
+Once you've installed these libraries, assign `pygments` to the `source-highlighter` attribute in your document's header.
+
+[,asciidoc]
+----
+:source-highlighter: pygments
+----
+
+== Pygments attributes
+
+You can further customize the source block output with additional Pygments attributes.
+
+pygments-style::
+Sets the name of the color theme Pygments uses.
+To see the list of available style names, see <<listing-pygments-style-names>>.
+Default: `pastie`.
+
+pygments-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` (CSS classes) or `style` (inline styles).
+See the xref:html-backend:source-highlighting-stylesheets.adoc#pygments[Pygments stylesheet section] to learn more about how the value `class` is handled.
+Default: `class`.
+
+pygments-linenums-mode::
+Controls how line numbers are arranged when line numbers are enabled on the source block.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+.Customizing a source block with Pygments attributes
+[source,asciidoc]
+....
+:source-highlighter: pygments
+:pygments-style: manni
+:pygments-linenums-mode: inline
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+////
+.Result: Source block using inline line numbers and the manni theme
+====
+image::custom-pygments.png[Line numbers and a custom Pygments theme for a source block.]
+====
+////
+
+[#listing-pygments-style-names]
+=== Available Pygments style names
+
+To list the available Pygments styles, run the following command in a terminal:
+
+ $ $(dirname $(gem which pygments.rb))/../vendor/pygments-main/pygmentize -L styles
+
+The pygments.rb gem uses a bundled version of Pygments (often ahead of the latest release).
+This command ensures that you are invoking the `pygmentize` command from the Pygments used by that gem.
+
+[#pygments-timeout]
+== Pygments timeout (pygments.rb 1.x only)
+
+If you're using pygments.rb 1.x, you may need to adjust the timeout.
+This configuration step is not necessary if you're using pygments.rb 2.x with Python 3.
+
+Since Pygments is an external program, the call to that command in pygments.rb 1.x is managed by a timeout to safeguard against a hanging process.
+By default, this timeout is 8 seconds.
+If you discover that the call is failing to complete within this timeout period, you can increase the timeout (in seconds) by setting the `MENTOS_TIMEOUT` environment variable.
+
+ export MENTOS_TIMEOUT=30
+
+Now the call to Pygments (via pygments.rb 1.x) will be allocated up to 30 seconds to complete.
+
+== Use a custom Pygments installation
+
+If you already have Pygments installed on your system, you want to use your own fork, or you want to customize how Pygments is configured, you can get Asciidoctor to use a custom version of Pygments instead of the one bundled with the pygments.rb gem.
+
+First, install your own version of Pygments.
+You can do this, for instance, by cloning the upstream Pygments repository:
+
+ $ hg clone https://bitbucket.org/birkenfeld/pygments-main pygments
+
+Find the directory that contains the file [.path]_pygmentize_ or the [.path]_Makefile_.
+That's your Pygments installation path.
+Make note of it.
+
+Next, create a script to run _before_ invoking Asciidoctor for the first time.
+Let's call it [.path]_pygments_init.rb_.
+Populate the script with the following content:
+
+.pygments_init.rb
+[,ruby]
+----
+require 'pygments'
+
+# use a custom Pygments installation (directory that contains pygmentize)
+Pygments.start '/path/to/pygments'
+
+# example of registering a missing or additional lexer
+#Pygments::Lexer.create name: 'Turtle', aliases: ['turtle'],
+#    filenames: ['*.ttl'], mimetypes: ['text/turtle', 'application/x-turtle']
+----
+
+TIP: You could enhance this script to read the Pygments installation path from an environment variable (or configuration file).
+
+Now just require this script before your invoke Asciidoctor the first time.
+When using the `asciidoctor` command, pass the script using the `-r` flag:
+
+ $ asciidoctor -r ./pygments_init.rb document.adoc
+
+When using the Asciidoctor API, require the script using `require` or `require_relative`:
+
+[,ruby]
+----
+require 'asciidoctor'
+require_relative './pygments_init.rb'
+
+Asciidoctor.convert_file 'document.adoc', safe: :safe
+----
+
+Now Asciidoctor is using your custom installation of Pygments instead of the one bundled with the pygments.rb gem.
+
+Alternately, you can xref:custom.adoc#extend[extend the adapter for Pygments] and put this logic inside that adapter.

--- a/ref/asciidoctor/docs/modules/syntax-highlighting/pages/rouge.adoc
+++ b/ref/asciidoctor/docs/modules/syntax-highlighting/pages/rouge.adoc
@@ -1,0 +1,93 @@
+= Rouge
+:url-rouge: http://rouge.jneen.net
+:url-rouge-gem: https://rubygems.org/gems/rouge
+:url-rouge-repo: https://github.com/rouge-ruby/rouge/tree/HEAD/lib/rouge/themes
+
+{url-rouge}[Rouge^] is an extendable code highlighter written in Ruby that supports a vast array of languages.
+
+== Install Rouge
+
+To use Rouge with Asciidoctor, you need the {url-rouge-gem}[rouge gem^].
+You can use one of the following methods to install Rouge.
+
+Install using `gem` (all systems)::
++
+ $ gem install rouge
+
+Install using `apt-get` (Debian-based systems)::
++
+ $ sudo apt-get install ruby-rouge
+
+Install using `dnf` (Fedora-based systems)::
++
+ $ sudo dnf install rubygem-rouge
+
+Install using `pacman` (Arch Linux-based systems)::
++
+ $ sudo pacman -S ruby-rouge
+
+== Assign rouge to source-highlighter
+
+Once you've installed the gem, assign the `rouge` value to the `source-highlighter` attribute in the document header to activate it.
+
+[,asciidoc]
+----
+:source-highlighter: rouge
+----
+
+== Rouge attributes
+
+You can further customize the source block output with additional Rouge attributes.
+
+rouge-css::
+Controls what method is used for applying CSS to the tokens.
+Can be `class` or `style`.
+Default: `class`.
+
+[.line-through]#rouge-linenums-mode# (not currently implemented, see https://github.com/asciidoctor/asciidoctor/issues/3641[#3641])::
+Controls how line numbers are laid out.
+Can be `table` or `inline`.
+If line wrapping is enabled on preformatted blocks (i.e., `prewrap`), and you want to use line numbering on source blocks, you must set the value of this attribute to `inline` in order for the numbers to line up properly with their target lines.
+Default: `table`.
+
+rouge-style::
+Controls the color theme used to for highlighting.
+You can find the list of themes in the {url-rouge-repo}[Rouge code repository^].
+
+Typically, you set these attributes using the CLI or API (e.g., `-a source-highlighter=rouge -a rouge-style=colorful`) so you don't have to define them in each document.
+However, you can define them per document as shown in the following example.
+
+.Activating the Rouge syntax highlighter and applying a different style
+[source,asciidoc]
+....
+:source-highlighter: rouge
+:rouge-style: monokai
+
+[,ruby]
+----
+puts "Hello, Rouge!"
+----
+....
+
+You can enable line numbering using the linenums option on the block.
+
+.Customizing a source block with Rouge line numbers
+[source,asciidoc]
+....
+:source-highlighter: rouge
+
+[%linenums,ruby]
+----
+ORDERED_LIST_KEYWORDS = {
+  'loweralpha' => 'a',
+  'lowerroman' => 'i',
+  'upperalpha' => 'A',
+  'upperroman' => 'I'
+   #'lowergreek' => 'a'
+   #'arabic'     => '1'
+   #'decimal'    => '1'
+}
+----
+....
+
+It's also possible to enable linenums for all source blocks by setting the `source-linenums-option` attribute on the document.

--- a/sdd/src/main.rs
+++ b/sdd/src/main.rs
@@ -11,8 +11,9 @@ use walkdir::{DirEntry, WalkDir};
 
 // Spec sources whose lines we measure coverage against, as `(root, extension,
 // within)` triples: the normative documentation prose (`.adoc`) of the AsciiDoc
-// language description, plus the Asciidoctor reference test suite (`.rb`) that
-// this crate is validated against.
+// language description, the Asciidoctor processor documentation (`.adoc`), and
+// the Asciidoctor reference test suite (`.rb`) that this crate is validated
+// against.
 //
 // `within`, when `Some`, restricts a source to files whose path contains that
 // segment.
@@ -21,8 +22,14 @@ use walkdir::{DirEntry, WalkDir};
 // `ref/asciidoctor/README.md`); every `.rb` file vendored under
 // `ref/asciidoctor/test` is picked up here automatically. Coverage grows as
 // more files are ported – at present `attribute_list_test.rb` is the first.
+//
+// The Asciidoctor processor documentation (`ref/asciidoctor/docs/modules`) is
+// likewise vendored and ported one module at a time; the `syntax-highlighting`
+// module is the first. Because these pages describe rendering behavior that
+// asciidoc-parser does not implement, they are largely non-normative here.
 const SPEC_SOURCES: &[(&str, &str, Option<&str>)] = &[
     ("../ref/asciidoc-lang/docs/modules", ".adoc", None),
+    ("../ref/asciidoctor/docs/modules", ".adoc", None),
     ("../ref/asciidoctor/test", ".rb", None),
 ];
 


### PR DESCRIPTION
## Summary

Ports Asciidoctor's `syntax-highlighting` documentation module into the SDD spec-coverage system, following the same one-module-at-a-time pattern already used for the Asciidoctor test suite.

- **Vendored** the six pages of the module (`pages/` only) verbatim from Asciidoctor **v2.0.26** under `ref/asciidoctor/docs/modules/syntax-highlighting/pages/`. `nav.adoc` and the `examples/` includes are intentionally not mirrored.
- **Registered** `ref/asciidoctor/docs/modules` as a new `.adoc` spec source in `sdd/`.
- **Mirrored** each page line-by-line under a new `parser/src/tests/asciidoctor_docs/` tree (mirroring how `asciidoc_lang/` mirrors the language docs), and updated `ref/asciidoctor/README.md` to document the `docs/` vendoring.

## Normativity

These pages describe how an AsciiDoc *processor* renders source blocks through a syntax highlighter. `asciidoc-parser` performs no rendering, so the material is largely non-normative here — consistent with the existing treatment of `verbatim/source-highlighter.adoc` and `syntax_highlighter_test.rb`.

- **Server-side (build-time) highlighting is a stated non-goal**, so the `rouge`, `coderay`, `pygments`, `custom`, and `index` pages are reproduced entirely as `non_normative!`.
- **Client-side:** the one behavior the parser actually models is verified — the built-in default value of `highlightjs-theme` (`github`), asserted via the empty-value resolution of a bare `:highlightjs-theme:`. (The parser returns `Unset` for a truly unset attribute; the documented default lives in the empty-value default table, so that is what the test exercises.)

## Noted, not addressed here

`pygments.adoc` documents `pygments-style` **Default: `pastie`**, but the crate's built-in default is `default` (`built_in_attrs.rs`). It's a rendering-only attribute and out of scope for this port, so it's left non-normative — flagging it as a real doc-vs-crate discrepancy worth a separate look.

## Verification

- `cargo +nightly fmt --all -- --check`: clean.
- Full parser suite: 4637 passed, 0 failed.
- `sdd` reports `highlightjs.adoc` line 23 covered and every other ported page fully non-normative with zero spurious uncovered lines (confirming byte-exact line matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)