### PR TITLE
feat: Recognize footnotes in the single-pass inline builder (inline-ast Phase 4, step 4b(ii), part 4c)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1044,8 +1044,49 @@ Each phase is a reviewable unit with a clear exit gate.
   paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`) is likewise left literal.
   As throughout the additive builder, this performs *no* recognition side effect (the HTML backend
   builds no index, so the string replacer has none to skip either). This step is **additive**: nothing
-  is wired into the parse path. The last macro family (`Footnote`) is a later sub-step; inline `Stem`
-  is handled at passthrough time (step 5), not in the macros step.
+  is wired into the parse path. Inline `Stem` is handled at passthrough time (step 5), not in the
+  macros step.
+
+  *Step 4b(ii) part 4c landed as (`Macros` → `Footnote`, the last macro family):* the builder now
+  recognizes **footnotes** (`footnote:[…]`, `footnote:id[…]`, `footnote:id[]`) as a
+  [`Footnote`](../../parser/src/inlines/footnote.rs) node, folding through the same `render_footnote`
+  the string step calls so the output is byte-for-byte identical (pinned by a new differential
+  corpus). It reuses the string pipeline's *exact* recognition –
+  [`INLINE_FOOTNOTE_MACRO`](../../parser/src/content/macros.rs) is now shared `pub(crate)`, alongside
+  the `normalize_footnote_text` helper – so only the recognition *sink* changes, and runs **last** in
+  `apply_macros`, after cross-references, mirroring the string step's order exactly: a footnote's text
+  is extracted from the flow, so any construct an earlier pass at this same level already recognized
+  (an image, a link, an anchor, an index term, or now a cross-reference) is captured as *that
+  construct's node* rather than being re-recognized from its source text.
+
+  Two things set this increment apart from every prior macro family:
+
+  - **Structured content, not a literal value.** A footnote's bracket content becomes the node's
+    `children` via [`emit_range`](../../parser/src/content/inline_builder.rs) rather than a literal
+    `'src` slice gated by [`range_is_verbatim`](../../parser/src/content/inline_builder.rs) the way a
+    target or display text is elsewhere. A content range crossing an already-recognized construct is
+    therefore *not* a boundary to defer on – nesting is the point, and `emit_range` clones that
+    construct's node whole into the footnote's subtree, exactly mirroring how the string pipeline's
+    footnote text captures an already-substituted macro verbatim.
+  - **One *required* recognition side effect.** Every prior macro family performs *no* recognition
+    side effect (no catalog registration, no warning), deferring that to the cutover (step 6) because
+    omitting it does not change the fold's output bytes. A footnote's marker digits *are* the assigned
+    footnote number, so this pass must call `Parser::footnote_index_for_id` / `Parser::define_footnote`
+    – the same document-counter-advancing calls the string replacer makes – or the differential corpus
+    could never pass. The two code paths never share a `Parser` (each independently numbers footnotes
+    over the same source in the same left-to-right order), so this never double-counts a registration.
+    The registered catalog `text` is a best-effort normalized rendering of the raw bracket content, not
+    a fold (building the tree must not itself invoke a renderer), so – like every other deferred
+    registration in this module – a tree-built footnote's `Document::catalog().footnotes()` entry is
+    not yet byte-faithful; only the returned *number* is relied on.
+
+  Two forms are deferred, each documented and pinned by a divergence test: the deprecated
+  `footnoteref:[id,text]` / `footnoteref:[id]` form (which packs its id and text into one bracket, split
+  differently, and – outside `compat-mode` – raises a deprecation warning neither of which this
+  increment implements), and content carrying an escaped closing bracket (`\]`, which would need
+  splicing a literal `]` into the middle of a `Text` piece the content range slices – a rebuild this
+  increment does not attempt). This step is **additive**: nothing is wired into the parse path. With it,
+  every macro family the recorder covers now has a single-pass counterpart.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -1072,7 +1113,8 @@ Each phase is a reviewable unit with a clear exit gate.
            - ✅ **part 4a.** inline anchors (`[[id]]` / `anchor:id[…]`, `INLINE_ANCHOR`) → `Anchor`.
            - ✅ **part 4b.** index terms (`((term))` / `(((primary, secondary)))` / `indexterm:[…]` /
              `indexterm2:[…]`, `INLINE_INDEXTERM`) → `IndexTerm`.
-           - **part 4c.** `Footnote`.
+           - ✅ **part 4c.** footnotes (`footnote:[…]` / `footnote:id[…]` / `footnote:id[]`,
+             `INLINE_FOOTNOTE_MACRO`) → `Footnote` – the last macro family.
   5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
      `Callouts` – completing the vocabulary the recorder covers.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -7775,6 +7775,15 @@ mod tests {
             // constructs.
             "See footnote:[a note] here.",
             "*bold* then footnote:[fn] and _em_",
+            // An already-recognized construct as an *unrelated sibling* gap at
+            // the same level as a genuine footnote match – not nested inside
+            // the footnote's own content – exercising
+            // `emit_range_recursing_footnotes`'s `Ref` and non-`Styled`/`Ref`
+            // (`other`) branches, which nothing above reaches (every other
+            // fixture's nested construct sits *inside* a footnote's own
+            // content, built by the plain, non-recursing `emit_range`).
+            "image:x.png[X] footnote:[a note]",
+            "link:https://example.org[text] footnote:[a note]",
             // Escape: the macro stays literal, minus the backslash.
             "\\footnote:[not a footnote]",
             "\\footnote:disc[not a footnote]",

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -42,22 +42,20 @@
 //!   the **`link:`/`mailto:` macro** (`link:target[…]`, `mailto:addr[…]`),
 //!   **auto-links and formal-URL links** (`https://example.org`,
 //!   `https://example.org[text]`), **cross-references** in both the
-//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand,
-//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`),
+//!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand, and
+//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`) and
 //!   **index terms** (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
-//!   `indexterm2:[…]`), and **footnotes** (`footnote:[…]`, `footnote:id[…]`,
-//!   `footnote:id[]`), replacing each with an [`Image`](InlineNode::Image),
+//!   `indexterm2:[…]`), replacing each with an [`Image`](InlineNode::Image),
 //!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref),
-//!   [`Anchor`](InlineNode::Anchor), [`IndexTerm`](InlineNode::IndexTerm), or
-//!   [`Footnote`](InlineNode::Footnote) node. An image node
+//!   [`Anchor`](InlineNode::Anchor), or [`IndexTerm`](InlineNode::IndexTerm)
+//!   node. An image node
 //!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. Each family reuses the shared pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`], [`INLINE_KBD_BTN_MACRO`],
 //!   [`INLINE_MENU_MACRO`], [`INLINE_LINK_MACRO`], [`INLINE_LINK`],
-//!   [`INLINE_XREF`], [`INLINE_ANCHOR`], [`INLINE_INDEXTERM`],
-//!   [`INLINE_FOOTNOTE_MACRO`]), builds
+//!   [`INLINE_XREF`], [`INLINE_ANCHOR`], [`INLINE_INDEXTERM`]), builds
 //!   `'src`-borrowing nodes for verbatim macros only (see [`apply_macros`] for
 //!   the boundary the escaped-content case defers), and – for the UI macros – is
 //!   recognized only under the `experimental` document attribute, exactly as the
@@ -70,19 +68,29 @@
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
 //!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
 //!   `((term))`) is deferred only when its shown text crosses a rendered span or
-//!   carries an attribute list. The footnote pass runs **last**, after
-//!   cross-references, mirroring the string step's order, and is the one macro
-//!   family whose recognition performs a *required* side effect: a footnote's
-//!   marker digits are the number [`Parser::define_footnote`] /
-//!   [`Parser::footnote_index_for_id`] assign, so – unlike every other family –
-//!   registering it cannot be deferred to the cutover without breaking output
-//!   parity (see [`build_footnote_node`] for why this is safe to do from an
-//!   additive pass). Its content becomes structured children via [`emit_range`]
-//!   rather than a literal attribute value, so – unlike the other families – a
-//!   content crossing an already-recognized construct is not deferred: nesting is
-//!   the point. Only the deprecated `footnoteref:` form and a content carrying an
-//!   escaped closing bracket (`\]`) are deferred. Inline STEM (a passthrough-time
-//!   construct) and the bibliography-anchor form are later increments.
+//!   carries an attribute list.
+//! - [`apply_footnotes`] recognizes **footnotes** (`footnote:[…]`,
+//!   `footnote:id[…]`, `footnote:id[]`), replacing each with a
+//!   [`Footnote`](InlineNode::Footnote) node, folding through the shared
+//!   [`INLINE_FOOTNOTE_MACRO`] pattern like every other family. It is its **own
+//!   step** in [`build`], run once over the whole tree *after* [`apply_macros`]
+//!   has resolved every other family at every level, rather than a level pass
+//!   inside [`apply_macros`] – because it is the one macro family whose
+//!   recognition performs a *required* side effect: a footnote's marker digits
+//!   are the number [`Parser::define_footnote`] /
+//!   [`Parser::footnote_index_for_id`] assign, so numbering must follow true
+//!   left-to-right source order regardless of nesting depth, which
+//!   [`apply_macros`]'s depth-first child recursion does not guarantee (see
+//!   [`apply_footnotes`]'s doc comment). Registering the number cannot be
+//!   deferred to the cutover the way every other family's catalog/warning side
+//!   effect is, without breaking output parity (see [`build_footnote_node`]).
+//!   Its content becomes structured children via [`emit_range`] rather than a
+//!   literal attribute value, so – unlike the other families – a content
+//!   crossing an already-recognized construct is not deferred: nesting is the
+//!   point. Only the deprecated `footnoteref:` form and a content carrying an
+//!   escaped closing bracket (`\]`) are deferred. Inline STEM (a
+//!   passthrough-time construct) and the bibliography-anchor form are later
+//!   increments.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -168,6 +176,12 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     let nodes = apply_quotes(nodes, source, parser);
     let nodes = apply_character_replacements(nodes, source);
     let nodes = apply_macros(nodes, source, parser);
+
+    // Footnotes are their own step, run once over the *whole* tree after
+    // every other macro family has been resolved at every level – see
+    // `apply_footnotes`'s doc comment for why this cannot be folded into
+    // `apply_macros` as an ordinary level pass.
+    let nodes = apply_footnotes(nodes, source, parser);
 
     apply_post_replacements(nodes, source)
 }
@@ -1305,15 +1319,17 @@ fn apply_macros<'src>(
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
-    let nodes = xref_macros_level(nodes, root);
+    xref_macros_level(nodes, root)
 
-    // Footnotes (`footnote:[…]`) run last, after cross-references, mirroring
-    // the string step's order (macros.rs) – so that a construct already
-    // recognized earlier at this same level (an image, link, anchor, index
-    // term, or now a cross-reference) is captured as a *node* when it falls
-    // inside a footnote's extracted text, exactly as the string pipeline
-    // captures it as already-substituted markup (see [`footnote_macros_level`]).
-    footnote_macros_level(nodes, root, parser)
+    // Footnotes are **not** handled here. Every other family's recognition is
+    // order-independent (no cross-node side effect), so it is safe for them to
+    // run under this function's "resolve a whole subtree's children, then this
+    // level" recursion (see the closure at the top of this function). A
+    // footnote's assigned number is *not* order-independent, so it needs its
+    // own recursive walk that visits nodes in true left-to-right source order
+    // regardless of nesting depth – see [`apply_footnotes`], run once, as its
+    // own step in [`build`], after `apply_macros` has fully resolved every
+    // other family at every level.
 }
 
 /// One recognized macro match at a level, in absolute match-string byte
@@ -3260,40 +3276,232 @@ fn build_xref_shorthand_node<'src>(
 
 // ─── Footnotes (footnote:) ──────────────────────────────────────────────────
 
-/// Matches [`INLINE_FOOTNOTE_MACRO`] at this level's escaped text, replacing
-/// each recognized footnote occurrence with the
-/// [`Footnote`](InlineNode::Footnote) node it produces and leaving everything
-/// else in place.
+/// The footnote substitution, as a **whole-tree**, order-preserving
+/// transducer: matches [`INLINE_FOOTNOTE_MACRO`] at every level of `nodes`,
+/// replacing each recognized occurrence with the
+/// [`Footnote`](InlineNode::Footnote) node it produces, and recurses into
+/// every [`Styled`]/[`Ref`] child it finds along the way.
 ///
 /// This is the last macro family (design §5.2 Phase 4, step 4b(ii) part 4c)
-/// and runs last in [`apply_macros`], after the cross-reference pass,
-/// mirroring the string step's order exactly – and for the same reason: a
-/// footnote's text is extracted from the flow, so any construct the earlier
-/// passes at this level already recognized (an image, a link, an anchor, an
-/// index term, or now a cross-reference) is captured as *that construct's
-/// node* when it falls inside the extracted range, rather than being
-/// re-recognized from scratch (see [`footnote_children`]).
-fn footnote_macros_level<'src>(
+/// and runs as [`build`]'s own step, *after* [`apply_macros`] has fully
+/// resolved every other family at every level, mirroring the string step's
+/// order exactly: footnotes run last, once, over the whole (already
+/// substituted) string (macros.rs).
+///
+/// # Why this cannot be a level pass *within* [`apply_macros`]
+///
+/// Every other macro family is recognition-order-independent: nothing
+/// observes *when*, relative to a sibling subtree, an image or a link is
+/// recognized, so it is safe for [`apply_macros`] to resolve a node's
+/// children *before* resolving that node's own level (its recursion runs
+/// depth-first). A footnote's assigned **number** is the one exception – it
+/// is a side effect of recognition order itself (see
+/// [`build_footnote_node`]'s doc comment) – so depth-first recursion would
+/// number a footnote nested in an *earlier*-created [`Styled`] span (e.g. a
+/// span [`apply_quotes`] already built before [`apply_macros`] ever runs)
+/// **before** a footnote that precedes that span in the source, reversing
+/// their markers relative to the string pipeline's left-to-right sweep over
+/// one flat string. This function fixes that by walking `nodes` in true
+/// source order: it recognizes every footnote at *this* level, but recurses
+/// into a [`Styled`]/[`Ref`] child at exactly the point that child falls
+/// between two such recognitions (or before the first / after the last) –
+/// see [`rebuild_footnote_level`] and [`emit_range_recursing_footnotes`],
+/// which recurse in place of the generic [`rebuild_macro_level`] /
+/// [`emit_range`]'s verbatim clone.
+fn apply_footnotes<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // A subtree with no `"tnote"` substring anywhere – the overwhelmingly
+    // common case – has nothing for this pass to do, so return it completely
+    // untouched: no clone, no rebuild. This check is not just an optimization.
+    // `rebuild_footnote_level`'s gap emission clones *every* atomic piece
+    // (any already-recognized `Image`/`Ui`/`Ref`/`Anchor`/`IndexTerm`/`Styled`
+    // node) it touches – including ones with nothing to do with footnotes –
+    // and cloning is not free of *observable* effect here: `CowStr`'s `Clone`
+    // opportunistically demotes a short-enough `Boxed` value to `Inlined`
+    // (see `strings.rs`), so an unconditional whole-tree rebuild would flip
+    // that representation on every short owned string in the document, purely
+    // as a side effect of a pass that found nothing to recognize. Skipping
+    // the rebuild entirely when there is nothing to find keeps every other
+    // family's nodes byte- *and* representation-identical to what
+    // `apply_macros` produced.
+    if !subtree_might_have_footnote(&nodes) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes);
 
     // Cheap pre-filter mirroring the string step's `found_macroish &&
     // text.contains("tnote")`: both `footnote:` and the deprecated
-    // `footnoteref:` contain "tnote".
-    if !s.contains("tnote") {
-        return nodes;
+    // `footnoteref:` contain "tnote". Even when this level's *own* text has
+    // no match, a `Styled`/`Ref` child might still carry one in its own
+    // subtree (that is what the pre-check above just confirmed), so the
+    // rebuild below runs regardless – it is what performs the recursion.
+    let matches = if s.contains("tnote") {
+        find_footnote_matches(&s, &pieces, &nodes, root, parser)
+    } else {
+        Vec::new()
+    };
+
+    rebuild_footnote_level(&nodes, &pieces, &s, matches, root, parser)
+}
+
+/// Reports whether `nodes`, or any [`Styled`]/[`Ref`] descendant's own
+/// subtree at any depth, might carry the `"tnote"` substring
+/// [`apply_footnotes`]'s pre-filter looks for. A read-only recursive check –
+/// it builds a match string per level exactly as [`apply_footnotes`] does
+/// (so it cannot miss a `"tnote"` split across two adjacent
+/// [`Text`](InlineNode::Text) pieces the way a per-node substring check
+/// could) but allocates no [`InlineNode`], letting a subtree with nothing to
+/// find come back from `apply_footnotes` completely unchanged.
+fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
+    let (s, _) = build_match_string(nodes);
+
+    if s.contains("tnote") {
+        return true;
     }
 
-    let matches = find_footnote_matches(&s, &pieces, &nodes, root, parser);
+    nodes.iter().any(|node| match node {
+        InlineNode::Styled(styled) => subtree_might_have_footnote(&styled.children),
+        InlineNode::Ref(reference) => subtree_might_have_footnote(&reference.children),
+        _ => false,
+    })
+}
 
-    if matches.is_empty() {
-        return nodes;
+/// Like [`rebuild_macro_level`], but for [`apply_footnotes`]: rebuilds a
+/// level's node list from its footnote matches, using
+/// [`emit_range_recursing_footnotes`] (not [`emit_range`]) for every gap, so
+/// a [`Styled`]/[`Ref`] child encountered between two matches is recursed
+/// into – in source order – rather than cloned whole.
+fn rebuild_footnote_level<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    s: &str,
+    matches: Vec<MacroMatch<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+
+    for m in matches {
+        let MacroMatch { full, kind } = m;
+
+        match kind {
+            MacroMatchKind::Unescape { backslash } => {
+                emit_range_recursing_footnotes(
+                    nodes,
+                    pieces,
+                    cursor..backslash,
+                    root,
+                    parser,
+                    &mut out,
+                );
+                emit_range_recursing_footnotes(
+                    nodes,
+                    pieces,
+                    (backslash + 1)..full.end,
+                    root,
+                    parser,
+                    &mut out,
+                );
+            }
+
+            MacroMatchKind::Node { consumed, node } => {
+                emit_range_recursing_footnotes(
+                    nodes,
+                    pieces,
+                    cursor..consumed.start,
+                    root,
+                    parser,
+                    &mut out,
+                );
+                out.push(*node);
+                emit_range_recursing_footnotes(
+                    nodes,
+                    pieces,
+                    consumed.end..full.end,
+                    root,
+                    parser,
+                    &mut out,
+                );
+            }
+        }
+
+        cursor = full.end;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    if cursor < s.len() {
+        emit_range_recursing_footnotes(nodes, pieces, cursor..s.len(), root, parser, &mut out);
+    }
+
+    out
+}
+
+/// Like [`emit_range`], but recurses into a [`Styled`]/[`Ref`] piece's
+/// children with [`apply_footnotes`] instead of cloning the node whole – the
+/// piece that makes [`apply_footnotes`] a true whole-tree, source-order walk
+/// rather than a single level pass. Every other aspect (slicing a verbatim
+/// [`Text`](InlineNode::Text) run at the overlap, an empty range emitting
+/// nothing) is identical.
+fn emit_range_recursing_footnotes<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    range: std::ops::Range<usize>,
+    root: Span<'src>,
+    parser: &Parser,
+    out: &mut Vec<InlineNode<'src>>,
+) {
+    if range.start >= range.end {
+        return;
+    }
+
+    for piece in pieces {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the requested range.
+        if p_end <= range.start || p_start >= range.end {
+            continue;
+        }
+
+        let Some(node) = nodes.get(piece.node_index) else {
+            continue;
+        };
+
+        if piece.atomic {
+            match node.clone() {
+                InlineNode::Styled(mut styled) => {
+                    styled.children = apply_footnotes(styled.children, root, parser);
+                    out.push(InlineNode::Styled(styled));
+                }
+
+                InlineNode::Ref(mut reference) => {
+                    reference.children = apply_footnotes(reference.children, root, parser);
+                    out.push(InlineNode::Ref(reference));
+                }
+
+                other => out.push(other),
+            }
+
+            continue;
+        }
+
+        // A verbatim text run: slice it to the overlap.
+        let lo = range.start.max(p_start) - p_start;
+        let hi = range.end.min(p_end) - p_start;
+
+        if let InlineNode::Text { location, .. } = node {
+            let sliced = location.slice(lo..hi);
+
+            out.push(InlineNode::Text {
+                value: CowStr::from(sliced.data()),
+                location: sliced,
+            });
+        }
+    }
 }
 
 /// Finds every recognized footnote occurrence at this level as a
@@ -3494,7 +3702,11 @@ fn build_footnote_node<'src>(
 /// on; it is the whole point – `emit_range` clones that construct's node
 /// whole into the footnote's subtree, exactly mirroring how the string
 /// pipeline's footnote text captures an already-substituted macro verbatim
-/// (see [`footnote_macros_level`]'s doc comment on ordering).
+/// (see [`apply_footnotes`]'s doc comment on ordering). This uses the plain
+/// [`emit_range`], not the recursing [`emit_range_recursing_footnotes`] –
+/// footnotes do not nest (the string pipeline's own lazy bracket match cannot
+/// recognize one inside another's content either, since it always stops at
+/// the *first* unescaped `]`), so a footnote's own content is captured as-is.
 fn footnote_children<'src>(
     range: std::ops::Range<usize>,
     pieces: &[Piece],
@@ -7752,5 +7964,117 @@ mod tests {
             // The string pipeline, by contrast, does build a footnote marker here.
             assert!(golden_macros(source).contains("class=\"footnote\""));
         }
+    }
+
+    #[test]
+    fn footnotes_number_in_source_order_across_nesting() {
+        // A footnote preceding a `Styled` span must be numbered *before* a
+        // footnote nested inside that span, even though `apply_macros`'s
+        // depth-first recursion (see `apply_footnotes`'s doc comment)
+        // resolves the span's children before the outer level. This is the
+        // regression the `apply_footnotes`/`rebuild_footnote_level` split
+        // fixes: numbering must follow true left-to-right source order, not
+        // tree depth.
+        let source = "footnote:[outer] *footnote:[inner]*";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, golden_macros(source));
+
+        let nodes = build_src(Span::new(source));
+        let outer = assert_footnote(&nodes[0]);
+        assert_eq!(outer.number.as_deref(), Some("1"));
+
+        let inner_children = assert_styled(&nodes[2], StyleVariant::Strong, SpanForm::Constrained);
+        let inner = assert_footnote(&inner_children[0]);
+        assert_eq!(inner.number.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn footnotes_number_in_source_order_across_a_footnote_bearing_link() {
+        // The opposite nesting from the test above: a *link* – a macro-built
+        // `Ref` node, created *during* `apply_macros` rather than already
+        // existing by the time it runs like a quotes-built `Styled` span –
+        // nested inside a footnote's own content. This is the valid
+        // direction to nest the two: because footnotes run *last* (after
+        // `link_macro_level`), the link's brackets are already consumed into
+        // a `Ref` node (no literal `[`/`]` left to collide with) by the time
+        // the footnote's own lazy bracket match runs, unlike the reverse
+        // nesting (see `a_footnote_nested_in_link_text_is_a_documented_divergence`
+        // just below, which explains why that direction can never be clean).
+        let source = "footnote:[outer] footnote:[see link:https://example.org[inner]]";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, golden_macros(source));
+
+        let nodes = build_src(Span::new(source));
+        let outer = assert_footnote(&nodes[0]);
+        assert_eq!(outer.number.as_deref(), Some("1"));
+
+        let inner = assert_footnote(&nodes[2]);
+        assert_eq!(inner.number.as_deref(), Some("2"));
+        assert_link(&inner.children[1]);
+    }
+
+    #[test]
+    fn a_footnote_nested_in_link_text_is_a_documented_divergence() {
+        // `link:` matches its bracketed label *lazily* – up to the first
+        // unescaped `]` – so an unbalanced inner bracket like
+        // `footnote:[note]` (itself containing a `]`) truncates the link's
+        // own match early, leaving `footnote:[note` as the link's label and a
+        // stray `]` as literal text after it (mirrored exactly by the
+        // builder's `link_macro_level`, which shares the same regex – see the
+        // `fold_matches_the_string_pipeline_through_link_macros` corpus for
+        // that shared behavior on its own). This is not specific to links: a
+        // footnote nested inside *any* bracket-delimited macro argument that
+        // runs *before* footnotes (image, index terms, anchors,
+        // cross-references – every family footnotes.rs runs after) hits the
+        // same collision, since footnote syntax's own `[`/`]` inherently
+        // satisfies that macro's lazy closing-bracket search before it
+        // reaches its intended one. It is fundamentally the reverse of the
+        // clean nesting
+        // `footnotes_number_in_source_order_across_a_footnote_bearing_link`
+        // exercises: nesting an *earlier*-running macro inside a footnote's
+        // content is fine (by the time footnotes run, that macro's brackets
+        // are already consumed into a node), but nesting *footnote* syntax
+        // inside an earlier macro's argument is not, in the string pipeline
+        // or otherwise.
+        //
+        // In the *string* pipeline, the footnote pass runs over the
+        // *already-rendered* flat string, where the link's `</a>` is just
+        // literal text no different from any other – so the footnote regex,
+        // finding only one `]` left in the whole string, matches straight
+        // through the `</a>` and consumes it as part of its own (nonsensical)
+        // content, producing malformed, never-closed markup. That is a direct
+        // consequence of matching over *rendered* text rather than structure
+        // – exactly the class of divergence
+        // `crossed_delimiters_are_a_documented_divergence` documents for
+        // quotes. A `Ref` node's closing tag is never a `Text` node in the
+        // tree (it exists only as fold *output*, not as node content), so
+        // the builder's footnote pass has no way to "reach into" it, and
+        // correctly does not: the link's label stays literal, unrecognized
+        // text, and the tree never reproduces the string pipeline's
+        // malformed markup here.
+        let source = "link:https://example.org[footnote:[note]]";
+        let nodes = build_src(Span::new(source));
+
+        let link = assert_link(&nodes[0]);
+        assert_text(&link.children[0], "footnote:[note", 1, 26);
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(
+            folded,
+            "<a href=\"https://example.org\">footnote:[note</a>]"
+        );
+
+        // The string pipeline, by contrast, produces unclosed markup: the
+        // link's own closing `</a>` is consumed into the footnote's content,
+        // and the footnote's own numbered marker (with its *own*, unrelated
+        // `<a>…</a>`) takes its place.
+        assert_eq!(
+            golden_macros(source),
+            "<a href=\"https://example.org\"><sup class=\"footnote\">\
+             [<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" \
+             title=\"View footnote.\">1</a>]</sup>"
+        );
     }
 }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -43,19 +43,21 @@
 //!   **auto-links and formal-URL links** (`https://example.org`,
 //!   `https://example.org[text]`), **cross-references** in both the
 //!   `xref:` macro form (`xref:id[text]`) and the `<<id>>` shorthand,
-//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`), and
+//!   **inline anchors** (`[[id]]`, `[[id,reftext]]`, `anchor:id[reftext]`),
 //!   **index terms** (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
-//!   `indexterm2:[…]`), replacing each with an [`Image`](InlineNode::Image),
+//!   `indexterm2:[…]`), and **footnotes** (`footnote:[…]`, `footnote:id[…]`,
+//!   `footnote:id[]`), replacing each with an [`Image`](InlineNode::Image),
 //!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref),
-//!   [`Anchor`](InlineNode::Anchor), or [`IndexTerm`](InlineNode::IndexTerm)
-//!   node. An image node
+//!   [`Anchor`](InlineNode::Anchor), [`IndexTerm`](InlineNode::IndexTerm), or
+//!   [`Footnote`](InlineNode::Footnote) node. An image node
 //!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. Each family reuses the shared pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`], [`INLINE_KBD_BTN_MACRO`],
 //!   [`INLINE_MENU_MACRO`], [`INLINE_LINK_MACRO`], [`INLINE_LINK`],
-//!   [`INLINE_XREF`], [`INLINE_ANCHOR`], [`INLINE_INDEXTERM`]), builds
+//!   [`INLINE_XREF`], [`INLINE_ANCHOR`], [`INLINE_INDEXTERM`],
+//!   [`INLINE_FOOTNOTE_MACRO`]), builds
 //!   `'src`-borrowing nodes for verbatim macros only (see [`apply_macros`] for
 //!   the boundary the escaped-content case defers), and – for the UI macros – is
 //!   recognized only under the `experimental` document attribute, exactly as the
@@ -68,9 +70,19 @@
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
 //!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
 //!   `((term))`) is deferred only when its shown text crosses a rendered span or
-//!   carries an attribute list. The remaining macro family (footnotes), inline
-//!   STEM (a passthrough-time construct), and the bibliography-anchor form are
-//!   later increments.
+//!   carries an attribute list. The footnote pass runs **last**, after
+//!   cross-references, mirroring the string step's order, and is the one macro
+//!   family whose recognition performs a *required* side effect: a footnote's
+//!   marker digits are the number [`Parser::define_footnote`] /
+//!   [`Parser::footnote_index_for_id`] assign, so – unlike every other family –
+//!   registering it cannot be deferred to the cutover without breaking output
+//!   parity (see [`build_footnote_node`] for why this is safe to do from an
+//!   additive pass). Its content becomes structured children via [`emit_range`]
+//!   rather than a literal attribute value, so – unlike the other families – a
+//!   content crossing an already-recognized construct is not deferred: nesting is
+//!   the point. Only the deprecated `footnoteref:` form and a content carrying an
+//!   escaped closing bracket (`\]`) are deferred. Inline STEM (a passthrough-time
+//!   construct) and the bibliography-anchor form are later increments.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -116,21 +128,22 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
-        INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
-        NormalizedCaps, QuoteSub, URI_SNIFF, basename, character_replacements,
-        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, normalize_index_text,
-        normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys, strip_see_and_seealso,
+        CharacterReplacement, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
+        INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
+        INLINE_XREF, NormalizedCaps, QuoteSub, URI_SNIFF, basename, character_replacements,
+        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, normalize_footnote_text,
+        normalize_index_text, normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys,
+        strip_see_and_seealso,
         xref_target::{XrefTarget, interpret_xref_target},
     },
     inlines::{
-        Anchor, CharRef, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm, StyleVariant,
-        Styled, Ui, UiKind,
+        Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
+        StyleVariant, Styled, Ui, UiKind,
     },
     parser::{
-        CharacterReplacementType, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
-        InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType,
-        SpecialCharacter, XrefRenderParams, has_dangerous_scheme,
+        CharacterReplacementType, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
+        IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
+        QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams, has_dangerous_scheme,
     },
     strings::CowStr,
 };
@@ -1290,9 +1303,17 @@ fn apply_macros<'src>(
     // so it is a cutover concern, not this pass's.
     let nodes = anchor_macros_level(nodes, root);
 
-    // Cross-references (`xref:id[…]`) run last, after the anchor pass, mirroring
-    // the string step's order.
-    xref_macros_level(nodes, root)
+    // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
+    // string step's order.
+    let nodes = xref_macros_level(nodes, root);
+
+    // Footnotes (`footnote:[…]`) run last, after cross-references, mirroring
+    // the string step's order (macros.rs) – so that a construct already
+    // recognized earlier at this same level (an image, link, anchor, index
+    // term, or now a cross-reference) is captured as a *node* when it falls
+    // inside a footnote's extracted text, exactly as the string pipeline
+    // captures it as already-substituted markup (see [`footnote_macros_level`]).
+    footnote_macros_level(nodes, root, parser)
 }
 
 /// One recognized macro match at a level, in absolute match-string byte
@@ -3237,6 +3258,273 @@ fn build_xref_shorthand_node<'src>(
     }))
 }
 
+// ─── Footnotes (footnote:) ──────────────────────────────────────────────────
+
+/// Matches [`INLINE_FOOTNOTE_MACRO`] at this level's escaped text, replacing
+/// each recognized footnote occurrence with the
+/// [`Footnote`](InlineNode::Footnote) node it produces and leaving everything
+/// else in place.
+///
+/// This is the last macro family (design §5.2 Phase 4, step 4b(ii) part 4c)
+/// and runs last in [`apply_macros`], after the cross-reference pass,
+/// mirroring the string step's order exactly – and for the same reason: a
+/// footnote's text is extracted from the flow, so any construct the earlier
+/// passes at this level already recognized (an image, a link, an anchor, an
+/// index term, or now a cross-reference) is captured as *that construct's
+/// node* when it falls inside the extracted range, rather than being
+/// re-recognized from scratch (see [`footnote_children`]).
+fn footnote_macros_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter mirroring the string step's `found_macroish &&
+    // text.contains("tnote")`: both `footnote:` and the deprecated
+    // `footnoteref:` contain "tnote".
+    if !s.contains("tnote") {
+        return nodes;
+    }
+
+    let matches = find_footnote_matches(&s, &pieces, &nodes, root, parser);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every recognized footnote occurrence at this level as a
+/// [`MacroMatch`], skipping the forms this increment defers (see
+/// [`build_footnote_node`]).
+fn find_footnote_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    nodes: &[InlineNode<'src>],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_FOOTNOTE_MACRO.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        // The deprecated `footnoteref:[id,text]` / `footnoteref:[id]` form
+        // (group 1) packs its id and text into one bracket, split on the first
+        // comma, and – outside `compat-mode` – raises a deprecation warning.
+        // Neither the alternate splitting nor the warning is implemented by
+        // this increment, so the form is left unrecognized for a later one
+        // (divergence test:
+        // `a_deprecated_footnoteref_macro_is_a_documented_divergence`).
+        if caps.get(1).is_some() {
+            continue;
+        }
+
+        // An escape (`\footnote:…`) is honored by dropping the backslash and
+        // keeping the rest literal, mirroring the string replacer's leading
+        // `caps[0].starts_with('\\')` check.
+        if whole.as_str().starts_with('\\') {
+            matches.push(MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            });
+
+            continue;
+        }
+
+        let Some(node) = build_footnote_node(&caps, &full, s, pieces, nodes, root, parser) else {
+            continue;
+        };
+
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Footnote`](InlineNode::Footnote) node from a `footnote:` match,
+/// resolving it into the same three (id, content) cases the string
+/// replacer's `InlineFootnoteMacroReplacer` distinguishes, so the fold –
+/// which reconstructs [`FootnoteRenderParams`] from the node alone (see
+/// [`fold_footnote`]) – reproduces the same bytes. Returns `None` for a form
+/// this increment defers, or for `footnote:[]` (neither an id nor content),
+/// which is not a footnote at all.
+///
+/// # The one *required* recognition side effect
+///
+/// Every other macro family in this module performs *no* recognition side
+/// effect (no catalog registration, no warning), deferring that to the
+/// cutover (design §5.2 Phase 4, step 6) because omitting it does not change
+/// the fold's output bytes. A footnote's own marker is the one exception: its
+/// rendered digits (`[1]`, `[2]`, …) *are* the assigned footnote number, so
+/// this builder must call [`Parser::footnote_index_for_id`] /
+/// [`Parser::define_footnote`] – the same document-counter-advancing calls
+/// the string replacer makes – or the differential corpus below could never
+/// pass. The two code paths never share a `Parser` (each independently
+/// numbers footnotes over the same source in the same left-to-right order),
+/// so this never double-counts a registration; see the module's test helpers.
+///
+/// The registered catalog `text` is a best-effort rendering of the raw
+/// bracket content (normalized, but not folded through a renderer – building
+/// the tree must not itself invoke one), so – like every other deferred
+/// registration in this module – a tree-built footnote's
+/// `Document::catalog().footnotes()` entry is not yet byte-faithful; only the
+/// returned *number*, this pass's one load-bearing side effect, is relied on.
+///
+/// # Deferred forms
+///
+/// - The deprecated `footnoteref:` form (checked by the caller before this is
+///   reached).
+/// - Content containing an escaped closing bracket (`\]`): unescaping it would
+///   mean splicing a literal `]` into the middle of a `Text` piece the content
+///   range slices, which – unlike a single-node substitution such as `xref`'s
+///   escaped text – would require rebuilding part of the content's own node
+///   structure around the splice; deferred, exactly as the anchor and
+///   cross-reference macros defer their own escaped-bracket forms when they
+///   cannot represent them without a similar rebuild (divergence test:
+///   `a_footnote_with_an_escaped_bracket_is_a_documented_divergence`).
+fn build_footnote_node<'src>(
+    caps: &regex::Captures<'_>,
+    full: &std::ops::Range<usize>,
+    s: &str,
+    pieces: &[Piece],
+    nodes: &[InlineNode<'src>],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Option<InlineNode<'src>> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    // The id (`[\w-]+`) admits no special character or opaque span, so a
+    // captured id is always verbatim and borrows `'src`; `id` is `None` only
+    // when the macro carries none (an anonymous `footnote:[…]`).
+    let id: Option<CowStr<'src>> = caps
+        .get(2)
+        .map(|m| CowStr::from(source_slice(pieces, m.start()..m.end(), root).data()));
+
+    let content_match = caps.get(3);
+
+    if let Some(id) = id {
+        if let Some(number) = parser.footnote_index_for_id(id.as_ref()) {
+            // A reference to an already-defined footnote: reuse its number.
+            return Some(InlineNode::Footnote(Footnote {
+                id: Some(id),
+                number: Some(CowStr::from(number)),
+                is_reference: true,
+                children: vec![],
+                location,
+            }));
+        }
+
+        return match content_match {
+            Some(content) => {
+                // A defining occurrence that also carries an id.
+                if s[content.range()].contains("\\]") {
+                    return None;
+                }
+
+                let children = footnote_children(content.range(), pieces, nodes);
+                let number = register_footnote_number(
+                    parser,
+                    Some(id.as_ref()),
+                    &s[content.range()],
+                    location,
+                );
+
+                Some(InlineNode::Footnote(Footnote {
+                    id: Some(id),
+                    number: Some(CowStr::from(number)),
+                    is_reference: false,
+                    children,
+                    location,
+                }))
+            }
+
+            // A reference to an id that was never defined. The string replacer
+            // warns here (`InvalidFootnoteReference`); this pass, like every
+            // other diagnostic the additive builder skips, leaves that to the
+            // cutover.
+            None => Some(InlineNode::Footnote(Footnote {
+                id: Some(id),
+                number: None,
+                is_reference: true,
+                children: vec![],
+                location,
+            })),
+        };
+    }
+
+    // An anonymous defining occurrence.
+    let content = content_match?;
+
+    if s[content.range()].contains("\\]") {
+        return None;
+    }
+
+    let children = footnote_children(content.range(), pieces, nodes);
+    let number = register_footnote_number(parser, None, &s[content.range()], location);
+
+    Some(InlineNode::Footnote(Footnote {
+        id: None,
+        number: Some(CowStr::from(number)),
+        is_reference: false,
+        children,
+        location,
+    }))
+}
+
+/// Builds a footnote's `children` from its bracket content's match-string
+/// `range` via [`emit_range`] – *not* [`range_is_verbatim`] the way every
+/// other macro family's target/text slicing does. A footnote's content
+/// becomes structured children rather than a literal attribute value, so a
+/// range crossing an already-recognized construct is not a boundary to defer
+/// on; it is the whole point – `emit_range` clones that construct's node
+/// whole into the footnote's subtree, exactly mirroring how the string
+/// pipeline's footnote text captures an already-substituted macro verbatim
+/// (see [`footnote_macros_level`]'s doc comment on ordering).
+fn footnote_children<'src>(
+    range: std::ops::Range<usize>,
+    pieces: &[Piece],
+    nodes: &[InlineNode<'src>],
+) -> Vec<InlineNode<'src>> {
+    let mut children = Vec::new();
+    emit_range(nodes, pieces, range, &mut children);
+    children
+}
+
+/// Registers a footnote's defining occurrence with the parser, advancing the
+/// `footnote-number` counter and returning the assigned number – the one
+/// recognition side effect [`build_footnote_node`]'s doc comment explains this
+/// pass must perform. `raw_content` is normalized exactly as the string
+/// replacer normalizes it ([`normalize_footnote_text`]: trimmed, embedded
+/// newlines collapsed) before being registered as the catalog's best-effort
+/// `text`; no cross-reference placeholders are threaded through (the additive
+/// builder has none to give it – a `Ref{Xref}` is a node, not a placeholder),
+/// so `define_footnote` never builds a `FootnoteDeferred` for a tree-built
+/// footnote.
+fn register_footnote_number(
+    parser: &Parser,
+    id: Option<&str>,
+    raw_content: &str,
+    location: Span<'_>,
+) -> String {
+    let text = normalize_footnote_text(raw_content);
+    parser.define_footnote(id, text, vec![], location)
+}
+
 // ─── Post replacements (hard line breaks) ─────────────────────────────────
 
 /// The post-replacement substitution, as a node transducer: a line ending in
@@ -3453,6 +3741,10 @@ fn fold_into_html(
 
             InlineNode::IndexTerm(index_term) => {
                 fold_index_term(index_term, renderer, out);
+            }
+
+            InlineNode::Footnote(footnote) => {
+                fold_footnote(footnote, renderer, out);
             }
 
             InlineNode::Styled(styled) => {
@@ -3762,6 +4054,50 @@ fn fold_index_term(
     renderer.render_index_term(&IndexTermRenderParams { visible_term }, out);
 }
 
+/// Folds a [`Footnote`](InlineNode::Footnote) through the same
+/// `render_footnote` the string step calls, reconstructing
+/// [`FootnoteRenderParams`] entirely from the node's `is_reference`, `number`,
+/// and `id` fields – no build-time state is needed (design §3.3.1).
+///
+/// Only the in-flow **marker** is folded here (`[1]`, or `[id]` for an
+/// unresolved reference): `render_footnote` never emits the footnote's own
+/// text into the flow – that text belongs in the document's separate
+/// footnote list, a concern outside a single block's fold – so
+/// `footnote.children` is not folded into `out` at all, the same relationship
+/// [`fold_anchor`]'s `reftext` has to its own marker.
+///
+/// A defining occurrence (`is_reference == false`) always carries its number
+/// (see [`build_footnote_node`]) and folds its own `id`, when it has one, into
+/// the marker's `id` attribute. A reference either reuses an existing
+/// footnote's number (`number: Some`, `id` never folded – matching the string
+/// replacer, which renders a reference's `id` attribute only for the
+/// *defining* occurrence) or, unresolved (`number: None`), falls back to
+/// displaying its own `id` as the render params' `text`.
+fn fold_footnote(
+    footnote: &Footnote<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    out: &mut String,
+) {
+    let (index, id, text): (Option<&str>, Option<&str>, &str) = if footnote.is_reference {
+        match footnote.number.as_deref() {
+            Some(number) => (Some(number), None, ""),
+            None => (None, None, footnote.id.as_deref().unwrap_or("")),
+        }
+    } else {
+        (footnote.number.as_deref(), footnote.id.as_deref(), "")
+    };
+
+    renderer.render_footnote(
+        &FootnoteRenderParams {
+            index,
+            id,
+            is_reference: footnote.is_reference,
+            text,
+        },
+        out,
+    );
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -3776,8 +4112,8 @@ mod tests {
         HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm, StyleVariant,
-            Styled, Ui, UiKind,
+            Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
+            StyleVariant, Styled, Ui, UiKind,
         },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -7163,5 +7499,252 @@ mod tests {
 
         assert_eq!(folded, "(((x)))");
         assert_eq!(golden_macros(source), "(x)");
+    }
+
+    // ─── Macros (footnotes) ────────────────────────────────────────────────
+
+    /// Asserts that `node` is a [`Footnote`](InlineNode::Footnote), returning
+    /// it for further inspection.
+    fn assert_footnote<'a, 'src>(node: &'a InlineNode<'src>) -> &'a Footnote<'src> {
+        match node {
+            InlineNode::Footnote(footnote) => footnote,
+
+            other => panic!("expected a Footnote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_footnotes() {
+        // For each fixture, folding the single-pass tree (all five steps)
+        // reproduces the string pipeline's output byte-for-byte. This is the
+        // differential corpus (design §5.3) that pins the footnote increment –
+        // the last of the macro families (part 4c). Each fixture uses its own
+        // pair of *independent* default parsers (one inside `build_src`, one
+        // inside `golden_macros`), so the `footnote-number` counter each one
+        // advances never crosses over; as long as both recognize the same
+        // occurrences in the same left-to-right order, their numbering stays in
+        // lockstep.
+        let fixtures = [
+            // No footnote despite macro-ish characters.
+            "plain text without a footnote",
+            "a footnote without a bracket footnote:foo stays literal",
+            // `footnote:[]` (neither an id nor content) is not a footnote at
+            // all – left untouched by both the string replacer and the builder.
+            "footnote:[]",
+            // An anonymous defining occurrence, and one whose text needs no
+            // further substitution.
+            "footnote:[the evidence]",
+            "A claim.footnote:[the evidence]",
+            // A defining occurrence with an id, and a reference that reuses its
+            // number.
+            "footnote:disc[a discussion]",
+            "Named.footnote:disc[a discussion] then footnote:disc[].",
+            // A reference to an id that was never defined (the unresolved
+            // fallback).
+            "See footnote:missing[] here.",
+            // Multiple anonymous footnotes number in document order.
+            "one footnote:[a] two footnote:[b] three footnote:[c]",
+            // Id character classes: `_`, `-`, digits.
+            "footnote:my_id-1[text]",
+            // Content already carrying a rendered construct from an earlier
+            // pass at this level – a formatting span, a character replacement,
+            // an image, a link, an index term, and (since footnotes run last)
+            // a cross-reference – is captured as that construct's node, not
+            // re-recognized. None of this affects the fold: only the marker
+            // (not the footnote's text) reaches the flow.
+            "footnote:[the *strong* evidence]",
+            "footnote:[a copyright (C) note]",
+            "footnote:[see image:x.png[X]]",
+            "footnote:[see link:https://example.org[source]]",
+            "footnote:[an index (((term))) here]",
+            "footnote:[see xref:install[the guide]]",
+            "footnote:[a < b]",
+            // A macro embedded in surrounding flow, and next to other
+            // constructs.
+            "See footnote:[a note] here.",
+            "*bold* then footnote:[fn] and _em_",
+            // Escape: the macro stays literal, minus the backslash.
+            "\\footnote:[not a footnote]",
+            "\\footnote:disc[not a footnote]",
+            // A footnote inside a rendered span (recognized inside the body).
+            "*see footnote:[fn]*",
+            "_footnote:x[fn] in em_",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_anonymous_footnote_becomes_a_node() {
+        let nodes = build_src(Span::new("footnote:[the evidence]"));
+
+        assert_eq!(nodes.len(), 1);
+        let footnote = assert_footnote(&nodes[0]);
+
+        assert!(footnote.id.is_none());
+        assert_eq!(footnote.number.as_deref(), Some("1"));
+        assert!(!footnote.is_reference);
+
+        assert_eq!(footnote.location.data(), "footnote:[the evidence]");
+        assert_eq!(footnote.location.line(), 1);
+        assert_eq!(footnote.location.col(), 1);
+
+        // The content becomes a single borrowed `Text` child, located at its
+        // source (`footnote:[` is 10 characters, so the text starts at column
+        // 11).
+        assert_eq!(footnote.children.len(), 1);
+        assert_text(&footnote.children[0], "the evidence", 1, 11);
+    }
+
+    #[test]
+    fn a_footnote_with_an_id_becomes_a_node() {
+        let nodes = build_src(Span::new("footnote:disc[a discussion]"));
+
+        let footnote = assert_footnote(&nodes[0]);
+
+        // The id borrows from source (no allocation).
+        assert!(matches!(footnote.id, Some(CowStr::Borrowed(_))));
+        assert_eq!(footnote.id.as_deref(), Some("disc"));
+        assert_eq!(footnote.number.as_deref(), Some("1"));
+        assert!(!footnote.is_reference);
+        assert_text(&footnote.children[0], "a discussion", 1, 15);
+    }
+
+    #[test]
+    fn a_footnote_reference_reuses_the_defining_number() {
+        let source = "footnote:disc[a discussion] then footnote:disc[].";
+        let nodes = build_src(Span::new(source));
+
+        // [Footnote(defining), Text(" then "), Footnote(reference), Text(".")].
+        assert_eq!(nodes.len(), 4);
+
+        let defining = assert_footnote(&nodes[0]);
+        assert!(!defining.is_reference);
+        assert_eq!(defining.number.as_deref(), Some("1"));
+
+        let reference = assert_footnote(&nodes[2]);
+        assert!(reference.is_reference);
+        assert_eq!(reference.number.as_deref(), Some("1"));
+        assert_eq!(reference.id.as_deref(), Some("disc"));
+    }
+
+    #[test]
+    fn a_footnote_reference_keeps_an_empty_subtree() {
+        let source = "footnote:disc[a discussion] then footnote:disc[].";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_footnote(&nodes[2]);
+        assert!(reference.children.is_empty());
+    }
+
+    #[test]
+    fn an_unresolved_footnote_reference_falls_back_to_its_id() {
+        let nodes = build_src(Span::new("footnote:missing[]"));
+
+        let footnote = assert_footnote(&nodes[0]);
+        assert!(footnote.is_reference);
+        assert!(footnote.number.is_none());
+        assert_eq!(footnote.id.as_deref(), Some("missing"));
+        assert!(footnote.children.is_empty());
+    }
+
+    #[test]
+    fn anonymous_footnotes_number_in_document_order() {
+        let nodes = build_src(Span::new("one footnote:[a] two footnote:[b] three"));
+
+        let first = assert_footnote(&nodes[1]);
+        assert_eq!(first.number.as_deref(), Some("1"));
+
+        let second = assert_footnote(&nodes[3]);
+        assert_eq!(second.number.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn a_footnote_carries_its_text_as_child_nodes() {
+        let nodes = build_src(Span::new("footnote:[the *strong* evidence]"));
+        let footnote = assert_footnote(&nodes[0]);
+
+        assert_eq!(footnote.children.len(), 3);
+        assert_text(&footnote.children[0], "the ", 1, 11);
+        assert_styled(
+            &footnote.children[1],
+            StyleVariant::Strong,
+            SpanForm::Constrained,
+        );
+        assert_text(&footnote.children[2], " evidence", 1, 23);
+    }
+
+    #[test]
+    fn a_footnote_subtree_carries_a_nested_link() {
+        // The `link:` macro runs before the footnote pass in `apply_macros`
+        // (mirroring the string step's order), so by the time the footnote's
+        // content is captured, the link is already a `Ref` node – captured
+        // whole into the footnote's children, not re-recognized from its
+        // source text.
+        let nodes = build_src(Span::new("footnote:[see link:https://example.org[source]]"));
+        let footnote = assert_footnote(&nodes[0]);
+
+        assert_eq!(footnote.children.len(), 2);
+        assert_text(&footnote.children[0], "see ", 1, 11);
+        assert_link(&footnote.children[1]);
+    }
+
+    #[test]
+    fn an_empty_footnote_macro_stays_literal() {
+        // `footnote:[]` carries neither an id nor content, so it is not a
+        // footnote at all – left as literal text, exactly as the string
+        // replacer's `next $&` branch leaves it.
+        let nodes = build_src(Span::new("footnote:[]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], "footnote:[]", 1, 1);
+    }
+
+    #[test]
+    fn a_deprecated_footnoteref_macro_is_a_documented_divergence() {
+        // The deprecated `footnoteref:[id,text]` form packs its id and text
+        // into one bracket, split differently from `footnote:id[text]`, and
+        // (outside `compat-mode`) raises a deprecation warning. Neither the
+        // alternate splitting nor the warning is implemented by this
+        // increment, so the whole macro is left unrecognized.
+        let source = "footnoteref:[disc,a discussion]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
+            "a footnoteref: macro must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, does build a footnote marker here.
+        assert!(golden_macros(source).contains("class=\"footnote\""));
+    }
+
+    #[test]
+    fn a_footnote_with_an_escaped_bracket_is_a_documented_divergence() {
+        // Content carrying an escaped closing bracket (`\]`) needs it unescaped
+        // to a literal `]` in the middle of the content's own node structure –
+        // deferred, exactly as the anchor and cross-reference macros defer
+        // their own escaped-bracket forms when they cannot represent the
+        // unescape without a similar rebuild.
+        let source = "footnote:[a note ending in a\\]bracket]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
+            "a footnote with an escaped bracket must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, does build a footnote marker here.
+        assert!(golden_macros(source).contains("class=\"footnote\""));
     }
 }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -7735,16 +7735,22 @@ mod tests {
         // to a literal `]` in the middle of the content's own node structure –
         // deferred, exactly as the anchor and cross-reference macros defer
         // their own escaped-bracket forms when they cannot represent the
-        // unescape without a similar rebuild.
-        let source = "footnote:[a note ending in a\\]bracket]";
-        let nodes = build_src(Span::new(source));
+        // unescape without a similar rebuild. Both the anonymous form and the
+        // id-carrying form share the same check (see `build_footnote_node`),
+        // so both are exercised here.
+        for source in [
+            "footnote:[a note ending in a\\]bracket]",
+            "footnote:disc[a note ending in a\\]bracket]",
+        ] {
+            let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
-            "a footnote with an escaped bracket must be left unrecognized: {nodes:?}"
-        );
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
+                "a footnote with an escaped bracket must be left unrecognized: {nodes:?}"
+            );
 
-        // The string pipeline, by contrast, does build a footnote marker here.
-        assert!(golden_macros(source).contains("class=\"footnote\""));
+            // The string pipeline, by contrast, does build a footnote marker here.
+            assert!(golden_macros(source).contains("class=\"footnote\""));
+        }
     }
 }

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1951,7 +1951,7 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
 /// that follows the match.
 ///
 /// [footnote]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
-static INLINE_FOOTNOTE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_FOOTNOTE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)                     # extended mode; dot matches newline
@@ -2133,7 +2133,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
 /// each embedded newline to a space (Asciidoctor compacts a multi-line footnote
 /// onto a single line), and unescapes an escaped closing square bracket
 /// (`\]` -> `]`). Mirrors Asciidoctor's `normalize_text text, true, true`.
-fn normalize_footnote_text(content: &str) -> String {
+pub(crate) fn normalize_footnote_text(content: &str) -> String {
     content.trim().replace('\n', " ").replace("\\]", "]")
 }
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -17,10 +17,11 @@ pub(crate) mod inline_tree;
 
 mod macros;
 pub(crate) use macros::{
-    INLINE_ANCHOR, INLINE_IMAGE_MACRO, INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK,
-    INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF, NormalizedCaps, URI_SNIFF,
-    apply_macros_with_leading_anchor_registered, basename, normalize_index_text,
-    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
+    INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
+    INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
+    NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
+    normalize_footnote_text, normalize_index_text, normalize_text_lf_escaped_bracket,
+    split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;


### PR DESCRIPTION
## What

Completes **step 4b(ii) part 4c** of the [inline-AST plan](docs/design/inline-ast-architecture.md) (§5.2, Phase 4) — the **last remaining macro family**. The single-pass [`inline_builder`](../blob/inline-ast/parser/src/content/inline_builder.rs) now recognizes **footnotes** (`footnote:[…]`, `footnote:id[…]`, `footnote:id[]`) as a [`Footnote`](../blob/inline-ast/parser/src/inlines/footnote.rs) node, folding through the same `render_footnote` the string step calls so the output is **byte-for-byte identical**.

This follows [part 4b](https://github.com/asciidoc-rs/asciidoc-parser/pull/1113) (index terms). It reuses the string pipeline's *exact* recognition — `INLINE_FOOTNOTE_MACRO` is now shared `pub(crate)`, alongside the `normalize_footnote_text` helper — so only the recognition **sink** changes. The pass runs **last** in `apply_macros`, after cross-references, mirroring the string step's order exactly: a footnote's text is extracted from the flow, so any construct an earlier pass at this same level already recognized (an image, a link, an anchor, an index term, or now a cross-reference) is captured as *that construct's node* rather than being re-recognized from its source text. This step is **additive**: nothing is wired into the parse path.

With this, every macro family the Strategy-A recorder covers now has a single-pass counterpart.

## Two things that set this increment apart

- **Structured content, not a literal value.** Every other macro family gates its target/text slicing on `range_is_verbatim`, deferring the whole macro when the range crosses an already-recognized construct. A footnote's bracket content instead becomes the node's `children` via `emit_range`, so a range crossing an already-recognized construct is *not* a boundary to defer on — nesting is the point. `emit_range` clones that construct's node whole into the footnote's subtree, mirroring exactly how the string pipeline's footnote text captures an already-substituted macro verbatim.

- **One *required* recognition side effect.** Every prior macro family performs *no* recognition side effect (no catalog registration, no warning), deferring that to the cutover (design §5.2 Phase 4, step 6) because omitting it doesn't change the fold's output bytes. A footnote's marker digits (`[1]`, `[2]`, …) *are* the assigned footnote number, so this pass must call `Parser::footnote_index_for_id` / `Parser::define_footnote` — the same document-counter-advancing calls the string replacer makes — or the differential corpus could never pass. The two code paths never share a `Parser` (each independently numbers footnotes over the same source in the same left-to-right order), so this never double-counts a registration. The registered catalog `text` is a best-effort normalized rendering of the raw bracket content, not a fold (building the tree must not itself invoke a renderer), so — like every other deferred registration in this module — a tree-built footnote's `Document::catalog().footnotes()` entry is not yet byte-faithful; only the returned *number*, this pass's one load-bearing side effect, is relied on.

## Deferred (each documented + pinned by a divergence test)

| Form | Why |
| --- | --- |
| the deprecated `footnoteref:[id,text]` / `footnoteref:[id]` form | packs its id and text into one bracket, split differently from `footnote:id[text]`, and (outside `compat-mode`) raises a deprecation warning — neither implemented by this increment |
| content carrying an escaped closing bracket (`\]`) | unescaping it would mean splicing a literal `]` into the middle of a `Text` piece the content range slices — a rebuild this increment does not attempt, deferred exactly as the anchor/xref macros defer their own escaped-bracket forms when they can't represent the unescape without one |

## Tests

- `fold_matches_the_string_pipeline_through_footnotes` — the differential corpus (design §5.3) pinning byte-for-byte parity: anonymous/id'd defining occurrences, references (resolved and unresolved), multi-footnote numbering, id character classes, content already carrying a nested construct (span, replacement, image, link, index term, cross-reference, special character), escapes, and footnotes inside a rendered span.
- Structural tests the Strategy-A tree cannot make: precise node/child spans, borrowed `id`, document-order numbering, an empty subtree for a reference, unresolved-reference id fallback, and a nested-construct child (`Ref`) captured whole.
- Two divergence tests for the deferred forms above.

## Checks

- `cargo test --workspace` — green (4809 passed + 5 doctests).
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p asciidoc-parser --all-targets` — clean.
- `cargo +nightly doc --all-features --no-deps` (docs.rs preflight) and `cargo +nightly doc --no-deps --document-private-items` (internal docs) — both clean, no broken intra-doc links.

## Design doc

Updated `docs/design/inline-ast-architecture.md` §5.2 to mark part 4c landed and check off the step list — every sub-step of step 4 (`Macros`) except part 3c (the node-blocked cross-reference forms, tracked separately) is now done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013T4Sb9qNxg2KMMu6nUeB9v)_