### PR TITLE
fix: Union docinfo/docinfo2 scopes and veto conflicting notitle writes

### DIFF
--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -109,17 +109,17 @@ impl Docinfo {
         // is equivalent to `docinfo=shared`, and `docinfo2` is equivalent to
         // `docinfo=private,shared`.
         // A `docinfo` value that resolves to exactly "private" -- whether
-        // from a bare `:docinfo:` entry (an API-set bare boolean stays
-        // `InterpretedValue::Set`, but a document header/body entry's empty
-        // value is defaulted to the literal `"private"` before this method
-        // ever sees it) or an explicit `:docinfo: private` -- does not
-        // preclude the legacy `docinfo1`/`docinfo2` booleans from also
-        // contributing their shared-file component. Asciidoctor unions them
-        // rather than letting the literal `docinfo` value suppress the
-        // derived "shared" component (issue #1138): `docinfo docinfo2`
-        // resolves the same as `docinfo2` alone, regardless of which was set
-        // first. A `docinfo` value with any other content (e.g.
-        // `shared-head`) is left as the caller's explicit, complete scope.
+        // from a bare `:docinfo:` entry or an explicit `:docinfo: private`
+        // (both read back as the literal `Value("private")` here, since
+        // `Parser::attribute_value` already resolves a bare boolean to its
+        // registered default) -- does not preclude the legacy
+        // `docinfo1`/`docinfo2` booleans from also contributing their
+        // shared-file component. Asciidoctor unions them rather than letting
+        // the literal `docinfo` value suppress the derived "shared"
+        // component: `docinfo docinfo2` resolves the same as `docinfo2`
+        // alone, regardless of which was set first. A `docinfo` value with
+        // any other content (e.g. `shared-head`) is left as the caller's
+        // explicit, complete scope.
         let union_legacy_shared = |mut tokens: Vec<String>| -> Vec<String> {
             if tokens == ["private"]
                 && (parser.is_attribute_set("docinfo1") || parser.is_attribute_set("docinfo2"))
@@ -139,6 +139,11 @@ impl Docinfo {
                     return Self::default();
                 }
             }
+            // Unreachable in practice: `Parser::attribute_value` never
+            // returns a bare `Set` for `docinfo`, since it always resolves
+            // one to its registered default (`Value("private")`, handled by
+            // the arm below) before this method observes it. Kept only for
+            // exhaustiveness, mirroring that same default.
             InterpretedValue::Set => union_legacy_shared(vec!["private".to_string()]),
             InterpretedValue::Value(v) => union_legacy_shared(
                 v.split(',')
@@ -276,7 +281,11 @@ fn docinfosubs_steps(parser: &Parser) -> SubstitutionGroup {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::{Parser, SafeMode, document::DocinfoLocation, parser::DocinfoFileHandler};
+    use crate::{
+        Parser, SafeMode,
+        document::DocinfoLocation,
+        parser::{DocinfoFileHandler, ModificationContext},
+    };
 
     /// A minimal handler that resolves docinfo from a fixed file-name map.
     #[derive(Debug)]
@@ -423,9 +432,9 @@ mod tests {
     fn bare_docinfo_and_docinfo2_union_to_private_and_shared() {
         // A bare `:docinfo:` ("private" only) and `:docinfo2:` ("private" +
         // "shared") set together union their effects rather than one
-        // suppressing the other's shared-file component (issue #1138):
-        // matches Asciidoctor's `docinfo docinfo2` test case, which is
-        // identical to `docinfo2` alone.
+        // suppressing the other's shared-file component: matches
+        // Asciidoctor's `docinfo docinfo2` test case, which is identical to
+        // `docinfo2` alone.
         let head = head_for(
             "= Doc\n:docinfo:\n:docinfo2:\n\nBody.",
             &[
@@ -443,6 +452,28 @@ mod tests {
                 ("mydoc-docinfo.html", "PRIVATE"),
             ],
         );
+        assert_eq!(head, "SHARED\nPRIVATE");
+    }
+
+    #[test]
+    fn api_set_bare_docinfo_unions_with_docinfo2() {
+        // A bare `docinfo` boolean set via the intrinsic-attribute API
+        // (rather than a document `:docinfo:` header entry) still reads back
+        // as `Value("private")` -- `Parser::attribute_value` resolves a bare
+        // `Set` to its registered default regardless of how it was set --
+        // so it unions with a document `:docinfo2:` entry's shared scope the
+        // same way.
+        let head = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("mydoc.adoc")
+            .with_docinfo_file_handler(MapHandler::new(&[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ]))
+            .with_intrinsic_attribute_bool("docinfo", true, ModificationContext::Anywhere)
+            .parse("= Doc\n:docinfo2:\n\nBody.")
+            .docinfo(DocinfoLocation::Head)
+            .to_string();
         assert_eq!(head, "SHARED\nPRIVATE");
     }
 

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -139,12 +139,15 @@ impl Docinfo {
                     return Self::default();
                 }
             }
-            // Unreachable in practice: `Parser::attribute_value` never
-            // returns a bare `Set` for `docinfo`, since it always resolves
-            // one to its registered default (`Value("private")`, handled by
-            // the arm below) before this method observes it. Kept only for
-            // exhaustiveness, mirroring that same default.
-            InterpretedValue::Set => union_legacy_shared(vec!["private".to_string()]),
+            // `docinfo` has a registered default (`"private"`, set in
+            // `built_in_default_values`), so `Parser::attribute_value`
+            // always resolves a bare boolean to that default -- see the
+            // `Value` arm below -- and never returns a bare `Set` for it.
+            // This arm exists only to satisfy match exhaustiveness.
+            InterpretedValue::Set => unreachable!(
+                "docinfo has a registered default, so Parser::attribute_value never returns \
+                 InterpretedValue::Set for it"
+            ),
             InterpretedValue::Value(v) => union_legacy_shared(
                 v.split(',')
                     .map(|t| t.trim().to_ascii_lowercase())

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -108,6 +108,27 @@ impl Docinfo {
         // standalone boolean attributes are consulted as a fallback: `docinfo1`
         // is equivalent to `docinfo=shared`, and `docinfo2` is equivalent to
         // `docinfo=private,shared`.
+        // A `docinfo` value that resolves to exactly "private" -- whether
+        // from a bare `:docinfo:` entry (an API-set bare boolean stays
+        // `InterpretedValue::Set`, but a document header/body entry's empty
+        // value is defaulted to the literal `"private"` before this method
+        // ever sees it) or an explicit `:docinfo: private` -- does not
+        // preclude the legacy `docinfo1`/`docinfo2` booleans from also
+        // contributing their shared-file component. Asciidoctor unions them
+        // rather than letting the literal `docinfo` value suppress the
+        // derived "shared" component (issue #1138): `docinfo docinfo2`
+        // resolves the same as `docinfo2` alone, regardless of which was set
+        // first. A `docinfo` value with any other content (e.g.
+        // `shared-head`) is left as the caller's explicit, complete scope.
+        let union_legacy_shared = |mut tokens: Vec<String>| -> Vec<String> {
+            if tokens == ["private"]
+                && (parser.is_attribute_set("docinfo1") || parser.is_attribute_set("docinfo2"))
+            {
+                tokens.push("shared".to_string());
+            }
+            tokens
+        };
+
         let tokens: Vec<String> = match parser.attribute_value("docinfo") {
             InterpretedValue::Unset => {
                 if parser.is_attribute_set("docinfo2") {
@@ -118,12 +139,13 @@ impl Docinfo {
                     return Self::default();
                 }
             }
-            InterpretedValue::Set => vec!["private".to_string()],
-            InterpretedValue::Value(v) => v
-                .split(',')
-                .map(|t| t.trim().to_ascii_lowercase())
-                .filter(|t| !t.is_empty())
-                .collect(),
+            InterpretedValue::Set => union_legacy_shared(vec!["private".to_string()]),
+            InterpretedValue::Value(v) => union_legacy_shared(
+                v.split(',')
+                    .map(|t| t.trim().to_ascii_lowercase())
+                    .filter(|t| !t.is_empty())
+                    .collect(),
+            ),
         };
 
         if tokens.is_empty() {
@@ -389,6 +411,48 @@ mod tests {
         // document-private docinfo files are included, shared first.
         let head = head_for(
             "= Doc\n:docinfo2:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED\nPRIVATE");
+    }
+
+    #[test]
+    fn bare_docinfo_and_docinfo2_union_to_private_and_shared() {
+        // A bare `:docinfo:` ("private" only) and `:docinfo2:` ("private" +
+        // "shared") set together union their effects rather than one
+        // suppressing the other's shared-file component (issue #1138):
+        // matches Asciidoctor's `docinfo docinfo2` test case, which is
+        // identical to `docinfo2` alone.
+        let head = head_for(
+            "= Doc\n:docinfo:\n:docinfo2:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED\nPRIVATE");
+
+        // Order does not matter.
+        let head = head_for(
+            "= Doc\n:docinfo2:\n:docinfo:\n\nBody.",
+            &[
+                ("docinfo.html", "SHARED"),
+                ("mydoc-docinfo.html", "PRIVATE"),
+            ],
+        );
+        assert_eq!(head, "SHARED\nPRIVATE");
+    }
+
+    #[test]
+    fn bare_docinfo_and_docinfo1_union_to_private_and_shared() {
+        // Same union behavior applies against the `docinfo1` legacy toggle
+        // ("shared" only): the bare `docinfo` attribute's "private" scope is
+        // combined with it rather than suppressing it.
+        let head = head_for(
+            "= Doc\n:docinfo:\n:docinfo1:\n\nBody.",
             &[
                 ("docinfo.html", "SHARED"),
                 ("mydoc-docinfo.html", "PRIVATE"),

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1438,6 +1438,19 @@ impl Parser {
     /// [`with_intrinsic_attribute()`](Self::with_intrinsic_attribute) and
     /// its siblings), including the partner it set.
     ///
+    /// Returns whether the caller should proceed with storing `attr_name`'s
+    /// own direct assignment. This is `false` only for a document-originated
+    /// `notitle` entry whose partner `showtitle` is locked against the
+    /// write: `showtitle` takes precedence when resolving title visibility
+    /// (see [`resolve_show_title`](Self::resolve_show_title)), so a locked
+    /// `showtitle` must veto the conflicting `notitle` entry outright, not
+    /// merely skip the partner-sync side effect – otherwise a direct probe
+    /// of `notitle` (e.g. `ifdef::notitle[]`) would see the raw, rejected
+    /// document value instead of staying consistent with the lock (issue
+    /// #1139). The reverse does not hold: a locked `notitle` never vetoes a
+    /// `showtitle` entry, since `showtitle`'s own precedence already decides
+    /// the resolved visibility regardless of `notitle`'s raw value.
+    ///
     /// [set]: https://docs.asciidoctor.org/asciidoc/latest/attributes/set-attributes/
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     fn apply_title_visibility_linkage(
@@ -1447,17 +1460,17 @@ impl Parser {
         modification_context: ModificationContext,
         silent_when_locked: bool,
         write_scope: Option<DocumentWriteScope>,
-    ) {
+    ) -> bool {
         let partner = match attr_name {
             "notitle" => "showtitle",
             "showtitle" => "notitle",
-            _ => return,
+            _ => return true,
         };
 
         if let Some(scope) = write_scope
             && self.partner_write_is_locked(partner, scope)
         {
-            return;
+            return attr_name != "notitle";
         }
 
         // Either way the partner supersedes (and resets) any counter of the
@@ -1481,6 +1494,8 @@ impl Parser {
             // no prior partner entry does not clone the shared map.)
             Arc::make_mut(&mut self.attribute_values).remove(partner);
         }
+
+        true
     }
 
     /// Forces the `doctype` attribute to `value`.
@@ -2570,14 +2585,19 @@ impl Parser {
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
         // A document header entry must not use the linkage to route around a
-        // lock on the partner spelling, so the lock is enforced here.
-        self.apply_title_visibility_linkage(
+        // lock on the partner spelling, so the lock is enforced here. A
+        // locked `showtitle` also vetoes a conflicting `notitle` entry
+        // outright (see the method doc), so the write is dropped entirely in
+        // that case.
+        if !self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
             Some(DocumentWriteScope::Header),
-        );
+        ) {
+            return;
+        }
 
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
@@ -2762,14 +2782,19 @@ impl Parser {
         // visibility toggle; keep the partner in sync (see
         // [`apply_title_visibility_linkage`](Self::apply_title_visibility_linkage)).
         // A document body entry must not use the linkage to route around a
-        // lock on the partner spelling, so the lock is enforced here.
-        self.apply_title_visibility_linkage(
+        // lock on the partner spelling, so the lock is enforced here. A
+        // locked `showtitle` also vetoes a conflicting `notitle` entry
+        // outright (see the method doc), so the write is dropped entirely in
+        // that case.
+        if !self.apply_title_visibility_linkage(
             &attr_name,
             &value,
             ModificationContext::Anywhere,
             false,
             Some(DocumentWriteScope::Body),
-        );
+        ) {
+            return;
+        }
 
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
@@ -4622,6 +4647,30 @@ mod tests {
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
             assert!(parser.resolve_show_title(false));
+
+            // Issue #1139: the conflicting `:notitle:` entry must be rejected
+            // outright, not just have its partner-sync side effect skipped --
+            // otherwise a direct probe of `notitle` (e.g. `ifdef::notitle[]`)
+            // would see the raw document value instead of staying consistent
+            // with the `showtitle` lock, as Asciidoctor does.
+            assert!(!parser.has_attribute("notitle"));
+        }
+
+        #[test]
+        fn header_unset_notitle_entry_also_rejected_when_showtitle_is_api_locked() {
+            // The rejection applies to any conflicting `notitle` write, not
+            // just a `Set` one: an explicit `:!notitle:` unset entry must not
+            // create a `notitle` tombstone either, since that would still make
+            // a direct `ifdef::notitle[]` probe diverge from the lock.
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                true,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Doc\n:!notitle:\n\nBody.");
+
+            assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
+            assert!(!parser.has_attribute("notitle"));
         }
 
         #[test]
@@ -4660,6 +4709,9 @@ mod tests {
 
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
+
+            // Issue #1139: rejected outright, same as the header case.
+            assert!(!parser.has_attribute("notitle"));
         }
 
         #[test]
@@ -4677,6 +4729,9 @@ mod tests {
 
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
+
+            // Issue #1139: rejected outright, same as the `ApiOnly` case.
+            assert!(!parser.has_attribute("notitle"));
         }
 
         #[test]

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1446,10 +1446,10 @@ impl Parser {
     /// `showtitle` must veto the conflicting `notitle` entry outright, not
     /// merely skip the partner-sync side effect – otherwise a direct probe
     /// of `notitle` (e.g. `ifdef::notitle[]`) would see the raw, rejected
-    /// document value instead of staying consistent with the lock (issue
-    /// #1139). The reverse does not hold: a locked `notitle` never vetoes a
-    /// `showtitle` entry, since `showtitle`'s own precedence already decides
-    /// the resolved visibility regardless of `notitle`'s raw value.
+    /// document value instead of staying consistent with the lock. The
+    /// reverse does not hold: a locked `notitle` never vetoes a `showtitle`
+    /// entry, since `showtitle`'s own precedence already decides the
+    /// resolved visibility regardless of `notitle`'s raw value.
     ///
     /// [set]: https://docs.asciidoctor.org/asciidoc/latest/attributes/set-attributes/
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
@@ -4648,8 +4648,8 @@ mod tests {
             assert!(parser.is_attribute_set("showtitle"));
             assert!(parser.resolve_show_title(false));
 
-            // Issue #1139: the conflicting `:notitle:` entry must be rejected
-            // outright, not just have its partner-sync side effect skipped --
+            // The conflicting `:notitle:` entry must be rejected outright,
+            // not just have its partner-sync side effect skipped --
             // otherwise a direct probe of `notitle` (e.g. `ifdef::notitle[]`)
             // would see the raw document value instead of staying consistent
             // with the `showtitle` lock, as Asciidoctor does.
@@ -4710,7 +4710,7 @@ mod tests {
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
 
-            // Issue #1139: rejected outright, same as the header case.
+            // Rejected outright, same as the header case.
             assert!(!parser.has_attribute("notitle"));
         }
 
@@ -4730,7 +4730,7 @@ mod tests {
             assert_eq!(parser.attribute_value("showtitle"), InterpretedValue::Set);
             assert!(parser.is_attribute_set("showtitle"));
 
-            // Issue #1139: rejected outright, same as the `ApiOnly` case.
+            // Rejected outright, same as the `ApiOnly` case.
             assert!(!parser.has_attribute("notitle"));
         }
 


### PR DESCRIPTION
## Summary

Fixes two independent parity gaps in attribute resolution, both surfaced from `asciidoc-html5`'s downstream tracking (#307):

* Fixes #1138 — Setting both bare `docinfo` and `docinfo2` together dropped the shared-file component instead of unioning it.
* Fixes #1139 — API-locking `showtitle` didn't veto a conflicting document `notitle` entry, leaving `notitle` inconsistent with the lock.

I evaluated splitting these into separate PRs but kept them together: both are narrow, single-file fixes in the same attribute-resolution subsystem (`Parser`'s intrinsic-attribute handling), filed by the same reporter from the same downstream context, with no interaction between the two changes.

## Changes

### `parser/src/document/docinfo.rs` (#1138)

When the `docinfo` attribute resolves to exactly `"private"` — whether from a bare `:docinfo:` entry or an explicit `:docinfo: private` — the legacy `docinfo1`/`docinfo2` boolean toggles now union in their `"shared"` scope instead of being ignored. This matches Asciidoctor's parity case `docinfo docinfo2`, which resolves identically to `docinfo2` alone. A `docinfo` value with any other content (e.g. `shared-head`) is left as-is, preserving the existing precedence behavior for genuinely explicit scopes.

### `parser/src/parser/parser.rs` (#1139)

`apply_title_visibility_linkage` now returns whether the caller should proceed with storing the attribute's own direct assignment. When `showtitle` is locked (via the API) and a document `notitle` entry conflicts with it, the `notitle` write is now rejected outright — not just its partner-sync side effect — so a direct probe of `notitle` (e.g. `ifdef::notitle[]`) stays consistent with the lock. The reverse direction is intentionally left unchanged: a locked `notitle` never vetoes a `showtitle` write, since `showtitle` already takes precedence when resolving title visibility.

## Test plan

- [x] Added regression tests for bare `docinfo` + `docinfo1`/`docinfo2` unioning (`parser/src/document/docinfo.rs`)
- [x] Added regression tests for the `notitle`/`showtitle` lock veto, covering header and body entries and both `Set`/`Unset` forms (`parser/src/parser/parser.rs`)
- [x] `cargo test -p asciidoc-parser` — all 4678 tests pass
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo fmt -p asciidoc-parser -- --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0153WtHBkKM3ow8PvXTzBjjt)_