### PR TITLE
fix: Treat explicitly-unset attributes as missing for attribute-missing

### DIFF
--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -764,8 +764,14 @@ impl Replacer for AttributeReplacer<'_> {
         // `key = $2.downcase`. The original spelling is still what is emitted
         // literally for a skipped or missing reference below.
         let lookup_name = attribute_lookup_name(attr_name);
+        let value = self.parser.attribute_value(&lookup_name);
 
-        if !self.parser.has_attribute(&lookup_name) {
+        // A reference is "missing" for `attribute-missing` purposes both when
+        // the attribute was never assigned at all and when it was explicitly
+        // unset (a document `:name!:` entry or an API override that unsets
+        // it) – both resolve to `InterpretedValue::Unset`. Only a value-less
+        // `Set` attribute or a concrete `Value` counts as present.
+        if !self.parser.has_attribute(&lookup_name) || matches!(value, InterpretedValue::Unset) {
             match self.mode {
                 AttributeMissing::Skip => dest.push_str(&caps[0]),
                 AttributeMissing::Drop => {
@@ -798,12 +804,11 @@ impl Replacer for AttributeReplacer<'_> {
             return;
         }
 
-        if let InterpretedValue::Value(value) = self.parser.attribute_value(&lookup_name) {
+        // A value-less `Set` attribute (e.g. `:foo:` with no `=value`)
+        // substitutes to an empty string, matching Asciidoctor.
+        if let InterpretedValue::Value(value) = value {
             dest.push_str(value.as_ref());
         }
-
-        // Language description is unclear as to what happens for "set" and
-        // "unset" attribute values. For now, we'll replace those with nothing.
     }
 }
 
@@ -1989,6 +1994,19 @@ mod tests {
             fn drop_line_can_empty_the_content() {
                 let p = parser_with_mode("drop-line");
                 assert_eq!(render("{missing}", &p), "");
+            }
+
+            #[test]
+            fn drop_line_removes_a_line_referencing_an_api_unset_attribute() {
+                // An attribute explicitly unset via the API (as opposed to one
+                // that was never assigned at all) still counts as "missing" for
+                // `attribute-missing` purposes (issue #1117).
+                let p = parser_with_mode("drop-line").with_intrinsic_attribute_bool(
+                    "version",
+                    false,
+                    ModificationContext::ApiOnly,
+                );
+                assert_eq!(render("bootstrap.{version}.min.js", &p), "");
             }
 
             #[test]

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -300,6 +300,18 @@ mod tests {
     }
 
     #[test]
+    fn drop_line_removes_docinfo_lines_with_an_unset_attribute() {
+        // A reference to an attribute explicitly unset via a document
+        // `:name!:` entry is dropped just like one that was never assigned at
+        // all (issue #1117).
+        let head = head_for(
+            "= Doc\n:attribute-missing: drop-line\n:license-url!:\n:docinfo: shared-head\n\nBody.",
+            &[("docinfo.html", "keep one\n{license-url}\nkeep two")],
+        );
+        assert_eq!(head, "keep one\nkeep two");
+    }
+
+    #[test]
     fn outfilesuffix_falls_back_to_html() {
         // A bare `:outfilesuffix:` (set, no value) is not a usable suffix, so
         // docinfo file names fall back to the `.html` default.

--- a/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
@@ -175,6 +175,19 @@ fn drop_line_only_drops_the_offending_line() {
 }
 
 #[test]
+fn drop_line_treats_an_explicitly_unset_attribute_as_missing() {
+    // `attribute-missing` fires for a reference to an attribute that was
+    // explicitly unset via a document `:name!:` entry, not only for one that
+    // was never assigned at all (issue #1117).
+    assert_eq!(
+        render_first_block(
+            ":attribute-missing: drop-line\n:version!:\n\nbootstrap.{version}.min.js"
+        ),
+        ""
+    );
+}
+
+#[test]
 fn attribute_missing_can_be_changed_mid_document() {
     // The setting is read each time references are replaced, so it can be
     // changed partway through a document.

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -308,8 +308,9 @@ fn store_attribute_with_negated_value() {
 
     // A negated name (`foo!` or `!foo`) stores the attribute as unset; the API
     // models this with `with_intrinsic_attribute_bool(name, false, ..)`. The
-    // unset value carries into a parsed document, and a `{foo}` reference
-    // resolves to nothing.
+    // unset value carries into a parsed document, and a `{foo}` reference is
+    // treated as a reference to a missing attribute: under the default
+    // `attribute-missing=skip` mode, it is left in place (issue #1117).
     let mut parser = Parser::default().with_intrinsic_attribute_bool(
         "foo",
         false,
@@ -317,7 +318,7 @@ fn store_attribute_with_negated_value() {
     );
     let doc = parser.parse("{foo}");
     assert_eq!(doc.attribute_value("foo"), InterpretedValue::Unset);
-    assert_eq!(rendered_paragraphs(&doc), vec![String::new()]);
+    assert_eq!(rendered_paragraphs(&doc), vec!["{foo}".to_string()]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `AttributeReplacer::replace_append` (`parser/src/content/substitution_step.rs`) only ran the `attribute-missing` policy (`skip`/`drop`/`drop-line`/`warn`) when an attribute reference's name had never been assigned at all (`has_attribute() == false`). An attribute explicitly *unset* — via a document `:name!:` entry or an API override like `with_intrinsic_attribute_bool(name, false, ..)` — resolves to `InterpretedValue::Unset`, but `has_attribute()` still reports `true` for it, so the reference silently substituted to an empty string regardless of the configured `attribute-missing` mode.
- Fixed by treating `InterpretedValue::Unset` the same as "never assigned" when deciding whether a reference is missing. This is the shared machinery behind `apply_attributes`, `substitute_attributes_in_macro_target`, and `substitute_attributes_in_text` (docinfo file substitution), so the fix covers all three call sites.
- One existing test (`store_attribute_with_negated_value`) had encoded the old buggy behavior and is updated to assert the correct (Asciidoctor-matching) default-mode behavior instead.

## Test plan

- [x] `cargo test` (4644 passed)
- [x] `cargo fmt --all` (no diff beyond intended changes)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] Added unit tests:
  - `attribute-missing=drop-line` with an API-unset attribute (`substitution_step.rs`)
  - `attribute-missing=drop-line` with a document `:name!:` unset attribute (`unresolved_references.rs`)
  - docinfo file substitution with an unset attribute (`docinfo.rs`)
  - regression coverage confirming the never-defined case still works
