### PR TITLE
fix: Register block image:: macro targets in the document catalog

### DIFF
--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -240,11 +240,27 @@ impl<'src> MediaBlock<'src> {
     /// [`TargetResolution::Drop`] is returned and the caller drops the
     /// entire block.
     ///
+    /// When this block is an image that survives resolution, it is also
+    /// recorded in the document catalog (a no-op unless
+    /// [`catalog_assets`](Parser::with_catalog_assets) is enabled), mirroring
+    /// the registration done for the inline `image:` macro.
+    ///
     /// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
     pub(crate) fn resolve_target(&mut self, parser: &Parser) -> TargetResolution {
         match substitute_attributes_in_macro_target(self.target, parser) {
             Some(resolved) => {
                 self.resolved_target = resolved;
+
+                if self.type_ == MediaType::Image {
+                    parser.register_image(
+                        self.resolved_target.to_string(),
+                        parser
+                            .attribute_value("imagesdir")
+                            .as_maybe_str()
+                            .map(str::to_owned),
+                    );
+                }
+
                 TargetResolution::Keep
             }
             None => TargetResolution::Drop,

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -5899,6 +5899,37 @@ mod macros {
         assert_eq!(doc.warnings().count(), 0);
     }
 
+    // The block `image::` macro (parsed via `MediaBlock`, a separate code
+    // path from the inline `image:` macro substitution above) must also
+    // register its target when `catalog_assets` is enabled, mirroring
+    // Asciidoctor's `doc.register :images, target` call in `Image#initialize`.
+    #[test]
+    fn catalog_records_block_image_targets_when_catalog_assets_enabled() {
+        let doc = Parser::default()
+            .with_catalog_assets(true)
+            .parse("image::foo.png[]");
+
+        let images = doc.catalog().images();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].target, "foo.png");
+        assert_eq!(images[0].imagesdir, None);
+    }
+
+    // Inline and block image macros share the same catalog, and both are
+    // recorded in document order regardless of which code path parsed them.
+    #[test]
+    fn catalog_records_inline_and_block_image_targets_in_document_order() {
+        let doc = Parser::default().with_catalog_assets(true).parse(
+            "An inline image:foo.png[] reference.\n\nimage::bar.png[]\n\nAnother image:baz.png[] reference.",
+        );
+
+        let images = doc.catalog().images();
+        assert_eq!(images.len(), 3);
+        assert_eq!(images[0].target, "foo.png");
+        assert_eq!(images[1].target, "bar.png");
+        assert_eq!(images[2].target, "baz.png");
+    }
+
     // Asciidoctor's `catalog[:links]` registry: like `catalog[:images]`, link
     // targets are recorded only when the `catalog_assets` option is enabled.
     // This exercises the crate's equivalent `Catalog::links` across a bare URL


### PR DESCRIPTION
## Summary

- `Parser::register_image` was only reached from the inline `image:` macro substitution path (`src/content/macros.rs`), so `Catalog::images()` silently omitted every block `image::` reference.
- `MediaBlock::resolve_target` (`src/blocks/media.rs`) now also calls `Parser::register_image` for image blocks that survive attribute resolution, using the same resolved-target/`imagesdir` logic as the inline path. This is a no-op unless `catalog_assets` is enabled, and doesn't fire for dropped blocks (`attribute-missing=drop-line`) or non-image media (`video::`/`audio::`).

Fixes #1118

## Test plan

- [x] Added `catalog_records_block_image_targets_when_catalog_assets_enabled` — a document with only `image::foo.png[]` is recorded in `Catalog::images()`.
- [x] Added `catalog_records_inline_and_block_image_targets_in_document_order` — verifies inline and block image macros are both recorded, in document order.
- [x] `cargo test` (4645 tests) passes.
- [x] `cargo clippy --all-targets` is clean.
- [x] `cargo fmt --check` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DRNeMeeUezYBCSmcSPvva7)_