### PR TITLE
fix: Preserve an absolute container's root when joining a nested include path

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -1900,18 +1900,69 @@ fn nested_file_name(container: Option<&str>, target: &str) -> String {
 /// returns `target`'s own cleaned-up path) using plain `/`-separated
 /// (filesystem-style) path arithmetic. See [`nested_file_name`], which
 /// dispatches here for a `container` that is not a URI.
+///
+/// `container`'s directory may itself be absolute (a Posix `/`, a Windows `\`
+/// or drive prefix, or a UNC/verbatim `\\` — see [`path_root`]); that root is
+/// carried through to the result rather than folded as a segment, so an
+/// absolute container's own absoluteness is not lost. Feeding it through
+/// [`push_path_segment`] undistinguished from an ordinary segment — as an
+/// earlier version of this function did — collapses a leading `/` (or `\\`)
+/// into an empty component and silently drops it, the same way a doubled
+/// separator would, turning `/tmp/docs/doc.adoc` into a relative-looking
+/// `tmp/docs/…`.
 fn join_local_path(container: Option<&str>, target: &str) -> String {
+    // The root must be split off *before* taking the directory: a container
+    // that names a file directly at its root (e.g. `/doc.adoc`) has nothing
+    // before its last separator, so finding the directory first and only then
+    // looking for a root would see an empty string and miss the root that was
+    // right there in the separator itself.
+    let (root, dir) = match container.map(path_root) {
+        Some((root, rest)) => (root, directory_of(rest)),
+        None => (String::new(), ""),
+    };
+
     let mut segments: Vec<&str> = Vec::new();
-    if let Some(dir) = container.map(directory_of).filter(|dir| !dir.is_empty()) {
-        for segment in dir.split(['/', '\\']) {
-            push_path_segment(&mut segments, segment);
-        }
+    for segment in dir.split(['/', '\\']) {
+        push_path_segment(&mut segments, segment);
     }
     for segment in target.split(['/', '\\']) {
         push_path_segment(&mut segments, segment);
     }
 
-    segments.join("/")
+    format!("{root}{}", segments.join("/"))
+}
+
+/// Splits `path` into its root — a Posix `/`, a two-separator UNC/verbatim
+/// prefix (`//` or `\\`), or a Windows drive prefix such as `C:/` or `C:\` —
+/// and the remainder that follows it, normalizing the root to forward
+/// slashes so it composes cleanly with the `/`-joined result
+/// [`join_local_path`] builds around it. A `path` with none of these (a
+/// relative path) has an empty root and is returned unchanged as the
+/// remainder.
+///
+/// Mirrors what [`is_absolute_path`] treats as absolute, but — unlike that
+/// predicate, which only asks yes/no — also hands back the root text
+/// separately from the rest of the path, so a caller can fold the remainder's
+/// segments (resolving `.`/`..`) without that folding mistaking the root's
+/// own separator(s) for empty segments to drop.
+fn path_root(path: &str) -> (String, &str) {
+    if path.starts_with("//") || path.starts_with(r"\\") {
+        return ("//".to_owned(), &path[2..]);
+    }
+
+    if let Some(rest) = path.strip_prefix(['/', '\\']) {
+        return ("/".to_owned(), rest);
+    }
+
+    let mut chars = path.chars();
+    if let (Some(letter), Some(':')) = (chars.next(), chars.next())
+        && letter.is_ascii_alphabetic()
+    {
+        let rest = path[2..].strip_prefix(['/', '\\']).unwrap_or(&path[2..]);
+        return (format!("{}:/", letter.to_ascii_uppercase()), rest);
+    }
+
+    (String::new(), path)
 }
 
 /// Joins `target` onto the directory of `container`, a URI (`container` must
@@ -5063,6 +5114,53 @@ mod tests {
                     "subdir/middle-include.adoc"
                 ),
                 "http://example.com:9876/fixtures/subdir/middle-include.adoc"
+            );
+        }
+
+        // A Posix-absolute container (e.g. a canonicalized primary document
+        // path, as a host application might supply) keeps its leading `/` in
+        // the result. Regression test: an earlier version fed the container's
+        // directory through the same segment-folding loop as an ordinary
+        // relative one, which treats a leading `/` as an empty (doubled
+        // separator) component and drops it — silently turning
+        // `/tmp/docs/doc.adoc` into a relative-looking `tmp/docs/…`.
+        #[test]
+        fn posix_absolute_container_keeps_its_leading_slash() {
+            assert_eq!(
+                nested_file_name(Some("/tmp/docs/doc.adoc"), "partials/section.adoc"),
+                "/tmp/docs/partials/section.adoc"
+            );
+
+            // A container that is itself the root has no directory segments
+            // to contribute, but the root is still kept.
+            assert_eq!(
+                nested_file_name(Some("/doc.adoc"), "chapter.adoc"),
+                "/chapter.adoc"
+            );
+        }
+
+        // A Windows drive-letter container keeps its drive prefix, normalized
+        // to a forward slash regardless of which separator the original path
+        // used.
+        #[test]
+        fn windows_drive_container_keeps_its_drive_prefix() {
+            assert_eq!(
+                nested_file_name(Some(r"C:\docs\doc.adoc"), r"partials\section.adoc"),
+                "C:/docs/partials/section.adoc"
+            );
+            assert_eq!(
+                nested_file_name(Some("d:/docs/doc.adoc"), "section.adoc"),
+                "D:/docs/section.adoc"
+            );
+        }
+
+        // A UNC (or Windows verbatim) container keeps its two-separator root
+        // rather than having it folded away as a doubled separator.
+        #[test]
+        fn unc_container_keeps_its_double_separator_root() {
+            assert_eq!(
+                nested_file_name(Some(r"\\server\share\docs\doc.adoc"), "section.adoc"),
+                "//server/share/docs/section.adoc"
             );
         }
     }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -1932,22 +1932,44 @@ fn join_local_path(container: Option<&str>, target: &str) -> String {
     format!("{root}{}", segments.join("/"))
 }
 
-/// Splits `path` into its root — a Posix `/`, a two-separator UNC/verbatim
-/// prefix (`//` or `\\`), or a Windows drive prefix such as `C:/` or `C:\` —
+/// Splits `path` into its root — a Posix `/`, a UNC/verbatim authority
+/// (`//server/share`), or a Windows drive prefix such as `C:/` or `C:\` —
 /// and the remainder that follows it, normalizing the root to forward
-/// slashes so it composes cleanly with the `/`-joined result
-/// [`join_local_path`] builds around it. A `path` with none of these (a
-/// relative path) has an empty root and is returned unchanged as the
-/// remainder.
+/// slashes (with a single trailing one) so it concatenates directly onto the
+/// `/`-joined result [`join_local_path`] builds around it. A `path` with none
+/// of these (a relative path) has an empty root and is returned unchanged as
+/// the remainder.
 ///
 /// Mirrors what [`is_absolute_path`] treats as absolute, but — unlike that
 /// predicate, which only asks yes/no — also hands back the root text
 /// separately from the rest of the path, so a caller can fold the remainder's
 /// segments (resolving `.`/`..`) without that folding mistaking the root's
-/// own separator(s) for empty segments to drop.
+/// own separator(s) for empty segments to drop, or — for a UNC path — its
+/// server and share components for ordinary foldable segments a `..` could
+/// pop past. A UNC path's authority is exactly two components (`server` and
+/// `share`); Windows requires both, so both are folded into the root here —
+/// leaving either foldable, as an earlier version of this function did,
+/// would let enough `..` segments in the target climb past the share, or even
+/// the server, producing a malformed result such as `//server/other.adoc` or
+/// `//../other.adoc`. The same reasoning is why [`join_uri_path`] carves a
+/// URI's `scheme://host` out as an untouched origin rather than folding it.
 fn path_root(path: &str) -> (String, &str) {
     if path.starts_with("//") || path.starts_with(r"\\") {
-        return ("//".to_owned(), &path[2..]);
+        let rest = &path[2..];
+
+        // Consume the server and share components (each up to its own
+        // trailing separator, or the rest of the string if there is no
+        // further separator) into the root before folding begins.
+        let mut end = 0;
+        for _ in 0..2 {
+            end += match rest[end..].find(['/', '\\']) {
+                Some(index) => index + 1,
+                None => rest.len() - end,
+            };
+        }
+        let authority = rest[..end].trim_end_matches(['/', '\\']).replace('\\', "/");
+
+        return (format!("//{authority}/"), &rest[end..]);
     }
 
     if let Some(rest) = path.strip_prefix(['/', '\\']) {
@@ -5161,6 +5183,35 @@ mod tests {
             assert_eq!(
                 nested_file_name(Some(r"\\server\share\docs\doc.adoc"), "section.adoc"),
                 "//server/share/docs/section.adoc"
+            );
+        }
+
+        // A target with enough `..` segments to climb past a UNC container's
+        // directory must not be able to pop the server or share components
+        // themselves — those are the UNC path's authority, not ordinary
+        // foldable segments. Regression test: an earlier version protected
+        // only the leading `//` and left `server`/`share` in the same
+        // foldable stack as everything else, so three levels of `..` here
+        // (one for `docs`, two more with nothing left to pop but the
+        // authority) would have popped `share` and then `server` too,
+        // producing the malformed `//other.adoc` — losing the authority
+        // outright rather than the harmless (if unresolved) `..` a caller can
+        // still recognize and clean up further, as this fix now produces.
+        #[test]
+        fn unc_authority_cannot_be_climbed_past_with_parent_segments() {
+            assert_eq!(
+                nested_file_name(Some(r"\\server\share\docs\doc.adoc"), "../../../other.adoc"),
+                "//server/share/../../other.adoc"
+            );
+        }
+
+        // A UNC container with nothing below its share still keeps the full
+        // authority as its root.
+        #[test]
+        fn unc_container_with_no_further_path_keeps_the_full_authority() {
+            assert_eq!(
+                nested_file_name(Some(r"\\server\share\doc.adoc"), "chapter.adoc"),
+                "//server/share/chapter.adoc"
             );
         }
     }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -5214,5 +5214,20 @@ mod tests {
                 "//server/share/chapter.adoc"
             );
         }
+
+        // A UNC container whose authority is *incomplete* — cut off before a
+        // separator ends its second (share) component, here because the
+        // container is exactly the share itself with nothing beyond it —
+        // still doesn't panic. `path_root`'s authority scan looks for a
+        // trailing separator to end each of the two components it consumes;
+        // with none left to find for the second, it takes the rest of the
+        // string instead of indexing past the end.
+        #[test]
+        fn unc_container_with_no_trailing_separator_after_the_share_still_works() {
+            assert_eq!(
+                nested_file_name(Some(r"\\server\share"), "doc.adoc"),
+                "//server/share/doc.adoc"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1146 (issue #131), found while bumping `asciidoc-html5`'s
dependency to the 0.29.16 release that contains that fix and hitting
two newly-failing sourcemap tests there.

- `nested_file_name`'s `join_local_path` fed a container's directory
  through the same segment-folding loop as its (always-relative)
  target, without distinguishing a leading root separator from an
  empty (doubled-separator) component to drop. That silently strips
  the root: an absolute container such as `/tmp/docs/doc.adoc` — e.g.
  a canonicalized primary document path, which is exactly what
  `asciidoc-html5`'s `load_file`/`load_file_with` always supplies —
  turns a nested include's tracked file name into a relative-looking
  `tmp/docs/…` instead of staying rooted at `/tmp/docs/…`.
- This is the same class of bug Greptile flagged on #1146 for a URI
  container (`scheme://host` losing its `//` to the same
  undistinguished folding, fixed there by carving out the origin) —
  just for a plain absolute filesystem path instead of a URI.
- Adds `path_root`, which splits a container's directory into its root
  (Posix `/`, a two-separator UNC/verbatim `\\`, or a Windows drive
  prefix such as `C:/`) and the remainder, so `join_local_path` folds
  only the remainder and carries the root through untouched. The root
  must be split off the *full* container before taking its directory
  — not after — so a container naming a file directly at its root
  (`/doc.adoc`) doesn't lose the root when its directory portion comes
  back empty.

## Test plan

- [x] New unit tests: a Posix-absolute container (including one at the
      root itself), a Windows drive-letter container (backslash and
      forward-slash forms), and a UNC container
- [x] `cargo test` (workspace) — all tests pass
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -Dwarnings`
- [x] `cargo +nightly doc --no-deps --document-private-items` — no
      broken intra-doc links

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaoYBFJYMPGnAvr4gEHrnv)_