### PR TITLE
feat: Recognize attribute references in the single-pass inline builder (inline-ast Phase 4, step 5b)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1125,6 +1125,45 @@ Each phase is a reviewable unit with a clear exit gate.
   but folds through its own [`Stem`](../../parser/src/inlines/stem.rs) node rather than `Raw`, so it is
   a separate, later increment. This step is **additive**: nothing is wired into the parse path.
 
+  *Step 5b landed as (`AttributeReferences` → expanded-value splicing):* a new
+  [`apply_attribute_references`](../../parser/src/content/inline_builder.rs) step is inserted between
+  `Quotes` and `CharacterReplacements` – its position in the *normal* effective order
+  (`specialcharacters → quotes → attributes → replacements → macros`, §3.4.1) – so whatever it splices
+  into the tree is exactly what the two steps still ahead of it see. It reuses the string pipeline's
+  *exact* recognition – [`ATTRIBUTE_REFERENCE`](../../parser/src/content/substitution_step.rs) is now
+  shared `pub(crate)` – so only the recognition *sink* differs (§4.1): a reference to a **set**
+  attribute has its resolved value spliced into the node stream, classified into
+  [`Text`](../../parser/src/inlines/inline_node.rs) and [`Raw`](../../parser/src/inlines/inline_node.rs)
+  runs by [`split_attribute_value`](../../parser/src/content/inline_builder.rs) – the §3.4.1 policy
+  applied for the first time: because `SpecialCharacters` has already run and will not run again over
+  spliced-in content, a literal `<`/`>`/`&` in the value becomes a `Raw` leaf (unescaped) rather than a
+  `CharRef` (which the fold would re-escape), while everything else stays `Text`. An **escaped**
+  reference (`\{name}`, `{name\}`, `\{name\}`) drops its backslash(es) and keeps the rest of its match
+  as literal nodes, replacing nothing, mirroring `AttributeReplacer`'s `caps[1]`/`caps[5]` branch – and,
+  because that check runs before any lookup, this works identically whether or not the named attribute
+  is set. An `InterpretedValue::Set`/`::Unset` attribute (no textual value – the language leaves this
+  case unclear, as the string replacer's own comment notes) expands to nothing, exactly as the string
+  pipeline's replacer does.
+
+  Three forms are deferred, each documented and pinned by a divergence test: a **`counter`/`counter2`
+  directive**, whose resolution *advances* a document counter – a required side effect this additive
+  step does not yet perform, the same reason every macro family deferred its own catalog/warning side
+  effect until the footnote and cutover increments; a reference to a **missing** attribute under
+  `AttributeMissing::Drop` / `::DropLine`, whose output *removes* content rather than leaving the
+  reference literal – the behavior this step *does* reproduce, since it is also what the default
+  `AttributeMissing::Skip` and `AttributeMissing::Warn` modes do (so those two are full parity, not a
+  divergence); and a **construct inside an expanded value** that `CharacterReplacements` or `Macros`
+  would recognize per §3.4.1 (a `(C)` becoming a `CharRef`, a `link:` becoming a `Ref`) but do not yet –
+  a spliced value is a synthesized run with no `'src` slice of its own, and
+  [`build_match_string`](../../parser/src/content/inline_builder.rs) (shared by those two steps and by
+  `Quotes`) only treats a *verbatim* `Text` node (`value == location.data()`) as literal content for
+  matching purposes; it does not yet look inside a synthesized one, so such a node is one opaque piece
+  to them, exactly like an already-built `Styled` span. Lifting that boundary is a follow-up that only
+  needs to extend `build_match_string` itself, not this step's splitting. All three deferred forms are
+  left **unrecognized** (no match, or no further node), so the surrounding gap logic reproduces the
+  source text unchanged, exactly as an unrecognized macro is left for a later increment. This step is
+  **additive**: nothing is wired into the parse path.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1156,7 +1195,7 @@ Each phase is a reviewable unit with a clear exit gate.
      `Callouts` – completing the vocabulary the recorder covers, each its own sub-step:
      - ✅ **5a.** Passthroughs, the delimited forms (`+++…+++`, `++…++`, `$$…$$`, bare
        `pass:[…]`) → `Raw`.
-     - **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
+     - ✅ **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
      - **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
      - **5d.** the deferred forms `5a` documents – an attribute-list-prefixed passthrough, a
        `pass:` macro with an explicit substitution list, the bare unconstrained `+text+` form,

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -31,21 +31,19 @@
 //!   a flat run. It reuses the *exact* [`quote_subs`] the string pipeline
 //!   matches with (changing the recognition *sink*, not the recognition), so
 //!   its fold is byte-identical to the string step.
-//! - [`apply_attribute_references`] recognizes attribute references
-//!   (`{name}`), splicing a set attribute's resolved value into the node
-//!   stream, classified into [`Text`](InlineNode::Text) and
-//!   [`Raw`](InlineNode::Raw) runs per design §3.4.1 – a literal `<`/`>`/`&`
-//!   in the value is *not* re-escaped, since [`apply_special_characters`] has
-//!   already run. It reuses the shared [`ATTRIBUTE_REFERENCE`] pattern, so
-//!   only the recognition *sink* differs. A `counter`/`counter2` directive
-//!   and a missing-attribute reference under `AttributeMissing::Drop` /
-//!   `::DropLine` are deferred (see [`apply_attribute_references`] for why);
-//!   so is a construct *inside* an expanded value that
-//!   [`apply_character_replacements`]/[`apply_macros`] would otherwise
-//!   recognize – the value is a synthesized, non-`'src` run, and
-//!   [`build_match_string`] does not yet look inside one (the same
-//!   "not verbatim" boundary a macro over a rendered span already
-//!   documents).
+//! - [`apply_attribute_references`] recognizes attribute references (`{name}`),
+//!   splicing a set attribute's resolved value into the node stream, classified
+//!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs per
+//!   design §3.4.1 – a literal `<`/`>`/`&` in the value is *not* re-escaped,
+//!   since [`apply_special_characters`] has already run. It reuses the shared
+//!   [`ATTRIBUTE_REFERENCE`] pattern, so only the recognition *sink* differs. A
+//!   `counter`/`counter2` directive and a missing-attribute reference under
+//!   `AttributeMissing::Drop` / `::DropLine` are deferred (see
+//!   [`apply_attribute_references`] for why); so is a construct *inside* an
+//!   expanded value that [`apply_character_replacements`]/[`apply_macros`]
+//!   would otherwise recognize – the value is a synthesized, non-`'src` run,
+//!   and [`build_match_string`] does not yet look inside one (the same "not
+//!   verbatim" boundary a macro over a rendered span already documents).
 //! - [`apply_character_replacements`] recognizes [character replacements] –
 //!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities – replacing
 //!   each with a [`CharRef::Replacement`] or [`CharRef::Entity`] leaf. It

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -31,6 +31,21 @@
 //!   a flat run. It reuses the *exact* [`quote_subs`] the string pipeline
 //!   matches with (changing the recognition *sink*, not the recognition), so
 //!   its fold is byte-identical to the string step.
+//! - [`apply_attribute_references`] recognizes attribute references
+//!   (`{name}`), splicing a set attribute's resolved value into the node
+//!   stream, classified into [`Text`](InlineNode::Text) and
+//!   [`Raw`](InlineNode::Raw) runs per design §3.4.1 – a literal `<`/`>`/`&`
+//!   in the value is *not* re-escaped, since [`apply_special_characters`] has
+//!   already run. It reuses the shared [`ATTRIBUTE_REFERENCE`] pattern, so
+//!   only the recognition *sink* differs. A `counter`/`counter2` directive
+//!   and a missing-attribute reference under `AttributeMissing::Drop` /
+//!   `::DropLine` are deferred (see [`apply_attribute_references`] for why);
+//!   so is a construct *inside* an expanded value that
+//!   [`apply_character_replacements`]/[`apply_macros`] would otherwise
+//!   recognize – the value is a synthesized, non-`'src` run, and
+//!   [`build_match_string`] does not yet look inside one (the same
+//!   "not verbatim" boundary a macro over a rendered span already
+//!   documents).
 //! - [`apply_character_replacements`] recognizes [character replacements] –
 //!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities – replacing
 //!   each with a [`CharRef::Replacement`] or [`CharRef::Entity`] leaf. It
@@ -136,14 +151,15 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        CharacterReplacement, Content, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
-        INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
-        INLINE_PASS_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub, SubstitutionGroup, URI_SNIFF,
-        basename, character_replacements, hard_line_break_pattern, maybe_has_quotes,
-        maybe_has_replacements, normalize_footnote_text, normalize_index_text,
+        ATTRIBUTE_REFERENCE, CharacterReplacement, Content, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO,
+        INLINE_IMAGE_MACRO, INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO,
+        INLINE_MENU_MACRO, INLINE_PASS_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub,
+        SubstitutionGroup, URI_SNIFF, basename, character_replacements, hard_line_break_pattern,
+        maybe_has_quotes, maybe_has_replacements, normalize_footnote_text, normalize_index_text,
         normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys, strip_see_and_seealso,
         xref_target::{XrefTarget, interpret_xref_target},
     },
+    document::InterpretedValue,
     inlines::{
         Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
         StyleVariant, Styled, Ui, UiKind,
@@ -151,7 +167,8 @@ use crate::{
     parser::{
         CharacterReplacementType, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
         IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
-        QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams, has_dangerous_scheme,
+        QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams, attribute_lookup_name,
+        has_dangerous_scheme,
     },
     strings::CowStr,
 };
@@ -179,6 +196,15 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     let nodes = apply_passthroughs(seed, source, parser);
     let nodes = apply_special_characters(nodes);
     let nodes = apply_quotes(nodes, source, parser);
+
+    // Attribute references sit here in the *normal* effective order
+    // (specialcharacters → quotes → attributes → replacements → macros,
+    // design §3.4.1): by this point `<`/`>`/`&` are already `CharRef` leaves
+    // and quoted spans are already `Styled` nodes, and whatever this step
+    // splices in is exactly what `apply_character_replacements` and
+    // `apply_macros` – still ahead – see and refine.
+    let nodes = apply_attribute_references(nodes, source, parser);
+
     let nodes = apply_character_replacements(nodes, source);
     let nodes = apply_macros(nodes, source, parser);
 
@@ -1159,6 +1185,278 @@ fn quote_type_of(variant: StyleVariant) -> QuoteType {
         StyleVariant::DoubleQuote => QuoteType::DoubleQuote,
         StyleVariant::SingleQuote => QuoteType::SingleQuote,
         StyleVariant::Unquoted => QuoteType::Unquoted,
+    }
+}
+
+// ─── Attribute references ──────────────────────────────────────────────────
+
+/// The attribute-references substitution, as a node transducer: descends into
+/// [`Styled`] children (a reference inside a rendered span is recognized just
+/// as the string pipeline recognizes one inside rendered markup), then matches
+/// and splices at this level.
+///
+/// It reuses the string pipeline's *exact* recognition –
+/// [`ATTRIBUTE_REFERENCE`] is now shared `pub(crate)` – so only the
+/// recognition *sink* differs (§4.1): a resolved reference's value is spliced
+/// into the node stream, classified by [`split_attribute_value`] (design
+/// §3.4.1) rather than written into a `&mut String`.
+///
+/// Three forms are deferred, each documented and pinned by a divergence test:
+/// a `counter`/`counter2` directive (whose resolution *advances* a document
+/// counter – a required side effect this additive step does not yet perform,
+/// the same reason every macro family deferred its own catalog/warning side
+/// effect until the [`apply_footnotes`] and cutover increments); a reference
+/// to a **missing** attribute under [`AttributeMissing::Drop`] /
+/// [`AttributeMissing::DropLine`] (whose output *removes* content, unlike
+/// leaving the reference literal – the behavior this step *does* reproduce,
+/// since it is also what [`AttributeMissing::Skip`] (the default) and
+/// [`AttributeMissing::Warn`] do); and a construct (a character replacement,
+/// a macro) *inside* an expanded value, which [`apply_character_replacements`]
+/// and [`apply_macros`] would recognize per design §3.4.1 but do not yet – a
+/// spliced value is a synthesized run with no `'src` slice of its own, and
+/// [`build_match_string`] (shared by those two steps and by
+/// [`apply_quotes`]) only treats a verbatim [`Text`](InlineNode::Text) node
+/// (`value == location.data()`) as literal content; it does not yet look
+/// inside a synthesized one, so such a node is one opaque piece to them,
+/// exactly like an already-built [`Styled`] span. All three are left
+/// **unrecognized**: no match is produced (or, for the third, no further
+/// node is produced), so the surrounding gap logic reproduces the source
+/// text unchanged, exactly as an unrecognized macro is left for a later
+/// increment.
+///
+/// [`AttributeMissing::Drop`]: crate::content::AttributeMissing::Drop
+/// [`AttributeMissing::DropLine`]: crate::content::AttributeMissing::DropLine
+/// [`AttributeMissing::Skip`]: crate::content::AttributeMissing::Skip
+/// [`AttributeMissing::Warn`]: crate::content::AttributeMissing::Warn
+fn apply_attribute_references<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let nodes: Vec<InlineNode<'src>> = nodes
+        .into_iter()
+        .map(|node| match node {
+            InlineNode::Styled(mut styled) => {
+                styled.children = apply_attribute_references(styled.children, root, parser);
+                InlineNode::Styled(styled)
+            }
+
+            other => other,
+        })
+        .collect();
+
+    attribute_references_level(nodes, root, parser)
+}
+
+/// One attribute-reference match at a level, in absolute match-string byte
+/// offsets.
+struct AttributeMatch {
+    /// The whole match, `[start, end)`.
+    full: std::ops::Range<usize>,
+
+    kind: AttributeMatchKind,
+}
+
+enum AttributeMatchKind {
+    /// An escaped reference (`\{name}`, `{name\}`, `\{name\}`): drop the
+    /// escaping backslash(es) and keep the rest of the match as literal
+    /// text, replacing nothing – mirroring the string replacer's
+    /// `caps[1]`/`caps[5]` branch. One or two absolute offsets, ascending.
+    Unescape { backslashes: Vec<usize> },
+
+    /// A reference to a set attribute: its `value` (already resolved from
+    /// `parser`) is spliced in, classified by [`split_attribute_value`]. An
+    /// `InterpretedValue::Set`/`::Unset` attribute resolves to an empty
+    /// `value`, mirroring the string replacer (whose behavior for those two
+    /// kinds the language leaves unclear – see `AttributeReplacer`).
+    Expand { value: String },
+}
+
+/// Matches [`ATTRIBUTE_REFERENCE`] over this level's escaped text, replacing
+/// each recognized match with the node(s) it produces and leaving everything
+/// else in place.
+fn attribute_references_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter: skip the pattern sweep when no reference can be
+    // present at this level.
+    if !s.contains('{') {
+        return nodes;
+    }
+
+    let matches = find_attribute_matches(&s, parser);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_attribute_level(&nodes, &pieces, &s, &matches, root)
+}
+
+/// Finds every non-overlapping [`ATTRIBUTE_REFERENCE`] match in the escaped
+/// match string `s`, left to right, exactly as the string pipeline's
+/// `replace_all` does. A `counter`/`counter2` directive and a reference to a
+/// missing attribute are left out of the returned list entirely – see the
+/// deferred forms documented on [`apply_attribute_references`].
+fn find_attribute_matches(s: &str, parser: &Parser) -> Vec<AttributeMatch> {
+    let mut matches = Vec::new();
+
+    for caps in ATTRIBUTE_REFERENCE.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+        let full = whole.start()..whole.end();
+
+        let backslashes: Vec<usize> = [caps.get(1), caps.get(5)]
+            .into_iter()
+            .flatten()
+            .map(|m| m.start())
+            .collect();
+
+        if !backslashes.is_empty() {
+            matches.push(AttributeMatch {
+                full,
+                kind: AttributeMatchKind::Unescape { backslashes },
+            });
+
+            continue;
+        }
+
+        // A `counter`/`counter2` directive resolves (and advances) a
+        // counter – deferred, see the doc comment on
+        // `apply_attribute_references`.
+        if caps.get(2).is_some() {
+            continue;
+        }
+
+        // Otherwise this is a plain attribute reference (group 4).
+        #[allow(clippy::unwrap_used)]
+        let attr_name = caps.get(4).unwrap().as_str();
+        let lookup_name = attribute_lookup_name(attr_name);
+
+        if !parser.has_attribute(&lookup_name) {
+            // Left unrecognized – correct parity under the default
+            // (`AttributeMissing::Skip`) and `AttributeMissing::Warn` modes,
+            // a documented divergence under `AttributeMissing::Drop` /
+            // `AttributeMissing::DropLine` (see the doc comment above).
+            continue;
+        }
+
+        let value = match parser.attribute_value(&lookup_name) {
+            InterpretedValue::Value(value) => value,
+            InterpretedValue::Set | InterpretedValue::Unset => String::new(),
+        };
+
+        matches.push(AttributeMatch {
+            full,
+            kind: AttributeMatchKind::Expand { value },
+        });
+    }
+
+    matches
+}
+
+/// Rebuilds a level's node list from its attribute-reference matches: each gap
+/// keeps its original nodes; each match becomes its unescaped literal text (an
+/// [`Unescape`](AttributeMatchKind::Unescape)) or its classified expansion (an
+/// [`Expand`](AttributeMatchKind::Expand)).
+fn rebuild_attribute_level<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    s: &str,
+    matches: &[AttributeMatch],
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+
+    for m in matches {
+        match &m.kind {
+            AttributeMatchKind::Unescape { backslashes } => {
+                // Keep the match's literal text, dropping each escaping
+                // backslash in turn. `piece_cursor` starts at `cursor`
+                // (before the match), so the first `emit_range` call also
+                // absorbs the untouched gap ahead of it, exactly as
+                // `rebuild_replacements`'s `Unescape` arm does.
+                let mut piece_cursor = cursor;
+
+                for &backslash in backslashes {
+                    emit_range(nodes, pieces, piece_cursor..backslash, &mut out);
+                    piece_cursor = backslash + 1;
+                }
+
+                emit_range(nodes, pieces, piece_cursor..m.full.end, &mut out);
+                cursor = m.full.end;
+            }
+
+            AttributeMatchKind::Expand { value } => {
+                emit_range(nodes, pieces, cursor..m.full.start, &mut out);
+
+                let location = source_slice(pieces, m.full.clone(), root);
+                split_attribute_value(value, location, &mut out);
+
+                cursor = m.full.end;
+            }
+        }
+    }
+
+    if cursor < s.len() {
+        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+    }
+
+    out
+}
+
+/// Splits a resolved attribute `value` into [`Text`](InlineNode::Text) and
+/// [`Raw`](InlineNode::Raw) runs (design §3.4.1). By the time this step runs,
+/// [`apply_special_characters`] has already run and will not run again over
+/// spliced-in content, so a literal `<`, `>`, or `&` in `value` must **not**
+/// be re-escaped by the fold: it becomes a `Raw` leaf (verbatim). Everything
+/// else stays `Text` – logical content that design §3.4.1 says
+/// [`apply_character_replacements`] and [`apply_macros`] (still ahead in the
+/// effective order) should recognize normally (a `(C)` in the value becomes
+/// a `CharRef`, a `link:` in it becomes a `Ref`); this increment does not yet
+/// reach that (see [`apply_attribute_references`]'s doc comment for why), so
+/// the resulting `Text` node's value stays untouched by those later steps for
+/// now, but is shaped so a later increment only needs to extend
+/// [`build_match_string`], not this splitting.
+///
+/// Both node kinds carry the reference's own `location` as their coarse
+/// fallback span (design §4.4: a synthesized value has no source of its own).
+/// A run is never emitted empty, and an empty `value` (an
+/// `InterpretedValue::Set`/`::Unset` attribute) emits no node at all.
+fn split_attribute_value<'src>(value: &str, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+    let mut rest = value;
+
+    while let Some(pos) = rest.find(is_special) {
+        if pos > 0 {
+            out.push(InlineNode::Text {
+                value: CowStr::from(rest[..pos].to_string()),
+                location,
+            });
+        }
+
+        // The three specials are ASCII, so the match is exactly one byte
+        // wide.
+        let ch = rest[pos..].chars().next().unwrap_or('\u{FFFD}');
+
+        out.push(InlineNode::Raw {
+            value: CowStr::from(ch.to_string()),
+            location,
+        });
+
+        rest = &rest[pos + 1..];
+    }
+
+    if !rest.is_empty() {
+        out.push(InlineNode::Text {
+            value: CowStr::from(rest.to_string()),
+            location,
+        });
     }
 }
 
@@ -5628,6 +5926,330 @@ mod tests {
 
             other => panic!("expected Styled, got {other:?}"),
         }
+    }
+
+    // ─── Attribute references ──────────────────────────────────────────────
+
+    /// A default parser with `name` set to `value` (an
+    /// [`InterpretedValue::Value`]).
+    fn parser_with_attribute(name: &str, value: &str) -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default().with_intrinsic_attribute(name, value, ModificationContext::Anywhere)
+    }
+
+    /// The string pipeline's output through the **attribute-references** step
+    /// for `source`, run against `parser`, used as the golden oracle: the six
+    /// steps [`build`] runs, in order (special characters, quotes, attribute
+    /// references, character replacements, macros, post replacement).
+    fn golden_attributes_with(source: &str, parser: &Parser) -> String {
+        let mut content = Content::from(Span::new(source));
+        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
+        SubstitutionStep::Quotes.apply(&mut content, parser, None);
+        SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
+        SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
+        SubstitutionStep::Macros.apply(&mut content, parser, None);
+        SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_attribute_references() {
+        // For each fixture, folding the single-pass tree (all six steps)
+        // reproduces the string pipeline's output byte-for-byte. This is the
+        // differential corpus (design §5.3) that pins the attribute-references
+        // increment (part 5b).
+        let fixtures = [
+            // No reference despite brace-ish characters.
+            "plain text without a reference",
+            "a lone { brace and a lone } brace",
+            "an empty pair {}",
+            // A reference to a missing attribute, under the default
+            // (`AttributeMissing::Skip`) mode, stays literal.
+            "a reference to {undefined-thing} here",
+            // Escapes: the reference stays literal, minus the backslash(es) –
+            // whether or not the attribute is set.
+            "\\{set-name} stays literal",
+            "{set-name\\} stays literal",
+            "\\{set-name\\} stays literal",
+            "\\{undefined-thing} stays literal",
+            // Multiple references on one run, and one next to plain text.
+            "{greeting}, {greeting}!",
+            "before{greeting}after",
+            // A reference inside an already-recognized quoted span.
+            "*{greeting}*",
+            "_{greeting} text_",
+            // Character-class coverage matching `ATTRIBUTE_REFERENCE`'s `\w`:
+            // digits, `-`, and a non-ASCII (Unicode word) name.
+            "{a-name-2}",
+        ];
+
+        for fixture in fixtures {
+            let parser = parser_with_attribute("greeting", "Hello")
+                .with_intrinsic_attribute(
+                    "set-name",
+                    "value",
+                    crate::parser::ModificationContext::Anywhere,
+                )
+                .with_intrinsic_attribute(
+                    "a-name-2",
+                    "value",
+                    crate::parser::ModificationContext::Anywhere,
+                );
+
+            let folded = fold_html(
+                &build(Span::new(fixture), &parser),
+                &HtmlSubstitutionRenderer {},
+            );
+
+            assert_eq!(
+                folded,
+                golden_attributes_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+
+        // A reference expanding to a literal special character emits it
+        // unescaped (`Raw`), exactly as design §3.4.1 requires.
+        let special_fixtures = [("tag", "<b>", "a {tag} value"), ("amp", "A & B", "{amp}")];
+
+        for (name, value, fixture) in special_fixtures {
+            let parser = parser_with_attribute(name, value);
+
+            let folded = fold_html(
+                &build(Span::new(fixture), &parser),
+                &HtmlSubstitutionRenderer {},
+            );
+
+            assert_eq!(
+                folded,
+                golden_attributes_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+
+        // A `Set`/`Unset` attribute (no textual value) expands to nothing.
+        use crate::parser::ModificationContext;
+        let bool_parser = Parser::default()
+            .with_intrinsic_attribute_bool("flag-on", true, ModificationContext::Anywhere)
+            .with_intrinsic_attribute_bool("flag-off", false, ModificationContext::Anywhere);
+
+        for fixture in ["before{flag-on}after", "before{flag-off}after"] {
+            let folded = fold_html(
+                &build(Span::new(fixture), &bool_parser),
+                &HtmlSubstitutionRenderer {},
+            );
+
+            assert_eq!(
+                folded,
+                golden_attributes_with(fixture, &bool_parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_reference_to_a_set_attribute_expands_to_a_text_node() {
+        let parser = parser_with_attribute("greeting", "Hello");
+        let nodes = build(Span::new("say {greeting}!"), &parser);
+
+        // [Text("say "), Text("Hello") (synthesized), Text("!")].
+        assert_eq!(nodes.len(), 3);
+        assert_text(&nodes[0], "say ", 1, 1);
+
+        match &nodes[1] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "Hello");
+                // A synthesized value has no source of its own, so it falls
+                // back to the whole reference's span (design §4.4).
+                assert_eq!(location.data(), "{greeting}");
+            }
+
+            other => panic!("expected Text(\"Hello\"), got {other:?}"),
+        }
+
+        assert_text(&nodes[2], "!", 1, 15);
+    }
+
+    #[test]
+    fn a_reference_to_a_missing_attribute_stays_literal() {
+        let nodes = build(Span::new("{undefined-thing}"), &Parser::default());
+
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], "{undefined-thing}", 1, 1);
+    }
+
+    #[test]
+    fn an_escaped_reference_drops_the_backslash() {
+        // The kept text is emitted as whatever nodes cover its (possibly
+        // split, around the dropped backslash) source range, so this asserts
+        // on the *fold*, not node count/shape – the same choice
+        // `an_escaped_quote_wraps_nothing` makes for the quotes step.
+        for (source, expected) in [
+            ("\\{name}", "{name}"),
+            ("{name\\}", "{name}"),
+            ("\\{name\\}", "{name}"),
+            ("\\{counter:x}", "{counter:x}"),
+        ] {
+            let nodes = build(Span::new(source), &Parser::default());
+
+            assert!(
+                nodes.iter().all(|n| matches!(n, InlineNode::Text { .. })),
+                "for {source:?}: {nodes:?}"
+            );
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                expected,
+                "for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_reference_expanding_to_a_special_character_becomes_raw() {
+        let parser = parser_with_attribute("tag", "<b>");
+        let nodes = build(Span::new("{tag}"), &parser);
+
+        // The expansion splits into `Raw("<")`, `Text("b")`, `Raw(">")` –
+        // design §3.4.1's mix of node kinds, since `specialcharacters` has
+        // already run and will not re-escape this spliced-in content.
+        assert_eq!(nodes.len(), 3);
+        let raw_location = assert_raw(&nodes[0], "<");
+
+        match &nodes[1] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "b");
+                // A synthesized value has no source of its own, so every
+                // sub-node falls back to the whole reference's span (design
+                // §4.4) – the same coarse fallback as `raw_location`.
+                assert_eq!(*location, raw_location);
+            }
+
+            other => panic!("expected Text(\"b\"), got {other:?}"),
+        }
+
+        assert_raw(&nodes[2], ">");
+
+        // The fold emits the tag verbatim, unescaped.
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "<b>");
+    }
+
+    #[test]
+    fn a_replacement_inside_an_expanded_value_is_a_documented_divergence() {
+        // Design §3.4.1 says `replacements` still runs over an expanded
+        // value, so a `(C)` inside it should become a `CharRef`. It does not
+        // yet: a synthesized `Text` node's `value` differs from
+        // `location.data()`, so `build_match_string` (shared by
+        // `apply_character_replacements` and `apply_macros`) treats it as one
+        // opaque piece – the same "not verbatim" boundary every macro family
+        // already documents for content it cannot slice from `'src`. Lifting
+        // this needs `build_match_string` itself to look inside a synthesized
+        // run, tracked as a follow-up to this increment.
+        let parser = parser_with_attribute("note", "(C) 2024");
+        let nodes = build(Span::new("{note}"), &parser);
+
+        assert!(
+            nodes
+                .iter()
+                .all(|n| !matches!(n, InlineNode::CharRef { .. })),
+            "a replacement inside a spliced value must not yet be recognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, *does* recognize it.
+        assert_eq!(golden_attributes_with("{note}", &parser), "&#169; 2024");
+    }
+
+    #[test]
+    fn a_macro_inside_an_expanded_value_is_a_documented_divergence() {
+        // The same boundary as
+        // `a_replacement_inside_an_expanded_value_is_a_documented_divergence`,
+        // for the macros step.
+        let parser = parser_with_attribute("linktext", "link:https://example.org[Example]");
+        let nodes = build(Span::new("see {linktext} now"), &parser);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a macro inside a spliced value must not yet be recognized: {nodes:?}"
+        );
+
+        assert!(golden_attributes_with("see {linktext} now", &parser).contains("<a href"));
+    }
+
+    #[test]
+    fn a_reference_inside_a_span_is_recognized() {
+        let parser = parser_with_attribute("greeting", "Hello");
+        let nodes = build(Span::new("*{greeting}*"), &parser);
+
+        assert_eq!(nodes.len(), 1);
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+
+        assert_eq!(children.len(), 1);
+        match &children[0] {
+            InlineNode::Text { value, .. } => assert_eq!(value.as_ref(), "Hello"),
+            other => panic!("expected Text(\"Hello\"), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_counter_directive_is_a_documented_divergence() {
+        // `counter`/`counter2` resolves *and advances* a document counter – a
+        // required side effect this additive step does not yet perform (see
+        // `apply_attribute_references`'s doc comment), so the reference is
+        // left unrecognized rather than replaced with the counter's value.
+        let parser = Parser::default();
+        let nodes = build(Span::new("{counter:x}"), &parser);
+
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], "{counter:x}", 1, 1);
+
+        // The string pipeline, by contrast, resolves it to `1`.
+        assert_eq!(golden_attributes_with("{counter:x}", &parser), "1");
+    }
+
+    #[test]
+    fn a_missing_attribute_under_drop_is_a_documented_divergence() {
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "attribute-missing",
+            "drop",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "before {undefined-thing} after";
+        let nodes = build(Span::new(source), &parser);
+
+        // Left unrecognized: the reference stays literal rather than being
+        // dropped.
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], source, 1, 1);
+
+        // The string pipeline, by contrast, drops the reference (keeping the
+        // rest of the line).
+        assert_eq!(golden_attributes_with(source, &parser), "before  after");
+    }
+
+    #[test]
+    fn a_missing_attribute_under_drop_line_is_a_documented_divergence() {
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "attribute-missing",
+            "drop-line",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "a line with {undefined-thing} in it";
+        let nodes = build(Span::new(source), &parser);
+
+        // Left unrecognized: the whole line is not dropped (this step has no
+        // line-granularity concept; the string pipeline's line-drop mode is
+        // orthogonal to node splicing).
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], source, 1, 1);
+
+        // The string pipeline, by contrast, drops the whole line.
+        assert_eq!(golden_attributes_with(source, &parser), "");
     }
 
     /// The string pipeline's output through the **post-replacement** step for

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -36,7 +36,7 @@ pub use substitution_group::SubstitutionGroup;
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
-    AttributeMissing, CharacterReplacement, QuoteSub, character_replacements,
+    ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, character_replacements,
     hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, quote_subs,
     substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
     substitute_attributes_in_text,

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -521,7 +521,7 @@ fn apply_quotes(content: &mut Content<'_>, parser: &Parser) {
     }
 }
 
-static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
     // Either a `counter`/`counter2` directive (group 2) with its `name[:seed]`
     // expression (group 3), or a plain attribute name (group 4). This mirrors
     // the `counter2?:` branch of Asciidoctor's `AttributeReferenceRx`.


### PR DESCRIPTION
## Summary

Implements design doc step **Phase 4, step 5b** (`docs/design/inline-ast-architecture.md`): `AttributeReferences` → expanded-value splicing, the next unimplemented sub-step after 5a (delimited passthroughs, #1135).

- Adds `apply_attribute_references` to the single-pass inline builder (`parser/src/content/inline_builder.rs`), inserted between `Quotes` and `CharacterReplacements` — its position in the *normal* effective substitution order (`specialcharacters → quotes → attributes → replacements → macros`, design §3.4.1).
- Reuses the string pipeline's exact recognition (`ATTRIBUTE_REFERENCE`, now shared `pub(crate)`) — only the recognition *sink* changes.
- A reference to a **set** attribute has its resolved value spliced into the node stream, classified into `Text`/`Raw` runs by `split_attribute_value` per §3.4.1: because `SpecialCharacters` has already run and won't run again over spliced-in content, a literal `<`/`>`/`&` in the value becomes an unescaped `Raw` leaf rather than a `CharRef` the fold would re-escape.
- An **escaped** reference (`\{name}`, `{name\}`, `\{name\}`) drops the backslash(es) and stays literal, mirroring `AttributeReplacer`'s escape branch — regardless of whether the attribute is set.
- An `InterpretedValue::Set`/`::Unset` attribute expands to nothing, matching the string replacer.

Three forms are deferred, each documented and pinned by a divergence test (same incremental discipline as every prior step in this migration):
1. A `counter`/`counter2` directive — its resolution *advances* a document counter, a required side effect this additive step doesn't perform yet (deferred the same way every macro family deferred its own side effect until the footnote/cutover increments).
2. A missing-attribute reference under `attribute-missing=drop`/`drop-line` — these modes *remove* content, unlike leaving the reference literal (the default `Skip` and `Warn` modes are full byte parity, not a divergence).
3. A construct (a character replacement, a macro) *inside* an expanded value — `build_match_string` (shared by `CharacterReplacements`/`Macros`/`Quotes`) only treats a *verbatim* `Text` node as literal content for matching; a spliced value is a synthesized run with no `'src` slice, so it's currently one opaque piece to those steps. Lifting this only needs to extend `build_match_string`, not this step's splitting — tracked as a follow-up.

This step is **additive**: nothing is wired into the authoritative parse path yet (per the branch's transition plan, §5).

## Test plan

- [x] `cargo test -p asciidoc-parser` — full suite green (4838 passed, up from 4827; no regressions from wiring the new step into `build()`)
- [x] New differential corpus test (`fold_matches_the_string_pipeline_through_attribute_references`) asserting the fold reproduces the string pipeline byte-for-byte across escapes, missing references, multi-reference runs, references inside quoted spans, and expansions containing literal specials
- [x] Structural unit tests for node shape/spans (`Text`/`Raw` splitting, coarse fallback span, escape handling, span nesting)
- [x] Divergence tests for the three deferred forms (counter directive, `drop`, `drop-line`, replacement/macro-inside-expansion)
- [x] `cargo clippy -p asciidoc-parser --lib --tests` — clean
- [x] `cargo fmt -p asciidoc-parser -- --check` — clean
- [x] Design doc (`docs/design/inline-ast-architecture.md`) updated: new "Step 5b landed as" entry and checklist mark


---
_Generated by [Claude Code](https://claude.ai/code/session_014JQKyRfm3MGhhFK5qRGmgi)_