### PR TITLE
feat: Recognize inline anchors in the single-pass inline builder (inline-ast Phase 4, step 4b(ii), part 4a)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -982,6 +982,39 @@ Each phase is a reviewable unit with a clear exit gate.
   text – remain for a later increment (part 3c), which needs new `Ref` fields pinned against a
   consumer.
 
+  *Step 4b(ii) part 4a landed as (`Macros` → `Anchor`, inline anchors):* the builder now recognizes
+  **inline anchors** in both spellings – the `[[id]]` / `[[id,reftext]]` shorthand and the
+  `anchor:id[reftext]` macro – as an [`Anchor`](../../parser/src/inlines/anchor.rs) node, folding
+  through the same `render_anchor` the string step calls so the output is byte-for-byte identical
+  (pinned by a new differential corpus). It reuses the string pipeline's *exact* recognition –
+  [`INLINE_ANCHOR`](../../parser/src/content/macros.rs) is now shared `pub(crate)` – so only the
+  recognition *sink* changes (a node instead of rendered markup). Taken out of pipeline order (it is
+  listed last under part 4) precisely because it is the cleanest of the remaining families: an
+  anchor's rendering (`<a id="…"></a>`) is a function of its **id alone**, and the pattern admits no
+  special character in an id, so an id is always verbatim and an anchor is **always recognized** –
+  there is no deferred-output boundary the way the link and cross-reference families have one. The id
+  borrows from `'src` and the whole `[[…]]` / `anchor:…[…]` is the node's `location`. An escaped
+  `\[[…` / `\anchor:…` drops its backslash and stays literal, and – because the id is always verbatim
+  while a reference text may not be – the unescape needs no verbatim gate at all.
+
+  The optional reference text becomes the node's `reftext` – a single
+  [`Text`](../../parser/src/inlines/inline_node.rs) child – **when it is verbatim** (borrowing
+  `'src`; a shorthand's trailing whitespace is trimmed and a macro's escaped `\]` is unescaped into an
+  owned value, mirroring the string replacer). A reference text carrying a rendered span or an escaped
+  special is *non-verbatim*; because it never reaches the flow (the anchor renders from its id alone),
+  such an anchor is still recognized and rendered – the whole match, the rendered-span reference text
+  included, is **consumed** by the node – but its `reftext` is left `None` rather than sliced wrongly
+  from `'src`. This is the same verbatim boundary the other macro families document, expressed here as
+  a node field the fold ignores rather than as a deferred construct; the field stays provisional
+  pending a re-flow consumer (design §6.6). As the additive builder does throughout, the anchor pass
+  performs *no* recognition side effect – it does **not** `register_ref` the id in the reference
+  catalog (so a cross-reference can resolve against it), nor raise the duplicate-id warning the string
+  replacer does; those, and the bibliography-anchor form (`[[[id]]]`, which the string step recognizes
+  only inside a bibliography list item – a context the additive builder is not wired into), are the
+  cutover's job (step 6). This step is **additive**: nothing is wired into the parse path. The
+  remaining macro families (`Footnote`, `IndexTerm`, `Stem`) and the node-blocked cross-reference
+  forms (part 3c) are later sub-steps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1002,7 +1035,9 @@ Each phase is a reviewable unit with a clear exit gate.
            - **part 3c.** the node-blocked forms both spellings share – inter-document targets (a
              *derived* destination) and an attribute-list text (an `Attrlist<'src>`) – which need
              new `Ref` fields, pinned against a consumer.
-         - **part 4.** `Footnote`, `IndexTerm`, `Stem`, `Anchor`.
+         - **part 4.** `Anchor`, `Footnote`, `IndexTerm`, `Stem`, each its own sub-step:
+           - ✅ **part 4a.** inline anchors (`[[id]]` / `anchor:id[…]`, `INLINE_ANCHOR`) → `Anchor`.
+           - **part 4b.** `Footnote`, `IndexTerm`, `Stem`.
   5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
      `Callouts` – completing the vocabulary the recorder covers.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -41,25 +41,30 @@
 //!   `icon:target[…]`), the **UI macros** (`kbd:[…]`, `btn:[…]`, `menu:…[…]`),
 //!   the **`link:`/`mailto:` macro** (`link:target[…]`, `mailto:addr[…]`),
 //!   **auto-links and formal-URL links** (`https://example.org`,
-//!   `https://example.org[text]`), and **cross-references** in both the
-//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand,
+//!   `https://example.org[text]`), **cross-references** in both the
+//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand, and
+//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`),
 //!   replacing each with an [`Image`](InlineNode::Image),
-//!   [`Ui`](InlineNode::Ui), or [`Ref`](InlineNode::Ref) node. An image node
+//!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref), or
+//!   [`Anchor`](InlineNode::Anchor) node. An image node
 //!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. Each family reuses the shared pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`], [`INLINE_KBD_BTN_MACRO`],
 //!   [`INLINE_MENU_MACRO`], [`INLINE_LINK_MACRO`], [`INLINE_LINK`],
-//!   [`INLINE_XREF`]), builds `'src`-borrowing nodes for verbatim macros only
-//!   (see [`apply_macros`] for the boundary the escaped-content case defers),
-//!   and – for the UI macros – is recognized only under the `experimental`
-//!   document attribute, exactly as the string step gates them. The
-//!   cross-reference pass claims the same-document form in both spellings
-//!   (`xref:id[text]` and `<<id>>` / `<<id,text>>`); inter-document targets, a
-//!   document-as-a-whole reference, and an attribute-list text are deferred. The
-//!   remaining macro families (footnotes, index terms, anchors, STEM) are later
-//!   increments.
+//!   [`INLINE_XREF`], [`INLINE_ANCHOR`]), builds `'src`-borrowing nodes for
+//!   verbatim macros only (see [`apply_macros`] for the boundary the
+//!   escaped-content case defers), and – for the UI macros – is recognized only
+//!   under the `experimental` document attribute, exactly as the string step
+//!   gates them. The cross-reference pass claims the same-document form in both
+//!   spellings (`xref:id[text]` and `<<id>>` / `<<id,text>>`); inter-document
+//!   targets, a document-as-a-whole reference, and an attribute-list text are
+//!   deferred. An anchor renders from its id alone, so it is *always* recognized
+//!   (never deferred): only a non-verbatim reference text – which does not reach
+//!   the flow – leaves the node's `reftext` unpopulated. The remaining macro
+//!   families (footnotes, index terms, STEM) and the bibliography-anchor form
+//!   are later increments.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -105,7 +110,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK,
+        CharacterReplacement, INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK,
         INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub, URI_SNIFF,
         basename, character_replacements, hard_line_break_pattern, maybe_has_quotes,
         maybe_has_replacements, normalize_index_text, normalize_text_lf_escaped_bracket,
@@ -113,7 +118,8 @@ use crate::{
         xref_target::{XrefTarget, interpret_xref_target},
     },
     inlines::{
-        CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled, Ui, UiKind,
+        Anchor, CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled, Ui,
+        UiKind,
     },
     parser::{
         CharacterReplacementType, IconRenderParams, ImageRenderParams, InlineSubstitutionRenderer,
@@ -1264,11 +1270,18 @@ fn apply_macros<'src>(
     // string step's order.
     let nodes = link_macro_level(nodes, root, parser);
 
-    // Cross-references (`xref:id[…]`) run last, after the link families. The
-    // string step runs the e-mail, then the anchor pass between links and
-    // cross-references; both are later increments, so with them absent this
-    // preserves the string step's relative order for the constructs the builder
-    // recognizes so far.
+    // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
+    // before cross-references, mirroring the string step's order. The e-mail
+    // pass the string step runs between the link macro and the anchor is a later
+    // increment, so with it absent this preserves the relative order for the
+    // constructs the builder recognizes so far. The bibliography-anchor pass the
+    // string step runs *first* (a `^`-anchored `[[[id]]]`) fires only inside a
+    // bibliography list item – a context the additive builder is not wired into –
+    // so it is a cutover concern, not this pass's.
+    let nodes = anchor_macros_level(nodes, root);
+
+    // Cross-references (`xref:id[…]`) run last, after the anchor pass, mirroring
+    // the string step's order.
     xref_macros_level(nodes, root)
 }
 
@@ -2302,6 +2315,200 @@ fn build_link_node<'src>(
     }))
 }
 
+// ─── Inline anchors ([[id]] / anchor:id[…]) ───────────────────────────────
+
+/// Matches `INLINE_ANCHOR` at this level's escaped text, replacing each
+/// recognized inline anchor – the `[[id]]` / `[[id,reftext]]` shorthand and the
+/// `anchor:id[reftext]` macro – with the [`Anchor`](InlineNode::Anchor) node it
+/// produces and leaving everything else in place.
+fn anchor_macros_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
+    // `anchor:` macro prefix. The `[` characters are not special, so a shorthand
+    // reaches the macros step with its `[[` intact.
+    if !s.contains("[[") && !s.contains("anchor:") {
+        return nodes;
+    }
+
+    let matches = find_anchor_matches(&s, &pieces, root);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every recognized inline anchor at this level – both spellings – as a
+/// [`MacroMatch`].
+///
+/// An anchor's HTML rendering (`<a id="…"></a>`) is a function of its **id
+/// alone**, and an id admits no special character (the pattern's id class is
+/// letters/digits/`_`/`-`/`:`/`.`), so an id is always verbatim and an anchor
+/// is *always* recognized – unlike the link/xref families, an anchor is never
+/// deferred on a non-verbatim boundary. A non-verbatim *reference text* (one
+/// carrying a rendered span or an escaped special) does not reach the flow, so
+/// it only leaves the node's `reftext` unpopulated (see [`build_anchor_node`]).
+fn find_anchor_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_ANCHOR.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        // An escape (`\[[…` / `\anchor:…`) is honored by dropping the backslash
+        // and keeping the rest literal, mirroring the string replacer's leading
+        // `caps.get(1)` check. [`rebuild_macro_level`] emits the kept range with
+        // [`emit_range`], which clones an atomic piece (a rendered-span reference
+        // text) whole, so the unescape works even across a non-verbatim reference
+        // text – just as the id itself is always verbatim, the whole anchor
+        // unescapes regardless.
+        if caps.get(1).is_some() {
+            matches.push(MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            });
+
+            continue;
+        }
+
+        let node = build_anchor_node(&caps, &full, pieces, root);
+
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Anchor`](InlineNode::Anchor) node from an inline-anchor match,
+/// slicing the id straight from `'src` (an id is always verbatim) so the fold
+/// reproduces the string replacer's `<a id="…"></a>` exactly.
+///
+/// Two spellings share this builder: the `[[id,reftext]]` shorthand (groups
+/// 2/3) and the `anchor:id[reftext]` macro (groups 4/5). Exactly one id group
+/// matches.
+///
+/// The optional reference text is captured as the node's `reftext` – a single
+/// [`Text`](InlineNode::Text) child – **when it is verbatim** (the common case,
+/// borrowing `'src`; a shorthand's trailing whitespace is trimmed and a macro's
+/// escaped `\]` is unescaped into an owned value, mirroring the string
+/// replacer). A reference text that carries a rendered span or an escaped
+/// special is non-verbatim; because it never reaches the flow (the anchor
+/// renders from its id alone), the anchor is still recognized but its `reftext`
+/// is left `None` rather than sliced wrongly from `'src` – the same verbatim
+/// boundary the other macro families document, and a shape a re-flow consumer
+/// can refine later (the field is provisional, per the node's Phase-0 note).
+///
+/// As in the additive builder generally, this performs *no* recognition side
+/// effect – notably it does **not** `register_ref` the id in the catalog (so a
+/// cross-reference can resolve against it), nor emit the duplicate-id warning
+/// the string replacer raises; the cutover (design §5.2 Phase 4, step 6) wires
+/// those in.
+fn build_anchor_node<'src>(
+    caps: &regex::Captures<'_>,
+    full: &std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> InlineNode<'src> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    // Exactly one id group matches: group 2 for the `[[…]]` shorthand (with its
+    // reference text in group 3), else group 4 for the `anchor:…[…]` macro (with
+    // its reference text in group 5).
+    #[allow(clippy::unwrap_used)]
+    let (id_match, reftext_match, is_shorthand) = if let Some(id) = caps.get(2) {
+        (id, caps.get(3), true)
+    } else {
+        // Group 4 always matches when group 2 does not; the alternation admits
+        // no third form.
+        (caps.get(4).unwrap(), caps.get(5), false)
+    };
+
+    // An id admits no special character, so it is verbatim and borrows `'src`.
+    let id_span = source_slice(pieces, id_match.start()..id_match.end(), root);
+    let id = CowStr::from(id_span.data());
+
+    let reftext = reftext_match
+        .and_then(|m| build_anchor_reftext(m.start()..m.end(), pieces, root, is_shorthand));
+
+    InlineNode::Anchor(Anchor {
+        id,
+        reftext,
+        location,
+    })
+}
+
+/// Builds an inline anchor's `reftext` – a single [`Text`](InlineNode::Text)
+/// child – from the reference-text capture's match-string `range`, or `None`
+/// when the reference text is non-verbatim or trims to empty (see
+/// [`build_anchor_node`] for why a non-verbatim reference text is not an
+/// error).
+///
+/// A `shorthand` reference text has its trailing whitespace stripped (the
+/// string replacer's `trim_end`; leading whitespace was already excluded by the
+/// pattern's `, \s*`). A macro reference text unescapes an escaped `\]` into an
+/// owned value, mirroring the replacer's `replace("\\]", "]")`; without one it
+/// borrows `'src`.
+fn build_anchor_reftext<'src>(
+    range: std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    shorthand: bool,
+) -> Option<Vec<InlineNode<'src>>> {
+    if !range_is_verbatim(pieces, &range) {
+        return None;
+    }
+
+    let span = source_slice(pieces, range, root);
+    let raw = span.data();
+
+    let child = if shorthand {
+        let trimmed_len = raw.trim_end().len();
+
+        if trimmed_len == 0 {
+            return None;
+        }
+
+        let text_location = span.slice(0..trimmed_len);
+
+        InlineNode::Text {
+            value: CowStr::from(text_location.data()),
+            location: text_location,
+        }
+    } else if raw.contains("\\]") {
+        // An escaped bracket makes the logical text a synthesized (owned) value
+        // whose `location` still covers the raw source it derives from.
+        InlineNode::Text {
+            value: CowStr::from(raw.replace("\\]", "]")),
+            location: span,
+        }
+    } else {
+        InlineNode::Text {
+            value: CowStr::from(raw),
+            location: span,
+        }
+    };
+
+    Some(vec![child])
+}
+
+// ─── Cross-references (xref: / <<id>>) ─────────────────────────────────────
+
 /// Matches `INLINE_XREF` at this level's escaped text, replacing each
 /// recognized `xref:` macro with the [`Ref`](InlineNode::Ref)`{Xref}` node it
 /// produces and leaving everything else in place.
@@ -2824,6 +3031,10 @@ fn fold_into_html(
                 fold_xref(reference, renderer, parser, out);
             }
 
+            InlineNode::Anchor(anchor) => {
+                fold_anchor(anchor, renderer, parser, out);
+            }
+
             InlineNode::Styled(styled) => {
                 // Fold the children to the body, then wrap it exactly as the
                 // string pipeline's quotes step did: the same `QuoteType`,
@@ -2849,9 +3060,9 @@ fn fold_into_html(
             other => {
                 // The steps wired up so far produce only `Text`,
                 // `CharRef::Special`, `Styled`, `Image`, `Ui`, `Ref` (link and
-                // cross-reference), and `LineBreak` nodes, and this fold
-                // additionally emits the design-legal `Raw` leaf; no other node
-                // kind reaches the fold in this increment. A later increment
+                // cross-reference), `Anchor`, and `LineBreak` nodes, and this
+                // fold additionally emits the design-legal `Raw` leaf; no other
+                // node kind reaches the fold in this increment. A later increment
                 // fills in the arms above as the transducer grows new kinds.
                 // Guard against a premature caller in debug builds and emit
                 // nothing in release, mirroring the safe defensive fallback in
@@ -3072,6 +3283,26 @@ fn fold_xref(
     renderer.render_xref(&params, out);
 }
 
+/// Folds an [`Anchor`](InlineNode::Anchor) through the same `render_anchor` the
+/// string step calls. The built-in HTML backend emits only `<a id="…"></a>`, so
+/// the reference text does not reach the flow; it is still folded and passed
+/// through so a custom backend that consults it (e.g. one using it as an
+/// `xreflabel`) sees the same value the string path passed.
+fn fold_anchor(
+    anchor: &Anchor<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+    out: &mut String,
+) {
+    let reftext = anchor.reftext.as_ref().map(|children| {
+        let mut s = String::new();
+        fold_into_html(children, renderer, parser, &mut s);
+        s
+    });
+
+    renderer.render_anchor(&anchor.id, reftext, out);
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -3086,7 +3317,8 @@ mod tests {
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled, Ui, UiKind,
+            Anchor, CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled,
+            Ui, UiKind,
         },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -5813,6 +6045,237 @@ mod tests {
 
         // The string pipeline, by contrast, *does* build a reference here.
         assert!(golden_xref(source).contains("<a href"));
+    }
+
+    // ─── Macros (inline anchors) ──────────────────────────────────────────
+
+    /// Asserts that `node` is an [`Anchor`](InlineNode::Anchor), returning it.
+    fn assert_anchor<'a, 'src>(node: &'a InlineNode<'src>) -> &'a Anchor<'src> {
+        match node {
+            InlineNode::Anchor(anchor) => anchor,
+
+            other => panic!("expected an Anchor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_anchors() {
+        // For each fixture, folding the single-pass tree (all five steps)
+        // reproduces the string pipeline's output byte-for-byte. This is the
+        // differential corpus (design §5.3) that pins the inline-anchor
+        // increment. An anchor renders from its id alone, so every fixture is
+        // recognized (there is no deferred-output boundary for anchors); the
+        // reference-text cases additionally exercise the node's `reftext`
+        // population, which does not affect the flow.
+        let fixtures = [
+            // No anchor despite bracket/colon characters.
+            "plain text without an anchor",
+            "a lone [ bracket and a colon : apart",
+            "an anchor without brackets anchor:foo stays literal",
+            // Shorthand: bare id, and with a reference text.
+            "[[install]]",
+            "[[install,Installation]]",
+            "[[sect-one,Section One]]",
+            // Macro form: empty brackets, and with a reference text.
+            "anchor:install[]",
+            "anchor:install[Installation]",
+            // Id character classes: `_`, `:`, `-`, `.`, digits.
+            "[[_foo]]",
+            "[[:bar]]",
+            "[[a-b.c:d]]",
+            "[[sect_1]]",
+            "anchor:a.b-c:d[]",
+            // A reference text with trailing whitespace (trimmed by the string
+            // replacer) and an escaped `]` (unescaped by the macro form).
+            "[[install, Installation ]]",
+            "anchor:foo[a\\]b]",
+            // Embedded in surrounding flow, and next to other constructs.
+            "See [[here]] for details.",
+            "text anchor:x[X] more",
+            "*bold* then [[x]] and _em_",
+            "a copyright (C) then [[x]]",
+            "[[a]] and [[b]] and anchor:c[C]",
+            // Escapes: the anchor stays literal, minus the backslash.
+            "\\[[install]]",
+            "\\[[install,Installation]]",
+            "\\anchor:install[]",
+            "\\anchor:foo[Ref]",
+            // Recognized inside a rendered span.
+            "*see [[x]]*",
+            "_anchor:y[] in em_",
+            // A reference text that is a rendered span or a special: the anchor is
+            // still recognized (its id alone renders), and the reference text –
+            // which never reaches the flow – is consumed with the match.
+            "[[id,*bold*]]",
+            "anchor:id[*bold*]",
+            "[[id,A & B]]",
+            // A triple-bracket `[[[id]]]` outside a bibliography list item is not
+            // a bibliography anchor (that pass fires only inside such an item); the
+            // inner `[[id]]` is a plain anchor with literal outer brackets, exactly
+            // as the string pipeline routes it here.
+            "[[[id]]]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_anchor_shorthand_becomes_a_node() {
+        let nodes = build_src(Span::new("[[install,Installation]]"));
+
+        assert_eq!(nodes.len(), 1);
+        let anchor = assert_anchor(&nodes[0]);
+
+        // The id borrows from source (no allocation).
+        assert!(matches!(anchor.id, CowStr::Borrowed(_)));
+        assert_eq!(anchor.id.as_ref(), "install");
+
+        // Its location covers the whole anchor, the `[[` / `]]` included.
+        assert_eq!(anchor.location.data(), "[[install,Installation]]");
+        assert_eq!(anchor.location.line(), 1);
+        assert_eq!(anchor.location.col(), 1);
+
+        // The reference text is a single borrowed `Text` child located at its
+        // source (`[[install,` is 10 characters, so it starts at column 11).
+        let reftext = anchor.reftext.as_ref().unwrap();
+        assert_eq!(reftext.len(), 1);
+        assert_text(&reftext[0], "Installation", 1, 11);
+    }
+
+    #[test]
+    fn an_anchor_macro_becomes_a_node() {
+        let nodes = build_src(Span::new("anchor:install[Installation]"));
+
+        let anchor = assert_anchor(&nodes[0]);
+        assert!(matches!(anchor.id, CowStr::Borrowed(_)));
+        assert_eq!(anchor.id.as_ref(), "install");
+        assert_eq!(anchor.location.data(), "anchor:install[Installation]");
+
+        // `anchor:install[` is 15 characters, so the text starts at column 16.
+        let reftext = anchor.reftext.as_ref().unwrap();
+        assert_text(&reftext[0], "Installation", 1, 16);
+    }
+
+    #[test]
+    fn a_bare_anchor_has_no_reftext() {
+        // A shorthand without a `, reference text` and an empty-bracket macro
+        // both leave `reftext` `None`.
+        for source in ["[[install]]", "anchor:install[]"] {
+            let nodes = build_src(Span::new(source));
+            let anchor = assert_anchor(&nodes[0]);
+            assert_eq!(anchor.id.as_ref(), "install");
+            assert!(anchor.reftext.is_none(), "no reftext for {source:?}");
+        }
+    }
+
+    #[test]
+    fn an_anchor_shorthand_reftext_is_trimmed() {
+        // A shorthand's trailing whitespace is stripped (the string replacer's
+        // `trim_end`); leading whitespace was already excluded by the pattern's
+        // `, \s*`.
+        let nodes = build_src(Span::new("[[install, Installation ]]"));
+
+        let anchor = assert_anchor(&nodes[0]);
+        let reftext = anchor.reftext.as_ref().unwrap();
+
+        // `[[install, ` is 11 characters, so the trimmed text starts at column 12.
+        assert_text(&reftext[0], "Installation", 1, 12);
+    }
+
+    #[test]
+    fn an_anchor_macro_reftext_unescapes_a_bracket() {
+        // A macro reference text unescapes `\]` into `]`, making the logical text
+        // a synthesized (owned) value whose `location` still covers the raw
+        // source it derives from.
+        let nodes = build_src(Span::new("anchor:foo[a\\]b]"));
+
+        let anchor = assert_anchor(&nodes[0]);
+        let reftext = anchor.reftext.as_ref().unwrap();
+        assert_eq!(reftext.len(), 1);
+
+        match &reftext[0] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "a]b");
+                assert!(
+                    matches!(value, CowStr::Boxed(_)),
+                    "an unescaped value is synthesized (owned), got {value:?}"
+                );
+                assert_eq!(location.data(), "a\\]b");
+            }
+
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_anchor_is_recognized_inside_a_span() {
+        // An anchor can appear inside a rendered span; the transducer descends
+        // into the span body and builds the node there.
+        let nodes = build_src(Span::new("*see [[x]]*"));
+
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+        assert_eq!(children.len(), 2);
+        assert_text(&children[0], "see ", 1, 2);
+
+        let anchor = assert_anchor(&children[1]);
+        assert_eq!(anchor.id.as_ref(), "x");
+    }
+
+    #[test]
+    fn an_escaped_anchor_stays_literal() {
+        // `\[[…]]` and `\anchor:…[…]` drop the backslash and keep the anchor as
+        // literal text – no anchor node – exactly as the string replacer's escape
+        // branch does.
+        for source in ["\\[[install]]", "\\anchor:install[Installation]"] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Anchor(_))),
+                "an escaped anchor must not produce an anchor node: {nodes:?}"
+            );
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_anchor_reference_text_over_a_span_is_consumed() {
+        // A reference text that is a rendered span (`[[id,*bold*]]`) does not
+        // reach the flow: the anchor is still recognized (its id alone renders),
+        // the span is consumed with the match, and the node's `reftext` is left
+        // `None` (a non-verbatim reference text the builder does not slice from
+        // `'src`). The fold still matches the string pipeline byte-for-byte.
+        let source = "[[id,*bold*]]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let anchor = assert_anchor(&nodes[0]);
+        assert_eq!(anchor.id.as_ref(), "id");
+        assert!(
+            anchor.reftext.is_none(),
+            "a non-verbatim reference text is left unpopulated"
+        );
+        assert_eq!(anchor.location.data(), "[[id,*bold*]]");
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(folded, golden_macros(source));
+
+        // The consumed span does not render into the flow.
+        assert!(!folded.contains("<strong>"), "folded: {folded}");
     }
 
     // ─── Fold robustness on hand-built nodes ──────────────────────────────

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -6089,6 +6089,9 @@ mod tests {
             // replacer) and an escaped `]` (unescaped by the macro form).
             "[[install, Installation ]]",
             "anchor:foo[a\\]b]",
+            // A shorthand whose reference text is whitespace only trims to empty:
+            // the node carries no reference text, exactly as the bare form.
+            "[[install, ]]",
             // Embedded in surrounding flow, and next to other constructs.
             "See [[here]] for details.",
             "text anchor:x[X] more",
@@ -6190,6 +6193,28 @@ mod tests {
 
         // `[[install, ` is 11 characters, so the trimmed text starts at column 12.
         assert_text(&reftext[0], "Installation", 1, 12);
+    }
+
+    #[test]
+    fn an_anchor_shorthand_reftext_that_is_whitespace_only_has_no_reftext() {
+        // A shorthand reference text that trims to empty (the pattern's `(.+?)`
+        // matched only the whitespace the string replacer's `trim_end` strips)
+        // leaves `reftext` `None`, the same shape as the bare `[[id]]` form – and
+        // it still folds to the same `<a id="…"></a>` the string pipeline emits.
+        let source = "[[install, ]]";
+        let nodes = build_src(Span::new(source));
+
+        let anchor = assert_anchor(&nodes[0]);
+        assert_eq!(anchor.id.as_ref(), "install");
+        assert!(
+            anchor.reftext.is_none(),
+            "a whitespace-only reftext trims away"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -3285,9 +3285,18 @@ fn fold_xref(
 
 /// Folds an [`Anchor`](InlineNode::Anchor) through the same `render_anchor` the
 /// string step calls. The built-in HTML backend emits only `<a id="…"></a>`, so
-/// the reference text does not reach the flow; it is still folded and passed
-/// through so a custom backend that consults it (e.g. one using it as an
-/// `xreflabel`) sees the same value the string path passed.
+/// the reference text never reaches the flow; a custom backend that consults it
+/// (e.g. one using it as an `xreflabel`) receives the folded reference text
+/// **when the node captured it**.
+///
+/// That capture is verbatim-only: a *non-verbatim* reference text (a rendered
+/// span or an escaped special) is `None` on the node (see
+/// [`build_anchor_reftext`]), so `render_anchor` receives `None` here where the
+/// string replacer would have passed the substituted text. This changes no HTML
+/// output – the built-in backend ignores the reference text entirely – and is
+/// the same verbatim boundary the node documents; a custom backend that needs
+/// the full reference text unconditionally will get it once a re-flow consumer
+/// pins richer `reftext` population.
 fn fold_anchor(
     anchor: &Anchor<'_>,
     renderer: &dyn InlineSubstitutionRenderer,

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1600,7 +1600,15 @@ impl Replacer for InlineBiblioAnchorReplacer<'_, '_> {
 /// * `[[idname,Reference Text]]`
 /// * `anchor:idname[]`
 /// * `anchor:idname[Reference Text]`
-static INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
+///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) recognizes inline anchors
+/// with the *exact* same pattern this string step matches with, changing only
+/// the recognition *sink* (an [`Anchor`](crate::inlines::Anchor) node instead
+/// of rendered markup). Group 1 is the optional escape backslash, groups 2/3
+/// the shorthand id and its optional reference text, and groups 4/5 the
+/// `anchor:id[…]` macro id and its optional reference text.
+pub(crate) static INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?x)

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -17,9 +17,10 @@ pub(crate) mod inline_tree;
 
 mod macros;
 pub(crate) use macros::{
-    INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
-    INLINE_XREF, NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
-    normalize_index_text, normalize_text_lf_escaped_bracket, split_kbd_keys,
+    INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO,
+    INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, URI_SNIFF,
+    apply_macros_with_leading_anchor_registered, basename, normalize_index_text,
+    normalize_text_lf_escaped_bracket, split_kbd_keys,
 };
 
 mod xref_target;


### PR DESCRIPTION
Lands the first slice of **step 4b(ii) part 4** of the [inline-AST plan](docs/design/inline-ast-architecture.md): the single-pass builder now recognizes **inline anchors** in both spellings — the `[[id]]` / `[[id,reftext]]` shorthand and the `anchor:id[reftext]` macro — as an `Anchor` node, folding through the same `render_anchor` the string step calls so the output is **byte-for-byte identical**.

Recognition reuses the string pipeline's *exact* pattern (`INLINE_ANCHOR`, now shared `pub(crate)`); only the *sink* changes (a node instead of rendered markup). This step is **additive** — nothing is wired into the parse path yet.

### Why anchors first (ahead of their listed position in part 4)

Anchors are the cleanest of the remaining macro families. An anchor's rendering (`<a id="…"></a>`) is a function of its **id alone**, and the pattern admits no special character in an id, so an id is *always* verbatim and an anchor is **always recognized** — there is no deferred-output boundary the way the link and cross-reference families have one. (STEM, listed under part 4, is actually handled at passthrough time — step 5 — not in the macros step.)

### Reference text

The optional reference text becomes the node's `reftext` — a single `Text` child — **when it is verbatim** (borrowing `'src`; a shorthand's trailing whitespace is trimmed and a macro's escaped `\]` is unescaped into an owned value, mirroring the string replacer). A reference text carrying a rendered span or an escaped special is *non-verbatim*; because it never reaches the flow, such an anchor is still recognized and rendered — the whole match is **consumed** by the node — but its `reftext` is left `None`. The field stays provisional pending a re-flow consumer (design §6.6).

### Deferred to the cutover (step 6)

As throughout the additive builder, this pass performs **no** recognition side effect: no `register_ref` into the reference catalog, no duplicate-id warning. The **bibliography-anchor** form (`[[[id]]]`) — which the string step recognizes only inside a bibliography list item, a context the additive builder is not wired into — is also a cutover concern.

### Tests

- **Differential corpus** (`fold_matches_the_string_pipeline_through_anchors`): both spellings, id character classes, trimmed/escaped reference texts, embedded/adjacent constructs, escapes, anchors inside spans, reference texts that are rendered spans or specials (consumed), and `[[[id]]]` — each folded and asserted equal to the string pipeline byte-for-byte.
- **Structural assertions** the Strategy-A recorder tree cannot make: borrowed id, precise `location`/`reftext` spans, trimmed shorthand text, owned unescaped macro text, recognition inside a span, escape-stays-literal, and the non-verbatim-reference-text-is-consumed case.

`cargo test -p asciidoc-parser` green; `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` clean.

Remaining sub-steps: part 4b (`Footnote`, `IndexTerm`, `Stem`) and the node-blocked cross-reference forms (part 3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)