### PR TITLE
feat: Recognize delimited passthroughs in the single-pass inline builder (inline-ast Phase 4, step 5a)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1088,6 +1088,43 @@ Each phase is a reviewable unit with a clear exit gate.
   increment does not attempt). This step is **additive**: nothing is wired into the parse path. With it,
   every macro family the recorder covers now has a single-pass counterpart.
 
+  *Step 5a landed as (Passthroughs → `Raw`, the delimited forms):* a new
+  [`apply_passthroughs`](../../parser/src/content/inline_builder.rs) step – the **first** step
+  [`build`](../../parser/src/content/inline_builder.rs) runs, ahead of `SpecialCharacters` –
+  recognizes the triple-plus (`+++…+++`), double-plus (`++…++`), double-dollar (`$$…$$`), and bare
+  `pass:[…]` macro (no explicit substitution list) as [`Raw`](../../parser/src/inlines/inline_node.rs)
+  leaves, mirroring
+  [`Passthroughs::extract_from`](../../parser/src/content/passthroughs.rs), which the string pipeline
+  runs *before* its own step loop – so a passthrough's content is never touched by specialcharacters,
+  quotes, replacements, or macros: it is a leaf, and every later step's match-string builder already
+  treats an unrecognized node kind as one opaque placeholder, exactly as it already does for an
+  earlier-built `Styled` span. It reuses the string pipeline's *exact* recognition –
+  [`INLINE_PASS_MACRO`](../../parser/src/content/passthroughs.rs) is now shared `pub(crate)` – so only
+  the recognition *sink* differs (§4.1). The triple-plus and bare `pass:[…]` forms resolve to
+  `SubstitutionGroup::None` (nothing applies), so their content borrows `'src` directly (a `pass:[…]`
+  body unescapes an escaped `\]`, as every other macro family's bracket content does, which makes the
+  unescaped case owned instead); the double-plus and double-dollar forms resolve to
+  `SubstitutionGroup::Verbatim` (special characters only) and are run through the real substitution
+  pipeline rather than hand-escaped, so a custom `InlineSubstitutionRenderer`'s escaping is honored –
+  the cost is an owned `Raw` value instead of a borrow.
+
+  Three forms are deferred, each documented and pinned by a divergence test: an
+  **attribute-list-prefixed** passthrough (`[quotes]++text++`, `[x-]\`text\``, `[attrs]+text+`), a
+  **`pass:` macro carrying an explicit substitution list** (`pass:c,q[…]`, whose content would need a
+  richer subtree than a single `Raw` leaf can hold – the same reason a footnote's content is
+  structured children rather than a literal value), and the **bare unconstrained form** (`+text+`,
+  matched by `INLINE_PASS` rather than `INLINE_PASS_MACRO` – its "must not follow a word" boundary
+  needs a lookbehind Rust's regex engine cannot express, which the string replacer works around with a
+  retry loop this increment does not reproduce). That same deferred boundary shows up once more,
+  indirectly: an **escaped triple- or double-plus** (`\+++text+++`, `\++text++`) drops its backslash
+  and keeps the delimited text literal here, but the string pipeline's *second* extraction pass
+  (`INLINE_PASS`) re-scans that same de-escaped text and consumes its leading `+++`/`++` as a bare
+  passthrough wrapping a shorter run – so these two escape forms are pinned as divergences rather than
+  folded into the main parity corpus; an escaped `$$…$$` or `pass:[…]` has no such residue and stays
+  parity. Inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) is an implicit passthrough too,
+  but folds through its own [`Stem`](../../parser/src/inlines/stem.rs) node rather than `Raw`, so it is
+  a separate, later increment. This step is **additive**: nothing is wired into the parse path.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1116,7 +1153,14 @@ Each phase is a reviewable unit with a clear exit gate.
            - ✅ **part 4c.** footnotes (`footnote:[…]` / `footnote:id[…]` / `footnote:id[]`,
              `INLINE_FOOTNOTE_MACRO`) → `Footnote` – the last macro family.
   5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
-     `Callouts` – completing the vocabulary the recorder covers.
+     `Callouts` – completing the vocabulary the recorder covers, each its own sub-step:
+     - ✅ **5a.** Passthroughs, the delimited forms (`+++…+++`, `++…++`, `$$…$$`, bare
+       `pass:[…]`) → `Raw`.
+     - **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
+     - **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
+     - **5d.** the deferred forms `5a` documents – an attribute-list-prefixed passthrough, a
+       `pass:` macro with an explicit substitution list, the bare unconstrained `+text+` form,
+       and inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) → `Stem`.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make
      `rendered_html()` a fold, delete the three production sentinel systems (§4.2), and retire
      the `with_inline_tree` opt-in flag (the deferred remainder of Phase 2). Re-attach the

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -4687,6 +4687,47 @@ mod tests {
     }
 
     #[test]
+    fn a_match_whose_content_crosses_an_already_built_node_is_deferred() {
+        // In practice `apply_passthroughs` only ever runs on the pristine
+        // whole-source seed (it is `build`'s first step, ahead of every node
+        // that could make a range non-verbatim), so `range_is_verbatim`'s
+        // false branch is defensive – kept for the same reason every other
+        // macro family keeps the check. Exercise it directly, feeding a
+        // hand-built level whose triple-plus content spans an already-built
+        // `Styled` node, to document the intended fallback: the whole match
+        // is left unrecognized rather than mis-sliced.
+        let location = Span::new("+++");
+
+        let nodes = vec![
+            InlineNode::Text {
+                value: CowStr::from("+++"),
+                location,
+            },
+            InlineNode::Styled(Styled {
+                variant: StyleVariant::Strong,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: vec![],
+                attrs: None,
+                children: vec![],
+                location,
+            }),
+            InlineNode::Text {
+                value: CowStr::from("+++"),
+                location,
+            },
+        ];
+
+        let root = Span::new("+++");
+        let result = apply_passthroughs(nodes.clone(), root, &Parser::default());
+
+        assert_eq!(
+            result, nodes,
+            "a non-verbatim match must be left unrecognized"
+        );
+    }
+
+    #[test]
     fn triple_plus_borrows_its_content_unescaped() {
         // `SubstitutionGroup::None` applies nothing, so the content is genuinely
         // raw – not even special characters are escaped – and borrows `'src`.

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -204,12 +204,14 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
 /// passthrough's content is never touched by specialcharacters, quotes,
 /// replacements, or macros: it is a leaf, and every later step's
 /// [`build_match_string`] already treats a node it does not specifically
-/// handle (an already-built [`Styled`] span, and now a [`Raw`] leaf) as a
+/// handle (an already-built [`Styled`] span, and now a
+/// [`Raw`](InlineNode::Raw) leaf) as a
 /// single opaque placeholder.
 ///
 /// It reuses the string pipeline's *exact* recognition –
 /// [`INLINE_PASS_MACRO`] is now shared `pub(crate)` – so only the recognition
-/// *sink* differs (§4.1). Two forms fold through a [`Raw`] node whose `value`
+/// *sink* differs (§4.1). Two forms fold through a [`Raw`](InlineNode::Raw)
+/// node whose `value`
 /// is the *content itself*, since their substitution list applies nothing:
 /// the triple-plus (`+++text+++`) and bare `pass:[…]` macro (with no
 /// substitution list) both resolve to [`SubstitutionGroup::None`], and the
@@ -222,12 +224,12 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
 /// ([`passthrough_text`]) so a custom
 /// [`InlineSubstitutionRenderer`]'s escaping is honored, exactly as it would
 /// be for the string pipeline's own restore step – the cost is an owned
-/// [`Raw`] value rather than a `'src` borrow, since the pipeline's output is
-/// not guaranteed to coincide with the source.
+/// [`Raw`](InlineNode::Raw) value rather than a `'src` borrow, since the
+/// pipeline's output is not guaranteed to coincide with the source.
 ///
 /// Three forms are deferred, each documented and pinned by a divergence test:
 /// an **attribute-list-prefixed** passthrough (`[quotes]++text++`,
-/// `[x-]\`text\``, `[attrs]+text+`), a **`pass:` macro carrying an explicit
+/// `` [x-]`text` ``, `[attrs]+text+`), a **`pass:` macro carrying an explicit
 /// substitution list** (`pass:c,q[…]`, whose content would need a richer
 /// subtree than a single `Raw` leaf – the same reason a footnote's content
 /// is structured children rather than a literal value), and the **bare
@@ -296,7 +298,7 @@ fn find_passthrough_matches<'src>(
         let full = whole.start()..whole.end();
 
         // An attribute list ahead of the delimiters (`[quotes]++text++`,
-        // `[x-]\`text\``) is deferred.
+        // `` [x-]`text` ``) is deferred.
         if caps.get(2).is_some() {
             continue;
         }
@@ -398,8 +400,8 @@ fn build_passthrough_node<'src>(
 }
 
 /// Runs `text` through the real substitution pipeline under `subs`, returning
-/// the resulting owned string. Used to compute a [`Raw`] passthrough's
-/// `value` under [`SubstitutionGroup::Verbatim`] – mirroring
+/// the resulting owned string. Used to compute a [`Raw`](InlineNode::Raw)
+/// passthrough's `value` under [`SubstitutionGroup::Verbatim`] – mirroring
 /// `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call in the string
 /// pipeline's restore step – so the result honors whatever
 /// [`InlineSubstitutionRenderer`] `parser` carries rather than a hand-rolled,

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -136,12 +136,12 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
+        CharacterReplacement, Content, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
         INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
-        INLINE_XREF, NormalizedCaps, QuoteSub, URI_SNIFF, basename, character_replacements,
-        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, normalize_footnote_text,
-        normalize_index_text, normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys,
-        strip_see_and_seealso,
+        INLINE_PASS_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub, SubstitutionGroup, URI_SNIFF,
+        basename, character_replacements, hard_line_break_pattern, maybe_has_quotes,
+        maybe_has_replacements, normalize_footnote_text, normalize_index_text,
+        normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys, strip_see_and_seealso,
         xref_target::{XrefTarget, interpret_xref_target},
     },
     inlines::{
@@ -172,7 +172,12 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
         location: source,
     }];
 
-    let nodes = apply_special_characters(seed);
+    // Passthroughs are extracted before every other step (mirroring
+    // `Passthroughs::extract_from`, which the string pipeline runs ahead of
+    // its own step loop), so their content is never touched by
+    // specialcharacters, quotes, replacements, or macros.
+    let nodes = apply_passthroughs(seed, source, parser);
+    let nodes = apply_special_characters(nodes);
     let nodes = apply_quotes(nodes, source, parser);
     let nodes = apply_character_replacements(nodes, source);
     let nodes = apply_macros(nodes, source, parser);
@@ -184,6 +189,225 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     let nodes = apply_footnotes(nodes, source, parser);
 
     apply_post_replacements(nodes, source)
+}
+
+// ─── Passthroughs ───────────────────────────────────────────────────────────
+
+/// The passthrough-extraction step, as a node transducer: replaces each
+/// recognized passthrough with a [`Raw`](InlineNode::Raw) leaf and leaves
+/// everything else as the whole-source seed [`Text`](InlineNode::Text) node,
+/// for [`apply_special_characters`] and the later steps to refine.
+///
+/// This is the **first** step [`build`] runs – mirroring
+/// [`Passthroughs::extract_from`](crate::content::Passthroughs::extract_from),
+/// which the string pipeline runs *before* its own step loop – so a
+/// passthrough's content is never touched by specialcharacters, quotes,
+/// replacements, or macros: it is a leaf, and every later step's
+/// [`build_match_string`] already treats a node it does not specifically
+/// handle (an already-built [`Styled`] span, and now a [`Raw`] leaf) as a
+/// single opaque placeholder.
+///
+/// It reuses the string pipeline's *exact* recognition –
+/// [`INLINE_PASS_MACRO`] is now shared `pub(crate)` – so only the recognition
+/// *sink* differs (§4.1). Two forms fold through a [`Raw`] node whose `value`
+/// is the *content itself*, since their substitution list applies nothing:
+/// the triple-plus (`+++text+++`) and bare `pass:[…]` macro (with no
+/// substitution list) both resolve to [`SubstitutionGroup::None`], and the
+/// content borrows `'src` directly (a `pass:[…]` body unescapes an escaped
+/// `\]`, as every other macro family's bracket content does, which makes the
+/// unescaped case owned). The double-plus (`++text++`) and double-dollar
+/// (`$$text$$`) forms resolve to [`SubstitutionGroup::Verbatim`] (special
+/// characters only); rather than hand-escape `<`/`>`/`&`, their content is
+/// run through the real substitution pipeline
+/// ([`passthrough_text`]) so a custom
+/// [`InlineSubstitutionRenderer`]'s escaping is honored, exactly as it would
+/// be for the string pipeline's own restore step – the cost is an owned
+/// [`Raw`] value rather than a `'src` borrow, since the pipeline's output is
+/// not guaranteed to coincide with the source.
+///
+/// Three forms are deferred, each documented and pinned by a divergence test:
+/// an **attribute-list-prefixed** passthrough (`[quotes]++text++`,
+/// `[x-]\`text\``, `[attrs]+text+`), a **`pass:` macro carrying an explicit
+/// substitution list** (`pass:c,q[…]`, whose content would need a richer
+/// subtree than a single `Raw` leaf – the same reason a footnote's content
+/// is structured children rather than a literal value), and the **bare
+/// unconstrained form** (`+text+`, matched by [`INLINE_PASS`] rather than
+/// [`INLINE_PASS_MACRO`] – its "must not follow a word" boundary needs a
+/// lookbehind Rust's regex engine cannot express, which the string
+/// replacer works around with a retry loop this increment does not yet
+/// reproduce). Inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) is
+/// an implicit passthrough too, but folds through its own
+/// [`Stem`](InlineNode::Stem) node rather than `Raw`, so it is a separate,
+/// later increment. This step is **additive**: nothing is wired into the
+/// parse path.
+///
+/// The same deferred bare-form boundary shows up once more, indirectly: an
+/// **escaped triple- or double-plus** (`\+++text+++`, `\++text++`) drops its
+/// backslash and keeps the delimited text literal here, but the string
+/// pipeline's *second* extraction pass ([`INLINE_PASS`]) re-scans that same
+/// de-escaped text and consumes its leading `+++`/`++` as a bare passthrough
+/// wrapping a shorter run – so these two escape forms are pinned as
+/// divergences (`an_escaped_triple_plus_stays_literal`,
+/// `an_escaped_double_plus_stays_literal`) rather than folded into the main
+/// parity corpus. An escaped `$$…$$` or `pass:[…]` has no such residue and
+/// stays parity, since [`INLINE_PASS`] never matches `$$` or `pass:` syntax.
+///
+/// [`INLINE_PASS`]: crate::content::passthroughs
+/// [`InlineSubstitutionRenderer`]: crate::parser::InlineSubstitutionRenderer
+fn apply_passthroughs<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard: a
+    // recognized form always contains `++`, `$$`, or (for `pass:`) `ss:`.
+    if !(s.contains("++") || s.contains("$$") || s.contains("ss:")) {
+        return nodes;
+    }
+
+    let matches = find_passthrough_matches(&s, &pieces, root, parser);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every passthrough at this level, skipping the deferred forms
+/// [`apply_passthroughs`] documents: an attribute-list-prefixed match (an
+/// optional group [`INLINE_PASS_MACRO`] captures ahead of the delimiters) and
+/// a `pass:` macro carrying an explicit substitution list.
+fn find_passthrough_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_PASS_MACRO.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        // An attribute list ahead of the delimiters (`[quotes]++text++`,
+        // `[x-]\`text\``) is deferred.
+        if caps.get(2).is_some() {
+            continue;
+        }
+
+        // A `pass:` macro carrying an explicit substitution list
+        // (`pass:c,q[…]`) is deferred.
+        if caps.get(14).is_some() {
+            continue;
+        }
+
+        // Only a wholly-verbatim match can slice its content from `'src`; a
+        // match crossing an already-recognized construct cannot occur here –
+        // this is the very first step – but the check is kept for the same
+        // reason every other family keeps it: a future caller of this
+        // function over a non-seed level must not silently mis-slice.
+        if !range_is_verbatim(pieces, &full) {
+            continue;
+        }
+
+        if whole.as_str().starts_with('\\') {
+            matches.push(MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            });
+
+            continue;
+        }
+
+        let node = build_passthrough_node(&caps, &full, pieces, root, parser);
+
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Raw`](InlineNode::Raw) node from a verbatim, unescaped
+/// passthrough match – see [`apply_passthroughs`] for how each delimiter form
+/// maps to its `value`.
+fn build_passthrough_node<'src>(
+    caps: &regex::Captures<'_>,
+    full: &std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> InlineNode<'src> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    if let Some(m) = caps.get(5) {
+        // `+++text+++`: `SubstitutionGroup::None` applies nothing, so the
+        // content is genuinely raw and borrows `'src` directly.
+        let content = source_slice(pieces, m.start()..m.end(), root);
+
+        return InlineNode::Raw {
+            value: CowStr::from(content.data()),
+            location,
+        };
+    }
+
+    if let Some(m) = caps.get(8).or_else(|| caps.get(11)) {
+        // `++text++` / `$$text$$`: `SubstitutionGroup::Verbatim` applies only
+        // special characters. Computed through the real substitution
+        // pipeline (rather than hand-escaping `<`/`>`/`&`) so a custom
+        // `InlineSubstitutionRenderer`'s escaping is honored.
+        let content = source_slice(pieces, m.start()..m.end(), root);
+        let value = passthrough_text(content.data(), &SubstitutionGroup::Verbatim, parser);
+
+        return InlineNode::Raw {
+            value: CowStr::from(value),
+            location,
+        };
+    }
+
+    // The bare `pass:[…]` macro (no explicit substitution list):
+    // `SubstitutionGroup::None` applies nothing, and an escaped closing
+    // bracket (`\]`) unescapes, mirroring the string replacer's
+    // `text.replace("\\]", "]")` – the same treatment every other macro
+    // family's bracket content gets.
+    #[allow(clippy::unwrap_used)]
+    let m = caps.get(15).unwrap();
+    let content = source_slice(pieces, m.start()..m.end(), root);
+    let raw = content.data();
+
+    let value = if raw.contains("\\]") {
+        CowStr::from(raw.replace("\\]", "]"))
+    } else {
+        CowStr::from(raw)
+    };
+
+    InlineNode::Raw { value, location }
+}
+
+/// Runs `text` through the real substitution pipeline under `subs`, returning
+/// the resulting owned string. Used to compute a [`Raw`] passthrough's
+/// `value` under [`SubstitutionGroup::Verbatim`] – mirroring
+/// `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call in the string
+/// pipeline's restore step – so the result honors whatever
+/// [`InlineSubstitutionRenderer`] `parser` carries rather than a hand-rolled,
+/// always-default escaping.
+fn passthrough_text(text: &str, subs: &SubstitutionGroup, parser: &Parser) -> String {
+    let mut content = Content::from(Span::new(text));
+    subs.apply(&mut content, parser, None);
+    content.rendered_str().to_string()
 }
 
 /// Reports whether `c` is one of the three characters the special-characters
@@ -4317,12 +4541,12 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::{
-        apply_character_replacements, apply_macros, apply_post_replacements, apply_quotes,
-        apply_special_characters, build,
+        apply_character_replacements, apply_macros, apply_passthroughs, apply_post_replacements,
+        apply_quotes, apply_special_characters, build,
     };
     use crate::{
         HasSpan, Parser, Span,
-        content::{Content, SubstitutionStep},
+        content::{Content, Passthroughs, SubstitutionStep},
         inlines::{
             Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
             StyleVariant, Styled, Ui, UiKind,
@@ -4404,6 +4628,326 @@ mod tests {
 
             other => panic!("expected CharRef::Special({ch:?}), got {other:?}"),
         }
+    }
+
+    // ─── Passthroughs ───────────────────────────────────────────────────────
+
+    /// Asserts that `node` is a [`Raw`](InlineNode::Raw) with the given
+    /// `value`, returning its `location`.
+    fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'src> {
+        match node {
+            InlineNode::Raw {
+                value: got,
+                location,
+            } => {
+                assert_eq!(got.as_ref(), value);
+                *location
+            }
+
+            other => panic!("expected Raw({value:?}), got {other:?}"),
+        }
+    }
+
+    /// The string pipeline's output for `source`, used as the golden oracle
+    /// for the passthrough increment: extract passthroughs, run the five
+    /// steps [`build`] runs (special characters, quotes, character
+    /// replacements, macros, post replacement), then restore them – exactly
+    /// what [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup::apply)'s
+    /// `run_pipeline` does for [`SubstitutionGroup::Normal`]. Attribute
+    /// references are skipped, as elsewhere in this module's golden helpers.
+    fn golden_passthroughs_with(source: &str, parser: &Parser) -> String {
+        let mut content = Content::from(Span::new(source));
+        let passthroughs = Passthroughs::extract_from(&mut content, parser);
+
+        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
+        SubstitutionStep::Quotes.apply(&mut content, parser, None);
+        SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
+        SubstitutionStep::Macros.apply(&mut content, parser, None);
+        SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
+
+        passthroughs.restore_to(&mut content, parser);
+        content.rendered_str().to_string()
+    }
+
+    /// [`golden_passthroughs_with`] with a default parser.
+    fn golden_passthroughs(source: &str) -> String {
+        golden_passthroughs_with(source, &Parser::default())
+    }
+
+    #[test]
+    fn apply_passthroughs_is_a_noop_without_passthrough_syntax() {
+        // The cheap pre-filter returns the seed unchanged when no `++`, `$$`, or
+        // `ss:` substring is present, so ordinary content never pays for the
+        // level-building machinery.
+        let source = Span::new("plain text, no passthrough syntax here");
+        let seeded = seed(source);
+        let nodes = apply_passthroughs(seeded.clone(), source, &Parser::default());
+
+        assert_eq!(nodes, seeded);
+    }
+
+    #[test]
+    fn triple_plus_borrows_its_content_unescaped() {
+        // `SubstitutionGroup::None` applies nothing, so the content is genuinely
+        // raw – not even special characters are escaped – and borrows `'src`.
+        let nodes = build_src(Span::new("+++<b>*not quotes*</b>+++"));
+
+        assert_eq!(nodes.len(), 1);
+
+        // `location` covers the whole `+++…+++` construct (delimiters
+        // included), matching every other macro node; only `value` is the
+        // unwrapped content.
+        let location = assert_raw(&nodes[0], "<b>*not quotes*</b>");
+        assert_eq!(location.data(), "+++<b>*not quotes*</b>+++");
+
+        match &nodes[0] {
+            InlineNode::Raw { value, .. } => {
+                assert!(
+                    matches!(value, CowStr::Borrowed(_)),
+                    "triple-plus content should borrow from source, got {value:?}"
+                );
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn double_plus_and_double_dollar_escape_specials_only() {
+        // `SubstitutionGroup::Verbatim` applies only special characters: `<`/`>`
+        // are escaped, but `*not quotes*` is left alone (quotes never runs over
+        // passthrough content).
+        for source in ["++<b>*not quotes*</b>++", "$$<b>*not quotes*</b>$$"] {
+            let nodes = build_src(Span::new(source));
+
+            assert_eq!(nodes.len(), 1, "for {source:?}: {nodes:?}");
+            assert_raw(&nodes[0], "&lt;b&gt;*not quotes*&lt;/b&gt;");
+        }
+    }
+
+    #[test]
+    fn bare_pass_macro_borrows_unescaped_content() {
+        let nodes = build_src(Span::new("pass:[<b>*not quotes*</b>]"));
+
+        assert_eq!(nodes.len(), 1);
+        let location = assert_raw(&nodes[0], "<b>*not quotes*</b>");
+        assert_eq!(location.data(), "pass:[<b>*not quotes*</b>]");
+    }
+
+    #[test]
+    fn an_empty_pass_macro_builds_an_empty_raw_node() {
+        let nodes = build_src(Span::new("pass:[]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "");
+    }
+
+    #[test]
+    fn a_pass_macro_unescapes_an_escaped_closing_bracket() {
+        // Mirrors the string replacer's `text.replace("\\]", "]")`, the same
+        // treatment every other macro family's bracket content gets. The
+        // unescape makes the value owned, unlike the no-escape case above.
+        let nodes = build_src(Span::new(r"pass:[a\]b]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "a]b");
+
+        match &nodes[0] {
+            InlineNode::Raw { value, .. } => {
+                assert!(matches!(value, CowStr::Boxed(_)), "got {value:?}");
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_escaped_triple_plus_stays_literal() {
+        // The builder drops the single backslash and keeps `+++text+++`
+        // literal, mirroring every other family's `\image:…` escape handling.
+        // The string pipeline instead runs a *second* pass (`INLINE_PASS`,
+        // the deferred bare `+text+` form) over that same de-escaped text,
+        // which re-consumes its leading `+++` as a bare passthrough wrapping
+        // a single `+` – so this is a documented divergence, not parity, and
+        // stems from the same deferred boundary as the bare unconstrained
+        // form.
+        let source = r"\+++text+++";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "an escaped passthrough must not build a Raw node: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(folded, "+++text+++");
+        assert_ne!(folded, golden_passthroughs(source));
+    }
+
+    #[test]
+    fn an_escaped_double_plus_stays_literal() {
+        // Same divergence as `an_escaped_triple_plus_stays_literal`, one
+        // delimiter layer down: de-escaping `\++text++` to `++text++` leaves
+        // a leading `++` the deferred bare-form pass also re-consumes.
+        let source = r"\++text++";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "an escaped passthrough must not build a Raw node: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(folded, "++text++");
+        assert_ne!(folded, golden_passthroughs(source));
+    }
+
+    #[test]
+    fn an_escaped_pass_macro_stays_literal() {
+        let nodes = build_src(Span::new(r"\pass:[x]"));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "an escaped passthrough must not build a Raw node: {nodes:?}"
+        );
+
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "pass:[x]");
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_passthroughs() {
+        // For each fixture, folding the single-pass tree (all six steps,
+        // passthroughs included) reproduces the string pipeline's output
+        // byte-for-byte. This is the differential corpus (design §5.3) that
+        // pins the passthrough increment.
+        let fixtures = [
+            // No passthrough despite passthrough-ish characters.
+            "plain text",
+            "a colon : and a plus + apart",
+            "one + two - not a passthrough",
+            // Triple-plus: no substitutions at all.
+            "+++<b>bold</b>+++",
+            "+++*not quotes*+++",
+            "prefix +++<raw/>+++ suffix",
+            "+++line one\nline two+++",
+            // Double-plus / double-dollar: special characters only.
+            "++<b>++",
+            "++*not quotes*++",
+            "$$<b>$$",
+            "$$*not quotes*$$",
+            // The bare `pass:[…]` macro.
+            "pass:[<b>]",
+            "pass:[]",
+            r"pass:[a\]b]",
+            "pass:[*not quotes*]",
+            // Multiple passthroughs, and passthroughs beside ordinary quoted
+            // text (proving the surrounding text is still substituted
+            // normally).
+            "a +++x+++ and a ++y++ and a $$z$$ and a pass:[w]",
+            "*bold* +++<raw/>+++ *more bold*",
+            // Escapes. The `+++`/`++` forms are handled elsewhere (see
+            // `an_escaped_triple_plus_stays_literal` and
+            // `an_escaped_double_plus_stays_literal`), since de-escaping them
+            // can leave a residue the deferred bare `+text+` pass would also
+            // consume – a documented divergence, not parity.
+            r"\$$text$$",
+            r"\pass:[x]",
+        ];
+
+        for source in fixtures {
+            let nodes = build_src(Span::new(source));
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(source),
+                "mismatch for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_prefixed_passthrough_is_a_documented_divergence() {
+        // `[.role]++text++` splices an attribute list ahead of the delimiters,
+        // wrapping the restored content in a `<span>` at restore time. The
+        // builder cannot yet carry that attribute list, so the whole match is
+        // left unrecognized (no `Raw` node; `++`/`++` stay literal, and the
+        // surrounding steps do not otherwise recognize them either).
+        let source = "[.role]++text++";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "an attribute-list-prefixed passthrough must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
+        assert!(golden.contains("role"), "golden: {golden:?}");
+    }
+
+    #[test]
+    fn a_pass_macro_with_an_explicit_subs_list_is_a_documented_divergence() {
+        // `pass:c[…]` names an explicit substitution list, which would need a
+        // richer subtree than a single `Raw` leaf can hold (the same reason a
+        // footnote's content is structured children rather than a literal
+        // value) – deferred to a later increment.
+        let source = "pass:c[<b>]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "a pass: macro with an explicit subs list must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
+    }
+
+    #[test]
+    fn a_bare_unconstrained_passthrough_is_a_documented_divergence() {
+        // The bare `+text+` form is matched by `INLINE_PASS`, not
+        // `INLINE_PASS_MACRO` – its "must not follow a word" boundary needs a
+        // lookbehind Rust's regex engine cannot express, which the string
+        // replacer works around with a retry loop this increment does not
+        // reproduce. Left unrecognized: the plus signs stay literal.
+        let source = "a +text+ b";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+            "a bare unconstrained passthrough must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
+        assert_eq!(folded, "a +text+ b");
+    }
+
+    #[test]
+    fn inline_stem_is_a_documented_divergence() {
+        // Inline STEM macros (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) are
+        // implicit passthroughs too, but fold through their own `Stem` node
+        // rather than `Raw`, so they are a separate, later increment; this
+        // step does not recognize them at all.
+        let source = "stem:[x^2]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes
+                .iter()
+                .all(|n| !matches!(n, InlineNode::Raw { .. } | InlineNode::Stem(_))),
+            "inline STEM must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
     }
 
     #[test]

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -28,7 +28,7 @@ mod xref_target;
 
 pub(crate) mod passthroughs;
 pub use passthroughs::Passthrough;
-pub(crate) use passthroughs::Passthroughs;
+pub(crate) use passthroughs::{INLINE_PASS_MACRO, Passthroughs};
 
 mod substitution_group;
 pub use substitution_group::SubstitutionGroup;

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -167,7 +167,7 @@ impl Passthroughs {
 ///
 /// NOTE: We have to support an empty `pass:[]` for compatibility with
 /// AsciiDoc.py.
-static INLINE_PASS_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_PASS_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)


### PR DESCRIPTION
## Summary

This is the next increment of the [inline AST architecture](docs/design/inline-ast-architecture.md) plan: Phase 4, step 5a (passthroughs, the delimited forms). Per the design doc's `Next steps` list, step 5 — passthroughs, `AttributeReferences`, and `Callouts` — is what remained after step 4 (the macro families) finished landing in #1130.

- Adds `apply_passthroughs`, a new transducer step in `inline_builder.rs` that runs **first** in `build` (ahead of `SpecialCharacters`), mirroring `Passthroughs::extract_from`, which the string pipeline runs before its own step loop. This keeps passthrough content untouched by specialcharacters, quotes, replacements, and macros — it becomes an opaque `Raw` leaf, exactly like an already-built `Styled` span is to a later step.
- Recognizes the triple-plus (`+++…+++`), double-plus (`++…++`), double-dollar (`$$…$$`), and bare `pass:[…]` macro (no explicit substitution list), reusing the string pipeline's exact `INLINE_PASS_MACRO` pattern (now shared `pub(crate)`) so only the recognition *sink* changes.
  - Triple-plus and bare `pass:[…]` resolve to `SubstitutionGroup::None`, so content borrows `'src` directly (an escaped `\]` in `pass:[…]` unescapes into an owned value, as every other macro family's bracket content does).
  - Double-plus and double-dollar resolve to `SubstitutionGroup::Verbatim`; rather than hand-escape `<`/`>`/`&`, their content is run through the real substitution pipeline so a custom `InlineSubstitutionRenderer`'s escaping is honored.
- Three forms are deferred and pinned by divergence tests: an attribute-list-prefixed passthrough (`[.role]++text++`), a `pass:` macro with an explicit substitution list (`pass:c[…]`), and the bare unconstrained `+text+` form (needs a lookbehind Rust's regex engine can't express). An escaped triple-/double-plus is *also* pinned as a divergence — the string pipeline's second extraction pass can re-consume the de-escaped delimiters as a bare passthrough, a subtle cascading quirk. Inline STEM stays unrecognized, left to its own later increment.
- This step is **additive**: nothing is wired into the parse path yet.

Updated `docs/design/inline-ast-architecture.md` to record this as step 5a landed, and split the remaining step-5 checklist into 5b (`AttributeReferences`), 5c (`Callouts`), and 5d (the deferred forms above).

## Test plan

- [x] `cargo test -p asciidoc-parser` — all 4826 tests pass, including a new differential corpus (`fold_matches_the_string_pipeline_through_passthroughs`) and divergence tests for each deferred form
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01E3fhojf33GjwL7nJhvHK3m


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3fhojf33GjwL7nJhvHK3m)_