### PR TITLE
fix: Trim whitespace around block anchor reftext after the comma

### DIFF
--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -27,8 +27,9 @@ pub(crate) struct BlockMetadata<'src> {
     /// closing square brace pair, nor reftext if it exists.
     pub(crate) anchor: Option<Span<'src>>,
 
-    /// The block anchor's reftext, if any. The span includes only the portion
-    /// from the first comma to just inside the closing square brace pair.
+    /// The block anchor's reftext, if any. The span covers the portion from
+    /// just after the first comma to just inside the closing square brace
+    /// pair, with any leading or trailing whitespace trimmed.
     pub(crate) anchor_reftext: Option<Span<'src>>,
 
     /// The block's attribute list, if any.
@@ -104,9 +105,12 @@ impl<'src> BlockMetadata<'src> {
                             end: comma_position,
                         });
 
-                        let reftext_span = anchor_content.slice_from(RangeFrom {
-                            start: comma_position + 1,
-                        });
+                        let reftext_span = anchor_content
+                            .slice_from(RangeFrom {
+                                start: comma_position + 1,
+                            })
+                            .discard_whitespace()
+                            .trim_trailing_whitespace();
 
                         // Validate anchor name.
                         if anchor_span.is_xml_name() {

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -8301,12 +8301,6 @@ mod references {
         );
     }
 
-    // NOTE: divergence from Asciidoctor. This crate does not trim the leading
-    // space after the id when a block reference's reftext contains a comma, so
-    // the reftext is " Debian, Ubuntu" rather than "Debian, Ubuntu". Kept
-    // `#[ignore]`d with the Ruby-intended reftext.
-    // TODO: trim the leading space of a comma-containing block reftext.
-    #[ignore]
     #[test]
     fn should_allow_comma_in_block_reference_text() {
         verifies!(
@@ -8338,6 +8332,10 @@ mod references {
             .get_ref("debian")
             .expect("ref should be registered");
         assert_eq!(entry.reftext.as_deref(), Some("Debian, Ubuntu"));
+        assert_eq!(
+            doc.catalog().resolve_id("Debian, Ubuntu").as_deref(),
+            Some("debian")
+        );
     }
 
     // NOTE: divergence from Asciidoctor. This test exercises resolving an


### PR DESCRIPTION
## Summary

Fixes #1111.

When a block anchor supplies reference text after the id (`[[id, reftext]]`), the parser was keeping the whitespace that follows the separating comma, registering a reftext with a leading space (e.g. `" Debian, Ubuntu"` instead of `"Debian, Ubuntu"`). This caused the registered reftext — and its reverse lookup via `resolve_id` — to diverge from Asciidoctor.

Asciidoctor splits the anchor on the first comma into id and reference text, then strips surrounding whitespace from the reference text (the comma *inside* the reftext, e.g. between `Debian` and `Ubuntu`, is preserved).

## Changes

* `parser/src/blocks/metadata.rs`: trim leading and trailing whitespace from the reftext span after splitting a block anchor on its first comma.
* `parser/src/tests/asciidoctor_rb/blocks_test.rs`: un-ignore `should_allow_comma_in_block_reference_text` (previously marked `non_normative!`/`#[ignore]`d pending this fix) and add a `resolve_id` assertion matching the issue's reproduction.

## Test plan

- [x] `cargo test -p asciidoc-parser` — all 4641 tests pass (0 failed, 68 pre-existing ignores)
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo fmt -p asciidoc-parser -- --check` — clean
- [x] Verified the issue's reproduction case now passes:
  ```rust
  let doc = Parser::default().parse("[[debian, Debian, Ubuntu]]\n----\nx\n----\n");
  assert_eq!(doc.catalog().get_ref("debian").unwrap().reftext.as_deref(), Some("Debian, Ubuntu"));
  assert_eq!(doc.catalog().resolve_id("Debian, Ubuntu"), Some("debian".to_string()));
  ```

---
_Generated by [Claude Code](https://claude.ai/code/session_01RonPtuz4aQbPRiFKSkMurA)_