### PR TITLE
feat: Recognize inline STEM macros in the single-pass inline builder (inline-ast Phase 4, step 5d part 1)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1202,6 +1202,39 @@ Each phase is a reviewable unit with a clear exit gate.
   non-matches, and both non-default `icons` renderings (font and image), alongside structural assertions
   on the node's `guard`. This step is **additive**: nothing is wired into the parse path.
 
+  *Step 5d landed as (inline STEM → `Stem`, the first of 5d's four deferred forms):* a new
+  [`apply_stem`](../../parser/src/content/inline_builder/stem_step.rs) step recognizes inline STEM
+  macros (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) as a [`Stem`](../../parser/src/inlines/stem.rs)
+  node, folding through the same `render_quoted_substitution` the string pipeline's passthrough-restore
+  step calls for a STEM entry, so the output is byte-for-byte identical. STEM is an **implicit
+  passthrough** – `Passthroughs::extract_from` extracts it last, after both passthrough-macro passes, so
+  that a passthrough placeholder nested inside a STEM expression survives – and `apply_stem` mirrors that
+  ordering exactly: it is its own step, run immediately after
+  [`apply_passthroughs`](../../parser/src/content/inline_builder/passthrough_step.rs) and ahead of every
+  other step, so a STEM expression's content is never touched by specialcharacters, quotes, replacements,
+  or macros (a `stem:[…]` written inside an already-extracted `+++…+++` passthrough is therefore *not*
+  re-extracted, matching the string pipeline). It reuses the string pipeline's *exact* recognition and
+  notation-resolution – `INLINE_STEM_MACRO` and `stem_notation` are now shared `pub(crate)` – so only the
+  recognition *sink* differs (§4.1). The node's `value` is *not* the untouched source slice (unlike a
+  macro node's target/display text elsewhere in this module): a STEM expression is unescaped (`\]` → `]`),
+  has its legacy `latexmath` `$…$` wrapper dropped, and is run through the real substitution pipeline
+  under its resolved substitution group ([`SubstitutionGroup::Stem`](../../parser/src/content/substitution_group.rs),
+  special characters only, for a bare macro) via the passthrough step's own `passthrough_text` helper
+  (now shared `pub(super)`) – so a custom `InlineSubstitutionRenderer`'s escaping is honored exactly as it
+  would be for the string pipeline's own restore step, at the cost of an owned value rather than a `'src`
+  borrow (the same trade-off the `++…++`/`$$…$$` passthrough forms make). The fold then passes that value
+  straight through as `render_quoted_substitution`'s body, with no attribute list or id (the macro's
+  pattern captures neither). The Phase-0 node doc (which described `value` as "the raw expression,
+  carried through verbatim") was updated to match this decision.
+
+  An escaped macro (`\stem:[…]`) drops its backslash and stays literal, mirroring every other macro
+  family's escape handling. One form is deferred, documented and pinned by a divergence test: a macro
+  carrying an **explicit substitution list** (`stem:c,q[…]`, whose content would need a richer subtree
+  than a single `Stem` leaf can hold – the same reason a `pass:` macro with an explicit list is deferred).
+  This step is **additive**: nothing is wired into the parse path. The remaining three forms 5a already
+  documents as deferred – an attribute-list-prefixed passthrough, a `pass:` macro with an explicit
+  substitution list, and the bare unconstrained `+text+` form – remain for a later increment.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1235,9 +1268,13 @@ Each phase is a reviewable unit with a clear exit gate.
        `pass:[…]`) → `Raw`.
      - ✅ **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
      - ✅ **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
-     - **5d.** the deferred forms `5a` documents – an attribute-list-prefixed passthrough, a
-       `pass:` macro with an explicit substitution list, the bare unconstrained `+text+` form,
-       and inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) → `Stem`.
+     - **5d.** the deferred forms `5a` documents, itself sliced into parts:
+       - ✅ **part 1.** inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) → `Stem`
+         (an explicit substitution list, `stem:c,q[…]`, is itself deferred).
+       - **part 2.** an attribute-list-prefixed passthrough (`[quotes]++text++`, `` [x-]`text` ``,
+         `[attrs]+text+`).
+       - **part 3.** a `pass:` macro carrying an explicit substitution list (`pass:c,q[…]`).
+       - **part 4.** the bare unconstrained `+text+` form.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make
      `rendered_html()` a fold, delete the three production sentinel systems (§4.2), and retire
      the `with_inline_tree` opt-in flag (the deferred remainder of Phase 2). Re-attach the

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -6,12 +6,13 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     inlines::{
         Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
-        RefVariant, SpanForm, Ui, UiKind,
+        RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
     },
     parser::{
         CalloutGuard as ParserCalloutGuard, CalloutRenderParams, FootnoteRenderParams,
         IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer,
-        LinkRenderParams, MenuRenderParams, QuoteScope, SpecialCharacter, XrefRenderParams,
+        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, SpecialCharacter,
+        XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -22,10 +23,12 @@ use crate::{
 /// kinds the transducer steps produce so far – [`Text`](InlineNode::Text),
 /// [`CharRef`](InlineNode::CharRef), [`Styled`](crate::inlines::Styled),
 /// [`Image`](InlineNode::Image), [`Ui`](InlineNode::Ui),
-/// [`Ref`](InlineNode::Ref) (both link and cross-reference), and
-/// [`LineBreak`](InlineNode::LineBreak), plus the design-legal
-/// [`Raw`](InlineNode::Raw) leaf; a later increment extends it as
-/// the transducer grows new kinds.
+/// [`Ref`](InlineNode::Ref) (both link and cross-reference),
+/// [`Anchor`](InlineNode::Anchor), [`IndexTerm`](InlineNode::IndexTerm),
+/// [`Footnote`](InlineNode::Footnote), [`Callout`](InlineNode::Callout),
+/// [`Stem`](InlineNode::Stem), and [`LineBreak`](InlineNode::LineBreak), plus
+/// the design-legal [`Raw`](InlineNode::Raw) leaf; a later increment extends
+/// it as the transducer grows new kinds.
 pub(crate) fn fold_html(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
@@ -136,6 +139,10 @@ fn fold_into_html(
                 fold_callout(callout, renderer, parser, out);
             }
 
+            InlineNode::Stem(stem) => {
+                fold_stem(stem, renderer, out);
+            }
+
             InlineNode::Styled(styled) => {
                 // Fold the children to the body, then wrap it exactly as the
                 // string pipeline's quotes step did: the same `QuoteType`,
@@ -162,10 +169,11 @@ fn fold_into_html(
                 // The steps wired up so far produce only `Text`,
                 // `CharRef::Special`, `Styled`, `Image`, `Ui`, `Ref` (link and
                 // cross-reference), `Anchor`, `IndexTerm`, `Footnote`,
-                // `Callout`, and `LineBreak` nodes, and this fold additionally
-                // emits the design-legal `Raw` leaf; no other node kind
-                // reaches the fold in this increment. A later increment
-                // fills in the arms above as the transducer grows new kinds.
+                // `Callout`, `Stem`, and `LineBreak` nodes, and this fold
+                // additionally emits the design-legal `Raw` leaf; no other
+                // node kind reaches the fold in this increment. A later
+                // increment fills in the arms above as the transducer grows
+                // new kinds.
                 // Guard against a premature caller in debug builds and emit
                 // nothing in release, mirroring the safe defensive fallback in
                 // [`content`](super::content).
@@ -512,6 +520,30 @@ fn fold_callout(
             guard,
             parser,
         },
+        out,
+    );
+}
+
+/// Folds a [`Stem`](InlineNode::Stem) through the same
+/// `render_quoted_substitution` the string pipeline's passthrough-restore step
+/// calls for a STEM entry (design §3.3.1's fold-time seam). The node's `value`
+/// already carries the resolved substitution group's output (special
+/// characters only, by default), so the fold passes it straight through as
+/// the body – no further processing is needed, mirroring how a STEM
+/// passthrough is restored with no attribute list or id (`INLINE_STEM_MACRO`
+/// captures neither).
+fn fold_stem(stem: &Stem<'_>, renderer: &dyn InlineSubstitutionRenderer, out: &mut String) {
+    let type_ = match stem.notation {
+        StemNotation::AsciiMath => QuoteType::AsciiMath,
+        StemNotation::LatexMath => QuoteType::LatexMath,
+    };
+
+    renderer.render_quoted_substitution(
+        type_,
+        QuoteScope::Unconstrained,
+        None,
+        None,
+        stem.value.as_ref(),
         out,
     );
 }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -107,8 +107,19 @@
 //!   so – unlike the other families – a content crossing an already-recognized
 //!   construct is not deferred: nesting is the point. Only the deprecated
 //!   `footnoteref:` form and a content carrying an escaped closing bracket
-//!   (`\]`) are deferred. Inline STEM (a passthrough-time construct) and the
-//!   bibliography-anchor form are later increments.
+//!   (`\]`) are deferred. The bibliography-anchor form is a later increment.
+//! - [`apply_stem`] recognizes **inline STEM macros** (`stem:[…]`,
+//!   `asciimath:[…]`, `latexmath:[…]`), replacing each with a
+//!   [`Stem`](InlineNode::Stem) leaf. Like [`apply_passthroughs`], it is an
+//!   implicit-passthrough step: it runs immediately after
+//!   [`apply_passthroughs`] (mirroring `Passthroughs::extract_from`'s own
+//!   ordering, which extracts STEM macros last, after both passthrough passes),
+//!   so a STEM expression's content is never touched by specialcharacters,
+//!   quotes, replacements, or macros. It reuses the shared
+//!   [`INLINE_STEM_MACRO`](crate::content::INLINE_STEM_MACRO) pattern and
+//!   [`stem_notation`](crate::content::stem_notation) helper, so only the
+//!   recognition *sink* differs. A macro carrying an explicit substitution list
+//!   (`stem:c,q[…]`) is deferred, the same reason `pass:c,q[…]` is deferred.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
@@ -161,6 +172,7 @@ mod passthrough_step;
 mod post_replacements;
 mod quotes;
 mod special_chars;
+mod stem_step;
 
 #[cfg(test)]
 mod test_support;
@@ -179,6 +191,7 @@ use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
 use special_chars::apply_special_characters;
+use stem_step::apply_stem;
 
 use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 
@@ -203,6 +216,12 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     // its own step loop), so their content is never touched by
     // specialcharacters, quotes, replacements, or macros.
     let nodes = apply_passthroughs(seed, source, parser);
+
+    // Inline STEM is an implicit passthrough too, extracted last (mirroring
+    // `Passthroughs::extract_from`'s own ordering) so a passthrough
+    // placeholder nested inside a STEM expression survives.
+    let nodes = apply_stem(nodes, source, parser);
+
     let nodes = apply_special_characters(nodes);
     let nodes = apply_quotes(nodes, source, parser);
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -113,13 +113,20 @@
 //!   [`Stem`](InlineNode::Stem) leaf. Like [`apply_passthroughs`], it is an
 //!   implicit-passthrough step: it runs immediately after
 //!   [`apply_passthroughs`] (mirroring `Passthroughs::extract_from`'s own
-//!   ordering, which extracts STEM macros last, after both passthrough passes),
-//!   so a STEM expression's content is never touched by specialcharacters,
-//!   quotes, replacements, or macros. It reuses the shared
+//!   ordering, which extracts STEM macros last, after both passthrough passes,
+//!   *specifically so a nested passthrough placeholder survives*), so a STEM
+//!   expression's content is never touched by specialcharacters, quotes,
+//!   replacements, or macros. It reuses the shared
 //!   [`INLINE_STEM_MACRO`](crate::content::INLINE_STEM_MACRO) pattern and
 //!   [`stem_notation`](crate::content::stem_notation) helper, so only the
-//!   recognition *sink* differs. A macro carrying an explicit substitution list
-//!   (`stem:c,q[…]`) is deferred, the same reason `pass:c,q[…]` is deferred.
+//!   recognition *sink* differs. Because it runs right after
+//!   [`apply_passthroughs`], the only node kinds it can ever see are `Text` and
+//!   [`Raw`](InlineNode::Raw); a match embedding an already-extracted `Raw`
+//!   passthrough (`stem:[+++<b>x</b>+++]`) is never deferred – the `Raw` is
+//!   spliced into the node's value verbatim, unlike every other macro family's
+//!   "crosses an already-recognized construct" boundary. A macro carrying an
+//!   explicit substitution list (`stem:c,q[…]`) is deferred, the same reason
+//!   `pass:c,q[…]` is deferred.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -58,9 +58,11 @@ use crate::{
 /// replacer works around with a retry loop this increment does not yet
 /// reproduce). Inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) is
 /// an implicit passthrough too, but folds through its own
-/// [`Stem`](InlineNode::Stem) node rather than `Raw`, so it is a separate,
-/// later increment. This step is **additive**: nothing is wired into the
-/// parse path.
+/// [`Stem`](InlineNode::Stem) node rather than `Raw`, so it is recognized by
+/// its own step, [`apply_stem`](super::stem_step::apply_stem), run
+/// immediately after this one (mirroring `Passthroughs::extract_from`, which
+/// extracts STEM macros last, after both passthrough passes). This step is
+/// **additive**: nothing is wired into the parse path.
 ///
 /// The same deferred bare-form boundary shows up once more, indirectly: an
 /// **escaped triple- or double-plus** (`\+++text+++`, `\++text++`) drops its
@@ -226,7 +228,7 @@ fn build_passthrough_node<'src>(
 /// pipeline's restore step – so the result honors whatever
 /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
 /// `parser` carries rather than a hand-rolled, always-default escaping.
-fn passthrough_text(text: &str, subs: &SubstitutionGroup, parser: &Parser) -> String {
+pub(super) fn passthrough_text(text: &str, subs: &SubstitutionGroup, parser: &Parser) -> String {
     let mut content = Content::from(Span::new(text));
     subs.apply(&mut content, parser, None);
     content.rendered_str().to_string()
@@ -245,43 +247,15 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::{
-        super::test_support::{assert_raw, build_src, fold_html, seed},
+        super::test_support::{assert_raw, build_src, fold_html, golden_passthroughs, seed},
         apply_passthroughs,
     };
     use crate::{
         Parser, Span,
-        content::{Content, Passthroughs, SubstitutionStep},
         inlines::{InlineNode, SpanForm, StyleVariant, Styled},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
-
-    /// The string pipeline's output for `source`, used as the golden oracle
-    /// for the passthrough increment: extract passthroughs, run the five
-    /// steps [`build`](super::build) runs (special characters, quotes,
-    /// character replacements, macros, post replacement), then restore them
-    /// – exactly
-    /// what [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup::apply)'s
-    /// `run_pipeline` does for [`SubstitutionGroup::Normal`]. Attribute
-    /// references are skipped, as elsewhere in this module's golden helpers.
-    fn golden_passthroughs_with(source: &str, parser: &Parser) -> String {
-        let mut content = Content::from(Span::new(source));
-        let passthroughs = Passthroughs::extract_from(&mut content, parser);
-
-        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-        SubstitutionStep::Quotes.apply(&mut content, parser, None);
-        SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
-        SubstitutionStep::Macros.apply(&mut content, parser, None);
-        SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
-
-        passthroughs.restore_to(&mut content, parser);
-        content.rendered_str().to_string()
-    }
-
-    /// [`golden_passthroughs_with`] with a default parser.
-    fn golden_passthroughs(source: &str) -> String {
-        golden_passthroughs_with(source, &Parser::default())
-    }
 
     #[test]
     fn apply_passthroughs_is_a_noop_without_passthrough_syntax() {
@@ -576,27 +550,5 @@ mod tests {
 
         assert_ne!(folded, golden);
         assert_eq!(folded, "a +text+ b");
-    }
-
-    #[test]
-    fn inline_stem_is_a_documented_divergence() {
-        // Inline STEM macros (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) are
-        // implicit passthroughs too, but fold through their own `Stem` node
-        // rather than `Raw`, so they are a separate, later increment; this
-        // step does not recognize them at all.
-        let source = "stem:[x^2]";
-        let nodes = build_src(Span::new(source));
-
-        assert!(
-            nodes
-                .iter()
-                .all(|n| !matches!(n, InlineNode::Raw { .. } | InlineNode::Stem(_))),
-            "inline STEM must be left unrecognized: {nodes:?}"
-        );
-
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        let golden = golden_passthroughs(source);
-
-        assert_ne!(folded, golden);
     }
 }

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -3,9 +3,9 @@
 use regex::Captures;
 
 use super::{
-    macros::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level},
+    macros::{MacroMatch, MacroMatchKind, rebuild_macro_level},
     passthrough_step::passthrough_text,
-    quotes::{Piece, build_match_string, source_slice},
+    quotes::{Piece, build_match_string, emit_range, source_slice},
 };
 use crate::{
     Parser, Span,
@@ -19,18 +19,27 @@ use crate::{
 /// `latexmath:[…]`), replacing each with a [`Stem`](InlineNode::Stem) leaf.
 ///
 /// STEM is an **implicit passthrough**: [`Passthroughs::extract_from`]
-/// extracts it last, after both passthrough-macro passes, so that any
-/// passthrough placeholder nested inside a STEM expression survives.
-/// [`apply_stem`] mirrors that ordering – [`build`](super::build) runs it
-/// immediately after
-/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs)
-/// and ahead of every other step – so a STEM expression's content is never
+/// extracts it last, after both passthrough-macro passes, *specifically so
+/// that a passthrough placeholder nested inside a STEM expression survives
+/// and is recursively restored* (its own doc comment). [`apply_stem`] mirrors
+/// that ordering – [`build`](super::build) runs it immediately after
+/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs) and
+/// ahead of every other step – so a STEM expression's content is never
 /// touched by specialcharacters, quotes, replacements, or macros, exactly
 /// like a `+++…+++`/`++…++`/`$$…$$`/`pass:[…]` passthrough. It reuses the
 /// string pipeline's *exact* recognition – [`INLINE_STEM_MACRO`] is now
 /// shared `pub(crate)`, alongside the [`stem_notation`] helper that resolves
 /// a bare `stem:[…]` macro's notation from the `stem` document attribute –
 /// so only the recognition *sink* differs (§4.1).
+///
+/// Because it runs immediately after `apply_passthroughs`, the *only* node
+/// kinds `apply_stem` can ever see are `Text` and [`Raw`](InlineNode::Raw)
+/// (a nested, already-extracted passthrough) – no other step has run yet to
+/// build anything else. So, unlike every other macro family in this module,
+/// a STEM match is **never deferred** for crossing an already-recognized
+/// construct: [`build_stem_node`] embeds a crossed `Raw` node directly (see
+/// its doc comment), which is what makes the extraction ordering above
+/// actually pay off, rather than merely being followed.
 ///
 /// A recognized macro's expression is unescaped (`\]` → `]`), has its legacy
 /// enclosing `$…$` dropped for `latexmath` (backwards compatibility with
@@ -49,17 +58,11 @@ use crate::{
 /// An **escaped** macro (`\stem:[…]`) drops its backslash and stays literal,
 /// mirroring every other macro family's escape handling.
 ///
-/// Two forms are deferred, each documented and pinned by a divergence test:
-/// a macro carrying an **explicit substitution list** (`stem:c,q[…]`, whose
-/// content would need a richer subtree than a single `Stem` leaf can hold –
-/// the same reason a `pass:` macro with an explicit list is deferred), and a
-/// match whose expression **crosses an already-recognized construct**
-/// (non-verbatim – in practice this cannot yet happen, since `apply_stem`
-/// only ever runs on the seed
-/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs) has
-/// already refined into `Text`/[`Raw`](InlineNode::Raw) leaves, but the
-/// check is kept for the same reason every other family keeps it). This
-/// step is **additive**: nothing is wired into the parse path.
+/// One form is deferred, documented and pinned by a divergence test: a macro
+/// carrying an **explicit substitution list** (`stem:c,q[…]`, whose content
+/// would need a richer subtree than a single `Stem` leaf can hold – the same
+/// reason a `pass:` macro with an explicit list is deferred). This step is
+/// **additive**: nothing is wired into the parse path.
 ///
 /// [`Passthroughs::extract_from`]: crate::content::Passthroughs::extract_from
 /// [`InlineStemMacroReplacer`]: crate::content::passthroughs
@@ -75,7 +78,7 @@ pub(super) fn apply_stem<'src>(
         return nodes;
     }
 
-    let matches = find_stem_matches(&s, &pieces, root, parser);
+    let matches = find_stem_matches(&s, &nodes, &pieces, root, parser);
 
     if matches.is_empty() {
         return nodes;
@@ -89,6 +92,7 @@ pub(super) fn apply_stem<'src>(
 /// (an optional group [`INLINE_STEM_MACRO`] captures ahead of the bracket).
 fn find_stem_matches<'src>(
     s: &str,
+    nodes: &[InlineNode<'src>],
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
@@ -107,10 +111,6 @@ fn find_stem_matches<'src>(
             continue;
         }
 
-        if !range_is_verbatim(pieces, &full) {
-            continue;
-        }
-
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -122,7 +122,7 @@ fn find_stem_matches<'src>(
             continue;
         }
 
-        let node = build_stem_node(&caps, &full, pieces, root, parser);
+        let node = build_stem_node(&caps, &full, nodes, pieces, root, parser);
 
         matches.push(MacroMatch {
             kind: MacroMatchKind::Node {
@@ -136,12 +136,20 @@ fn find_stem_matches<'src>(
     matches
 }
 
-/// Builds one [`Stem`](InlineNode::Stem) node from a verbatim, unescaped STEM
-/// macro match – see [`apply_stem`] for how the expression is unescaped, has
-/// its legacy `$…$` wrapper dropped, and is substituted into `value`.
+/// Builds one [`Stem`](InlineNode::Stem) node from a STEM macro match – see
+/// [`apply_stem`] for how the expression is unescaped, has its legacy `$…$`
+/// wrapper dropped, and is substituted into `value`.
+///
+/// The expression body (capture group 4) is recovered via
+/// [`emit_range`] rather than sliced as one literal string, because it may
+/// embed an already-extracted [`Raw`](InlineNode::Raw) passthrough
+/// (`stem:[+++<b>x</b>+++]`) – the case `apply_stem`'s own doc comment
+/// explains the extraction ordering exists to support.
+/// [`stem_expression_value`] does the actual reconstruction.
 fn build_stem_node<'src>(
     caps: &Captures<'_>,
     full: &std::ops::Range<usize>,
+    nodes: &[InlineNode<'src>],
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
@@ -161,29 +169,90 @@ fn build_stem_node<'src>(
         },
     };
 
-    // Unescape any escaped closing brackets in the expression.
-    let mut expr = caps[4].to_string();
-    if expr.contains("\\]") {
-        expr = expr.replace("\\]", "]");
-    }
+    #[allow(clippy::unwrap_used)]
+    let expr_match = caps.get(4).unwrap();
+    let expr_range = expr_match.start()..expr_match.end();
 
-    // Drop legacy enclosing `$…$` around latexmath content (for backwards
-    // compatibility with AsciiDoc.py).
-    if notation == StemNotation::LatexMath
-        && expr.len() >= 2
-        && expr.starts_with('$')
-        && expr.ends_with('$')
-    {
-        expr = expr[1..expr.len() - 1].to_string();
-    }
+    let mut emitted = Vec::new();
+    emit_range(nodes, pieces, expr_range, &mut emitted);
 
-    let value = passthrough_text(&expr, &SubstitutionGroup::Stem, parser);
+    let value = stem_expression_value(&emitted, notation, parser);
 
     InlineNode::Stem(Stem {
         notation,
         value: CowStr::from(value),
         location,
     })
+}
+
+/// Computes a [`Stem`](InlineNode::Stem) node's `value` from the expression
+/// body's [`emit_range`]-recovered nodes.
+///
+/// The common case – the whole expression is one `Text` run, no nested
+/// passthrough – matches the string pipeline exactly: the raw source is
+/// unescaped (`\]` → `]`), has its legacy `latexmath` `$…$` wrapper dropped
+/// (AsciiDoc.py backward-compat), and is run through the resolved
+/// substitution group ([`SubstitutionGroup::Stem`] for a bare macro).
+///
+/// When the expression embeds one or more already-extracted
+/// [`Raw`](InlineNode::Raw) passthroughs, each `Text` run around them is
+/// unescaped and substituted the same way and each `Raw` run is spliced in
+/// **verbatim, with no further substitution** – mirroring how the string
+/// pipeline's passthrough-restore recursion re-splices a nested passthrough
+/// into an outer construct's already-substituted text
+/// (`PassthroughRestoreReplacer`'s own recursive `if … contains('\u{96}')`
+/// branch). The legacy `$…$` wrapper is dropped only in the single-`Text`-run
+/// case; a `$` immediately beside a nested passthrough is a narrower
+/// divergence, documented and pinned by a test.
+fn stem_expression_value(
+    emitted: &[InlineNode<'_>],
+    notation: StemNotation,
+    parser: &Parser,
+) -> String {
+    if let [InlineNode::Text { value: text, .. }] = emitted {
+        let mut expr = text.to_string();
+
+        if expr.contains("\\]") {
+            expr = expr.replace("\\]", "]");
+        }
+
+        if notation == StemNotation::LatexMath
+            && expr.len() >= 2
+            && expr.starts_with('$')
+            && expr.ends_with('$')
+        {
+            expr = expr[1..expr.len() - 1].to_string();
+        }
+
+        return passthrough_text(&expr, &SubstitutionGroup::Stem, parser);
+    }
+
+    let mut value = String::new();
+
+    for node in emitted {
+        match node {
+            InlineNode::Text { value: text, .. } => {
+                let mut text = text.to_string();
+
+                if text.contains("\\]") {
+                    text = text.replace("\\]", "]");
+                }
+
+                value.push_str(&passthrough_text(&text, &SubstitutionGroup::Stem, parser));
+            }
+
+            InlineNode::Raw { value: raw, .. } => {
+                value.push_str(raw);
+            }
+
+            // Unreachable: `apply_stem` runs immediately after
+            // `apply_passthroughs`, whose output is `Text`/`Raw` only – no
+            // other step has run yet to build any other kind.
+            _ => {}
+        }
+    }
+
+    value
 }
 
 #[cfg(test)]
@@ -198,9 +267,8 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{InlineNode, SpanForm, Stem, StemNotation, StyleVariant, Styled},
+        inlines::{InlineNode, Stem, StemNotation},
         parser::HtmlSubstitutionRenderer,
-        strings::CowStr,
     };
 
     /// Asserts that `node` is a [`Stem`](InlineNode::Stem) of `notation`
@@ -230,53 +298,67 @@ mod tests {
     }
 
     #[test]
-    fn a_match_whose_content_crosses_an_already_built_node_is_deferred() {
-        // In practice `apply_stem` only ever runs on the level
-        // `apply_passthroughs` has already refined into `Text`/`Raw` leaves
-        // (never a `Styled` node), so `range_is_verbatim`'s false branch is
-        // defensive – kept for the same reason every other macro family keeps
-        // it (see `passthrough_step`'s own
-        // `a_match_whose_content_crosses_an_already_built_node_is_deferred`).
-        // Exercise it directly, feeding a hand-built level whose STEM match
-        // spans an already-built `Styled` node, to document the intended
-        // fallback: the whole match is left unrecognized rather than
-        // mis-sliced.
-        // `build_match_string` only treats a `Text` node as verbatim (rather
-        // than an opaque placeholder) when its `value` equals its own
-        // `location.data()` – so, unlike the passthrough version of this test
-        // (whose `+++` delimiter is the same literal on both sides), each
-        // `Text` node here needs its *own* matching span.
-        let prefix_location = Span::new("stem:[x");
-        let styled_location = Span::new("*b*");
-        let suffix_location = Span::new("]");
+    fn a_nested_delimited_passthrough_is_embedded_verbatim() {
+        // The whole reason `Passthroughs::extract_from` extracts STEM *after*
+        // both passthrough passes: a `+++…+++` inside a STEM expression is
+        // already a `Raw` node by the time `apply_stem` runs, and must be
+        // spliced into the STEM's value verbatim (no specialcharacters
+        // escaping) rather than deferred.
+        let nodes = build_src(Span::new("stem:[+++<b>x</b>+++]"));
 
-        let nodes = vec![
-            InlineNode::Text {
-                value: CowStr::from("stem:[x"),
-                location: prefix_location,
-            },
-            InlineNode::Styled(Styled {
-                variant: StyleVariant::Strong,
-                form: SpanForm::Constrained,
-                id: None,
-                roles: vec![],
-                attrs: None,
-                children: vec![],
-                location: styled_location,
-            }),
-            InlineNode::Text {
-                value: CowStr::from("]"),
-                location: suffix_location,
-            },
-        ];
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "<b>x</b>");
+    }
 
-        let root = Span::new("stem:[x]");
-        let result = apply_stem(nodes.clone(), root, &Parser::default());
+    #[test]
+    fn a_nested_passthrough_beside_ordinary_text_mixes_both() {
+        // The surrounding text is still unescaped and substituted normally
+        // (special characters only, under the default `SubstitutionGroup::
+        // Stem`); only the passthrough's own content is exempt.
+        let nodes = build_src(Span::new("stem:[a < b +++<i>or</i>+++ c]"));
 
-        assert_eq!(
-            result, nodes,
-            "a non-verbatim match must be left unrecognized"
-        );
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "a &lt; b <i>or</i> c");
+    }
+
+    #[test]
+    fn a_text_segment_beside_a_nested_passthrough_unescapes_a_closing_bracket() {
+        // Each `Text` segment around a nested passthrough is unescaped
+        // (`\]` → `]`) independently, exactly like the single-run case.
+        let nodes = build_src(Span::new(r"stem:[+++<b>x</b>+++ a\]b]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "<b>x</b> a]b");
+    }
+
+    #[test]
+    fn a_nested_bare_pass_macro_is_embedded_verbatim() {
+        let nodes = build_src(Span::new("stem:[pass:[<b>x</b>]]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "<b>x</b>");
+    }
+
+    #[test]
+    fn a_latexmath_dollar_wrapper_beside_a_nested_passthrough_is_a_documented_divergence() {
+        // The legacy `$…$` wrapper is dropped only on the common
+        // single-`Text`-run case; a `$` immediately beside a nested
+        // passthrough is a narrower, honestly-labeled divergence from the
+        // string pipeline (which strips it even here, since its `$…$` check
+        // runs on the raw captured text before the nested passthrough's
+        // sentinel is ever resolved).
+        let source = "latexmath:[$+++x+++$]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        // Not stripped here (divergence): the golden fold *does* strip it.
+        assert_stem(&nodes[0], StemNotation::LatexMath, "$x$");
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
+        assert_eq!(golden, r"\(x\)");
     }
 
     #[test]
@@ -395,6 +477,13 @@ mod tests {
             "a stem:[x] and a stem:[y]",
             "*bold* stem:[x^2] *more bold*",
             r"\stem:[x]",
+            // A nested, already-extracted passthrough inside the expression –
+            // the case `Passthroughs::extract_from` orders STEM extraction
+            // after both passthrough passes to support.
+            "stem:[+++<b>x</b>+++]",
+            "stem:[a < b +++<i>or</i>+++ c]",
+            "stem:[pass:[<b>x</b>]]",
+            "latexmath:[+++x+++]",
         ];
 
         for source in fixtures {

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -198,8 +198,9 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{InlineNode, Stem, StemNotation},
+        inlines::{InlineNode, SpanForm, Stem, StemNotation, StyleVariant, Styled},
         parser::HtmlSubstitutionRenderer,
+        strings::CowStr,
     };
 
     /// Asserts that `node` is a [`Stem`](InlineNode::Stem) of `notation`
@@ -226,6 +227,56 @@ mod tests {
         let nodes = apply_stem(seeded.clone(), source, &Parser::default());
 
         assert_eq!(nodes, seeded);
+    }
+
+    #[test]
+    fn a_match_whose_content_crosses_an_already_built_node_is_deferred() {
+        // In practice `apply_stem` only ever runs on the level
+        // `apply_passthroughs` has already refined into `Text`/`Raw` leaves
+        // (never a `Styled` node), so `range_is_verbatim`'s false branch is
+        // defensive – kept for the same reason every other macro family keeps
+        // it (see `passthrough_step`'s own
+        // `a_match_whose_content_crosses_an_already_built_node_is_deferred`).
+        // Exercise it directly, feeding a hand-built level whose STEM match
+        // spans an already-built `Styled` node, to document the intended
+        // fallback: the whole match is left unrecognized rather than
+        // mis-sliced.
+        // `build_match_string` only treats a `Text` node as verbatim (rather
+        // than an opaque placeholder) when its `value` equals its own
+        // `location.data()` – so, unlike the passthrough version of this test
+        // (whose `+++` delimiter is the same literal on both sides), each
+        // `Text` node here needs its *own* matching span.
+        let prefix_location = Span::new("stem:[x");
+        let styled_location = Span::new("*b*");
+        let suffix_location = Span::new("]");
+
+        let nodes = vec![
+            InlineNode::Text {
+                value: CowStr::from("stem:[x"),
+                location: prefix_location,
+            },
+            InlineNode::Styled(Styled {
+                variant: StyleVariant::Strong,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: vec![],
+                attrs: None,
+                children: vec![],
+                location: styled_location,
+            }),
+            InlineNode::Text {
+                value: CowStr::from("]"),
+                location: suffix_location,
+            },
+        ];
+
+        let root = Span::new("stem:[x]");
+        let result = apply_stem(nodes.clone(), root, &Parser::default());
+
+        assert_eq!(
+            result, nodes,
+            "a non-verbatim match must be left unrecognized"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -1,0 +1,382 @@
+//! The inline-STEM extraction step.
+
+use regex::Captures;
+
+use super::{
+    macros::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level},
+    passthrough_step::passthrough_text,
+    quotes::{Piece, build_match_string, source_slice},
+};
+use crate::{
+    Parser, Span,
+    content::{INLINE_STEM_MACRO, SubstitutionGroup, stem_notation},
+    inlines::{InlineNode, Stem, StemNotation},
+    parser::QuoteType,
+    strings::CowStr,
+};
+
+/// Recognizes inline STEM macros (`stem:[…]`, `asciimath:[…]`,
+/// `latexmath:[…]`), replacing each with a [`Stem`](InlineNode::Stem) leaf.
+///
+/// STEM is an **implicit passthrough**: [`Passthroughs::extract_from`]
+/// extracts it last, after both passthrough-macro passes, so that any
+/// passthrough placeholder nested inside a STEM expression survives.
+/// [`apply_stem`] mirrors that ordering – [`build`](super::build) runs it
+/// immediately after
+/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs)
+/// and ahead of every other step – so a STEM expression's content is never
+/// touched by specialcharacters, quotes, replacements, or macros, exactly
+/// like a `+++…+++`/`++…++`/`$$…$$`/`pass:[…]` passthrough. It reuses the
+/// string pipeline's *exact* recognition – [`INLINE_STEM_MACRO`] is now
+/// shared `pub(crate)`, alongside the [`stem_notation`] helper that resolves
+/// a bare `stem:[…]` macro's notation from the `stem` document attribute –
+/// so only the recognition *sink* differs (§4.1).
+///
+/// A recognized macro's expression is unescaped (`\]` → `]`), has its legacy
+/// enclosing `$…$` dropped for `latexmath` (backwards compatibility with
+/// AsciiDoc.py, mirroring [`InlineStemMacroReplacer`]), and is then run
+/// through the real substitution pipeline under its resolved substitution
+/// group – [`SubstitutionGroup::Stem`] (special characters only) for a bare
+/// macro – via [`passthrough_text`], so a custom
+/// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)'s
+/// escaping is honored exactly as it would be for the string pipeline's own
+/// restore step. The result becomes the node's `value`; the cost is an owned
+/// value rather than a `'src` borrow, since the pipeline's output is not
+/// guaranteed to coincide with the source (the same trade-off
+/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs) makes
+/// for `++…++`/`$$…$$`).
+///
+/// An **escaped** macro (`\stem:[…]`) drops its backslash and stays literal,
+/// mirroring every other macro family's escape handling.
+///
+/// Two forms are deferred, each documented and pinned by a divergence test:
+/// a macro carrying an **explicit substitution list** (`stem:c,q[…]`, whose
+/// content would need a richer subtree than a single `Stem` leaf can hold –
+/// the same reason a `pass:` macro with an explicit list is deferred), and a
+/// match whose expression **crosses an already-recognized construct**
+/// (non-verbatim – in practice this cannot yet happen, since `apply_stem`
+/// only ever runs on the seed
+/// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs) has
+/// already refined into `Text`/[`Raw`](InlineNode::Raw) leaves, but the
+/// check is kept for the same reason every other family keeps it). This
+/// step is **additive**: nothing is wired into the parse path.
+///
+/// [`Passthroughs::extract_from`]: crate::content::Passthroughs::extract_from
+/// [`InlineStemMacroReplacer`]: crate::content::passthroughs
+pub(super) fn apply_stem<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard.
+    if !(s.contains(':') && (s.contains("stem:") || s.contains("math:"))) {
+        return nodes;
+    }
+
+    let matches = find_stem_matches(&s, &pieces, root, parser);
+
+    if matches.is_empty() {
+        return nodes;
+    }
+
+    rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Finds every STEM macro at this level, skipping the deferred form
+/// [`apply_stem`] documents: a macro carrying an explicit substitution list
+/// (an optional group [`INLINE_STEM_MACRO`] captures ahead of the bracket).
+fn find_stem_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<MacroMatch<'src>> {
+    let mut matches = Vec::new();
+
+    for caps in INLINE_STEM_MACRO.captures_iter(s) {
+        // `unwrap` on group 0 is safe: a capture always has an overall match.
+        #[allow(clippy::unwrap_used)]
+        let whole = caps.get(0).unwrap();
+
+        let full = whole.start()..whole.end();
+
+        // An explicit substitution list (`stem:c,q[…]`) is deferred.
+        if caps.get(3).is_some() {
+            continue;
+        }
+
+        if !range_is_verbatim(pieces, &full) {
+            continue;
+        }
+
+        if whole.as_str().starts_with('\\') {
+            matches.push(MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full,
+            });
+
+            continue;
+        }
+
+        let node = build_stem_node(&caps, &full, pieces, root, parser);
+
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
+    }
+
+    matches
+}
+
+/// Builds one [`Stem`](InlineNode::Stem) node from a verbatim, unescaped STEM
+/// macro match – see [`apply_stem`] for how the expression is unescaped, has
+/// its legacy `$…$` wrapper dropped, and is substituted into `value`.
+fn build_stem_node<'src>(
+    caps: &Captures<'_>,
+    full: &std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> InlineNode<'src> {
+    let location = source_slice(pieces, full.clone(), root);
+
+    let notation = match &caps[2] {
+        "latexmath" => StemNotation::LatexMath,
+
+        "asciimath" => StemNotation::AsciiMath,
+
+        // `stem`: the notation is resolved from the `stem` document
+        // attribute (defaulting to AsciiMath).
+        _ => match stem_notation(parser) {
+            QuoteType::LatexMath => StemNotation::LatexMath,
+            _ => StemNotation::AsciiMath,
+        },
+    };
+
+    // Unescape any escaped closing brackets in the expression.
+    let mut expr = caps[4].to_string();
+    if expr.contains("\\]") {
+        expr = expr.replace("\\]", "]");
+    }
+
+    // Drop legacy enclosing `$…$` around latexmath content (for backwards
+    // compatibility with AsciiDoc.py).
+    if notation == StemNotation::LatexMath
+        && expr.len() >= 2
+        && expr.starts_with('$')
+        && expr.ends_with('$')
+    {
+        expr = expr[1..expr.len() - 1].to_string();
+    }
+
+    let value = passthrough_text(&expr, &SubstitutionGroup::Stem, parser);
+
+    InlineNode::Stem(Stem {
+        notation,
+        value: CowStr::from(value),
+        location,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::{
+        super::test_support::{build_src, fold_html, golden_passthroughs, seed},
+        apply_stem,
+    };
+    use crate::{
+        Parser, Span,
+        inlines::{InlineNode, Stem, StemNotation},
+        parser::HtmlSubstitutionRenderer,
+    };
+
+    /// Asserts that `node` is a [`Stem`](InlineNode::Stem) of `notation`
+    /// with the given `value`.
+    fn assert_stem(node: &InlineNode<'_>, notation: StemNotation, value: &str) {
+        match node {
+            InlineNode::Stem(Stem {
+                notation: n,
+                value: v,
+                ..
+            }) => {
+                assert_eq!(*n, notation, "notation");
+                assert_eq!(v.as_ref(), value, "value");
+            }
+
+            other => panic!("expected Stem({notation:?}, {value:?}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_stem_is_a_noop_without_stem_syntax() {
+        let source = Span::new("plain text, no stem syntax here");
+        let seeded = seed(source);
+        let nodes = apply_stem(seeded.clone(), source, &Parser::default());
+
+        assert_eq!(nodes, seeded);
+    }
+
+    #[test]
+    fn bare_stem_macro_defaults_to_asciimath() {
+        let nodes = build_src(Span::new("stem:[x^2]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "x^2");
+    }
+
+    #[test]
+    fn asciimath_macro_is_recognized_explicitly() {
+        let nodes = build_src(Span::new("asciimath:[x != 0]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "x != 0");
+    }
+
+    #[test]
+    fn latexmath_macro_is_recognized() {
+        let nodes = build_src(Span::new(r"latexmath:[\sqrt{4} = 2]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::LatexMath, r"\sqrt{4} = 2");
+    }
+
+    #[test]
+    fn latexmath_drops_a_legacy_dollar_wrapper() {
+        let nodes = build_src(Span::new(r"latexmath:[$x = 1$]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::LatexMath, "x = 1");
+    }
+
+    #[test]
+    fn a_bare_stem_macro_honors_the_stem_document_attribute() {
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "stem",
+            "latexmath",
+            ModificationContext::Anywhere,
+        );
+
+        let source = Span::new("stem:[x]");
+        let nodes = apply_stem(seed(source), source, &parser);
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::LatexMath, "x");
+    }
+
+    #[test]
+    fn a_stem_macro_unescapes_an_escaped_closing_bracket() {
+        let nodes = build_src(Span::new(r"stem:[a\]b]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "a]b");
+    }
+
+    #[test]
+    fn a_stem_macro_escapes_special_characters() {
+        // The default (no explicit substitution list) substitution group is
+        // `SubstitutionGroup::Stem`, which applies only special characters.
+        let nodes = build_src(Span::new("stem:[a < b]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_stem(&nodes[0], StemNotation::AsciiMath, "a &lt; b");
+    }
+
+    #[test]
+    fn an_escaped_stem_macro_stays_literal() {
+        let source = r"\stem:[x]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Stem(_))),
+            "an escaped STEM macro must not build a Stem node: {nodes:?}"
+        );
+
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "stem:[x]");
+    }
+
+    #[test]
+    fn a_stem_macro_with_an_explicit_subs_list_is_a_documented_divergence() {
+        // `stem:c[…]` names an explicit substitution list, which would need a
+        // richer subtree than a single `Stem` leaf can hold (the same reason
+        // `pass:c[…]` is deferred) – deferred to a later increment.
+        let source = "stem:c[a < b]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Stem(_))),
+            "a stem: macro with an explicit subs list must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        let golden = golden_passthroughs(source);
+
+        assert_ne!(folded, golden);
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_through_stem() {
+        // For each fixture, folding the single-pass tree (all steps, STEM
+        // included) reproduces the string pipeline's output byte-for-byte.
+        // This is the differential corpus (design §5.3) that pins the STEM
+        // increment.
+        let fixtures = [
+            "stem:[x^2]",
+            "asciimath:[x != 0]",
+            r"latexmath:[\sqrt{4} = 2]",
+            r"latexmath:[$x = 1$]",
+            "stem:[a < b]",
+            r"stem:[a\]b]",
+            "before stem:[x] after",
+            "a stem:[x] and a stem:[y]",
+            "*bold* stem:[x^2] *more bold*",
+            r"\stem:[x]",
+        ];
+
+        for source in fixtures {
+            let nodes = build_src(Span::new(source));
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(source),
+                "mismatch for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stem_macro_inside_a_passthrough_is_not_re_extracted() {
+        // `Passthroughs::extract_from` extracts STEM last, after the
+        // passthrough-macro passes, precisely so a placeholder already
+        // extracted (here, the whole `+++…+++` content) is not re-scanned for
+        // STEM syntax. `apply_stem` reproduces this by running over the level
+        // `apply_passthroughs` already refined into a `Raw` leaf, which is
+        // opaque to `INLINE_STEM_MACRO`'s match string.
+        let source = "+++stem:[x]+++";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Stem(_))),
+            "STEM syntax inside a passthrough must not be re-extracted: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+}

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -10,7 +10,7 @@
 use super::{build, quotes::apply_quotes, special_chars::apply_special_characters};
 use crate::{
     Parser, Span,
-    content::{Content, SubstitutionStep},
+    content::{Content, Passthroughs, SubstitutionStep},
     inlines::{InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
     parser::HtmlSubstitutionRenderer,
     strings::CowStr,
@@ -151,4 +151,32 @@ pub(super) fn link_text_of(reference: &Ref<'_>) -> String {
     }
 
     s
+}
+
+/// The string pipeline's output for `source`, used as the golden oracle for
+/// both the passthrough and STEM increments (their steps share one
+/// extraction pass, [`Passthroughs::extract_from`]): extract passthroughs
+/// (including inline STEM macros), run the five steps [`build`] runs
+/// (special characters, quotes, character replacements, macros, post
+/// replacement), then restore them – exactly what
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup::apply)'s
+/// `run_pipeline` does for [`SubstitutionGroup::Normal`]. Attribute
+/// references are skipped, as elsewhere in this module's golden helpers.
+pub(super) fn golden_passthroughs_with(source: &str, parser: &Parser) -> String {
+    let mut content = Content::from(Span::new(source));
+    let passthroughs = Passthroughs::extract_from(&mut content, parser);
+
+    SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
+    SubstitutionStep::Quotes.apply(&mut content, parser, None);
+    SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
+    SubstitutionStep::Macros.apply(&mut content, parser, None);
+    SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
+
+    passthroughs.restore_to(&mut content, parser);
+    content.rendered_str().to_string()
+}
+
+/// [`golden_passthroughs_with`] with a default parser.
+pub(super) fn golden_passthroughs(source: &str) -> String {
+    golden_passthroughs_with(source, &Parser::default())
 }

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -28,7 +28,7 @@ mod xref_target;
 
 pub(crate) mod passthroughs;
 pub use passthroughs::Passthrough;
-pub(crate) use passthroughs::{INLINE_PASS_MACRO, Passthroughs};
+pub(crate) use passthroughs::{INLINE_PASS_MACRO, INLINE_STEM_MACRO, Passthroughs, stem_notation};
 
 mod substitution_group;
 pub use substitution_group::SubstitutionGroup;

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -541,7 +541,7 @@ impl Replacer for InlinePassReplacer<'_> {
 ///
 /// The content group requires at least one character whose final character is
 /// not a backslash, so an empty macro (e.g. `stem:[]`) is not recognized.
-static INLINE_STEM_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_STEM_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)
@@ -634,7 +634,7 @@ impl Replacer for InlineStemMacroReplacer<'_> {
 /// Resolves the STEM notation to apply for a bare `stem` macro or block from
 /// the `stem` document attribute. Any value other than `latexmath`, `latex`, or
 /// `tex` (including an unset, empty, or unrecognized value) maps to AsciiMath.
-fn stem_notation(parser: &Parser) -> QuoteType {
+pub(crate) fn stem_notation(parser: &Parser) -> QuoteType {
     match parser.attribute_value("stem").as_maybe_str() {
         Some("latexmath") | Some("latex") | Some("tex") => QuoteType::LatexMath,
         _ => QuoteType::AsciiMath,

--- a/parser/src/inlines/stem.rs
+++ b/parser/src/inlines/stem.rs
@@ -9,7 +9,16 @@ pub struct Stem<'src> {
     /// The notation the expression is written in.
     pub notation: StemNotation,
 
-    /// The raw expression, carried through verbatim.
+    /// The expression, with its resolved substitution group already applied
+    /// (special characters only, by default — [`SubstitutionGroup::Stem`]).
+    /// This mirrors a passthrough [`Raw`](crate::inlines::InlineNode::Raw)
+    /// node's `value`, which likewise holds already-substituted content
+    /// rather than the untouched source slice: STEM is an implicit
+    /// passthrough (extracted before every other step), so nothing further
+    /// acts on this text before the fold wraps it via
+    /// `render_quoted_substitution`.
+    ///
+    /// [`SubstitutionGroup::Stem`]: crate::content::SubstitutionGroup::Stem
     pub value: CowStr<'src>,
 
     /// The source location of the whole STEM macro.


### PR DESCRIPTION
## Summary

Continues the inline-ast single-pass builder (design doc: `docs/design/inline-ast-architecture.md`, Phase 4) with the next step after #1140/#1142: recognizing **inline STEM macros** (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) as a [`Stem`](parser/src/inlines/stem.rs) node.

- Adds a new `apply_stem` transducer step ([`parser/src/content/inline_builder/stem_step.rs`](parser/src/content/inline_builder/stem_step.rs)), run immediately after `apply_passthroughs` — mirroring `Passthroughs::extract_from`'s own ordering, since STEM is an **implicit passthrough** extracted last (after both passthrough-macro passes), so a passthrough placeholder nested inside a STEM expression survives, and a `stem:[…]` written inside an already-extracted `+++…+++` passthrough is *not* re-extracted.
- Reuses the string pipeline's *exact* recognition and notation resolution — `INLINE_STEM_MACRO` and `stem_notation` are now shared `pub(crate)` — so only the recognition *sink* differs.
- The node's `value` is *not* the untouched source slice: the expression is unescaped (`\]` → `]`), has its legacy `latexmath` `$…$` wrapper dropped, and is run through the real substitution pipeline under its resolved substitution group (`SubstitutionGroup::Stem` — special characters only — for a bare macro) via the passthrough step's own `passthrough_text` helper (now shared `pub(super)`), so a custom `InlineSubstitutionRenderer`'s escaping is honored exactly as the string pipeline's own restore step would. The fold passes that value straight through to `render_quoted_substitution`, byte-for-byte matching the string pipeline's output.
- The Phase-0 `Stem::value` doc comment (which described it as "the raw expression, carried through verbatim") is updated to reflect this.
- An escaped macro (`\stem:[…]`) drops its backslash and stays literal, mirroring every other macro family's escape handling.
- One form is deferred, documented and pinned by a divergence test: a macro carrying an **explicit substitution list** (`stem:c,q[…]`), which would need a richer subtree than a single `Stem` leaf can hold — the same reason `pass:c,q[…]` is deferred.
- This step is **additive**: nothing is wired into the parse path.

The design doc's step 5d (previously "the deferred forms `5a` documents … and inline STEM") is split into four parts to track this incrementally, matching the granularity used for step 4b's macro families; STEM lands as part 1, leaving the three remaining passthrough forms (attribute-list-prefixed, `pass:` with an explicit subs list, and the bare unconstrained `+text+` form) as later increments.

## Verification

- `cargo build --workspace` succeeds.
- `cargo test -p asciidoc-parser` passes in full (4,865 tests, 0 failed), including 12 new `stem_step` tests.
- `cargo clippy --all-features --all-targets -- -Dwarnings` passes.
- `cargo +nightly fmt --all -- --check` passes.
- `cargo +nightly doc --no-deps --document-private-items` succeeds.
- `RUSTDOCFLAGS="--cfg docsrs" DOCS_RS=1 cargo +nightly doc --all-features --no-deps` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176qz2jYjFZ4UMJQ2Ja17CL)_