### PR TITLE
fix: Honor an explicitly-set docname attribute in Parser::docname()

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2390,11 +2390,28 @@ impl Parser {
     /// Returns the document name (`docname`): the base name of the primary
     /// file, stripped of its directory and final extension.
     ///
+    /// An explicitly-set `docname` attribute (e.g. via
+    /// [`with_intrinsic_attribute`]) takes precedence and is returned verbatim,
+    /// mirroring Asciidoctor's model where `doc.attributes['docname']` is the
+    /// single source of truth (seeded from the primary file name at load time,
+    /// but overridable through the API). Only when no `docname` attribute is
+    /// set does this fall back to deriving the stem from the primary file
+    /// name.
+    ///
     /// This is the `<docname>` used to build private docinfo file names (e.g.
-    /// `mydoc-docinfo.html` for `mydoc.adoc`). Returns `None` when no primary
-    /// file name has been set, in which case private docinfo files cannot be
-    /// resolved.
+    /// `mydoc-docinfo.html` for `mydoc.adoc`). Returns `None` when neither a
+    /// `docname` attribute nor a primary file name has been set, in which case
+    /// private docinfo files cannot be resolved.
+    ///
+    /// [`with_intrinsic_attribute`]: Self::with_intrinsic_attribute
     pub(crate) fn docname(&self) -> Option<String> {
+        // An explicitly-set `docname` attribute is the source of truth.
+        if let Some(docname) = self.attribute_value("docname").as_maybe_str()
+            && !docname.is_empty()
+        {
+            return Some(docname.to_string());
+        }
+
         let primary = self.primary_file_name.as_deref()?;
 
         // Strip the directory portion (handling both separators, since the
@@ -4694,11 +4711,39 @@ mod tests {
     }
 
     mod docname {
-        use crate::Parser;
+        use crate::{Parser, parser::ModificationContext};
 
         #[test]
         fn none_without_primary_file_name() {
             assert_eq!(Parser::default().docname(), None);
+        }
+
+        #[test]
+        fn explicit_attribute_takes_precedence() {
+            // An explicitly-set `docname` attribute is the source of truth, even
+            // when no primary file name has been supplied.
+            assert_eq!(
+                Parser::default()
+                    .with_intrinsic_attribute("docname", "test", ModificationContext::ApiOnly)
+                    .docname()
+                    .as_deref(),
+                Some("test")
+            );
+        }
+
+        #[test]
+        fn explicit_attribute_overrides_primary_file_name() {
+            // When both are present, the attribute wins and is returned verbatim
+            // (no directory/extension stripping), mirroring Asciidoctor's
+            // `doc.attributes['docname']` being the single source of truth.
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name("mydoc.adoc")
+                    .with_intrinsic_attribute("docname", "other", ModificationContext::ApiOnly)
+                    .docname()
+                    .as_deref(),
+                Some("other")
+            );
         }
 
         #[test]

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -424,6 +424,34 @@ fn reference_to_this_document_by_name_resolves_within_it() {
 }
 
 #[test]
+fn reference_to_this_document_by_explicit_docname_attribute_resolves_within_it() {
+    // Same as above, but the current document is identified by an explicitly-set
+    // `docname` attribute rather than a primary file name. Asciidoctor treats
+    // `doc.attributes['docname']` as the single source of truth for the
+    // self-reference match, so an API-provided `docname` must be honored too.
+    let mut doc = Parser::default()
+        .with_intrinsic_attribute(
+            "docname",
+            "guide",
+            crate::parser::ModificationContext::ApiOnly,
+        )
+        .parse_deferred("See <<guide.adoc#install>>.\n\n[#install]\n== Installation\n");
+
+    assert!(first_simple(&doc).content().has_unresolved_refs());
+
+    let catalog = doc.catalog().clone();
+    let resolver = CatalogResolver::new(&catalog);
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+
+    assert!(warnings.is_empty());
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#install\">Installation</a>."
+    );
+}
+
+#[test]
 fn reference_to_document_title_resolves_to_its_title() {
     // A document title carrying an explicit ID is registered in the catalog
     // under that ID (mirroring Asciidoctor, which registers the document itself


### PR DESCRIPTION
## Summary

`Parser::docname()` computed the document name **solely** from `primary_file_name` (set via `with_primary_file_name`), ignoring a `docname` value supplied through the attribute API (`with_intrinsic_attribute("docname", …)` / `Parser::attribute`). Because the xref self-reference match in `content/macros.rs` reads `docname()`, an inter-document `xref:`/`<<>>` whose path named the current document was **not** collapsed to a same-document reference when `docname` was set as an attribute rather than derived from a file name.

This diverges from Asciidoctor, where `doc.attributes['docname']` is the single source of truth for that match (seeded from the input file name at load time, but overridable through the API).

## Fix

`docname()` now prefers an explicitly-set, non-empty `docname` attribute and returns it verbatim, falling back to the `primary_file_name`-derived stem only when no such attribute is present — mirroring Asciidoctor's "attribute is the source of truth, seeded from the file name" model.

## Tests

- `docname::explicit_attribute_takes_precedence` — attribute honored with no primary file name.
- `docname::explicit_attribute_overrides_primary_file_name` — attribute wins over a file name, returned verbatim.
- `xref::reference_to_this_document_by_explicit_docname_attribute_resolves_within_it` — end-to-end: `<<guide.adoc#install>>` collapses to `href="#install"` when the current doc is identified by an API-set `docname` (mirrors the existing primary-file-name test, matching Asciidoctor's `attributes: { 'docname' => … }` test style).

Full suite (4640 tests) passes; `cargo +nightly fmt --all -- --check` clean.

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)