### PR TITLE
fix: Leave revdate unset when the revision line's date field is empty

### DIFF
--- a/parser/src/document/revision_line.rs
+++ b/parser/src/document/revision_line.rs
@@ -58,7 +58,9 @@ impl<'src> RevisionLine<'src> {
 
         let revdate = {
             let resolved = apply_header_subs(&revdate, parser);
-            parser.set_attribute_by_value_from_header("revdate", &resolved);
+            if !resolved.is_empty() {
+                parser.set_attribute_by_value_from_header("revdate", &resolved);
+            }
             resolved
         };
 
@@ -389,7 +391,10 @@ mod tests {
             Some("1.2.3")
         );
 
-        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), Some(""));
+        // No date component was given, so `revdate` stays unset (matching
+        // Asciidoctor's `nil`), unlike `RevisionLine::revdate()` which always
+        // returns a `&str` and is `""` here.
+        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), None);
         assert_eq!(parser.attribute_value("revremark").as_maybe_str(), None);
     }
 
@@ -459,7 +464,7 @@ mod tests {
             Some("1.2.3")
         );
 
-        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), Some(""));
+        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), None);
 
         assert_eq!(
             parser.attribute_value("revremark").as_maybe_str(),
@@ -520,7 +525,30 @@ mod tests {
             Some("1.2.3-beta.1")
         );
 
-        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), Some(""));
+        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), None);
         assert_eq!(parser.attribute_value("revremark").as_maybe_str(), None);
+    }
+
+    #[test]
+    fn sets_document_attributes_empty_date_between_comma_and_colon() {
+        // Regression test for https://github.com/asciidoc-rs/asciidoc-parser/issues/1125:
+        // a revision line with a revision number and remark, but an empty date
+        // field between the two commas, must leave `revdate` unset rather than
+        // setting it to an empty string.
+        let mut parser = Parser::default();
+        let _result =
+            crate::document::RevisionLine::parse(Span::new("v1.0.0,:remark"), &mut parser);
+
+        assert_eq!(
+            parser.attribute_value("revnumber").as_maybe_str(),
+            Some("1.0.0")
+        );
+
+        assert_eq!(parser.attribute_value("revdate").as_maybe_str(), None);
+
+        assert_eq!(
+            parser.attribute_value("revremark").as_maybe_str(),
+            Some("remark")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1125.

A revision line with an empty date field (e.g. `v1.0.0,:remark` — number and remark given, date left blank between the two commas) previously set the `revdate` document attribute to a set-but-empty value (`InterpretedValue::Value("")`), rather than leaving it unset. Asciidoctor leaves `revdate` unset (`nil`) whenever the date component resolves to an empty string — not just for the two-comma case, but also for a standalone revision number with no date at all (e.g. `v8.6.8` or `v8.6.8,`), per `Asciidoctor::Parser`'s `unless m[2].empty?` guard.

## Changes

* `document/revision_line.rs`: only call `parser.set_attribute_by_value_from_header("revdate", ...)` when the resolved date string is non-empty. `RevisionLine::revdate()` is unaffected and still returns `""` when no date was given — only the recorded document attribute changes.
* Updated the three existing unit tests that asserted the (buggy) `Some("")` attribute value to now assert `None`, matching Asciidoctor's behavior for revision lines with no date component.
* Added a regression test (`sets_document_attributes_empty_date_between_comma_and_colon`) covering the exact scenario from the issue (`v1.0.0,:remark`).

## Test plan

- [x] `cargo test -p asciidoc-parser revision_line` — all pass
- [x] `cargo test` (full workspace) — 4673 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_016vByYExcswm9Q3uDwCXw15)_