### PR TITLE
feat: Recognize index terms in the single-pass inline builder (inline-ast Phase 4, step 4b(ii), part 4b)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1015,6 +1015,38 @@ Each phase is a reviewable unit with a clear exit gate.
   remaining macro families (`Footnote`, `IndexTerm`, `Stem`) and the node-blocked cross-reference
   forms (part 3c) are later sub-steps.
 
+  *Step 4b(ii) part 4b landed as (`Macros` → `IndexTerm`, index terms):* the builder now recognizes
+  **index terms** in both spellings – the `((term))` / `(((primary, secondary, tertiary)))` shorthand
+  and the `indexterm:[…]` (concealed) / `indexterm2:[…]` (flow) macro – as an
+  [`IndexTerm`](../../parser/src/inlines/index_term.rs) node, folding through the same
+  `render_index_term` the string step calls so the output is byte-for-byte identical (pinned by a new
+  differential corpus). It reuses the string pipeline's *exact* recognition –
+  [`INLINE_INDEXTERM`](../../parser/src/content/macros.rs) is now shared `pub(crate)`, alongside the
+  `strip_see_and_seealso` helper – so only the recognition *sink* changes. Like the anchor increment,
+  a **concealed** term renders to nothing (a function of no shown text), so it is recognized regardless
+  of what its argument crosses and its node carries an empty `terms`; a **visible** term shows its
+  text in the flow and is recognized whenever that text – reconstructed from the level's escaped match
+  string, so a `CharRef` entity or a stripped `see`/`see-also` clause (`&gt;&gt;` / `&amp;&gt;` by
+  macro time) is handled as parity, not a divergence – crosses no opaque span. The node mirrors the
+  Strategy-A recorder's shape (the shown term for a visible node, empty for a concealed one), leaving
+  the richer primary/secondary/tertiary structure to a re-flow consumer to pin (the field is
+  provisional, per the node's Phase-0 note). The shorthand reproduces the string replacer's
+  trailing-`)` absorption (its `(?!\))` look-ahead re-creation) by folding the absorbed parens into
+  the match, and keeps a literal parenthesis adjacent to a term via the shared `MacroMatch` sub-range
+  seam. One subtle string-pipeline behavior is reproduced exactly: a level of *only* concealed
+  shorthand terms (`(((coffee)))`, `(((a)))(((b)))`) accumulates no output and ends in a look-ahead
+  retry, so [`replace_with_lookahead`](../../parser/src/internal/regex.rs) returns `Cow::Borrowed` and
+  the string step leaves it **literal** – the builder detects that no-op and mirrors it. Two forms are
+  deferred, each documented and pinned by a divergence test: a **visible term crossing a rendered
+  span** (unreconstructable from the escaped string, the same verbatim boundary the other macro
+  families document) and an **`indexterm2:[…]` carrying an attribute list** (an `=`, deferred until
+  the node can hold an `Attrlist<'src>`, as the link/xref macros defer the same); the one escaped
+  paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`) is likewise left literal.
+  As throughout the additive builder, this performs *no* recognition side effect (the HTML backend
+  builds no index, so the string replacer has none to skip either). This step is **additive**: nothing
+  is wired into the parse path. The last macro family (`Footnote`) is a later sub-step; inline `Stem`
+  is handled at passthrough time (step 5), not in the macros step.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1035,9 +1067,12 @@ Each phase is a reviewable unit with a clear exit gate.
            - **part 3c.** the node-blocked forms both spellings share – inter-document targets (a
              *derived* destination) and an attribute-list text (an `Attrlist<'src>`) – which need
              new `Ref` fields, pinned against a consumer.
-         - **part 4.** `Anchor`, `Footnote`, `IndexTerm`, `Stem`, each its own sub-step:
+         - **part 4.** `Anchor`, `IndexTerm`, `Footnote`, each its own sub-step (inline `Stem` is
+           *not* a macros-step family – it is extracted at passthrough time, so it lands in step 5):
            - ✅ **part 4a.** inline anchors (`[[id]]` / `anchor:id[…]`, `INLINE_ANCHOR`) → `Anchor`.
-           - **part 4b.** `Footnote`, `IndexTerm`, `Stem`.
+           - ✅ **part 4b.** index terms (`((term))` / `(((primary, secondary)))` / `indexterm:[…]` /
+             `indexterm2:[…]`, `INLINE_INDEXTERM`) → `IndexTerm`.
+           - **part 4c.** `Footnote`.
   5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
      `Callouts` – completing the vocabulary the recorder covers.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -7074,6 +7074,25 @@ mod tests {
     }
 
     #[test]
+    fn a_visible_macro_term_over_a_span_is_a_documented_divergence() {
+        // The same span boundary for the *macro* spelling: an `indexterm2:[…]`
+        // whose shown text crosses a rendered span is left unrecognized (the
+        // `indexterm2:[` stays literal), where the string pipeline folds the span
+        // markup into the shown term and consumes the macro.
+        let source = "indexterm2:[*bold* term]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "a visible macro term crossing a span must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert!(folded.contains("indexterm2:["));
+        assert_eq!(golden_macros(source), "<strong>bold</strong> term");
+    }
+
+    #[test]
     fn an_indexterm2_attribute_list_is_a_documented_divergence() {
         // An `indexterm2:[…]` argument carrying an `=` splits into an attribute
         // list whose first positional attribute is the shown term. The builder

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -2360,6 +2360,13 @@ fn indexterm_macros_level<'src>(
     // but concealed shorthand terms (`(((coffee)))`, `(((a)))(((b)))`) is left
     // *literal*, where the same terms with any surrounding output render to
     // nothing. Detect that no-op and mirror it: leave the level untouched.
+    //
+    // This mirrors a **known string-pipeline bug**
+    // (asciidoc-rs/asciidoc-parser#1123): a whole-content concealed term should
+    // render empty, not literal. The additive builder reproduces it here to
+    // keep byte-for-byte parity (design §5.3); the fix for both is to drop this
+    // call at the cutover (design §5.2, Phase 4, step 6),
+    // where `rendered_html()` becomes the fold and the golden output is updated.
     if indexterm_substitution_is_a_noop(&matches) {
         return nodes;
     }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -42,29 +42,35 @@
 //!   the **`link:`/`mailto:` macro** (`link:target[…]`, `mailto:addr[…]`),
 //!   **auto-links and formal-URL links** (`https://example.org`,
 //!   `https://example.org[text]`), **cross-references** in both the
-//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand, and
-//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`),
-//!   replacing each with an [`Image`](InlineNode::Image),
-//!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref), or
-//!   [`Anchor`](InlineNode::Anchor) node. An image node
+//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand,
+//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`), and
+//!   **index terms** (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
+//!   `indexterm2:[…]`), replacing each with an [`Image`](InlineNode::Image),
+//!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref),
+//!   [`Anchor`](InlineNode::Anchor), or [`IndexTerm`](InlineNode::IndexTerm)
+//!   node. An image node
 //!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. Each family reuses the shared pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`], [`INLINE_KBD_BTN_MACRO`],
 //!   [`INLINE_MENU_MACRO`], [`INLINE_LINK_MACRO`], [`INLINE_LINK`],
-//!   [`INLINE_XREF`], [`INLINE_ANCHOR`]), builds `'src`-borrowing nodes for
-//!   verbatim macros only (see [`apply_macros`] for the boundary the
-//!   escaped-content case defers), and – for the UI macros – is recognized only
-//!   under the `experimental` document attribute, exactly as the string step
-//!   gates them. The cross-reference pass claims the same-document form in both
-//!   spellings (`xref:id[text]` and `<<id>>` / `<<id,text>>`); inter-document
-//!   targets, a document-as-a-whole reference, and an attribute-list text are
-//!   deferred. An anchor renders from its id alone, so it is *always* recognized
-//!   (never deferred): only a non-verbatim reference text – which does not reach
-//!   the flow – leaves the node's `reftext` unpopulated. The remaining macro
-//!   families (footnotes, index terms, STEM) and the bibliography-anchor form
-//!   are later increments.
+//!   [`INLINE_XREF`], [`INLINE_ANCHOR`], [`INLINE_INDEXTERM`]), builds
+//!   `'src`-borrowing nodes for verbatim macros only (see [`apply_macros`] for
+//!   the boundary the escaped-content case defers), and – for the UI macros – is
+//!   recognized only under the `experimental` document attribute, exactly as the
+//!   string step gates them. The cross-reference pass claims the same-document
+//!   form in both spellings (`xref:id[text]` and `<<id>>` / `<<id,text>>`);
+//!   inter-document targets, a document-as-a-whole reference, and an
+//!   attribute-list text are deferred. An anchor renders from its id alone, so it
+//!   is *always* recognized (never deferred): only a non-verbatim reference text
+//!   – which does not reach the flow – leaves the node's `reftext` unpopulated.
+//!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
+//!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
+//!   `((term))`) is deferred only when its shown text crosses a rendered span or
+//!   carries an attribute list. The remaining macro family (footnotes), inline
+//!   STEM (a passthrough-time construct), and the bibliography-anchor form are
+//!   later increments.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -110,21 +116,21 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK,
-        INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub, URI_SNIFF,
-        basename, character_replacements, hard_line_break_pattern, maybe_has_quotes,
-        maybe_has_replacements, normalize_index_text, normalize_text_lf_escaped_bracket,
-        quote_subs, split_kbd_keys,
+        CharacterReplacement, INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
+        INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
+        NormalizedCaps, QuoteSub, URI_SNIFF, basename, character_replacements,
+        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, normalize_index_text,
+        normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys, strip_see_and_seealso,
         xref_target::{XrefTarget, interpret_xref_target},
     },
     inlines::{
-        Anchor, CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled, Ui,
-        UiKind,
+        Anchor, CharRef, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm, StyleVariant,
+        Styled, Ui, UiKind,
     },
     parser::{
-        CharacterReplacementType, IconRenderParams, ImageRenderParams, InlineSubstitutionRenderer,
-        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, SpecialCharacter,
-        XrefRenderParams, has_dangerous_scheme,
+        CharacterReplacementType, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
+        InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType,
+        SpecialCharacter, XrefRenderParams, has_dangerous_scheme,
     },
     strings::CowStr,
 };
@@ -1260,10 +1266,14 @@ fn apply_macros<'src>(
 
     let nodes = image_macros_level(nodes, root, parser);
 
-    // Auto-links and formal-URL links (`INLINE_LINK`) run after image/icon and
-    // before the `link:`/`mailto:` macro, mirroring the string step's order
-    // (`INLINE_LINK` precedes `INLINE_LINK_MACRO`); the index-term pass the
-    // string step runs between them is a later increment.
+    // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
+    // `indexterm2:[…]`) run after image/icon and before the link families,
+    // mirroring the string step's order.
+    let nodes = indexterm_macros_level(nodes, root);
+
+    // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
+    // pass and before the `link:`/`mailto:` macro, mirroring the string step's
+    // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
     let nodes = inline_link_level(nodes, root, parser);
 
     // The `link:`/`mailto:` macro runs after the auto-link pass, mirroring the
@@ -2315,6 +2325,405 @@ fn build_link_node<'src>(
     }))
 }
 
+// ─── Index terms (((term)) / (((primary, secondary))) / indexterm:[…]) ─────
+
+/// Matches [`INLINE_INDEXTERM`] at this level's escaped text, replacing each
+/// recognized index term – the `((term))` / `(((primary, secondary,
+/// tertiary)))` shorthand and the `indexterm:[…]` / `indexterm2:[…]` macro –
+/// with the [`IndexTerm`](InlineNode::IndexTerm) node it produces and leaving
+/// everything else in place.
+fn indexterm_macros_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter mirroring the string step's guard: a shorthand needs a
+    // `((` … `))` pair (its parens are not special, so they reach the macros
+    // step intact), and a macro form needs a `:[` and `dexterm` (matching both
+    // `indexterm:` and `indexterm2:`).
+    if !((s.contains("((") && s.contains("))")) || (s.contains(":[") && s.contains("dexterm"))) {
+        return nodes;
+    }
+
+    let matches = find_indexterm_matches(&s, &pieces, root);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    // The string replacer runs the shorthand through [`replace_with_lookahead`],
+    // whose look-ahead retry (a shorthand absorbing trailing parens) has a subtle
+    // consequence: if the whole substitution accumulates *no* output and the last
+    // event is such a retry, the helper returns `Cow::Borrowed` and the caller
+    // keeps the original text **unchanged**. Concretely, content that is nothing
+    // but concealed shorthand terms (`(((coffee)))`, `(((a)))(((b)))`) is left
+    // *literal*, where the same terms with any surrounding output render to
+    // nothing. Detect that no-op and mirror it: leave the level untouched.
+    if indexterm_substitution_is_a_noop(&matches) {
+        return nodes;
+    }
+
+    let macro_matches = matches.into_iter().map(|m| m.macro_match).collect();
+
+    rebuild_macro_level(&nodes, &pieces, &s, macro_matches)
+}
+
+/// A recognized index-term match, plus the two facts the string replacer's
+/// look-ahead loop needs to reproduce its `Cow::Borrowed` (no-op) return (see
+/// [`indexterm_substitution_is_a_noop`]).
+struct RecognizedIndexterm<'src> {
+    macro_match: MacroMatch<'src>,
+
+    /// Whether this match renders any output (a shown term, a kept parenthesis,
+    /// or an unescaped literal). A concealed term renders nothing.
+    rendered_nonempty: bool,
+
+    /// Whether recognizing this match advances the string replacer via a
+    /// look-ahead retry (`SkipAheadAndRetry`) – true only for a shorthand that
+    /// absorbed trailing parens. The macro forms always `Continue`.
+    is_skip: bool,
+}
+
+/// Reports whether the string replacer's index-term substitution over this
+/// level would be a **no-op** – returning `Cow::Borrowed` and so leaving the
+/// content unchanged (see [`indexterm_macros_level`]).
+///
+/// That happens exactly when the accumulated output is empty *and* the last
+/// recognized match advanced via a look-ahead retry: an empty gap before every
+/// match, every match rendering nothing, and the final match a paren-absorbing
+/// shorthand. Any non-empty gap or shown term – or a trailing macro form, which
+/// `Continue`s instead of retrying – makes the substitution `Cow::Owned` and
+/// the terms are recognized normally.
+fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
+    let mut emitted_nonempty = false;
+    let mut prev_end = 0;
+    let mut last_is_skip = false;
+
+    for m in matches {
+        let full = &m.macro_match.full;
+
+        // A non-empty gap before the match is literal text the replacer pushes,
+        // making the accumulated output non-empty.
+        if full.start > prev_end {
+            emitted_nonempty = true;
+        }
+
+        if m.rendered_nonempty {
+            emitted_nonempty = true;
+        }
+
+        prev_end = full.end;
+        last_is_skip = m.is_skip;
+    }
+
+    last_is_skip && !emitted_nonempty
+}
+
+/// Finds every recognized index term at this level – both the macro forms
+/// (`indexterm:[…]`, `indexterm2:[…]`) and the shorthand forms (`((term))`,
+/// `(((primary, secondary, tertiary)))`) – as a [`MacroMatch`].
+///
+/// # Concealed vs. visible, and the recognition boundary
+///
+/// A **concealed** term (`indexterm:[…]`, `(((…)))`) renders to *nothing* –
+/// [`render_index_term`](InlineSubstitutionRenderer::render_index_term) emits
+/// no output for it – so, much like an inline anchor whose output is a function
+/// of its id alone (see [`find_anchor_matches`]), it is recognized regardless
+/// of what its argument crosses; the node simply carries an empty `terms`. (The
+/// one exception is the string replacer's whole-substitution no-op for a level
+/// of *only* concealed shorthand terms, which [`indexterm_macros_level`]
+/// mirrors by leaving the level literal.)
+///
+/// A **visible** (flow) term (`indexterm2:[…]`, `((term))`) shows its term text
+/// in the flow, so that text must be reconstructible from this level's escaped
+/// match string. It is – with the *same* entity bytes the string pipeline sees,
+/// since a [`CharRef`](InlineNode::CharRef) contributes its canonical entity to
+/// the match string – whenever the term crosses no *opaque span* (an
+/// earlier-recognized [`Styled`]/[`Ref`], carried here as a single
+/// [`SPAN_PLACEHOLDER`] rather than its rendered markup). A visible term
+/// crossing such a span, or an `indexterm2:[…]` term carrying an attribute list
+/// (an `=`, whose first positional attribute becomes the shown term), is
+/// **deferred** – the match is left as literal source for a later increment,
+/// each pinned by a divergence test.
+///
+/// As in the additive builder generally, this performs *no* recognition side
+/// effect; the string replacer records nothing in a catalog either (the HTML
+/// backend generates no index), so there is none to skip here.
+fn find_indexterm_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Vec<RecognizedIndexterm<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_INDEXTERM.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let escaped = whole.as_str().starts_with('\\');
+
+        // Macro form: group 1 is the name (`indexterm` / `indexterm2`), group 2
+        // its argument.
+        if let Some(name) = caps.get(1) {
+            let full = whole.start()..whole.end();
+            let is_visible = name.as_str() == "indexterm2";
+
+            #[allow(clippy::unwrap_used)]
+            let arg = caps.get(2).unwrap().as_str();
+
+            if let Some(m) =
+                build_indexterm_macro_match(is_visible, arg, full, escaped, pieces, root)
+            {
+                matches.push(m);
+            }
+
+            continue;
+        }
+
+        // Shorthand form: group 3 is the text enclosed by the outermost `((` …
+        // `))`. Absorb any `)` immediately after the matched `))` so the closing
+        // pair is the *last* in the run, mirroring the string replacer's
+        // `(?!\))` look-ahead re-creation. `captures_iter` cannot skip ahead, so
+        // the absorbed parens are folded into this match's `full` range instead;
+        // a run of `)` never starts a new match, so the next `captures_iter`
+        // match still lands past them.
+        #[allow(clippy::unwrap_used)]
+        let inner = caps.get(3).unwrap().as_str();
+
+        let extra = s[whole.end()..].bytes().take_while(|b| *b == b')').count();
+        let full = whole.start()..(whole.end() + extra);
+
+        if let Some(m) = build_indexterm_shorthand_match(inner, extra, full, escaped, pieces, root)
+        {
+            matches.push(m);
+        }
+    }
+
+    matches
+}
+
+/// Builds the [`MacroMatch`] for an index-term **macro** (`indexterm:[…]` /
+/// `indexterm2:[…]`), or `None` when this increment defers it.
+///
+/// A concealed `indexterm:[…]` is always recognized (it renders nothing, so its
+/// argument is never reconstructed). A visible `indexterm2:[…]` is deferred
+/// when its argument crosses an opaque span (unreconstructable from the escaped
+/// string) or carries an attribute list (an `=` the node cannot hold yet) – see
+/// [`find_indexterm_matches`]. The visible term is normalized exactly as the
+/// string replacer does ([`normalize_index_text`] with bracket-unescaping) and
+/// baked into the node's `terms` in its already-substituted form, which is what
+/// [`fold_index_term`] feeds back to `render_index_term` for byte-identical
+/// output.
+fn build_indexterm_macro_match<'src>(
+    is_visible: bool,
+    arg: &str,
+    full: std::ops::Range<usize>,
+    escaped: bool,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Option<RecognizedIndexterm<'src>> {
+    // An escape (`\indexterm:…`) drops the backslash and keeps the rest literal,
+    // mirroring the string replacer's `caps[0][1..]`. A macro form always
+    // `Continue`s (no look-ahead retry), and the unescaped literal is non-empty.
+    if escaped {
+        return Some(RecognizedIndexterm {
+            macro_match: MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            },
+            rendered_nonempty: true,
+            is_skip: false,
+        });
+    }
+
+    let location = source_slice(pieces, full.clone(), root);
+
+    let (node, rendered_nonempty) = if is_visible {
+        // A visible flow term crossing an opaque span cannot be reconstructed
+        // from this level's escaped string (a span is a placeholder here, not
+        // its markup), so it is deferred.
+        if arg.contains(SPAN_PLACEHOLDER) {
+            return None;
+        }
+
+        let term = normalize_index_text(arg, true);
+
+        // A term carrying an attribute list (an `=`) is parsed as an `Attrlist`
+        // the node cannot hold yet; deferred exactly as the link/xref macros
+        // defer their attribute-list text.
+        if term.contains('=') {
+            return None;
+        }
+
+        let rendered_nonempty = !term.is_empty();
+
+        (
+            InlineNode::IndexTerm(IndexTerm {
+                terms: vec![CowStr::from(term)],
+                visible: true,
+                location,
+            }),
+            rendered_nonempty,
+        )
+    } else {
+        // A concealed term renders nothing, so it is always recognized; its
+        // argument (which never reaches the flow) is not reconstructed.
+        (
+            InlineNode::IndexTerm(IndexTerm {
+                terms: vec![],
+                visible: false,
+                location,
+            }),
+            false,
+        )
+    };
+
+    Some(RecognizedIndexterm {
+        macro_match: MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        },
+        rendered_nonempty,
+        // The macro forms always `Continue`; only the shorthand can retry.
+        is_skip: false,
+    })
+}
+
+/// Builds the [`MacroMatch`] for an index-term **shorthand** (`((term))`,
+/// `(((primary, secondary, tertiary)))`), or `None` when the visible term
+/// crosses an opaque span (see [`find_indexterm_matches`]).
+///
+/// `inner` is the text between the outermost `((` and `))` (match group 3);
+/// `extra` is the count of `)` absorbed after the closing pair. Together they
+/// form the string replacer's `encl_text`, whose leading/trailing parentheses
+/// classify the term as concealed vs. visible and carry any literal parenthesis
+/// adjacent to (but not part of) the term:
+///
+/// - `(((x)))` → **concealed** `x` (the node consumes the whole match and
+///   renders nothing);
+/// - a leading extra paren → **visible** term preceded by a literal `(`;
+/// - a trailing extra paren → **visible** term followed by a literal `)`;
+/// - `((x))` → **visible** `x`.
+///
+/// A single literal parenthesis kept beside the term is expressed by pointing
+/// the node's `consumed` sub-range one byte inside the match, so
+/// [`rebuild_macro_level`] emits that edge `(`/`)` as literal text – the same
+/// sub-range mechanism the auto-link pass uses for a bare URL's kept prefix.
+///
+/// An **escaped** shorthand (`\((…))`) drops its backslash and stays literal
+/// (an [`Unescape`](MacroMatchKind::Unescape)); the one string-replacer form
+/// that instead re-renders an escaped *paren-wrapped* term (`\(((x)))` →
+/// `(x)`) is left literal here, a documented divergence pinned by a test.
+fn build_indexterm_shorthand_match<'src>(
+    inner: &str,
+    extra: usize,
+    full: std::ops::Range<usize>,
+    escaped: bool,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Option<RecognizedIndexterm<'src>> {
+    // An escaped shorthand drops its backslash and keeps the rest (including any
+    // absorbed parens) literal. The one form the string replacer treats
+    // specially – an escaped, paren-wrapped `\(((x)))`, which it collapses to
+    // `(x)` – is left literal here, a divergence documented and pinned by a
+    // test. Every other escaped spelling matches the string replacer's plain
+    // `caps[0][1..]` byte-for-byte.
+    if escaped {
+        return Some(RecognizedIndexterm {
+            macro_match: MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            },
+            rendered_nonempty: true,
+            is_skip: extra > 0,
+        });
+    }
+
+    // `encl_text` = the enclosed text plus any absorbed trailing parens, exactly
+    // as the string replacer builds it before classifying.
+    let mut encl_text = inner.to_string();
+    for _ in 0..extra {
+        encl_text.push(')');
+    }
+
+    // Classify the term, mirroring the string replacer's paren stripping. `term`
+    // is the inner text whose primary term is shown (visible) or indexed only
+    // (concealed); `before`/`after` flag a single literal parenthesis kept
+    // beside the term.
+    let (term_src, visible, before, after): (&str, bool, bool, bool) =
+        if let Some(without_open) = encl_text.strip_prefix('(') {
+            if let Some(inner) = without_open.strip_suffix(')') {
+                (inner, false, false, false) // `(((concealed)))`
+            } else {
+                (without_open, true, true, false) // visible, kept `(`
+            }
+        } else if let Some(inner) = encl_text.strip_suffix(')') {
+            (inner, true, false, true) // visible, kept `)`
+        } else {
+            (encl_text.as_str(), true, false, false) // `((visible))`
+        };
+
+    let location = source_slice(pieces, full.clone(), root);
+
+    let (node, rendered_nonempty) = if visible {
+        // A visible term crossing an opaque span cannot be reconstructed from
+        // the escaped string; defer it (see [`find_indexterm_matches`]).
+        if term_src.contains(SPAN_PLACEHOLDER) {
+            return None;
+        }
+
+        let term = strip_see_and_seealso(&normalize_index_text(term_src, false));
+
+        // The match renders output when it shows a non-empty term or keeps a
+        // literal parenthesis beside it.
+        let rendered_nonempty = before || after || !term.is_empty();
+
+        (
+            InlineNode::IndexTerm(IndexTerm {
+                terms: vec![CowStr::from(term)],
+                visible: true,
+                location,
+            }),
+            rendered_nonempty,
+        )
+    } else {
+        (
+            InlineNode::IndexTerm(IndexTerm {
+                terms: vec![],
+                visible: false,
+                location,
+            }),
+            false,
+        )
+    };
+
+    // A kept literal parenthesis is left outside the node's `consumed` sub-range
+    // so [`rebuild_macro_level`] emits it as literal text: a `before` keeps the
+    // match's first `(`; an `after` keeps its last `)`.
+    let consumed = (full.start + usize::from(before))..(full.end - usize::from(after));
+
+    Some(RecognizedIndexterm {
+        macro_match: MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed,
+                node: Box::new(node),
+            },
+            full,
+        },
+        rendered_nonempty,
+        is_skip: extra > 0,
+    })
+}
+
 // ─── Inline anchors ([[id]] / anchor:id[…]) ───────────────────────────────
 
 /// Matches `INLINE_ANCHOR` at this level's escaped text, replacing each
@@ -3035,6 +3444,10 @@ fn fold_into_html(
                 fold_anchor(anchor, renderer, parser, out);
             }
 
+            InlineNode::IndexTerm(index_term) => {
+                fold_index_term(index_term, renderer, out);
+            }
+
             InlineNode::Styled(styled) => {
                 // Fold the children to the body, then wrap it exactly as the
                 // string pipeline's quotes step did: the same `QuoteType`,
@@ -3060,9 +3473,10 @@ fn fold_into_html(
             other => {
                 // The steps wired up so far produce only `Text`,
                 // `CharRef::Special`, `Styled`, `Image`, `Ui`, `Ref` (link and
-                // cross-reference), `Anchor`, and `LineBreak` nodes, and this
-                // fold additionally emits the design-legal `Raw` leaf; no other
-                // node kind reaches the fold in this increment. A later increment
+                // cross-reference), `Anchor`, `IndexTerm`, and `LineBreak`
+                // nodes, and this fold additionally emits the design-legal `Raw`
+                // leaf; no other node kind reaches the fold in this increment.
+                // A later increment
                 // fills in the arms above as the transducer grows new kinds.
                 // Guard against a premature caller in debug builds and emit
                 // nothing in release, mirroring the safe defensive fallback in
@@ -3312,6 +3726,35 @@ fn fold_anchor(
     renderer.render_anchor(&anchor.id, reftext, out);
 }
 
+/// Folds an [`IndexTerm`](InlineNode::IndexTerm) through the same
+/// `render_index_term` the string step's macros pass calls.
+///
+/// A **concealed** term (`visible == false`) has an empty `terms` and renders
+/// nothing – the HTML backend generates no index. A **visible** (flow) term
+/// carries its shown text as `terms[0]` in the *already-substituted* form the
+/// recognizer computed (matching the seam's "already-substituted visible term"
+/// contract), so `render_index_term` emits it verbatim and the fold reproduces
+/// the string pipeline's bytes exactly.
+///
+/// The node's `terms` mirrors what the [`inline_tree`](super::inline_tree)
+/// recorder stores – the single shown term for a visible node, empty for a
+/// concealed one; the richer primary/secondary/tertiary structure the field can
+/// hold is left to a re-flow consumer to pin (the field is provisional, per the
+/// node's Phase-0 note), exactly as an anchor's `reftext` is.
+fn fold_index_term(
+    index_term: &IndexTerm<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    out: &mut String,
+) {
+    let visible_term = if index_term.visible {
+        Some(index_term.terms.first().map_or("", CowStr::as_ref))
+    } else {
+        None
+    };
+
+    renderer.render_index_term(&IndexTermRenderParams { visible_term }, out);
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -3326,8 +3769,8 @@ mod tests {
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Image, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled,
-            Ui, UiKind,
+            Anchor, CharRef, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm, StyleVariant,
+            Styled, Ui, UiKind,
         },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -6386,5 +6829,280 @@ mod tests {
 
             other => panic!("expected the Ref to survive, got {other:?}"),
         }
+    }
+
+    // ─── Macros (index terms) ─────────────────────────────────────────────
+
+    /// Asserts that `node` is an [`IndexTerm`](InlineNode::IndexTerm),
+    /// returning it.
+    fn assert_index_term<'a, 'src>(node: &'a InlineNode<'src>) -> &'a IndexTerm<'src> {
+        match node {
+            InlineNode::IndexTerm(index_term) => index_term,
+
+            other => panic!("expected an IndexTerm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_index_terms() {
+        // For each fixture, folding the single-pass tree (all five steps)
+        // reproduces the string pipeline's output byte-for-byte. This is the
+        // differential corpus (design §5.3) that pins the index-term increment.
+        // A concealed term renders nothing, a visible term renders its shown
+        // text; both spellings and the trailing-paren / see-also handling are
+        // exercised.
+        let fixtures = [
+            // No index term despite paren/colon/bracket characters.
+            "plain text without a term",
+            "a single ( paren and a lone ) paren",
+            "indexterm without a bracket stays literal",
+            "a colon : and brackets [] but no term",
+            // Macro form: concealed (no output) and visible (flow) primary.
+            "indexterm:[coffee]",
+            "indexterm:[coffee, robusta]",
+            "indexterm2:[coffee]",
+            "an indexterm2:[Coffee] in the flow",
+            // Shorthand: visible `((…))` and concealed `(((…)))`.
+            "((coffee))",
+            "See ((coffee)) for more.",
+            "(((coffee)))",
+            "(((coffee, robusta, arabica)))",
+            // Trailing-paren absorption: the closing pair is the *last* in a run,
+            // so an extra `)` is kept as literal flow text after the term.
+            "((coffee)))",
+            // A leading extra paren is kept as literal flow text before the term.
+            "(((coffee))",
+            // A visible term with a `see` / `see-also` clause shows only its
+            // primary; the `>>` / `&>` separators are `&gt;`/`&amp;` entities by
+            // macro time, but the term is still reconstructed from the escaped
+            // match string, so this is parity (not a divergence).
+            "((Coffee >> Beans))",
+            "((Coffee &> Tea))",
+            // A concealed term whose inner crosses a rendered span still renders
+            // nothing on both paths (the span markup is inside the discarded
+            // term), so it is parity.
+            "(((*bold* term)))",
+            // Escapes: the term stays literal, minus the backslash.
+            "\\indexterm:[x]",
+            "\\indexterm2:[x]",
+            "\\((coffee))",
+            // Embedded in surrounding flow and next to other constructs.
+            "*bold* then ((x)) here",
+            "a copyright (C) then ((x))",
+            "((a)) and ((b)) and indexterm:[c]",
+            "((a))((b))",
+            // Recognized inside a rendered span (the macros step descends).
+            "*see ((x))*",
+            "_indexterm2:[y] in em_",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_concealed_indexterm_macro_becomes_an_empty_node() {
+        let nodes = build_src(Span::new("indexterm:[coffee, robusta]"));
+
+        assert_eq!(nodes.len(), 1);
+        let index_term = assert_index_term(&nodes[0]);
+
+        // A concealed term carries no shown text and renders nothing.
+        assert!(!index_term.visible);
+        assert!(index_term.terms.is_empty());
+
+        // Its location covers the whole macro.
+        assert_eq!(index_term.location.data(), "indexterm:[coffee, robusta]");
+        assert_eq!(index_term.location.line(), 1);
+        assert_eq!(index_term.location.col(), 1);
+    }
+
+    #[test]
+    fn a_visible_indexterm_macro_becomes_a_flow_node() {
+        let nodes = build_src(Span::new("indexterm2:[coffee]"));
+
+        let index_term = assert_index_term(&nodes[0]);
+
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms.len(), 1);
+        assert_eq!(index_term.terms[0].as_ref(), "coffee");
+        assert_eq!(index_term.location.data(), "indexterm2:[coffee]");
+    }
+
+    #[test]
+    fn a_visible_shorthand_becomes_a_flow_node_with_precise_span() {
+        // Embedded so the node's location is not at column 1.
+        let nodes = build_src(Span::new("x ((coffee)) y"));
+
+        // `x ` then the term then ` y`.
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "x ", 1, 1);
+
+        let index_term = assert_index_term(&nodes[1]);
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms[0].as_ref(), "coffee");
+
+        // The location covers the whole `((coffee))`, the delimiters included,
+        // starting at column 3.
+        assert_eq!(index_term.location.data(), "((coffee))");
+        assert_eq!(index_term.location.col(), 3);
+
+        assert_text(&nodes[2], " y", 1, 13);
+    }
+
+    #[test]
+    fn a_concealed_shorthand_becomes_an_empty_node() {
+        // Embedded after literal text so the level is not the all-concealed
+        // no-op the string replacer leaves untouched (see the parity test
+        // below); the concealed term is then recognized as an empty node.
+        let nodes = build_src(Span::new("x (((coffee, robusta)))"));
+
+        assert_eq!(nodes.len(), 2);
+        assert_text(&nodes[0], "x ", 1, 1);
+
+        let index_term = assert_index_term(&nodes[1]);
+        assert!(!index_term.visible);
+        assert!(index_term.terms.is_empty());
+        assert_eq!(index_term.location.data(), "(((coffee, robusta)))");
+        assert_eq!(index_term.location.col(), 3);
+    }
+
+    #[test]
+    fn an_all_concealed_shorthand_level_stays_literal() {
+        // A level that is *only* concealed shorthand terms accumulates no output
+        // and ends in a look-ahead retry, so the string replacer returns
+        // `Cow::Borrowed` and leaves it literal. The builder mirrors that: the
+        // terms are left unrecognized (no `IndexTerm` node), byte-for-byte.
+        for source in ["(((coffee)))", "(((a)))(((b)))", "indexterm:[x](((y)))"] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+                "an all-concealed level must be left literal for {source:?}: {nodes:?}"
+            );
+
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+            assert_eq!(folded, source, "left-literal fold for {source:?}");
+            assert_eq!(
+                golden_macros(source),
+                source,
+                "golden literal for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_see_clause_leaves_only_the_primary_term() {
+        // The `see` separator (` >> `) is `&gt;&gt;` by macro time; the term is
+        // reconstructed from the escaped match string, so the node carries only
+        // the primary `Coffee`, exactly as the string replacer renders.
+        let nodes = build_src(Span::new("((Coffee >> Beans))"));
+
+        let index_term = assert_index_term(&nodes[0]);
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms[0].as_ref(), "Coffee");
+    }
+
+    #[test]
+    fn a_kept_paren_rides_beside_the_term_as_literal_text() {
+        // A leading extra paren is kept as flow text before the visible term.
+        let nodes = build_src(Span::new("(((coffee))"));
+
+        // A literal `(` then the term node.
+        assert_eq!(nodes.len(), 2);
+        assert_text(&nodes[0], "(", 1, 1);
+
+        let index_term = assert_index_term(&nodes[1]);
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms[0].as_ref(), "coffee");
+    }
+
+    #[test]
+    fn an_index_term_is_recognized_inside_a_span() {
+        // The macros step descends into a `Styled` span's children, so a term
+        // inside a rendered span becomes an `IndexTerm` there.
+        let nodes = build_src(Span::new("*a ((b)) c*"));
+
+        assert_eq!(nodes.len(), 1);
+
+        match &nodes[0] {
+            InlineNode::Styled(styled) => {
+                assert!(
+                    styled
+                        .children
+                        .iter()
+                        .any(|n| matches!(n, InlineNode::IndexTerm(_))),
+                    "expected an IndexTerm inside the span, got {:?}",
+                    styled.children
+                );
+            }
+
+            other => panic!("expected a Styled span, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_visible_term_over_a_span_is_a_documented_divergence() {
+        // A *visible* term whose shown text crosses a rendered span (`*bold*`
+        // became a `Styled` placeholder by macro time) cannot be reconstructed
+        // from this level's escaped match string, so the builder leaves it
+        // unrecognized – the `((` / `))` stay literal around the span. The string
+        // pipeline, by contrast, folds the span markup into the shown term and
+        // consumes the delimiters.
+        let source = "((*bold* term))";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "a visible term crossing a span must be left unrecognized: {nodes:?}"
+        );
+
+        // The delimiters survive literally in the builder's output, but the
+        // string pipeline consumes them.
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert!(folded.contains("(("));
+        assert!(!golden_macros(source).contains("(("));
+    }
+
+    #[test]
+    fn an_indexterm2_attribute_list_is_a_documented_divergence() {
+        // An `indexterm2:[…]` argument carrying an `=` splits into an attribute
+        // list whose first positional attribute is the shown term. The builder
+        // cannot carry that as an `Attrlist<'src>` yet, so it defers the whole
+        // macro (left literal), exactly as the link/xref macros defer their
+        // attribute-list text.
+        let source = "indexterm2:[Coffee, region=Kona]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "an attribute-list-in-text index term must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, shows the first positional term.
+        assert_eq!(golden_macros(source), "Coffee");
+    }
+
+    #[test]
+    fn an_escaped_paren_wrapped_shorthand_is_a_documented_divergence() {
+        // The one escaped shorthand the string replacer re-renders rather than
+        // leaving literal: an escaped, paren-wrapped `\(((x)))`, which it
+        // collapses to `(x)`. The builder drops the backslash and keeps the rest
+        // literal (`(((x)))`), a documented divergence – every other escaped
+        // spelling matches byte-for-byte (pinned by the corpus above).
+        let source = "\\(((x)))";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, "(((x)))");
+        assert_eq!(golden_macros(source), "(x)");
     }
 }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -6985,11 +6985,25 @@ mod tests {
 
     #[test]
     fn an_all_concealed_shorthand_level_stays_literal() {
-        // A level that is *only* concealed shorthand terms accumulates no output
-        // and ends in a look-ahead retry, so the string replacer returns
-        // `Cow::Borrowed` and leaves it literal. The builder mirrors that: the
-        // terms are left unrecognized (no `IndexTerm` node), byte-for-byte.
-        for source in ["(((coffee)))", "(((a)))(((b)))", "indexterm:[x](((y)))"] {
+        // A level whose only *output* would be from concealed shorthand terms
+        // accumulates no output and ends in a look-ahead retry, so the string
+        // replacer returns `Cow::Borrowed` and leaves it literal (the #1123
+        // bug). The builder mirrors that byte-for-byte: the terms are left
+        // unrecognized (no `IndexTerm` node).
+        //
+        // Note the `(((coffee))) trailing` case: **trailing** text does *not*
+        // rescue recognition, because it is appended only on the replacer's
+        // normal completion — the `Cow::Borrowed` early-return on the empty-`new`
+        // retry happens first and discards it. Only output emitted *before* the
+        // retry (a leading/between gap, or a shown term) makes `new` non-empty;
+        // see `a_concealed_term_after_leading_output_is_consumed` for that
+        // contrast. (Both mirror the string pipeline exactly — verified below.)
+        for source in [
+            "(((coffee)))",
+            "(((a)))(((b)))",
+            "indexterm:[x](((y)))",
+            "(((coffee))) trailing",
+        ] {
             let nodes = build_src(Span::new(source));
 
             assert!(
@@ -7004,6 +7018,25 @@ mod tests {
                 source,
                 "golden literal for {source:?}"
             );
+        }
+    }
+
+    #[test]
+    fn a_concealed_term_after_leading_output_is_consumed() {
+        // The contrast to the all-concealed no-op: **leading** text makes the
+        // replacer's accumulator non-empty *before* the look-ahead retry, so the
+        // substitution is `Cow::Owned` and the concealed term is recognized and
+        // consumed (renders nothing) — leaving only the leading text. The builder
+        // reproduces this byte-for-byte, so `leading (((coffee)))` folds to
+        // `leading `, not the literal source.
+        for source in ["leading (((coffee)))", "((a)) (((b)))"] {
+            let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+            assert_eq!(
+                folded,
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+            assert_ne!(folded, source, "the term should be consumed for {source:?}");
         }
     }
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -609,8 +609,13 @@ pub(crate) fn normalize_text_lf_escaped_bracket(text: &str) -> String {
 /// engine has no look-ahead, so [`InlineIndextermReplacer`] re-creates that
 /// behavior by absorbing any trailing `)` that follow the matched `))`.
 ///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) recognizes index terms
+/// with the *exact* same pattern this string step matches with, changing only
+/// the recognition *sink* (a node instead of rendered markup).
+///
 /// [index term]: https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/
-static INLINE_INDEXTERM: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_INDEXTERM: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)                         # extended mode; dot matches newline
@@ -777,7 +782,11 @@ pub(crate) fn normalize_index_text(text: &str, unescape_brackets: bool) -> Strin
 /// text. By the time macros are processed, the special-characters substitution
 /// has already turned `>` into `&gt;` and `&` into `&amp;`, so the separators
 /// appear here as ` &gt;&gt; ` and ` &amp;&gt; `.
-fn strip_see_and_seealso(term: &str) -> String {
+///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) strips a visible
+/// shorthand term's `see`/`see-also` clause exactly as this string step does.
+pub(crate) fn strip_see_and_seealso(term: &str) -> String {
     // Cheap guard mirroring Asciidoctor's `term.include? ';&'`.
     if term.contains(";&") {
         if let Some((primary, _see)) = term.split_once(" &gt;&gt; ") {

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -17,10 +17,10 @@ pub(crate) mod inline_tree;
 
 mod macros;
 pub(crate) use macros::{
-    INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO,
-    INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, URI_SNIFF,
+    INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK,
+    INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, URI_SNIFF,
     apply_macros_with_leading_anchor_registered, basename, normalize_index_text,
-    normalize_text_lf_escaped_bracket, split_kbd_keys,
+    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;

--- a/parser/src/internal/regex.rs
+++ b/parser/src/internal/regex.rs
@@ -17,6 +17,20 @@ pub fn replace_with_lookahead<'h, LR: LookaheadReplacer>(
         // source.
         let mut it = regex.captures_iter(haystack).enumerate().peekable();
 
+        // KNOWN BUG — inline-ast: do NOT fix before the inline-AST cutover.
+        //
+        // On a retry iteration (reached via `SkipAheadAndRetry`), `new` can be
+        // empty because prior matches rendered *nothing* (e.g. a concealed
+        // index-term shorthand). Returning `Cow::Borrowed` here then conflates
+        // "no work done" with "work done, empty output", so the caller keeps the
+        // *original* text and a whole-content `(((concealed)))` is left literal
+        // instead of rendering empty. See asciidoc-rs/asciidoc-parser#1123.
+        //
+        // The `inline-ast` single-pass builder deliberately *reproduces* this
+        // behavior (see `content::inline_builder::indexterm_substitution_is_a_noop`)
+        // to preserve byte-for-byte parity during the additive phase. Fixing this
+        // now would change the golden output and break that branch's differential
+        // corpus; the fix lands with the cutover (design §5.2, Phase 4, step 6).
         if new.is_empty() && it.peek().is_none() {
             return Cow::Borrowed(haystack);
         }


### PR DESCRIPTION
## What

Continues **Phase 4, step 4b(ii)** of the [inline-AST plan](docs/design/inline-ast-architecture.md) (§5.2). The single-pass [`inline_builder`](../blob/inline-ast/parser/src/content/inline_builder.rs) now recognizes **inline index terms** in both spellings — the `((term))` / `(((primary, secondary, tertiary)))` shorthand and the `indexterm:[…]` (concealed) / `indexterm2:[…]` (flow) macro — as an [`IndexTerm`](../blob/inline-ast/parser/src/inlines/index_term.rs) node, folding through the same `render_index_term` the string step calls so the output is **byte-for-byte identical**.

This follows [part 4a](https://github.com/asciidoc-rs/asciidoc-parser/pull/1109) (inline anchors). It reuses the string pipeline's *exact* recognition — `INLINE_INDEXTERM` is now shared `pub(crate)`, alongside the `strip_see_and_seealso` helper — so only the recognition **sink** changes. The pass runs after image/icon and before the link families, mirroring the string step's order. This step is **additive**: nothing is wired into the parse path.

## Concealed vs. visible — the recognition boundary

Following the anchor precedent (output-from-X-alone ⇒ always recognized; output-that-reaches-the-flow ⇒ verbatim-gated):

- A **concealed** term (`indexterm:[…]`, `(((…)))`) renders **nothing**, so it is recognized regardless of what its argument crosses; the node carries an empty `terms`.
- A **visible** (flow) term (`indexterm2:[…]`, `((term))`) shows its text in the flow, so it is recognized whenever that text — reconstructed from the level's *escaped* match string, so a `CharRef` entity or a stripped `see`/`see-also` clause (`&gt;&gt;` / `&amp;&gt;` by macro time) is **parity**, not a divergence — crosses no opaque span.

The node mirrors the Strategy-A recorder's shape (the shown term for a visible node, empty for a concealed one); the richer primary/secondary/tertiary structure the field can hold is left to a re-flow consumer to pin (the field is provisional, per the node's Phase-0 note).

## Two string-pipeline quirks reproduced exactly

- **Trailing-`)` absorption.** The shorthand's `(?!\))` look-ahead re-creation (the closing `))` is the *last* pair in a run) is reproduced by folding the absorbed parens into the match; a literal parenthesis kept beside a term rides on the shared `MacroMatch` sub-range seam.
- **The all-concealed no-op.** A level of *only* concealed shorthand terms (`(((coffee)))`, `(((a)))(((b)))`) accumulates no output and ends in a look-ahead retry, so [`replace_with_lookahead`](../blob/inline-ast/parser/src/internal/regex.rs) returns `Cow::Borrowed` and the string step leaves it **literal** (where the same terms with any surrounding output render to nothing). The builder detects that no-op and mirrors it — verified against the string pipeline before implementing.

## Deferred (each documented + pinned by a divergence test)

| Form | Why |
| --- | --- |
| a **visible term crossing a rendered span** (`((*bold* term))`) | unreconstructable from the escaped string — the same verbatim boundary the image/link/xref increments document |
| an **`indexterm2:[…]` carrying an attribute list** (`=`) | parsed as an `Attrlist<'src>` the node cannot hold yet, as the link/xref macros defer the same |
| the one **escaped paren-wrapped shorthand** the string replacer re-renders (`\(((x)))` → `(x)`) | left literal; every other escaped spelling matches byte-for-byte |

As throughout the additive builder, this performs **no** recognition side effect (the HTML backend builds no index, so the string replacer has none to skip either).

## Scope note

Inline **STEM** (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`), listed under part 4 in the original plan, is actually extracted at *passthrough* time — step 5, not the macros step — so the design's step list is re-sliced accordingly: **4a** anchors ✅, **4b** index terms (this PR), **4c** `Footnote`, with STEM moved to step 5. `Footnote` is the last remaining macros-step family.

## Tests

- `fold_matches_the_string_pipeline_through_index_terms` — the differential corpus (design §5.3) pinning byte-for-byte parity across macro/shorthand, concealed/visible, trailing-paren, see/see-also, escapes, and terms next to and inside spans.
- Structural precise-span assertions the Strategy-A tree cannot make (concealed/visible nodes, kept-paren-as-literal, recognition inside a span), plus an all-concealed-level no-op parity test.
- A divergence test per deferred form above.

## Checks

- `cargo test -p asciidoc-parser` — green (4795 passed).
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p asciidoc-parser --all-targets` — clean.
- rustdoc intra-doc links — resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgyqj7vMkLVV6WWc4aqNVq)_