### PR TITLE
fix: Do not warn for a doctitle attribute reference resolved later in the header

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -334,7 +334,27 @@ impl<'src> Header<'src> {
                     implicit_doctitle_str = Some(existing.clone());
                     title = Some(existing);
                 } else {
+                    let warnings_before_implicit_title = parser.substitution_warnings_len();
                     let title_str = apply_title_subs(title_span.data(), parser);
+
+                    // Under `attribute-missing: warn`, a reference to an
+                    // attribute defined later in the header is still
+                    // unresolved at this point in the scan and trips a
+                    // `SkippingReferenceToMissingAttribute` warning here, even
+                    // though the title is re-resolved against the final
+                    // header state below and, in that case, resolves
+                    // correctly. Discard the eager warning whenever that
+                    // later re-resolution will run – i.e. the substituted
+                    // text still contains a `{`, mirroring the condition at
+                    // the re-resolution site below – since that pass raises
+                    // its own warning if the reference is still genuinely
+                    // unresolved once the full header is known. Warnings from
+                    // a fully-resolved title, or from `drop`/`drop-line` mode
+                    // (which does not leave a `{` behind), are left as they
+                    // are not superseded by a later pass.
+                    if title_str.contains('{') {
+                        parser.truncate_substitution_warnings(warnings_before_implicit_title);
+                    }
 
                     parser.set_attribute_by_value_from_header("doctitle", &title_str);
 

--- a/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
@@ -163,6 +163,39 @@ fn warn_only_warns_about_truly_missing_attributes() {
 }
 
 #[test]
+fn warn_does_not_fire_for_a_doctitle_reference_to_an_attribute_defined_later_in_the_header() {
+    // Issue #1124: the implicit doctitle (`= {attr} …`) is scanned before the
+    // rest of the header, but `doctitle`/`{doctitle}` resolve lazily against
+    // the *final* header state (issue #716). The eager, at-title-line scan
+    // must not raise `SkippingReferenceToMissingAttribute` for a reference
+    // that resolves once the full header (including a later `:attr:` entry)
+    // is known.
+    let doc = Parser::default().parse(
+        "= {project-name} Docs\n:project-name: ACME\n:attribute-missing: warn\n\n{doctitle}",
+    );
+
+    assert!(doc.warnings().next().is_none());
+    assert_eq!(doc.doctitle(), Some("ACME Docs"));
+}
+
+#[test]
+fn warn_still_fires_for_a_doctitle_reference_that_is_never_defined() {
+    // A genuinely missing reference in the doctitle is not swallowed by the
+    // issue #1124 fix: it still raises exactly one warning, from the
+    // re-resolution pass against the final header state rather than the
+    // eager, at-title-line pass.
+    let doc = Parser::default()
+        .parse(":attribute-missing: warn\n= {never-defined} Docs\n\n{doctitle}");
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::SkippingReferenceToMissingAttribute("never-defined".to_string())
+    );
+}
+
+#[test]
 fn drop_line_only_drops_the_offending_line() {
     // Only the line carrying the missing reference is dropped; the surrounding
     // lines (including one with a resolvable reference) are preserved.

--- a/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
@@ -184,8 +184,8 @@ fn warn_still_fires_for_a_doctitle_reference_that_is_never_defined() {
     // issue #1124 fix: it still raises exactly one warning, from the
     // re-resolution pass against the final header state rather than the
     // eager, at-title-line pass.
-    let doc = Parser::default()
-        .parse(":attribute-missing: warn\n= {never-defined} Docs\n\n{doctitle}");
+    let doc =
+        Parser::default().parse(":attribute-missing: warn\n= {never-defined} Docs\n\n{doctitle}");
 
     let warnings: Vec<_> = doc.warnings().collect();
     assert_eq!(warnings.len(), 1);

--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -1129,16 +1129,18 @@ mod structure {
 "##
         );
 
-        let doc =
-            Parser::default().parse("= {project-name} Docs\n:project-name: ACME\n\n{doctitle}");
+        let doc = Parser::default()
+            .with_intrinsic_attribute("attribute-missing", "warn", ModificationContext::Anywhere)
+            .parse("= {project-name} Docs\n:project-name: ACME\n\n{doctitle}");
 
         // The implicit title references an attribute defined *later* in the
         // header. The `doctitle` attribute keeps the eager (at-title-line)
-        // value, where the reference was still unresolved (and, in `skip` mode,
-        // left literal without warning); `doctitle` itself resolves lazily
-        // against the final attribute state (issue #716). As in the sibling
-        // (defined-earlier) test, the port parses under the default
-        // `attribute-missing=skip` rather than `warn`.
+        // value, where the reference was still unresolved; `doctitle` itself
+        // resolves lazily against the final attribute state (issue #716).
+        // Under `attribute-missing: warn`, that eager scan must not raise a
+        // `SkippingReferenceToMissingAttribute` warning either, since the
+        // reference does resolve once the full header is known (issue
+        // #1124).
         assert_eq!(doc.warnings().count(), 0);
         assert_eq!(
             doc.attribute_value("doctitle"),


### PR DESCRIPTION
## Summary

Fixes #1124.

The implicit doctitle (`= {attr} …`) is substituted eagerly while first scanning the title line, before the rest of the header has been parsed. Under `attribute-missing: warn`, that eager pass raised a spurious `SkippingReferenceToMissingAttribute` warning whenever the title referenced an attribute that is assigned *later* in the same header — even though `doctitle()`/`{doctitle}` already resolve such references correctly via a lazy re-resolution pass once the full header is known (the fix for #716).

This is a narrower remnant of #716: that fix made the *value* resolve lazily, but left the eager warning emitted during the first scan untouched.

## Fix

In `Header::parse` (`parser/src/document/header.rs`), the eager implicit-title substitution now snapshots the substitution-warnings buffer length before running, and discards any warnings it recorded whenever the substituted title still contains an unresolved `{...}` reference — the same condition that already triggers a later re-resolution pass against the *final* header state. That later pass raises its own (correctly-timed) warning if the reference is still genuinely unresolved once the whole header has been parsed, so no warning is lost for attributes that are truly missing — only the premature, superseded one from the eager pass is dropped.

Warnings from a fully-resolved title, or from `drop`/`drop-line` mode (which doesn't leave a `{` behind to signal a later re-resolution), are untouched since there is no follow-up pass to supersede them.

## Testing

- Added `warn_does_not_fire_for_a_doctitle_reference_to_an_attribute_defined_later_in_the_header` and `warn_still_fires_for_a_doctitle_reference_that_is_never_defined` in `parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs`, covering both the fixed case and a regression guard that a genuinely missing doctitle reference still warns exactly once.
- Updated `should_not_warn_if_implicit_document_title_contains_attribute_reference_for_attribute_defined_later_in_header` in `parser/src/tests/asciidoctor_rb/document_test.rs` to actually exercise `attribute-missing: warn` (as the ported Ruby test does), rather than the default `skip` mode which couldn't have caught this bug.
- `cargo test -p asciidoc-parser --lib`: 4674 passed, 0 failed.
- `cargo clippy -p asciidoc-parser --lib --tests`: clean.
- `cargo fmt -p asciidoc-parser -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V1Xm8RC2hcpK8pcgYRPSQq)_