### PR TITLE
fix: Recognize docinfo1/docinfo2 and honor full docinfosubs step list

### DIFF
--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -26,5 +26,4 @@ mod substitution_step;
 pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
     AttributeMissing, substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
-    substitute_attributes_in_text,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -2071,7 +2071,7 @@ mod tests {
             /// than the block substitution pipeline.
             mod free_standing_text {
                 use super::parser_with_mode;
-                use crate::content::substitute_attributes_in_text;
+                use crate::content::substitution_step::substitute_attributes_in_text;
 
                 #[test]
                 fn drop_removes_line_that_only_contained_the_reference() {

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -8,6 +8,7 @@ use crate::{
     Parser, SafeMode, Span,
     content::{Content, SubstitutionGroup, SubstitutionStep},
     document::InterpretedValue,
+    parser::{CatalogResolver, ReferenceWarnings},
 };
 
 /// Where a [docinfo] file's content is injected into the converted output.
@@ -197,6 +198,25 @@ impl Docinfo {
             let saved = parser.substitution_warnings_len();
             let mut content = Content::from(Span::new(&joined));
             docinfo_subs.apply(&mut content, parser, None);
+
+            // A `docinfosubs` list that includes `macros` may have discovered
+            // cross-references (`<<id>>`, `xref:id[…]`), left deferred with an
+            // unresolved-fallback rendering. Docinfo content isn't part of the
+            // document's own block tree, so the later document-wide
+            // `resolve_against_own_catalog` pass never visits it; resolve it
+            // here instead, directly against the parser's catalog. This is
+            // safe because `Docinfo::resolve` runs only after the entire
+            // document body has been parsed, so the catalog is already
+            // complete. Any unresolved-reference warning is discarded for the
+            // same reason the substitution warnings above are: its span
+            // refers to the docinfo text, not the document source.
+            if content.has_unresolved_refs() {
+                let catalog = parser.catalog();
+                let resolver = CatalogResolver::new(&catalog);
+                let mut ref_warnings = ReferenceWarnings::default();
+                content.resolve_references(&resolver, &*parser.renderer, &mut ref_warnings);
+            }
+
             let substituted = content.rendered_owned();
             parser.truncate_substitution_warnings(saved);
             substituted
@@ -390,6 +410,20 @@ mod tests {
             &[("docinfo.html", "{license-url} (C)")],
         );
         assert_eq!(head, "https://example.org &#169;");
+    }
+
+    #[test]
+    fn docinfosubs_macros_resolves_cross_references_against_the_document_catalog() {
+        // `docinfosubs=macros` runs the macros substitution on docinfo
+        // content, which can discover a cross-reference. Docinfo content
+        // isn't part of the document's own block tree, so the reference must
+        // still resolve against the document's catalog rather than being left
+        // as unresolved-fallback text.
+        let head = head_for(
+            "= Doc\n:docinfo: shared-head\n:docinfosubs: macros\n\n[#section-a]\n== Section A\n\ncontent",
+            &[("docinfo.html", "xref:section-a[]")],
+        );
+        assert_eq!(head, r##"<a href="#section-a">Section A</a>"##);
     }
 
     #[test]

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -4,7 +4,11 @@
 //!
 //! [docinfo]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
 
-use crate::{Parser, SafeMode, content::substitute_attributes_in_text, document::InterpretedValue};
+use crate::{
+    Parser, SafeMode, Span,
+    content::{Content, SubstitutionGroup, SubstitutionStep},
+    document::InterpretedValue,
+};
 
 /// Where a [docinfo] file's content is injected into the converted output.
 ///
@@ -98,8 +102,21 @@ impl Docinfo {
         // The `docinfo` attribute selects which scopes/locations apply. An unset
         // attribute means no docinfo; an empty value (a bare `:docinfo:`) is
         // equivalent to `private`.
+        //
+        // When `docinfo` itself is unset, the legacy `docinfo1`/`docinfo2`
+        // standalone boolean attributes are consulted as a fallback: `docinfo1`
+        // is equivalent to `docinfo=shared`, and `docinfo2` is equivalent to
+        // `docinfo=private,shared`.
         let tokens: Vec<String> = match parser.attribute_value("docinfo") {
-            InterpretedValue::Unset => return Self::default(),
+            InterpretedValue::Unset => {
+                if parser.is_attribute_set("docinfo2") {
+                    vec!["private".to_string(), "shared".to_string()]
+                } else if parser.is_attribute_set("docinfo1") {
+                    vec!["shared".to_string()]
+                } else {
+                    return Self::default();
+                }
+            }
             InterpretedValue::Set => vec!["private".to_string()],
             InterpretedValue::Value(v) => v
                 .split(',')
@@ -130,7 +147,7 @@ impl Docinfo {
         // private scope is only available when a primary file name is known.
         let docname = parser.docname();
 
-        let apply_attribute_subs = docinfosubs_includes_attributes(parser);
+        let docinfo_subs = docinfosubs_steps(parser);
 
         let resolve_location = |location: DocinfoLocation| -> String {
             let token = location.token();
@@ -170,15 +187,17 @@ impl Docinfo {
 
             let joined = parts.join("\n");
 
-            if !apply_attribute_subs {
+            if docinfo_subs.steps().is_empty() {
                 return joined;
             }
 
-            // Attribute substitution may record `warn`-mode warnings whose
-            // offsets refer to the docinfo text, not the document source.
-            // Discard them so they are not reported against the document.
+            // Substitution may record `warn`-mode warnings whose offsets refer
+            // to the docinfo text, not the document source. Discard them so
+            // they are not reported against the document.
             let saved = parser.substitution_warnings_len();
-            let substituted = substitute_attributes_in_text(&joined, parser);
+            let mut content = Content::from(Span::new(&joined));
+            docinfo_subs.apply(&mut content, parser, None);
+            let substituted = content.rendered_owned();
             parser.truncate_substitution_warnings(saved);
             substituted
         };
@@ -191,17 +210,23 @@ impl Docinfo {
     }
 }
 
-/// Returns whether the `attributes` substitution should be applied to docinfo
+/// Resolves the ordered list of substitution steps applied to docinfo
 /// content, per the `docinfosubs` attribute.
 ///
 /// When `docinfosubs` is unset it has an implied default of `attributes`, so
-/// substitution is applied. When set, substitution is applied only if the
-/// comma-separated list names `attributes`.
-fn docinfosubs_includes_attributes(parser: &Parser) -> bool {
+/// only the attribute-references substitution is applied. When set with no
+/// value (a bare `:docinfosubs:`), no substitutions are applied. When set
+/// with a value, the comma-separated list is parsed with the same vocabulary
+/// and ordering rules as a block's `subs` attribute (see
+/// [`SubstitutionGroup::from_custom_string`]); unrecognized names are
+/// silently ignored.
+fn docinfosubs_steps(parser: &Parser) -> SubstitutionGroup {
     match parser.attribute_value("docinfosubs") {
-        InterpretedValue::Unset => true,
-        InterpretedValue::Set => false,
-        InterpretedValue::Value(v) => v.split(',').any(|s| s.trim() == "attributes"),
+        InterpretedValue::Unset => {
+            SubstitutionGroup::Custom(vec![SubstitutionStep::AttributeReferences])
+        }
+        InterpretedValue::Set => SubstitutionGroup::Custom(vec![]),
+        InterpretedValue::Value(v) => SubstitutionGroup::from_custom_string(None, &v).0,
     }
 }
 
@@ -308,5 +333,74 @@ mod tests {
             &[("docinfo.html", "HEAD")],
         );
         assert_eq!(head, "HEAD");
+    }
+
+    #[test]
+    fn docinfo1_is_equivalent_to_shared_docinfo() {
+        // `docinfo1` is a legacy standalone boolean attribute equivalent to
+        // `docinfo=shared` (issue #1115): only the shared docinfo file is
+        // included, not a document-private one.
+        let head = head_for(
+            "= Doc\n:docinfo1:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED");
+    }
+
+    #[test]
+    fn docinfo2_is_equivalent_to_private_and_shared_docinfo() {
+        // `docinfo2` is a legacy standalone boolean attribute equivalent to
+        // `docinfo=private,shared` (issue #1115): both the shared and
+        // document-private docinfo files are included, shared first.
+        let head = head_for(
+            "= Doc\n:docinfo2:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED\nPRIVATE");
+    }
+
+    #[test]
+    fn explicit_docinfo_attribute_takes_precedence_over_legacy_toggles() {
+        // When `docinfo` is explicitly set, the legacy `docinfo1`/`docinfo2`
+        // toggles are not consulted at all.
+        let head = head_for(
+            "= Doc\n:docinfo: shared-head\n:docinfo2:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED");
+    }
+
+    #[test]
+    fn docinfosubs_multiple_tokens_apply_additional_steps() {
+        // `docinfosubs=attributes,replacements` (issue #1116) applies both the
+        // attribute-references substitution and the character-replacements
+        // substitution, not just attribute references: `(C)` becomes the
+        // copyright character reference.
+        let head = head_for(
+            "= Doc\n:license-url: https://example.org\n:docinfo: shared-head\n:docinfosubs: attributes,replacements\n\nBody.",
+            &[("docinfo.html", "{license-url} (C)")],
+        );
+        assert_eq!(head, "https://example.org &#169;");
+    }
+
+    #[test]
+    fn docinfosubs_replacements_only_skips_attribute_substitution() {
+        // `docinfosubs=replacements` names only the replacements step, so
+        // attribute references are left untouched while `(C)` is still
+        // replaced.
+        let head = head_for(
+            "= Doc\n:license-url: https://example.org\n:docinfo: shared-head\n:docinfosubs: replacements\n\nBody.",
+            &[("docinfo.html", "{license-url} (C)")],
+        );
+        assert_eq!(head, "{license-url} &#169;");
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1920,6 +1920,18 @@ impl Parser {
         std::mem::take(&mut *self.catalog.borrow_mut())
     }
 
+    /// Returns a read-only borrow of the parser's current reference catalog,
+    /// without taking it.
+    ///
+    /// Used to resolve cross-references discovered outside the document's own
+    /// block tree (e.g. docinfo content) against the catalog while it is still
+    /// held by the parser – after the document body has been parsed (so the
+    /// catalog is complete) but before [`take_catalog`](Self::take_catalog)
+    /// transfers it to the `Document`.
+    pub(crate) fn catalog(&self) -> std::cell::Ref<'_, Catalog> {
+        self.catalog.borrow()
+    }
+
     /* Comment out until we're prepared to use and test this.
         /// Sets the default value for an [intrinsic attribute].
         ///


### PR DESCRIPTION
## Summary

- `Docinfo::resolve` (`parser/src/document/docinfo.rs`) only ever read the `docinfo` attribute, so the legacy `docinfo1`/`docinfo2` standalone boolean attributes were silently ignored. They now act as a fallback when `docinfo` is unset: `docinfo1` behaves like `docinfo=shared`, and `docinfo2` behaves like `docinfo=private,shared`. An explicitly set `docinfo` attribute still takes precedence.
- `docinfosubs` was only ever checked for the literal token `attributes`, so no other named substitution step (`replacements`, `macros`, `specialchars`, etc.) was ever applied to docinfo content. It's now parsed with `SubstitutionGroup::from_custom_string` — the same vocabulary/ordering logic the inline pass macro's custom-substitutions list uses — and every named step is applied via `SubstitutionGroup::apply`, in Asciidoctor's documented order.
- Removed the now-unused `substitute_attributes_in_text` re-export from `content/mod.rs` (docinfo.rs was its only external consumer); its own test module now uses the direct `substitution_step` path.

Fixes #1115
Fixes #1116

## Test plan

- [x] Added unit tests in `parser/src/document/docinfo.rs` covering `docinfo1`, `docinfo2`, explicit-`docinfo`-takes-precedence, and `docinfosubs` with multiple tokens (`attributes,replacements` and `replacements`-only)
- [x] `cargo test -p asciidoc-parser` (4646 tests passing)
- [x] `cargo clippy --all-features --all-targets -- -Dwarnings`
- [x] `cargo +nightly fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01C651n3wWdR52xHUYfywPLS)_