### PR TITLE
fix: Apply full title substitution to document title; add sanitized doctitle accessor

### DIFF
--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -916,6 +916,63 @@ mod tests {
         }
     }
 
+    mod sanitize_title {
+        use super::super::sanitize_title;
+
+        #[test]
+        fn leaves_plain_text_unchanged() {
+            assert_eq!(sanitize_title("Plain title"), "Plain title");
+        }
+
+        #[test]
+        fn strips_a_tag_pair_keeping_its_inner_text() {
+            assert_eq!(sanitize_title("<strong>bold</strong>"), "bold");
+        }
+
+        #[test]
+        fn strips_a_self_contained_tag() {
+            assert_eq!(
+                sanitize_title(r#"Before <img src="a.png" alt="a"> after"#),
+                "Before after",
+            );
+        }
+
+        #[test]
+        fn squeezes_spaces_left_behind_by_a_removed_tag() {
+            // A run of spaces left behind after tags are stripped (e.g. two
+            // images rendered back-to-back, or a tag flanked by spaces on
+            // both sides) collapses to one, and the ends are trimmed,
+            // mirroring Ruby's `tr_s(' ', ' ').strip`.
+            assert_eq!(
+                sanitize_title(r#"<img src="a.png">  <img src="b.png">"#),
+                "",
+            );
+            assert_eq!(
+                sanitize_title("Before <b>bold</b>   after"),
+                "Before bold after",
+            );
+        }
+
+        #[test]
+        fn an_empty_tag_does_not_match_and_is_kept_verbatim() {
+            // `[^>]+` in Ruby's `XmlSanitizeRx` requires at least one
+            // character between `<` and `>`; an empty `<>` does not match
+            // and is copied through as literal text.
+            assert_eq!(sanitize_title("a<>b"), "a<>b");
+        }
+
+        #[test]
+        fn an_unclosed_angle_bracket_is_kept_verbatim() {
+            // A `<` with no `>` anywhere after it in the rest of the string
+            // is not a tag and is left as literal text, along with
+            // everything after it.
+            assert_eq!(
+                sanitize_title("Title <dangling and more"),
+                "Title <dangling and more",
+            );
+        }
+    }
+
     mod footnote_deferred {
         use super::super::{
             FootnoteDeferred, XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, XrefSegment,

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -179,6 +179,59 @@ pub(crate) fn strip_footnote_marker_spans(s: &str) -> String {
     out
 }
 
+/// Strips markup down to plain text, mirroring Asciidoctor's
+/// `Document::Title` sanitize option (`XmlSanitizeRx = /<[^>]+>/`): every tag
+/// – opening, closing, or self-contained (e.g. an `<img>` rendered from an
+/// inline `image:` macro) – is removed, any run of interior spaces left
+/// behind by a removed tag is squeezed to one, and the result is trimmed.
+///
+/// A value with no `<` is returned unchanged, matching Asciidoctor, which
+/// skips the squeeze-and-trim pass entirely when there is nothing to
+/// sanitize. Used both by the sanitized doctitle accessor
+/// (`Document::doctitle_sanitized`) and by this document's own
+/// cross-reference fallback text (`this_document_reference`), which embeds
+/// the doctitle inside its own `<a>` and so cannot carry nested markup.
+pub(crate) fn sanitize_title(source: &str) -> String {
+    if !source.contains('<') {
+        return source.to_string();
+    }
+
+    let mut stripped = String::with_capacity(source.len());
+    let mut rest = source;
+
+    while let Some(lt) = rest.find('<') {
+        stripped.push_str(&rest[..lt]);
+
+        let after_lt = &rest[lt + 1..];
+        match after_lt.find('>') {
+            // `[^>]+` requires at least one character between `<` and `>`;
+            // an empty `<>` does not match and is copied through verbatim.
+            Some(gt) if gt > 0 => rest = &after_lt[gt + 1..],
+            _ => {
+                stripped.push('<');
+                rest = after_lt;
+            }
+        }
+    }
+    stripped.push_str(rest);
+
+    let mut squeezed = String::with_capacity(stripped.len());
+    let mut prev_was_space = false;
+    for c in stripped.chars() {
+        if c == ' ' {
+            if prev_was_space {
+                continue;
+            }
+            prev_was_space = true;
+        } else {
+            prev_was_space = false;
+        }
+        squeezed.push(c);
+    }
+
+    squeezed.trim().to_string()
+}
+
 /// A fully-owned snapshot of a rendered title, including any deferred
 /// cross-references it carries.
 ///

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -7,7 +7,7 @@ mod content;
 pub use content::Content;
 pub(crate) use content::{
     FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
-    rehome_xref_placeholders, render_xref_template, strip_footnote_marker_spans,
+    rehome_xref_placeholders, render_xref_template, sanitize_title, strip_footnote_marker_spans,
 };
 
 mod macros;

--- a/parser/src/content/xref_target.rs
+++ b/parser/src/content/xref_target.rs
@@ -202,11 +202,10 @@ pub(crate) fn this_document_reference(parser: &Parser) -> DerivedReference {
     let doctitle = parser.attribute_value("doctitle");
 
     // An empty `reftext` names nothing, so it falls through to the title just
-    // as an unset one does. The doctitle now carries real rendered markup
-    // (see #1121) – formatting, or even a live link from an autolinked bare
-    // URL – which cannot be embedded as-is inside this reference's own
-    // wrapping `<a>`, so it is sanitized down to plain text first, mirroring
-    // Asciidoctor.
+    // as an unset one does. The doctitle carries real rendered markup –
+    // formatting, or even a live link from an autolinked bare URL – which
+    // cannot be embedded as-is inside this reference's own wrapping `<a>`,
+    // so it is sanitized down to plain text first, mirroring Asciidoctor.
     let text = reftext
         .as_maybe_str()
         .filter(|reftext| !reftext.is_empty())

--- a/parser/src/content/xref_target.rs
+++ b/parser/src/content/xref_target.rs
@@ -14,7 +14,7 @@
 //!
 //! [inter-document cross reference]: https://docs.asciidoctor.org/asciidoc/latest/macros/inter-document-xref/
 
-use crate::{Parser, parser::DerivedReference};
+use crate::{Parser, content::sanitize_title, parser::DerivedReference};
 
 /// The file extensions an AsciiDoc processor recognizes as AsciiDoc source.
 ///
@@ -202,13 +202,17 @@ pub(crate) fn this_document_reference(parser: &Parser) -> DerivedReference {
     let doctitle = parser.attribute_value("doctitle");
 
     // An empty `reftext` names nothing, so it falls through to the title just
-    // as an unset one does.
+    // as an unset one does. The doctitle now carries real rendered markup
+    // (see #1121) – formatting, or even a live link from an autolinked bare
+    // URL – which cannot be embedded as-is inside this reference's own
+    // wrapping `<a>`, so it is sanitized down to plain text first, mirroring
+    // Asciidoctor.
     let text = reftext
         .as_maybe_str()
         .filter(|reftext| !reftext.is_empty())
         .or_else(|| doctitle.as_maybe_str().filter(|title| !title.is_empty()))
-        .unwrap_or(SELF_REFERENCE_FALLBACK_TEXT)
-        .to_string();
+        .map(sanitize_title)
+        .unwrap_or_else(|| SELF_REFERENCE_FALLBACK_TEXT.to_string());
 
     DerivedReference {
         href: "#".to_string(),

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -332,6 +332,21 @@ impl<'src> Document<'src> {
         self.header().doctitle()
     }
 
+    /// Return the document title (see [`doctitle`]) with any rendered markup
+    /// stripped down to plain text, mirroring Ruby Asciidoctor's
+    /// `Document#doctitle(sanitize: true)`.
+    ///
+    /// Use this in contexts where markup is not allowed, such as the text of
+    /// a standalone HTML `<title>` element: a title rendered with formatting
+    /// (`*bold*`) or an inline macro (`image:...[]`) has that markup removed
+    /// rather than passed through verbatim. Returns `None` when there is no
+    /// title, matching [`doctitle`].
+    ///
+    /// [`doctitle`]: Self::doctitle
+    pub fn doctitle_sanitized(&self) -> Option<String> {
+        self.header().doctitle_sanitized()
+    }
+
     /// Return the document subtitle, if the document title contained one.
     ///
     /// A subtitle is the text following the final subtitle separator (a colon

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1426,22 +1426,6 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_title_squeezes_spaces_left_by_a_removed_tag() {
-        // A run of spaces left behind after tags are stripped (e.g. two
-        // images rendered back-to-back, or a tag flanked by spaces on both
-        // sides) collapses to one, and the ends are trimmed, mirroring
-        // Ruby's `tr_s(' ', ' ').strip`.
-        assert_eq!(
-            super::sanitize_title("<img src=\"a.png\">  <img src=\"b.png\">"),
-            "",
-        );
-        assert_eq!(
-            super::sanitize_title("Before <b>bold</b>   after"),
-            "Before bold after",
-        );
-    }
-
-    #[test]
     fn impl_clone() {
         // Silly test to mark the #[derive(...)] line as covered.
         let mut parser = Parser::default();

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -399,6 +399,11 @@ impl<'src> Header<'src> {
             // (`= {project-name} footnote:[…]`) is defined twice. This is a
             // rare combination – a document title is an unusual place for a
             // footnote or anchor to begin with – and no test exercises it.
+            // Tracked as a follow-up in #1132: fixing it well wants a way to
+            // resolve attribute references once and branch into the
+            // remaining substitution steps without re-invoking macros – a
+            // shape that may fall out more naturally once inline content is
+            // a materialized tree instead of a re-run string pipeline.
             let base = if !implicit_overridden_from_above
                 && let Some(raw) = title_source
                 && implicit_doctitle_str

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1269,7 +1269,7 @@ fn split_author_entries(value: &str) -> Vec<&str> {
 /// substitution of the `= Title` line into the `doctitle` attribute. Unlike
 /// the restricted `Header` group used for author/revision lines and
 /// attribute-entry values, this renders quotes (formatting), replacements,
-/// and inline macros (e.g. `image:`) in the title itself (see #1121).
+/// and inline macros (e.g. `image:`) in the title itself.
 fn apply_title_subs(source: &str, parser: &Parser) -> String {
     let span = Span::new(source);
 
@@ -1352,7 +1352,7 @@ mod tests {
         // The document title line goes through the `Title` substitution group
         // (the same steps as `Normal`), not the restricted `Header` group
         // used for author/revision lines — so formatting (quotes) and inline
-        // macros (`image:`) render, matching Asciidoctor (see #1121).
+        // macros (`image:`) render, matching Asciidoctor.
         let doc = Parser::default()
             .parse("= *Document* image:logo.png[] _Title_ image:another-logo.png[another logo]");
 
@@ -1372,7 +1372,7 @@ mod tests {
     fn title_substitutions_apply_before_subtitle_partition() {
         // A subtitle carved out of the (now fully substituted) title retains
         // its own rendered formatting, rather than the literal, unprocessed
-        // source it kept before #1121 was fixed.
+        // source it used to keep.
         let doc = Parser::default().parse("= Main Title: *Subtitle*");
 
         assert_eq!(doc.header().main_title(), Some("Main Title"));
@@ -1381,10 +1381,11 @@ mod tests {
 
     #[test]
     fn author_and_revision_lines_keep_restricted_header_substitutions() {
-        // The #1121 fix is scoped to the title line only: author and revision
-        // lines must still see just the restricted `Header` group (special
-        // characters, attribute references, and the inline pass macro) —
-        // formatting is left as literal, unprocessed text.
+        // The fuller title substitution is scoped to the title line only:
+        // author and revision lines must still see just the restricted
+        // `Header` group (special characters, attribute references, and the
+        // inline pass macro) — formatting is left as literal, unprocessed
+        // text.
         let doc = Parser::default().parse("= Title\n*Jane Smith*\nv1, *2025-09-28*");
 
         let author_line = doc.header().author_line().unwrap();
@@ -1401,8 +1402,8 @@ mod tests {
     fn doctitle_sanitized_strips_rendered_markup_to_plain_text() {
         // Mirrors Ruby Asciidoctor's `Document#doctitle(sanitize: true)`,
         // used for contexts (like the standalone HTML `<title>` element)
-        // where markup is not allowed (see #1122). Depends on #1121: without
-        // the fuller title substitution there would be no rendered markup
+        // where markup is not allowed. Relies on the fuller title
+        // substitution above: without it there would be no rendered markup
         // (bold, italic, an `<img>` from `image:`) to strip in the first
         // place.
         let doc = Parser::default()

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -2,7 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     blocks::metadata::block_title_text,
-    content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
+    content::{Content, SubstitutionGroup, sanitize_title, substitute_attributes_in_reftext},
     document::{
         Attribute, Author, AuthorLine, InterpretedValue, RefType, RevisionLine,
         is_attribute_entry_pass_macro, matches_author_pattern, set_author_metadata,
@@ -332,7 +332,7 @@ impl<'src> Header<'src> {
                     implicit_doctitle_str = Some(existing.clone());
                     title = Some(existing);
                 } else {
-                    let title_str = apply_header_subs(title_span.data(), parser);
+                    let title_str = apply_title_subs(title_span.data(), parser);
 
                     parser.set_attribute_by_value_from_header("doctitle", &title_str);
 
@@ -395,7 +395,7 @@ impl<'src> Header<'src> {
                     .as_deref()
                     .is_some_and(|s| s.contains('{'))
             {
-                Some(apply_header_subs(raw.data(), parser))
+                Some(apply_title_subs(raw.data(), parser))
             } else {
                 title
             };
@@ -533,6 +533,20 @@ impl<'src> Header<'src> {
     /// [`Document::doctitle`]: crate::Document::doctitle
     pub(crate) fn doctitle(&self) -> Option<&str> {
         self.doctitle.as_deref()
+    }
+
+    /// Return the effective document title (see [`doctitle`]) with any
+    /// rendered markup stripped down to plain text, mirroring Ruby
+    /// Asciidoctor's `Document#doctitle(sanitize: true)`.
+    ///
+    /// This is intended for contexts where markup is not allowed, such as
+    /// the text of the standalone HTML `<title>` element: a title rendered
+    /// with formatting (`*bold*`) or an inline macro (`image:...[]`) has that
+    /// markup removed rather than passed through verbatim.
+    ///
+    /// [`doctitle`]: Self::doctitle
+    pub(crate) fn doctitle_sanitized(&self) -> Option<String> {
+        self.doctitle.as_deref().map(sanitize_title)
     }
 
     /// Return the main portion of the document title, if there was a title.
@@ -1250,11 +1264,17 @@ fn split_author_entries(value: &str) -> Vec<&str> {
     entries
 }
 
-fn apply_header_subs(source: &str, parser: &Parser) -> String {
+/// Applies the document title's substitutions – the `Title` group, the same
+/// steps as `Normal` – to `source`, mirroring Asciidoctor's eager
+/// substitution of the `= Title` line into the `doctitle` attribute. Unlike
+/// the restricted `Header` group used for author/revision lines and
+/// attribute-entry values, this renders quotes (formatting), replacements,
+/// and inline macros (e.g. `image:`) in the title itself (see #1121).
+fn apply_title_subs(source: &str, parser: &Parser) -> String {
     let span = Span::new(source);
 
     let mut content = Content::from(span);
-    SubstitutionGroup::Header.apply(&mut content, parser, None);
+    SubstitutionGroup::Title.apply(&mut content, parser, None);
 
     content.rendered().to_string()
 }
@@ -1325,6 +1345,100 @@ mod tests {
         let doc = Parser::default().parse(":leveloffset: -6\n======= Not A Title");
 
         assert_eq!(doc.doctitle(), None);
+    }
+
+    #[test]
+    fn title_applies_full_normal_substitutions() {
+        // The document title line goes through the `Title` substitution group
+        // (the same steps as `Normal`), not the restricted `Header` group
+        // used for author/revision lines — so formatting (quotes) and inline
+        // macros (`image:`) render, matching Asciidoctor (see #1121).
+        let doc = Parser::default()
+            .parse("= *Document* image:logo.png[] _Title_ image:another-logo.png[another logo]");
+
+        let expected = concat!(
+            "<strong>Document</strong> ",
+            r#"<span class="image"><img src="logo.png" alt="logo"></span> "#,
+            "<em>Title</em> ",
+            r#"<span class="image"><img src="another-logo.png" alt="another logo"></span>"#,
+        );
+
+        assert_eq!(doc.doctitle(), Some(expected));
+        assert_eq!(doc.header().main_title(), Some(expected));
+        assert_eq!(doc.header().subtitle(), None);
+    }
+
+    #[test]
+    fn title_substitutions_apply_before_subtitle_partition() {
+        // A subtitle carved out of the (now fully substituted) title retains
+        // its own rendered formatting, rather than the literal, unprocessed
+        // source it kept before #1121 was fixed.
+        let doc = Parser::default().parse("= Main Title: *Subtitle*");
+
+        assert_eq!(doc.header().main_title(), Some("Main Title"));
+        assert_eq!(doc.header().subtitle(), Some("<strong>Subtitle</strong>"));
+    }
+
+    #[test]
+    fn author_and_revision_lines_keep_restricted_header_substitutions() {
+        // The #1121 fix is scoped to the title line only: author and revision
+        // lines must still see just the restricted `Header` group (special
+        // characters, attribute references, and the inline pass macro) —
+        // formatting is left as literal, unprocessed text.
+        let doc = Parser::default().parse("= Title\n*Jane Smith*\nv1, *2025-09-28*");
+
+        let author_line = doc.header().author_line().unwrap();
+        assert_eq!(
+            author_line.authors().next().map(|a| a.name().to_string()),
+            Some("*Jane Smith*".to_string())
+        );
+
+        let revision_line = doc.header().revision_line().unwrap();
+        assert_eq!(revision_line.revdate(), "*2025-09-28*");
+    }
+
+    #[test]
+    fn doctitle_sanitized_strips_rendered_markup_to_plain_text() {
+        // Mirrors Ruby Asciidoctor's `Document#doctitle(sanitize: true)`,
+        // used for contexts (like the standalone HTML `<title>` element)
+        // where markup is not allowed (see #1122). Depends on #1121: without
+        // the fuller title substitution there would be no rendered markup
+        // (bold, italic, an `<img>` from `image:`) to strip in the first
+        // place.
+        let doc = Parser::default()
+            .parse("= *Document* image:logo.png[] _Title_ image:another-logo.png[another logo]");
+
+        assert_eq!(doc.doctitle_sanitized(), Some("Document Title".to_string()));
+    }
+
+    #[test]
+    fn doctitle_sanitized_passes_through_plain_title_unchanged() {
+        let doc = Parser::default().parse("= Just the Title");
+
+        assert_eq!(doc.doctitle_sanitized(), Some("Just the Title".to_string()));
+    }
+
+    #[test]
+    fn doctitle_sanitized_is_none_without_a_title() {
+        let doc = Parser::default().parse("No title here.");
+
+        assert_eq!(doc.doctitle_sanitized(), None);
+    }
+
+    #[test]
+    fn sanitize_title_squeezes_spaces_left_by_a_removed_tag() {
+        // A run of spaces left behind after tags are stripped (e.g. two
+        // images rendered back-to-back, or a tag flanked by spaces on both
+        // sides) collapses to one, and the ends are trimmed, mirroring
+        // Ruby's `tr_s(' ', ' ').strip`.
+        assert_eq!(
+            super::sanitize_title("<img src=\"a.png\">  <img src=\"b.png\">"),
+            "",
+        );
+        assert_eq!(
+            super::sanitize_title("Before <b>bold</b>   after"),
+            "Before bold after",
+        );
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -384,13 +384,21 @@ impl<'src> Header<'src> {
             // was overridden by a `doctitle` set above it, `title` already holds
             // that (resolved) value and is not re-substituted.
             //
-            // Residual edge: a title that *mixes* a counter with a later-defined
-            // reference (e.g. `= {counter:n} {project-name}`) still contains a
-            // `{` after the eager pass, so the re-resolution runs and advances the
-            // counter a second time. Re-resolving is done from the raw title (not
-            // the eager result) so that escaped `\{…}` and specialchars stay
-            // correct; the counter here is the price of that. This is a rare
-            // combination and no test exercises it.
+            // Residual edge: a title that *mixes* a stateful, one-shot
+            // substitution with a later-defined reference (e.g. `= {counter:n}
+            // {project-name}`) still contains a `{` after the eager pass, so the
+            // re-resolution runs that one-shot substitution a second time.
+            // Re-resolving is done from the raw title (not the eager result) so
+            // that escaped `\{…}` and specialchars stay correct; the duplicated
+            // side effect here is the price of that. Since the eager pass now
+            // uses the `Title` group, this extends beyond a `{counter:…}`
+            // advancing twice to any stateful macro sharing the title with a
+            // later-defined reference – an anchor
+            // (`= {project-name} [[id]]`) can raise a spurious
+            // `DuplicateId` warning on its second registration, and a footnote
+            // (`= {project-name} footnote:[…]`) is defined twice. This is a
+            // rare combination – a document title is an unusual place for a
+            // footnote or anchor to begin with – and no test exercises it.
             let base = if !implicit_overridden_from_above
                 && let Some(raw) = title_source
                 && implicit_doctitle_str

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -130,7 +130,7 @@ mod default_macros_substitution {
         // The document *title* line itself is not part of this "Headers" row
         // – it uses `SubstitutionGroup::Title` (the same steps as `Normal`),
         // so the same `icon:` macro there is rendered (verified against
-        // Asciidoctor 2.0.26; see #1121).
+        // Asciidoctor 2.0.26).
         let doc = Parser::default().parse("= Title icon:heart[]-less");
 
         let title = doc.header().title().unwrap();

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -117,10 +117,24 @@ mod default_macros_substitution {
 "#
         );
 
+        // This table row describes the *metadata* lines in a document header
+        // (author and revision information, and attribute-entry values),
+        // which stay on the restricted `Header` substitution group and so
+        // never see macro substitution: an `icon:` macro on the revision
+        // line is left as literal text.
+        let doc = Parser::default().parse("= Title\nJane Doe\nv1, 2025-09-28: icon:heart[]-less");
+
+        let revremark = doc.header().revision_line().unwrap().revremark().unwrap();
+        assert_eq!(revremark, "icon:heart[]-less");
+
+        // The document *title* line itself is not part of this "Headers" row
+        // – it uses `SubstitutionGroup::Title` (the same steps as `Normal`),
+        // so the same `icon:` macro there is rendered (verified against
+        // Asciidoctor 2.0.26; see #1121).
         let doc = Parser::default().parse("= Title icon:heart[]-less");
 
         let title = doc.header().title().unwrap();
-        assert_eq!(title, "Title icon:heart[]-less");
+        assert_eq!(title, r#"Title <span class="icon">[heart&#93;</span>-less"#);
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -163,10 +163,25 @@ mod default_post_replacements_substitution {
 "#
         );
 
+        // This table row describes the *metadata* lines in a document header
+        // (author and revision information, and attribute-entry values),
+        // which stay on the restricted `Header` substitution group and so
+        // never see post_replacements: a trailing ` +` on the revision line
+        // is left as literal text.
+        let doc = Parser::default().parse("= Title\nJane Doe\nv1, 2025-09-28: remark +");
+
+        let revremark = doc.header().revision_line().unwrap().revremark().unwrap();
+        assert_eq!(revremark, "remark +");
+
+        // The document *title* line itself is not part of this "Headers" row
+        // – like a block or section title (see the `titles` test below), it
+        // uses `SubstitutionGroup::Title`, so the same trailing ` +` there
+        // does convert to a line break (verified against Asciidoctor 2.0.26;
+        // see #1121).
         let doc = Parser::default().parse("= abc +\ndef");
 
         let title = doc.header().title().unwrap();
-        assert_eq!(title, "abc +");
+        assert_eq!(title, "abc<br>");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -176,8 +176,7 @@ mod default_post_replacements_substitution {
         // The document *title* line itself is not part of this "Headers" row
         // – like a block or section title (see the `titles` test below), it
         // uses `SubstitutionGroup::Title`, so the same trailing ` +` there
-        // does convert to a line break (verified against Asciidoctor 2.0.26;
-        // see #1121).
+        // does convert to a line break (verified against Asciidoctor 2.0.26).
         let doc = Parser::default().parse("= abc +\ndef");
 
         let title = doc.header().title().unwrap();

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -372,7 +372,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         // The document *title* line itself is not part of this "Headers" row
         // – it uses `SubstitutionGroup::Title` (the same steps as `Normal`),
         // so the same `(C)` there is replaced (verified against Asciidoctor
-        // 2.0.26; see #1121).
+        // 2.0.26).
         let doc = Parser::default().parse("= Title (C) So On");
 
         let title = doc.header().title().unwrap();

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -359,10 +359,24 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
 "#
         );
 
+        // This table row describes the *metadata* lines in a document header
+        // (author and revision information, and attribute-entry values),
+        // which stay on the restricted `Header` substitution group and so
+        // never see character replacements: `(C)` on the revision line is
+        // left as literal text.
+        let doc = Parser::default().parse("= Title\nJane Doe\nv1, 2025-09-28: (C) So On");
+
+        let revremark = doc.header().revision_line().unwrap().revremark().unwrap();
+        assert_eq!(revremark, "(C) So On");
+
+        // The document *title* line itself is not part of this "Headers" row
+        // – it uses `SubstitutionGroup::Title` (the same steps as `Normal`),
+        // so the same `(C)` there is replaced (verified against Asciidoctor
+        // 2.0.26; see #1121).
         let doc = Parser::default().parse("= Title (C) So On");
 
         let title = doc.header().title().unwrap();
-        assert_eq!(title, "Title (C) So On");
+        assert_eq!(title, "Title &#169; So On");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

* Fixes #1121: `Header::parse` substituted the document title line with the restricted `Header` substitution group, so formatting (quotes), replacements, and inline macros like `image:` rendered as literal, unprocessed source — in `Document::doctitle()`, `Header::title()`, and the `main_title`/`subtitle` partition. The title line (and its lazy re-resolution path) now goes through `SubstitutionGroup::Title` (the same steps as `Normal`), matching Asciidoctor. Author/revision lines and attribute-entry values are unaffected — they still use the restricted `Header` group.
* Fixes #1122: added `Document::doctitle_sanitized()` (and `Header::doctitle_sanitized()`), mirroring Ruby Asciidoctor's `Document#doctitle(sanitize: true)` — strips rendered markup down to plain text, for contexts like a standalone HTML `<title>` element. Backed by a new shared `sanitize_title` helper (`content/content.rs`) that strips `<...>` tags, squeezes any resulting double spaces, and trims.
* Since the doctitle can now carry real rendered markup (including a live link from an autolinked bare URL), `this_document_reference` (the fallback text for a cross-reference to the document itself) now sanitizes the doctitle before embedding it inside its own `<a>` tag, to avoid nested markup — this keeps an existing Asciidoctor-parity test passing.

## Test plan

- [x] Added unit tests in `header.rs`: full title substitution (formatting + `image:` macro) reflected in `doctitle()`/`main_title()`/`subtitle()`; subtitle retains its own formatting; author/revision lines keep the restricted `Header` group; `doctitle_sanitized()` strips markup, passes plain titles through unchanged, and returns `None` without a title.
- [x] Updated three golden "Headers" tests (`subs/macros.rs`, `subs/post_replacements.rs`, `subs/replacements.rs`) that had used the document title line as their example of "header metadata doesn't get this substitution" — that was actually exercising the bug. Each now demonstrates the true metadata-line case (a revision remark) alongside a new example showing the title line does get the substitution.
- [x] `cargo test` — 4648 lib tests + 6 doctests pass.
- [x] `cargo fmt` and `cargo clippy --all-targets` are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Az3V8se96gNQe8kCgikPUL)_