### PR TITLE
fix: Respect API attribute locks for title-separator and notitle/showtitle

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -244,7 +244,9 @@ impl<'src> Header<'src> {
                 //
                 // A `separator` sets the subtitle separator; it behaves exactly
                 // like assigning the `title-separator` document attribute here, so
-                // both mechanisms share the same partitioning logic.
+                // both mechanisms share the same partitioning logic and the same
+                // modification-context lock check (an API-locked `title-separator`
+                // is not overwritten by this block attribute; see #1119).
                 //
                 // The line is only intercepted when a document title eventually
                 // follows – possibly after further stacked block attribute lines,
@@ -256,7 +258,7 @@ impl<'src> Header<'src> {
                     id = Some(doc_id);
                 }
                 if let Some(separator) = metadata.separator {
-                    parser.set_attribute_by_value_from_header("title-separator", separator);
+                    parser.set_attribute_by_value_from_header_checked("title-separator", separator);
                 }
                 if let Some(reftext) = metadata.reftext {
                     parser.set_attribute_by_value_from_header("reftext", reftext);
@@ -2452,6 +2454,24 @@ mod tests {
 
         assert_eq!(header.main_title(), Some("Main Title"));
         assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn separator_block_attribute_does_not_override_api_locked_title_separator() {
+        // An API-locked `title-separator` (see #1119) must not be overwritten
+        // by a `[separator=…]` block attribute above the title, exactly as an
+        // ordinary `:title-separator:` header entry is already blocked.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("title-separator", " -", ModificationContext::ApiOnly)
+            .parse("[separator=::]\n= Main Title - *Subtitle*\nAuthor Name\n\ncontent\n");
+
+        assert_eq!(
+            doc.attribute_value("title-separator"),
+            InterpretedValue::Value(" -")
+        );
+
+        let header = doc.header();
+        assert_eq!(header.main_title(), Some("Main Title"));
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -246,7 +246,7 @@ impl<'src> Header<'src> {
                 // like assigning the `title-separator` document attribute here, so
                 // both mechanisms share the same partitioning logic and the same
                 // modification-context lock check (an API-locked `title-separator`
-                // is not overwritten by this block attribute; see #1119).
+                // is not overwritten by this block attribute).
                 //
                 // The line is only intercepted when a document title eventually
                 // follows – possibly after further stacked block attribute lines,
@@ -2458,8 +2458,8 @@ mod tests {
 
     #[test]
     fn separator_block_attribute_does_not_override_api_locked_title_separator() {
-        // An API-locked `title-separator` (see #1119) must not be overwritten
-        // by a `[separator=…]` block attribute above the title, exactly as an
+        // An API-locked `title-separator` must not be overwritten by a
+        // `[separator=…]` block attribute above the title, exactly as an
         // ordinary `:title-separator:` header entry is already blocked.
         let doc = Parser::default()
             .with_intrinsic_attribute("title-separator", " -", ModificationContext::ApiOnly)

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -2475,6 +2475,29 @@ mod tests {
     }
 
     #[test]
+    fn separator_block_attribute_does_not_override_api_or_document_body_locked_title_separator() {
+        // `ApiOrDocumentBody` also locks `title-separator` against a *header*
+        // assignment (it may only be changed from the document body) -- the
+        // `[separator=…]` block attribute above the title is itself part of
+        // the header, so it must be rejected the same as `ApiOnly`.
+        let doc = Parser::default()
+            .with_intrinsic_attribute(
+                "title-separator",
+                " -",
+                ModificationContext::ApiOrDocumentBody,
+            )
+            .parse("[separator=::]\n= Main Title - *Subtitle*\n\ncontent\n");
+
+        assert_eq!(
+            doc.attribute_value("title-separator"),
+            InterpretedValue::Value(" -")
+        );
+
+        let header = doc.header();
+        assert_eq!(header.main_title(), Some("Main Title"));
+    }
+
+    #[test]
     fn unrecognized_block_attribute_above_title_is_consumed() {
         // A well-formed block attribute line above the document title is now
         // parsed as document metadata, so the title that follows is recognized

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -595,6 +595,24 @@ impl Default for Parser {
     }
 }
 
+/// The document scope a `notitle`/`showtitle` assignment originated from, for
+/// [`Parser::apply_title_visibility_linkage`]'s partner-lock check.
+///
+/// This mirrors the two document-side write-permission checks
+/// ([`Parser::set_attribute_from_header`] and
+/// [`Parser::set_attribute_from_body`]): which
+/// [`ModificationContext`] values block a write depends on whether the write
+/// is happening in the header or the body, since [`ApiOrHeader`] and
+/// [`ApiOrDocumentBody`] each permit one scope and forbid the other.
+///
+/// [`ApiOrHeader`]: ModificationContext::ApiOrHeader
+/// [`ApiOrDocumentBody`]: ModificationContext::ApiOrDocumentBody
+#[derive(Clone, Copy)]
+enum DocumentWriteScope {
+    Header,
+    Body,
+}
+
 impl Parser {
     /// The default value of [`max_block_nesting`](Self::max_block_nesting),
     /// mirroring the `max-block-nesting` built-in default (see
@@ -1406,14 +1424,17 @@ impl Parser {
     /// `{showtitle}` reference stays literal after `:notitle:` rather than
     /// silently resolving to an empty string).
     ///
-    /// `enforce_partner_lock` distinguishes a document-originated assignment
-    /// (a header or body attribute entry) from an API-originated one: when
-    /// `true`, the partner is left untouched if it currently carries an
-    /// [`ApiOnly`](ModificationContext::ApiOnly) override, so a document entry
-    /// cannot use the linkage as a back door around an API lock on the
-    /// *other* spelling. An API call always passes `false`, since a later API
-    /// call is always permitted to override an earlier one (matching the
-    /// "last call wins" contract of
+    /// `write_scope` distinguishes a document-originated assignment (a header
+    /// or body attribute entry) from an API-originated one: when `Some`, the
+    /// partner is left untouched if its current [`ModificationContext`]
+    /// forbids a write from that scope (the same rule
+    /// [`set_attribute_from_header`](Self::set_attribute_from_header) and
+    /// [`set_attribute_from_body`](Self::set_attribute_from_body) apply to
+    /// the attribute being assigned directly), so a document entry cannot use
+    /// the linkage as a back door around an API- or header/body-scoped lock
+    /// on the *other* spelling. An API call always passes `None`, since a
+    /// later API call is always permitted to override an earlier one
+    /// (matching the "last call wins" contract of
     /// [`with_intrinsic_attribute()`](Self::with_intrinsic_attribute) and
     /// its siblings), including the partner it set.
     ///
@@ -1425,7 +1446,7 @@ impl Parser {
         value: &InterpretedValue,
         modification_context: ModificationContext,
         silent_when_locked: bool,
-        enforce_partner_lock: bool,
+        write_scope: Option<DocumentWriteScope>,
     ) {
         let partner = match attr_name {
             "notitle" => "showtitle",
@@ -1433,7 +1454,9 @@ impl Parser {
             _ => return,
         };
 
-        if enforce_partner_lock && self.attribute_is_locked(partner) {
+        if let Some(scope) = write_scope
+            && self.partner_write_is_locked(partner, scope)
+        {
             return;
         }
 
@@ -1545,7 +1568,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, false, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, false, None);
 
         self.capture_attribute_baseline();
 
@@ -1599,7 +1622,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, true, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, true, None);
 
         self.capture_attribute_baseline();
 
@@ -2006,7 +2029,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, false, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, false, None);
 
         self.capture_attribute_baseline();
 
@@ -2056,7 +2079,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, true, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, true, None);
 
         self.capture_attribute_baseline();
 
@@ -2534,14 +2557,14 @@ impl Parser {
         // `notitle` and `showtitle` are inverse spellings of one title-
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
-        // A document header entry must not use the linkage to route around an
-        // API lock on the partner spelling, so the lock is enforced here.
+        // A document header entry must not use the linkage to route around a
+        // lock on the partner spelling, so the lock is enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
-            true,
+            Some(DocumentWriteScope::Header),
         );
 
         let attribute_value = AttributeValue {
@@ -2726,14 +2749,14 @@ impl Parser {
         // `notitle` and `showtitle` are inverse spellings of one title-
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
-        // A document body entry must not use the linkage to route around an
-        // API lock on the partner spelling, so the lock is enforced here.
+        // A document body entry must not use the linkage to route around a
+        // lock on the partner spelling, so the lock is enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
-            true,
+            Some(DocumentWriteScope::Body),
         );
 
         let attribute_value = AttributeValue {
@@ -2948,6 +2971,36 @@ impl Parser {
     fn attribute_is_locked(&self, name: &str) -> bool {
         self.effective_attribute(name)
             .is_some_and(|a| a.modification_context == ModificationContext::ApiOnly)
+    }
+
+    /// Reports whether `name` currently resolves to an attribute that a write
+    /// from `scope` is not permitted to change, for
+    /// [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)'s
+    /// partner-lock check.
+    ///
+    /// Applies the exact blocking condition
+    /// [`set_attribute_from_header`](Self::set_attribute_from_header) and
+    /// [`set_attribute_from_body`](Self::set_attribute_from_body) apply to
+    /// the attribute being assigned directly: a header write is blocked by
+    /// [`ApiOnly`](ModificationContext::ApiOnly) or
+    /// [`ApiOrDocumentBody`](ModificationContext::ApiOrDocumentBody) (the
+    /// latter permits only the body), and a body write is blocked by
+    /// [`ApiOnly`](ModificationContext::ApiOnly) or
+    /// [`ApiOrHeader`](ModificationContext::ApiOrHeader) (the latter permits
+    /// only the API or the header). Unlike
+    /// [`attribute_is_locked`](Self::attribute_is_locked), this also treats a
+    /// scope-mismatched `ApiOrHeader`/`ApiOrDocumentBody` value as locked, so
+    /// a header entry cannot use the linkage to reach a body-only partner (or
+    /// a body entry a header-only one).
+    fn partner_write_is_locked(&self, name: &str, scope: DocumentWriteScope) -> bool {
+        self.effective_attribute(name).is_some_and(|a| {
+            let mc = a.modification_context;
+            mc == ModificationContext::ApiOnly
+                || match scope {
+                    DocumentWriteScope::Header => mc == ModificationContext::ApiOrDocumentBody,
+                    DocumentWriteScope::Body => mc == ModificationContext::ApiOrHeader,
+                }
+        })
     }
 }
 
@@ -4595,6 +4648,39 @@ mod tests {
 
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
+        }
+
+        #[test]
+        fn header_notitle_does_not_override_document_body_locked_showtitle() {
+            // `ApiOrDocumentBody` permits only a *body* write, so a header
+            // `:notitle:` entry must not be able to use the linkage to reach
+            // an `ApiOrDocumentBody`-locked `showtitle` either -- not just an
+            // `ApiOnly` one.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                true,
+                ModificationContext::ApiOrDocumentBody,
+            );
+            let _ = parser.parse("= Doc\n:notitle:\n\nBody.");
+
+            assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
+            assert!(parser.is_attribute_set("showtitle"));
+        }
+
+        #[test]
+        fn body_showtitle_does_not_override_header_locked_notitle() {
+            // `ApiOrHeader` permits only the API or a *header* write, so a
+            // body `:showtitle:` entry must not be able to use the linkage to
+            // reach an `ApiOrHeader`-locked `notitle`.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "notitle",
+                true,
+                ModificationContext::ApiOrHeader,
+            );
+            let _ = parser.parse("= Doc\n\nintro\n\n:showtitle:\n\nmore");
+
+            assert_eq!(parser.attribute_value("notitle"), InterpretedValue::Set);
+            assert!(parser.is_attribute_set("notitle"));
         }
 
         #[test]

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1411,9 +1411,9 @@ impl Parser {
     /// `true`, the partner is left untouched if it currently carries an
     /// [`ApiOnly`](ModificationContext::ApiOnly) override, so a document entry
     /// cannot use the linkage as a back door around an API lock on the
-    /// *other* spelling (see #1120). An API call always passes `false`,
-    /// since a later API call is always permitted to override an earlier one
-    /// (matching the "last call wins" contract of
+    /// *other* spelling. An API call always passes `false`, since a later API
+    /// call is always permitted to override an earlier one (matching the
+    /// "last call wins" contract of
     /// [`with_intrinsic_attribute()`](Self::with_intrinsic_attribute) and
     /// its siblings), including the partner it set.
     ///
@@ -2535,8 +2535,7 @@ impl Parser {
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
         // A document header entry must not use the linkage to route around an
-        // API lock on the partner spelling (see #1120), so the lock is
-        // enforced here.
+        // API lock on the partner spelling, so the lock is enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
@@ -2596,9 +2595,9 @@ impl Parser {
     /// ([`ApiOnly`](ModificationContext::ApiOnly) or
     /// [`ApiOrDocumentBody`](ModificationContext::ApiOrDocumentBody)) is not
     /// silently overwritten just because the equivalent value arrived via
-    /// block-attribute syntax rather than an attribute entry (see #1119). The
-    /// write is dropped silently on a lock: this path has no attribute span
-    /// to attach an `AttributeValueIsLocked` warning to.
+    /// block-attribute syntax rather than an attribute entry. The write is
+    /// dropped silently on a lock: this path has no attribute span to attach
+    /// an `AttributeValueIsLocked` warning to.
     ///
     /// [`Header::parse()`]: crate::document::Header::parse
     pub(crate) fn set_attribute_by_value_from_header_checked<N: AsRef<str>, V: AsRef<str>>(
@@ -2728,8 +2727,7 @@ impl Parser {
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
         // A document body entry must not use the linkage to route around an
-        // API lock on the partner spelling (see #1120), so the lock is
-        // enforced here.
+        // API lock on the partner spelling, so the lock is enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
@@ -4546,9 +4544,9 @@ mod tests {
 
         #[test]
         fn header_notitle_does_not_override_api_locked_showtitle() {
-            // Asciidoctor asciidoctor/asciidoctor#1120: an API-locked `showtitle`
-            // must win over a header `:notitle:` entry -- the linkage must not
-            // use the partner update as a back door around the lock.
+            // An API-locked `showtitle` must win over a header `:notitle:`
+            // entry -- the linkage must not use the partner update as a back
+            // door around the lock.
             let mut parser = Parser::default().with_intrinsic_attribute_bool(
                 "showtitle",
                 true,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1406,6 +1406,17 @@ impl Parser {
     /// `{showtitle}` reference stays literal after `:notitle:` rather than
     /// silently resolving to an empty string).
     ///
+    /// `enforce_partner_lock` distinguishes a document-originated assignment
+    /// (a header or body attribute entry) from an API-originated one: when
+    /// `true`, the partner is left untouched if it currently carries an
+    /// [`ApiOnly`](ModificationContext::ApiOnly) override, so a document entry
+    /// cannot use the linkage as a back door around an API lock on the
+    /// *other* spelling (see #1120). An API call always passes `false`,
+    /// since a later API call is always permitted to override an earlier one
+    /// (matching the "last call wins" contract of
+    /// [`with_intrinsic_attribute()`](Self::with_intrinsic_attribute) and
+    /// its siblings), including the partner it set.
+    ///
     /// [set]: https://docs.asciidoctor.org/asciidoc/latest/attributes/set-attributes/
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     fn apply_title_visibility_linkage(
@@ -1414,12 +1425,17 @@ impl Parser {
         value: &InterpretedValue,
         modification_context: ModificationContext,
         silent_when_locked: bool,
+        enforce_partner_lock: bool,
     ) {
         let partner = match attr_name {
             "notitle" => "showtitle",
             "showtitle" => "notitle",
             _ => return,
         };
+
+        if enforce_partner_lock && self.attribute_is_locked(partner) {
+            return;
+        }
 
         // Either way the partner supersedes (and resets) any counter of the
         // same name, mirroring a direct assignment.
@@ -1529,7 +1545,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, false, false);
 
         self.capture_attribute_baseline();
 
@@ -1583,7 +1599,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, true);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, true, false);
 
         self.capture_attribute_baseline();
 
@@ -1990,7 +2006,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, false);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, false, false);
 
         self.capture_attribute_baseline();
 
@@ -2040,7 +2056,7 @@ impl Parser {
 
         Arc::make_mut(&mut self.attribute_values).insert(name.clone(), attribute_value);
 
-        self.apply_title_visibility_linkage(&name, &value, modification_context, true);
+        self.apply_title_visibility_linkage(&name, &value, modification_context, true, false);
 
         self.capture_attribute_baseline();
 
@@ -2518,11 +2534,15 @@ impl Parser {
         // `notitle` and `showtitle` are inverse spellings of one title-
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
+        // A document header entry must not use the linkage to route around an
+        // API lock on the partner spelling (see #1120), so the lock is
+        // enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
+            true,
         );
 
         let attribute_value = AttributeValue {
@@ -2561,6 +2581,41 @@ impl Parser {
 
         self.counter_values.borrow_mut().remove(&attr_name);
         Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
+    }
+
+    /// Called from [`Header::parse()`] for a value that is derived from a
+    /// block attribute above the document title (e.g. `[separator=::]` sets
+    /// `title-separator`) and that has a direct document-attribute-entry
+    /// equivalent.
+    ///
+    /// Unlike [`set_attribute_by_value_from_header()`](Self::set_attribute_by_value_from_header),
+    /// this applies the same modification-context lock check that an
+    /// ordinary `:title-separator:` header entry goes through (see
+    /// [`set_attribute_from_header()`](Self::set_attribute_from_header)), so
+    /// an attribute locked via the API
+    /// ([`ApiOnly`](ModificationContext::ApiOnly) or
+    /// [`ApiOrDocumentBody`](ModificationContext::ApiOrDocumentBody)) is not
+    /// silently overwritten just because the equivalent value arrived via
+    /// block-attribute syntax rather than an attribute entry (see #1119). The
+    /// write is dropped silently on a lock: this path has no attribute span
+    /// to attach an `AttributeValueIsLocked` warning to.
+    ///
+    /// [`Header::parse()`]: crate::document::Header::parse
+    pub(crate) fn set_attribute_by_value_from_header_checked<N: AsRef<str>, V: AsRef<str>>(
+        &mut self,
+        name: N,
+        value: V,
+    ) {
+        let attr_name = remap_attr_name(name);
+
+        if let Some(existing_attr) = self.effective_attribute(&attr_name)
+            && (existing_attr.modification_context == ModificationContext::ApiOnly
+                || existing_attr.modification_context == ModificationContext::ApiOrDocumentBody)
+        {
+            return;
+        }
+
+        self.set_attribute_by_value_from_header(attr_name, value);
     }
 
     /// Applies the `imagesdir`-relative default for the `iconsdir` attribute.
@@ -2672,11 +2727,15 @@ impl Parser {
         // `notitle` and `showtitle` are inverse spellings of one title-
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
+        // A document body entry must not use the linkage to route around an
+        // API lock on the partner spelling (see #1120), so the lock is
+        // enforced here.
         self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
+            true,
         );
 
         let attribute_value = AttributeValue {
@@ -4482,6 +4541,75 @@ mod tests {
             // the linkage is a no-op for every other attribute.
             let parser = parse_header(":sectnums:");
             assert!(!parser.has_attribute("notitle"));
+            assert!(!parser.has_attribute("showtitle"));
+        }
+
+        #[test]
+        fn header_notitle_does_not_override_api_locked_showtitle() {
+            // Asciidoctor asciidoctor/asciidoctor#1120: an API-locked `showtitle`
+            // must win over a header `:notitle:` entry -- the linkage must not
+            // use the partner update as a back door around the lock.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                true,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Doc\n:notitle:\n\nBody.");
+
+            assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
+            assert!(parser.is_attribute_set("showtitle"));
+            assert!(parser.resolve_show_title(false));
+        }
+
+        #[test]
+        fn header_showtitle_does_not_override_api_locked_notitle() {
+            // Same as above, in the opposite direction: a header `:showtitle:`
+            // entry is itself unlocked (only `notitle` was API-locked), so the
+            // direct write is permitted -- but its partner-update side effect
+            // must not clobber the API-locked `notitle` value.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "notitle",
+                true,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Doc\n:showtitle:\n\nBody.");
+
+            assert_eq!(parser.attribute_value("notitle"), InterpretedValue::Set);
+            assert!(parser.is_attribute_set("notitle"));
+
+            // `showtitle` itself was never locked, so the direct write stands,
+            // and per its documented precedence over `notitle` it decides the
+            // resolved visibility here -- that precedence rule is unrelated to
+            // the API lock on `notitle`'s raw value, which this test guards.
+            assert!(parser.resolve_show_title(false));
+        }
+
+        #[test]
+        fn body_notitle_does_not_override_api_locked_showtitle() {
+            // The lock is enforced from the document body too, not just the
+            // header.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                true,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Doc\n\nintro\n\n:notitle:\n\nmore");
+
+            assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
+            assert!(parser.is_attribute_set("showtitle"));
+        }
+
+        #[test]
+        fn api_reassignment_still_updates_locked_partner() {
+            // The partner lock is enforced only against a *document*
+            // assignment; a later API call is always permitted to override an
+            // earlier one (including the partner it previously set), matching
+            // the "last call wins" contract of `with_intrinsic_attribute*`.
+            let parser = Parser::default()
+                .with_intrinsic_attribute_bool("showtitle", true, ModificationContext::ApiOnly)
+                .with_intrinsic_attribute_bool("notitle", true, ModificationContext::ApiOnly);
+
+            assert_eq!(parser.attribute_value("notitle"), InterpretedValue::Set);
             assert!(!parser.has_attribute("showtitle"));
         }
     }


### PR DESCRIPTION
## Summary

- Fix `[separator=...]` block attribute silently overwriting an API-locked `title-separator` document attribute, by routing it through a new lock-checked variant of `set_attribute_by_value_from_header` (the same check an ordinary `:title-separator:` header entry already goes through).
- Fix the `notitle`/`showtitle` inverse-toggle linkage always letting the most recent *document* assignment overwrite its partner, even when the partner carries an API-level (`ModificationContext::ApiOnly`) lock. The linkage now skips updating the partner in that case for document-originated writes (header or body), while API-originated writes (`with_intrinsic_attribute*`) are unaffected, since a later API call is always allowed to override an earlier one.

Fixes #1119
Fixes #1120

## Test plan

- [x] Added unit tests in `parser/src/document/header.rs` covering an API-locked `title-separator` vs. a `[separator=...]` block attribute
- [x] Added unit tests in `parser/src/parser/parser.rs` covering an API-locked `showtitle`/`notitle` vs. conflicting document entries in both directions (header and body)
- [x] `cargo test`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets -- -D warnings`


---
_Generated by [Claude Code](https://claude.ai/code/session_01M6bB2Fa3WtTZjAa8AZJ4ga)_