### PR TITLE
feat: Recognize callouts in the single-pass inline builder (inline-ast Phase 4, step 5c)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1164,6 +1164,44 @@ Each phase is a reviewable unit with a clear exit gate.
   source text unchanged, exactly as an unrecognized macro is left for a later increment. This step is
   **additive**: nothing is wired into the parse path.
 
+  *Step 5c landed as (`Callouts` → `Callout`, verbatim-group content):* a new
+  [`apply_callouts`](../../parser/src/content/inline_builder.rs) step recognizes a trailing callout
+  token (`<1>`, `<.>`, or `<!--1-->` for XML) in literal, listing, and source blocks as a
+  [`Callout`](../../parser/src/inlines/callout.rs) node, folding through the same `render_callout` the
+  string step calls so the output is byte-for-byte identical. This is the first increment for
+  [`SubstitutionGroup::Verbatim`](../../parser/src/content/substitution_group.rs) rather than the
+  *normal* order every step through 5b runs: literal/listing/source blocks apply only
+  `SpecialCharacters` ahead of `Callouts`, so – unlike every other transducer in this module – the
+  function need not descend into `Styled`/`Ref` children, since neither can exist at this point in that
+  group's order. It reuses the string pipeline's *exact* recognition and trailing-position lookahead –
+  [`build_callout_regexes`](../../parser/src/content/substitution_step.rs) is now shared `pub(crate)` –
+  so only the recognition *sink* differs (§4.1): a match that fails the lookahead (not the last token on
+  its line) is simply left out of the match list, so the surrounding gap reproduces its original nodes
+  unchanged, the same outcome the string pipeline's `LookaheadReplacer` fallback produces.
+  Auto-numbering (`<.>`) is scoped to one call of the step, exactly as the string replacer's counter is
+  scoped to one block.
+
+  This is also the node vocabulary's first real consumer for `Callout`, so its field set (Phase 0
+  provisional) was refined here: alongside `number`, it now carries a `guard` – a new
+  [`CalloutGuard`](../../parser/src/inlines/callout.rs) enum (`LineComment(prefix)` / `Xml`) recording
+  which characters hide the callout in the raw source, decoupled from the render-seam's own
+  `CalloutGuard` the same way every other node is decoupled from its `*RenderParams` counterpart (§4.6):
+  the fold reconstructs `CalloutRenderParams` fresh from the node's `number` and `guard`, rather than the
+  node carrying a render-params type directly. The Phase 1/2 recorder
+  ([`inline_tree.rs`](../../parser/src/content/inline_tree.rs)), which had never captured a callout's
+  guard (its differential corpus fixtures happened not to need it), now captures it too, so the two
+  construction strategies agree on the node's shape.
+
+  An escaped callout (`\<1>`) drops its backslash and stays literal, mirroring every other macro
+  family's escape handling. As throughout the additive builder, this pass performs **no** recognition
+  side effect: it does not call `Parser::register_callout`, deferring the callout catalog's validation
+  to the cutover (step 6), exactly as the image and link increments defer their own catalog
+  registrations. A differential corpus pins bare/explicit and auto-numbered callouts, multiple callouts
+  on one line, XML callouts, the default line-comment prefixes, a custom or disabled `line-comment`
+  (block-attribute and document-attribute), escapes, non-trailing-position and half-XML-comment
+  non-matches, and both non-default `icons` renderings (font and image), alongside structural assertions
+  on the node's `guard`. This step is **additive**: nothing is wired into the parse path.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1196,7 +1234,7 @@ Each phase is a reviewable unit with a clear exit gate.
      - ✅ **5a.** Passthroughs, the delimited forms (`+++…+++`, `++…++`, `$$…$$`, bare
        `pass:[…]`) → `Raw`.
      - ✅ **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
-     - **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
+     - ✅ **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
      - **5d.** the deferred forms `5a` documents – an attribute-list-prefixed passthrough, a
        `pass:` macro with an explicit substitution list, the bare unconstrained `+text+` form,
        and inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) → `Stem`.

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -145,6 +145,8 @@
 // up so far; later Strategy-B increments consume the rest.
 #![allow(dead_code)]
 
+use regex::Regex;
+
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
@@ -152,21 +154,22 @@ use crate::{
         ATTRIBUTE_REFERENCE, CharacterReplacement, Content, INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO,
         INLINE_IMAGE_MACRO, INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO,
         INLINE_MENU_MACRO, INLINE_PASS_MACRO, INLINE_XREF, NormalizedCaps, QuoteSub,
-        SubstitutionGroup, URI_SNIFF, basename, character_replacements, hard_line_break_pattern,
-        maybe_has_quotes, maybe_has_replacements, normalize_footnote_text, normalize_index_text,
-        normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys, strip_see_and_seealso,
+        SubstitutionGroup, URI_SNIFF, basename, build_callout_regexes, character_replacements,
+        hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, normalize_footnote_text,
+        normalize_index_text, normalize_text_lf_escaped_bracket, quote_subs, split_kbd_keys,
+        strip_see_and_seealso,
         xref_target::{XrefTarget, interpret_xref_target},
     },
     document::InterpretedValue,
     inlines::{
-        Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
-        StyleVariant, Styled, Ui, UiKind,
+        Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
+        RefVariant, SpanForm, StyleVariant, Styled, Ui, UiKind,
     },
     parser::{
-        CharacterReplacementType, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
-        IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
-        QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams, attribute_lookup_name,
-        has_dangerous_scheme,
+        CalloutGuard as ParserCalloutGuard, CalloutRenderParams, CharacterReplacementType,
+        FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
+        InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType,
+        SpecialCharacter, XrefRenderParams, attribute_lookup_name, has_dangerous_scheme,
     },
     strings::CowStr,
 };
@@ -4340,6 +4343,251 @@ fn apply_post_replacements<'src>(
     out
 }
 
+// ─── Callouts ───────────────────────────────────────────────────────────────
+
+/// The callouts substitution, as a node transducer: a trailing callout token
+/// (`<1>`, `<.>`, or `<!--1-->` for XML) is replaced with a
+/// [`Callout`](InlineNode::Callout) leaf.
+///
+/// Unlike every other step in this module, this is not a step of the
+/// *normal* effective order [`build`] runs: callouts belong to
+/// [`SubstitutionGroup::Verbatim`] (literal, listing, and source blocks),
+/// whose only steps are `SpecialCharacters` then `Callouts` – so `nodes` here
+/// can never contain a [`Styled`] or [`Ref`] span (`Quotes` and `Macros`
+/// never ran) and this function need not descend into anything; the level it
+/// matches against is the only level. It is additive like every increment
+/// before the cutover: nothing wires it into a block's actual parse, so a
+/// caller (today, only this module's tests) runs it directly after
+/// [`apply_special_characters`].
+///
+/// It reuses the string pipeline's *exact* recognition –
+/// [`build_callout_regexes`] is now shared `pub(crate)` – so only the
+/// recognition *sink* differs (§4.1): a matched, trailing-position callout
+/// becomes a node instead of rendered markup, folding through the same
+/// `render_callout` the string step calls (see [`fold_callout`]) so the
+/// output is byte-for-byte identical. `attrlist` is the block's own
+/// attribute list (`None` when the caller has none); together with `parser`
+/// it resolves the `line-comment` attribute exactly as
+/// [`apply_callouts`](crate::content::substitution_step)'s string-pipeline
+/// counterpart does: absent, the default line-comment prefixes (`//`, `#`,
+/// `--`, `;;`) and XML callouts are recognized; present (non-empty), only
+/// that prefix is; present but empty, no prefix is recognized (and neither
+/// are XML callouts).
+///
+/// An escaped callout (`\<1>`) drops its backslash and stays literal,
+/// mirroring every other macro family's escape handling. As throughout the
+/// additive builder, this pass performs **no** recognition side effect: it
+/// does not call `Parser::register_callout`, deferring the callout catalog's
+/// validation to the cutover (design §5.2 Phase 4, step 6), exactly as the
+/// image and link increments defer their own catalog registrations.
+fn apply_callouts<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+    attrlist: Option<&Attrlist<'_>>,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // A callout's opening bracket is always rendered as `&lt;` by
+    // `apply_special_characters`, so we can cheaply skip content without any
+    // (mirrors the string pipeline's own guard).
+    if !s.contains("&lt;") {
+        return nodes;
+    }
+
+    // The `line-comment` attribute (block-level, falling back to
+    // document-level) customizes or disables line-comment recognition; see
+    // this function's doc comment.
+    let line_comment: Option<String> = attrlist
+        .and_then(|a| a.named_attribute("line-comment"))
+        .map(|a| a.value().to_string())
+        .or_else(|| {
+            if parser.has_attribute("line-comment") {
+                Some(
+                    parser
+                        .attribute_value("line-comment")
+                        .as_maybe_str()
+                        .unwrap_or("")
+                        .to_string(),
+                )
+            } else {
+                None
+            }
+        });
+
+    let (callout_rx, tail_rx) = build_callout_regexes(line_comment.as_deref());
+
+    let matches = find_callout_matches(&s, &callout_rx, tail_rx);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_callout_level(&nodes, &pieces, &s, &matches, root)
+}
+
+/// One callout match at a level, in absolute match-string byte offsets.
+struct CalloutMatch {
+    /// The whole match, `[start, end)`.
+    full: std::ops::Range<usize>,
+
+    kind: CalloutMatchKind,
+}
+
+enum CalloutMatchKind {
+    /// An escaped callout (`\<1>`): drop the escaping backslash and keep the
+    /// rest of the match as literal text, replacing nothing.
+    Unescape { backslash: usize },
+
+    /// A recognized, trailing-position callout token.
+    Callout {
+        /// The callout number to display (already resolved for an
+        /// automatically-numbered `<.>`).
+        number: String,
+
+        /// Whether this is the XML comment form (`<!--N-->`).
+        is_xml: bool,
+
+        /// The captured line-comment prefix, if any (its absence does not by
+        /// itself mean "no guard" – see [`rebuild_callout_level`], which also
+        /// consults `is_xml`).
+        prefix: Option<std::ops::Range<usize>>,
+    },
+}
+
+/// Finds every [`build_callout_regexes`] match in the match string `s`, left
+/// to right, honoring the trailing-position lookahead (`tail_rx`) exactly as
+/// the string pipeline's `CalloutReplacer` does: a callout is only recognized
+/// when nothing but further callouts follows it up to the end of the line.
+/// Unlike the string pipeline (whose `LookaheadReplacer` never skips ahead
+/// and retries for this step), a match that fails the lookahead is simply
+/// left out of the returned list – the surrounding gap then reproduces its
+/// original nodes unchanged, exactly the same outcome as the string
+/// pipeline's `dest.push_str(&caps[0])` fallback.
+fn find_callout_matches(s: &str, callout_rx: &Regex, tail_rx: &Regex) -> Vec<CalloutMatch> {
+    let mut matches = Vec::new();
+    let mut autonum = 0u32;
+
+    for caps in callout_rx.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        if !tail_rx.is_match(&s[whole.end()..]) {
+            continue;
+        }
+
+        let full = whole.start()..whole.end();
+
+        if let Some(esc) = caps.name("esc") {
+            matches.push(CalloutMatch {
+                full,
+                kind: CalloutMatchKind::Unescape {
+                    backslash: esc.start(),
+                },
+            });
+
+            continue;
+        }
+
+        let (number_raw, is_xml) = if let Some(xnum) = caps.name("xnum") {
+            (xnum.as_str(), true)
+        } else {
+            // The regex guarantees one of `xnum` or `num` is present.
+            #[allow(clippy::unwrap_used)]
+            (caps.name("num").unwrap().as_str(), false)
+        };
+
+        // Auto-numbering (`<.>`) is scoped to this level's whole scan, exactly
+        // as the string pipeline's `CalloutReplacer::autonum` is scoped to one
+        // block, and only advances for a match that reaches this point (past
+        // the lookahead and escape checks).
+        let number = if number_raw == "." {
+            autonum += 1;
+            autonum.to_string()
+        } else {
+            number_raw.to_string()
+        };
+
+        let prefix = caps.name("prefix").map(|m| m.start()..m.end());
+
+        matches.push(CalloutMatch {
+            full,
+            kind: CalloutMatchKind::Callout {
+                number,
+                is_xml,
+                prefix,
+            },
+        });
+    }
+
+    matches
+}
+
+/// Rebuilds a level's node list from its callout matches: each gap keeps its
+/// original nodes; each match becomes its unescaped literal text (an
+/// [`Unescape`](CalloutMatchKind::Unescape)) or a
+/// [`Callout`](InlineNode::Callout) node (a
+/// [`Callout`](CalloutMatchKind::Callout) match), whose guard mirrors
+/// [`CalloutReplacer`](crate::content::substitution_step)'s resolution: a
+/// captured line-comment prefix takes precedence; otherwise an XML callout
+/// uses the XML guard; failing both, an empty line-comment guard (there is no
+/// "no guard" state – the fold's non-icon fallback always guards with
+/// *something*).
+fn rebuild_callout_level<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    s: &str,
+    matches: &[CalloutMatch],
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+
+    for m in matches {
+        match &m.kind {
+            CalloutMatchKind::Unescape { backslash } => {
+                emit_range(nodes, pieces, cursor..*backslash, &mut out);
+                emit_range(nodes, pieces, backslash + 1..m.full.end, &mut out);
+                cursor = m.full.end;
+            }
+
+            CalloutMatchKind::Callout {
+                number,
+                is_xml,
+                prefix,
+            } => {
+                emit_range(nodes, pieces, cursor..m.full.start, &mut out);
+
+                let guard = match prefix {
+                    Some(range) => {
+                        let prefix_span = source_slice(pieces, range.clone(), root);
+                        CalloutGuard::LineComment(CowStr::from(prefix_span.data()))
+                    }
+
+                    None if *is_xml => CalloutGuard::Xml,
+
+                    None => CalloutGuard::LineComment(CowStr::Borrowed("")),
+                };
+
+                out.push(InlineNode::Callout(Callout {
+                    number: CowStr::from(number.clone()),
+                    guard,
+                    location: source_slice(pieces, m.full.clone(), root),
+                }));
+
+                cursor = m.full.end;
+            }
+        }
+    }
+
+    if cursor < s.len() {
+        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+    }
+
+    out
+}
+
 /// The inverse of the classifier's value assignment: the
 /// [`CharacterReplacementType`] the fold renders a [`CharRef::Replacement`]
 /// value with. The mapping is a bijection – each replacement type produces a
@@ -4481,6 +4729,10 @@ fn fold_into_html(
                 fold_footnote(footnote, renderer, out);
             }
 
+            InlineNode::Callout(callout) => {
+                fold_callout(callout, renderer, parser, out);
+            }
+
             InlineNode::Styled(styled) => {
                 // Fold the children to the body, then wrap it exactly as the
                 // string pipeline's quotes step did: the same `QuoteType`,
@@ -4506,10 +4758,10 @@ fn fold_into_html(
             other => {
                 // The steps wired up so far produce only `Text`,
                 // `CharRef::Special`, `Styled`, `Image`, `Ui`, `Ref` (link and
-                // cross-reference), `Anchor`, `IndexTerm`, and `LineBreak`
-                // nodes, and this fold additionally emits the design-legal `Raw`
-                // leaf; no other node kind reaches the fold in this increment.
-                // A later increment
+                // cross-reference), `Anchor`, `IndexTerm`, `Footnote`,
+                // `Callout`, and `LineBreak` nodes, and this fold additionally
+                // emits the design-legal `Raw` leaf; no other node kind
+                // reaches the fold in this increment. A later increment
                 // fills in the arms above as the transducer grows new kinds.
                 // Guard against a premature caller in debug builds and emit
                 // nothing in release, mirroring the safe defensive fallback in
@@ -4832,6 +5084,34 @@ fn fold_footnote(
     );
 }
 
+/// Folds a [`Callout`](InlineNode::Callout) through the same `render_callout`
+/// the string step's `Callouts` group calls, reconstructing
+/// [`CalloutRenderParams`] from the node's `number` and `guard` – no
+/// build-time state is needed, mirroring [`fold_footnote`]. This is the
+/// decoupling design §4.6 previews for Phase 5: the node is the canonical,
+/// structured record; the `*RenderParams` struct is rebuilt from it fresh at
+/// fold time, not carried alongside it.
+fn fold_callout(
+    callout: &Callout<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+    out: &mut String,
+) {
+    let guard = match &callout.guard {
+        CalloutGuard::LineComment(prefix) => ParserCalloutGuard::LineComment(prefix.as_ref()),
+        CalloutGuard::Xml => ParserCalloutGuard::Xml,
+    };
+
+    renderer.render_callout(
+        &CalloutRenderParams {
+            number: callout.number.as_ref(),
+            guard,
+            parser,
+        },
+        out,
+    );
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -4839,15 +5119,16 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::{
-        apply_character_replacements, apply_macros, apply_passthroughs, apply_post_replacements,
-        apply_quotes, apply_special_characters, build,
+        apply_callouts, apply_character_replacements, apply_macros, apply_passthroughs,
+        apply_post_replacements, apply_quotes, apply_special_characters, build,
     };
     use crate::{
         HasSpan, Parser, Span,
+        attributes::{Attrlist, AttrlistContext},
         content::{Content, Passthroughs, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant, SpanForm,
-            StyleVariant, Styled, Ui, UiKind,
+            Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
+            RefVariant, SpanForm, StyleVariant, Styled, Ui, UiKind,
         },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -9292,5 +9573,331 @@ mod tests {
              [<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" \
              title=\"View footnote.\">1</a>]</sup>"
         );
+    }
+
+    // ─── Callouts ────────────────────────────────────────────────────────────
+    //
+    // Unlike every section above (whose helpers run through `build`'s *normal*
+    // effective order), callouts belong to `SubstitutionGroup::Verbatim`
+    // (literal, listing, and source blocks): only special characters, then
+    // callouts. These helpers run that two-step order directly instead.
+
+    /// Builds the tree through the **callouts** step for `source`: special
+    /// characters, then callouts – the two (and only) steps
+    /// [`SubstitutionGroup::Verbatim`](crate::content::SubstitutionGroup::Verbatim)
+    /// runs.
+    fn build_verbatim<'src>(
+        source: Span<'src>,
+        parser: &Parser,
+        attrlist: Option<&Attrlist<'_>>,
+    ) -> Vec<InlineNode<'src>> {
+        apply_callouts(
+            apply_special_characters(seed(source)),
+            source,
+            parser,
+            attrlist,
+        )
+    }
+
+    /// [`build_verbatim`] with a default parser and no attribute list.
+    fn build_verbatim_src(source: Span<'_>) -> Vec<InlineNode<'_>> {
+        build_verbatim(source, &Parser::default(), None)
+    }
+
+    /// The string pipeline's output through the **callouts** step for
+    /// `source`, used as the golden oracle: `SubstitutionGroup::Verbatim`'s
+    /// two steps, in order (special characters, then callouts).
+    fn golden_callouts_with(
+        source: &str,
+        parser: &Parser,
+        attrlist: Option<&Attrlist<'_>>,
+    ) -> String {
+        let mut content = Content::from(Span::new(source));
+        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
+        SubstitutionStep::Callouts.apply(&mut content, parser, attrlist);
+        content.rendered_str().to_string()
+    }
+
+    /// [`golden_callouts_with`] with a default parser and no attribute list.
+    fn golden_callouts(source: &str) -> String {
+        golden_callouts_with(source, &Parser::default(), None)
+    }
+
+    /// Collects every [`Callout`](InlineNode::Callout) node in `nodes`, in
+    /// order.
+    fn callouts<'a, 'src>(nodes: &'a [InlineNode<'src>]) -> Vec<&'a Callout<'src>> {
+        nodes
+            .iter()
+            .filter_map(|n| match n {
+                InlineNode::Callout(callout) => Some(callout),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_callouts() {
+        // For each fixture, folding the single-pass tree (special characters
+        // then callouts) reproduces the string pipeline's output
+        // byte-for-byte. This is the differential corpus (design §5.3) that
+        // pins the callouts increment (part 5c).
+        let fixtures = [
+            "just some text",
+            "a <b> c",
+            "require 'x' <1>",
+            "puts 'x' # <1>",
+            "puts x <5><6>",
+            "puts \"<1> in the middle\"",
+            "a <.>\nb <.>\nc <.>",
+            "a <.>\nb <1>\nc <.>",
+            "<child/> <!--1-->",
+            "First line <1-->",
+            "require 'x' # \\<1>",
+        ];
+
+        for fixture in fixtures {
+            let parser = Parser::default();
+
+            let folded = fold_html(
+                &build_verbatim(Span::new(fixture), &parser, None),
+                &HtmlSubstitutionRenderer {},
+            );
+
+            assert_eq!(
+                folded,
+                golden_callouts(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_callouts_under_icons() {
+        // Both non-default `icons` renderings (font and image) read `guard`
+        // and `number` through the same `render_callout` the fold calls, so
+        // parity holds under them too. `super::fold_html` is called directly
+        // (not this module's `fold_html` test helper, which always uses a
+        // default parser) so the custom parser reaches the renderer.
+        use crate::parser::ModificationContext;
+
+        let font_parser = Parser::default().with_intrinsic_attribute(
+            "icons",
+            "font",
+            ModificationContext::Anywhere,
+        );
+        let image_parser =
+            Parser::default().with_intrinsic_attribute("icons", "", ModificationContext::Anywhere);
+
+        for parser in [&font_parser, &image_parser] {
+            let fixture = "puts x # <1>";
+
+            let folded = super::fold_html(
+                &build_verbatim(Span::new(fixture), parser, None),
+                &HtmlSubstitutionRenderer {},
+                parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_callouts_with(fixture, parser, None),
+                "fold diverged from the string pipeline under a custom `icons` attribute"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_callout_becomes_a_callout_node_with_an_empty_line_comment_guard() {
+        let nodes = build_verbatim_src(Span::new("require 'x' <1>"));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].number.as_ref(), "1");
+        assert_eq!(found[0].guard, CalloutGuard::LineComment(CowStr::from("")));
+        assert_eq!(found[0].location.data(), "<1>");
+    }
+
+    #[test]
+    fn a_line_comment_guarded_callout_captures_its_prefix() {
+        let nodes = build_verbatim_src(Span::new("puts 'x' # <1>"));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].guard,
+            CalloutGuard::LineComment(CowStr::from("# "))
+        );
+    }
+
+    #[test]
+    fn an_xml_callout_captures_the_xml_guard() {
+        let nodes = build_verbatim_src(Span::new("<child/> <!--1-->"));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].number.as_ref(), "1");
+        assert_eq!(found[0].guard, CalloutGuard::Xml);
+    }
+
+    #[test]
+    fn multiple_callouts_on_one_line_are_each_their_own_node() {
+        let nodes = build_verbatim_src(Span::new("puts x <5><6>"));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].number.as_ref(), "5");
+        assert_eq!(found[1].number.as_ref(), "6");
+    }
+
+    #[test]
+    fn auto_numbering_advances_per_recognized_callout_in_source_order() {
+        let nodes = build_verbatim_src(Span::new("a <.>\nb <.>\nc <.>"));
+        let found = callouts(&nodes);
+
+        assert_eq!(
+            found.iter().map(|c| c.number.as_ref()).collect::<Vec<_>>(),
+            vec!["1", "2", "3"]
+        );
+    }
+
+    #[test]
+    fn auto_numbering_ignores_explicit_numbers() {
+        // Auto-numbering is not aware of explicit numbers.
+        let nodes = build_verbatim_src(Span::new("a <.>\nb <1>\nc <.>"));
+        let found = callouts(&nodes);
+
+        assert_eq!(
+            found.iter().map(|c| c.number.as_ref()).collect::<Vec<_>>(),
+            vec!["1", "1", "2"]
+        );
+    }
+
+    #[test]
+    fn a_callout_not_at_the_trailing_position_is_left_unrecognized() {
+        let nodes = build_verbatim_src(Span::new("puts \"<1> in the middle\""));
+
+        assert!(
+            callouts(&nodes).is_empty(),
+            "a non-trailing callout token must not produce a node: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn a_half_xml_comment_is_not_a_callout() {
+        let nodes = build_verbatim_src(Span::new("First line <1-->"));
+
+        assert!(
+            callouts(&nodes).is_empty(),
+            "a half XML comment must not produce a callout node: {nodes:?}"
+        );
+    }
+
+    #[test]
+    fn an_escaped_callout_drops_its_backslash_and_stays_literal() {
+        let nodes = build_verbatim_src(Span::new("require 'x' # \\<1>"));
+
+        assert!(
+            callouts(&nodes).is_empty(),
+            "an escaped callout must not produce a node: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_callouts("require 'x' # \\<1>")
+        );
+    }
+
+    #[test]
+    fn a_custom_line_comment_prefix_from_the_attribute_list_is_honored() {
+        // `line-comment=%` (Erlang). Only `%` is recognized as a prefix.
+        let attrlist = Attrlist::parse(
+            Span::new("source,erlang,line-comment=%"),
+            &Parser::default(),
+            AttrlistContext::Block,
+        )
+        .item
+        .item;
+
+        let source = "hello() -> % <1>";
+        let nodes = build_verbatim(Span::new(source), &Parser::default(), Some(&attrlist));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].guard,
+            CalloutGuard::LineComment(CowStr::from("% "))
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_callouts_with(source, &Parser::default(), Some(&attrlist))
+        );
+    }
+
+    #[test]
+    fn an_empty_line_comment_attribute_disables_prefix_recognition() {
+        // `line-comment=` (empty) disables prefix recognition, so the `--`
+        // before the callout is preserved verbatim (not consumed as a
+        // default line-comment prefix).
+        let attrlist = Attrlist::parse(
+            Span::new("source,asciidoc,line-comment="),
+            &Parser::default(),
+            AttrlistContext::Block,
+        )
+        .item
+        .item;
+
+        let source = "-- <1>";
+        let nodes = build_verbatim(Span::new(source), &Parser::default(), Some(&attrlist));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].guard, CalloutGuard::LineComment(CowStr::from("")));
+        assert_text(&nodes[0], "-- ", 1, 1);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_callouts_with(source, &Parser::default(), Some(&attrlist))
+        );
+    }
+
+    #[test]
+    fn a_document_level_line_comment_attribute_is_a_fallback() {
+        // The `line-comment` attribute can be set at the document level (here,
+        // with no block attribute list), and is honored as a fallback.
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "line-comment",
+            "%",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "hello() -> % <1>";
+        let nodes = build_verbatim(Span::new(source), &parser, None);
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].guard,
+            CalloutGuard::LineComment(CowStr::from("% "))
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_callouts_with(source, &parser, None)
+        );
+    }
+
+    #[test]
+    fn apply_callouts_is_a_noop_without_a_special_character() {
+        // The cheap pre-filter returns the seed unchanged when no `&lt;` is
+        // present at this level, so plain verbatim content never pays for the
+        // level-building machinery.
+        let source = Span::new("plain verbatim, no callouts here");
+        let seeded = apply_special_characters(seed(source));
+
+        let nodes = apply_callouts(seeded.clone(), source, &Parser::default(), None);
+
+        assert_eq!(nodes, seeded);
     }
 }

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -9653,6 +9653,12 @@ mod tests {
             "<child/> <!--1-->",
             "First line <1-->",
             "require 'x' # \\<1>",
+            // Trailing content survives a recognized callout that is not the
+            // last thing in the level: the callout is still trailing-position
+            // *on its own line* (immediately followed by a newline), but more
+            // text follows on the next line, exercising the rebuild's final
+            // gap after the last match.
+            "line one <1>\nmore code after",
         ];
 
         for fixture in fixtures {
@@ -9746,6 +9752,26 @@ mod tests {
         assert_eq!(found.len(), 2);
         assert_eq!(found[0].number.as_ref(), "5");
         assert_eq!(found[1].number.as_ref(), "6");
+    }
+
+    #[test]
+    fn content_after_the_last_callout_is_kept_as_a_trailing_node() {
+        // The callout is trailing-position on its own line (immediately
+        // followed by a newline), but more text follows on the next line, so
+        // the rebuild's final gap (after the last match) is non-empty.
+        let nodes = build_verbatim_src(Span::new("line one <1>\nmore code after"));
+        let found = callouts(&nodes);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].number.as_ref(), "1");
+
+        match nodes.last() {
+            Some(InlineNode::Text { value, .. }) => {
+                assert_eq!(value.as_ref(), "\nmore code after");
+            }
+
+            other => panic!("expected a trailing Text node, got {other:?}"),
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -61,13 +61,13 @@ use crate::{
     Span,
     attributes::Attrlist,
     inlines::{
-        Anchor, Callout, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant,
-        SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
+        Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
+        RefVariant, SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
     },
     parser::{
-        CalloutRenderParams, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
-        IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
-        QuoteScope, QuoteType, XrefRenderParams,
+        CalloutGuard as ParserCalloutGuard, CalloutRenderParams, FootnoteRenderParams,
+        IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer,
+        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -203,6 +203,7 @@ pub(crate) enum LeafNode {
     },
     Callout {
         number: String,
+        guard: CalloutGuardMeta,
     },
     IndexTerm {
         terms: Vec<String>,
@@ -214,6 +215,15 @@ pub(crate) enum LeafNode {
         number: Option<String>,
         is_reference: bool,
     },
+}
+
+/// Owned counterpart of [`crate::parser::CalloutGuard`], captured from
+/// [`CalloutRenderParams`] at recording time (this module stores owned
+/// strings throughout, matching Strategy A's "owned strings" limitation).
+#[derive(Clone, Debug)]
+pub(crate) enum CalloutGuardMeta {
+    LineComment(String),
+    Xml,
 }
 
 #[derive(Clone, Debug)]
@@ -490,9 +500,17 @@ impl InlineSubstitutionRenderer for RecordingRenderer {
         let mut fragment = String::new();
         self.inner.render_callout(params, &mut fragment);
 
+        let guard = match params.guard {
+            ParserCalloutGuard::LineComment(prefix) => {
+                CalloutGuardMeta::LineComment(prefix.to_string())
+            }
+            ParserCalloutGuard::Xml => CalloutGuardMeta::Xml,
+        };
+
         self.leaf(
             LeafNode::Callout {
                 number: params.number.to_string(),
+                guard,
             },
             &fragment,
             dest,
@@ -914,8 +932,14 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             location: span,
         }),
 
-        LeafNode::Callout { number } => InlineNode::Callout(Callout {
+        LeafNode::Callout { number, guard } => InlineNode::Callout(Callout {
             number: CowStr::from(number.clone()),
+            guard: match guard {
+                CalloutGuardMeta::LineComment(prefix) => {
+                    CalloutGuard::LineComment(CowStr::from(prefix.clone()))
+                }
+                CalloutGuardMeta::Xml => CalloutGuard::Xml,
+            },
             location: span,
         }),
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -36,8 +36,8 @@ pub use substitution_group::SubstitutionGroup;
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
-    ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, character_replacements,
-    hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements, quote_subs,
-    substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
+    ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, build_callout_regexes,
+    character_replacements, hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements,
+    quote_subs, substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
     substitute_attributes_in_text,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1445,7 +1445,9 @@ static CUSTOM_CALLOUT_TAIL_RX: LazyLock<Regex> = LazyLock::new(|| {
 /// The default-mode regexes and both tail regexes are constant, so they are
 /// built once. Only a custom (non-empty) prefix requires building a regex from
 /// the attribute value, which is borrowed otherwise.
-fn build_callout_regexes(line_comment: Option<&str>) -> (Cow<'static, Regex>, &'static Regex) {
+pub(crate) fn build_callout_regexes(
+    line_comment: Option<&str>,
+) -> (Cow<'static, Regex>, &'static Regex) {
     match line_comment {
         // Default: recognize the common line-comment prefixes and XML callouts.
         None => (Cow::Borrowed(&DEFAULT_CALLOUT_RX), &DEFAULT_CALLOUT_TAIL_RX),

--- a/parser/src/inlines/callout.rs
+++ b/parser/src/inlines/callout.rs
@@ -1,14 +1,17 @@
 use crate::{HasSpan, Span, strings::CowStr};
 
-/// A callout number in verbatim content (`<1>`, `<.>`).
-///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer.
+/// A callout number in verbatim content (`<1>`, `<.>`, or `<!--1-->` for
+/// XML).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Callout<'src> {
     /// The callout number to display. For an automatically-numbered callout
     /// (`<.>`) this is the resolved sequential number.
     pub number: CowStr<'src>,
+
+    /// The guard that hides the callout in the raw verbatim source, so the
+    /// fold can preserve it when icons are not enabled (see
+    /// [`CalloutGuard`]).
+    pub guard: CalloutGuard<'src>,
 
     /// The source location of the callout.
     pub location: Span<'src>,
@@ -18,4 +21,21 @@ impl<'src> HasSpan<'src> for Callout<'src> {
     fn span(&self) -> Span<'src> {
         self.location
     }
+}
+
+/// Describes the characters that guard (hide) a callout number in verbatim
+/// source. Mirrors [`crate::parser::CalloutGuard`], the render-time
+/// counterpart the fold reconstructs this into, but is decoupled from it (as
+/// every node in this module is decoupled from its `*RenderParams`
+/// counterpart) so the node stays canonical, structured data rather than a
+/// render-seam type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CalloutGuard<'src> {
+    /// A line-comment (or absent) guard. Holds the line-comment prefix that
+    /// precedes the callout in the source (e.g. `# `), or an empty string
+    /// when the callout is not tucked behind a line comment.
+    LineComment(CowStr<'src>),
+
+    /// An XML comment guard (`<!--N-->`).
+    Xml,
 }

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -124,8 +124,8 @@ mod tests {
     use crate::{
         HasSpan, Span,
         inlines::{
-            Anchor, Callout, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant,
-            SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
+            Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
+            RefVariant, SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
         },
         strings::CowStr,
     };
@@ -197,6 +197,7 @@ mod tests {
             }),
             InlineNode::Callout(Callout {
                 number: CowStr::from("1"),
+                guard: CalloutGuard::LineComment(CowStr::from("# ")),
                 location,
             }),
             InlineNode::Stem(Stem {
@@ -266,6 +267,11 @@ mod tests {
             },
         ];
 
+        let callout_guards = [
+            CalloutGuard::LineComment(CowStr::from("// ")),
+            CalloutGuard::Xml,
+        ];
+
         // Touch each collection so the constructed values are observed.
         assert_eq!(styles.len(), 9);
         assert_eq!(forms.len(), 2);
@@ -273,5 +279,6 @@ mod tests {
         assert_eq!(stems.len(), 2);
         assert_eq!(char_refs.len(), 3);
         assert_eq!(ui_kinds.len(), 3);
+        assert_eq!(callout_guards.len(), 2);
     }
 }

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -35,7 +35,7 @@ mod anchor;
 pub use anchor::Anchor;
 
 mod callout;
-pub use callout::Callout;
+pub use callout::{Callout, CalloutGuard};
 
 mod char_ref;
 pub use char_ref::CharRef;

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -332,6 +332,7 @@ const VERBATIM_CORPUS: &[&str] = &[
     "verbatim < & > chars",
     "line of code <1>",
     "tag <.> auto callout",
+    "line of xml code <!--1-->",
 ];
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the next step in the [inline AST architecture](docs/design/inline-ast-architecture.md) plan: Phase 4, step 5c, `Callouts` → `Callout`.

- Adds `apply_callouts`, the single-pass builder's first step for `SubstitutionGroup::Verbatim` (literal, listing, and source blocks) rather than the *normal* order every step through 5b runs. Literal/listing/source blocks apply only `SpecialCharacters` ahead of `Callouts`, so — unlike every other transducer in the module — this step never needs to descend into `Styled`/`Ref` children, since neither can exist at that point in the verbatim group's order.
- Reuses the string pipeline's *exact* recognition and trailing-position lookahead (`build_callout_regexes`, now shared `pub(crate)`), so only the recognition *sink* differs: a trailing callout token (`<1>`, `<.>`, or `<!--1-->` for XML) becomes a `Callout` node instead of rendered markup, folding through the same `render_callout` the string step calls so the output is byte-for-byte identical.
- This is `Callout`'s first real consumer, so its field set (Phase 0 provisional) gains a `guard` — a new `CalloutGuard` enum (`LineComment(prefix)` / `Xml`) recording which characters hide the callout in the raw source, decoupled from the render seam's own `CalloutGuard` the same way every other node is decoupled from its `*RenderParams` counterpart.
- The Phase 1/2 recorder (`inline_tree.rs`), which had never captured a callout's guard (its fixtures happened not to need it), now captures it too, so both construction strategies agree on the node's shape.
- An escaped callout (`\<1>`) drops its backslash and stays literal. As throughout the additive builder, this pass performs no recognition side effect (no `register_callout` call), deferring the callout catalog's validation to the cutover (step 6).
- Updates the design doc with the step's "landed as" writeup and checks off 5c in the phase-4 step list.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib` — full suite green (4853 passed, including the new differential and structural callout tests)
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo +nightly fmt -p asciidoc-parser -- --check` — clean
- [x] New differential corpus asserts the folded tree matches the string pipeline byte-for-byte for bare/explicit/auto-numbered callouts, multiple callouts on one line, XML callouts, default/custom/disabled `line-comment` prefixes (block- and document-attribute), escapes, non-trailing-position and half-XML-comment non-matches, and both non-default `icons` renderings (font and image)
- [x] New structural tests assert the `Callout` node's `guard` for each guard kind


---
_Generated by [Claude Code](https://claude.ai/code/session_01UA82DUeVxcZFm6o6rYKPtn)_