### PR TITLE
fix: Expose the canonical notitle/showtitle resolution as a public API

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -407,6 +407,36 @@ impl<'src> Document<'src> {
             .is_attribute_set(name)
     }
 
+    /// Resolves whether this document's title should be displayed, from the
+    /// `showtitle`/`notitle` [document attribute] pair (which are
+    /// complements), as of the end of parsing.
+    ///
+    /// This mirrors [`Parser::resolve_show_title`] and is the accessor to use
+    /// on the *embed* path -- rendering a [`Document`] you already hold,
+    /// without a [`Parser`] in hand. Use it instead of reading `notitle` or
+    /// `showtitle` directly: `notitle` and `showtitle` are two spellings of
+    /// one toggle (assigning either updates the other, per
+    /// [Asciidoctor#3804]), and precedence between the two default-then-decide
+    /// how a raw read of just one name resolves. Re-deriving that precedence
+    /// from a direct attribute read is easy to get subtly wrong -- see [issue
+    /// #1148], where a downstream re-implementation of this exact logic
+    /// repeatedly drifted out of sync with the parser's.
+    ///
+    /// `default_shown` decides the outcome when neither attribute is present:
+    /// a standalone document shows its title by default, while embedded
+    /// output does not.
+    ///
+    /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
+    /// [Asciidoctor#3804]: https://github.com/asciidoctor/asciidoctor/issues/3804
+    /// [issue #1148]: https://github.com/asciidoc-rs/asciidoc-parser/issues/1148
+    /// [`Parser::resolve_show_title`]: crate::Parser::resolve_show_title
+    pub fn show_title(&self, default_shown: bool) -> bool {
+        self.internal
+            .borrow_dependent()
+            .attributes
+            .resolve_show_title(default_shown)
+    }
+
     /// Return where (and whether) this document's table of contents is
     /// generated, resolved from the [`toc` attribute].
     ///
@@ -1913,6 +1943,65 @@ mod tests {
                 doc.attribute_value("my-counter"),
                 InterpretedValue::Value("2".to_string())
             );
+        }
+    }
+
+    mod show_title {
+        use crate::{parser::ModificationContext, tests::prelude::*};
+
+        #[test]
+        fn default_shown_decides_when_neither_attribute_is_present() {
+            let doc = Parser::default().parse("= Title\n\nBody.");
+
+            assert!(doc.show_title(true));
+            assert!(!doc.show_title(false));
+        }
+
+        #[test]
+        fn header_notitle_hides_the_title() {
+            let doc = Parser::default().parse("= Title\n:notitle:\n\nBody.");
+
+            assert!(!doc.show_title(true));
+        }
+
+        #[test]
+        fn header_notitle_entry_shows_title_when_showtitle_is_api_hard_unset() {
+            // Issue #1148 (reopened): a hard-unset `showtitle` lock
+            // (`Options::unset("showtitle")`) combined with an unrelated
+            // document `:!notitle:` entry must still resolve to showing the
+            // title end-to-end through the `Document` accessor (parity
+            // oracle: `test/document_test.rb`, "should be able to enable
+            // doctitle for embedded document", case
+            // `[{ 'showtitle' => false }, [':!notitle:']]`).
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool("showtitle", false, ModificationContext::ApiOnly)
+                .parse("= Document Title\n:!notitle:\n\nBody.");
+
+            assert!(doc.show_title(false));
+        }
+
+        #[test]
+        fn header_showtitle_entry_shows_title_when_notitle_is_api_hard_unset() {
+            // Mirror of the above, in the other direction (same Ruby test,
+            // case `[{ 'notitle' => nil }, [':!showtitle:']]`).
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool("notitle", false, ModificationContext::ApiOnly)
+                .parse("= Document Title\n:!showtitle:\n\nBody.");
+
+            assert!(doc.show_title(false));
+        }
+
+        #[test]
+        fn matches_parser_state() {
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                false,
+                ModificationContext::ApiOnly,
+            );
+            let doc = parser.parse("= Title\n:!notitle:\n\nBody.");
+
+            assert_eq!(doc.show_title(false), parser.resolve_show_title(false));
+            assert_eq!(doc.show_title(true), parser.resolve_show_title(true));
         }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1402,7 +1402,7 @@ impl Parser {
     /// re-implementation of this exact logic repeatedly drifted out of sync
     /// with this one). After parsing, prefer
     /// [`Document::show_title`](crate::Document::show_title), which mirrors
-    /// this method and needs no [`Parser`](crate::Parser) in hand.
+    /// this method and needs no [`Parser`] in hand.
     pub fn resolve_show_title(&self, default_shown: bool) -> bool {
         if self.is_attribute_set("showtitle") {
             true

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1393,7 +1393,17 @@ impl Parser {
     /// attribute is present, `default_shown` decides – a standalone document
     /// shows its title, while embedded output does not. A nested AsciiDoc
     /// table cell is embedded output, so it passes `default_shown = false`.
-    pub(crate) fn resolve_show_title(&self, default_shown: bool) -> bool {
+    ///
+    /// Use this rather than reading `notitle` or `showtitle` directly:
+    /// re-deriving this precedence from a raw attribute read is easy to get
+    /// subtly wrong, as the pair's mirroring can leave one spelling's stored
+    /// value looking inconsistent with the toggle's true, resolved state
+    /// (see issue asciidoc-rs/asciidoc-parser#1148, where a downstream
+    /// re-implementation of this exact logic repeatedly drifted out of sync
+    /// with this one). After parsing, prefer
+    /// [`Document::show_title`](crate::Document::show_title), which mirrors
+    /// this method and needs no [`Parser`](crate::Parser) in hand.
+    pub fn resolve_show_title(&self, default_shown: bool) -> bool {
         if self.is_attribute_set("showtitle") {
             true
         } else if self.has_attribute("notitle") {
@@ -4594,6 +4604,42 @@ mod tests {
             let mut parser = Parser::default();
             let _ = parser.parse(&format!("= Title\n{entries}\n\nbody"));
             parser
+        }
+
+        #[test]
+        fn header_notitle_entry_shows_title_when_showtitle_is_api_hard_unset() {
+            // Issue #1148 (reopened): a hard-unset `showtitle` lock
+            // (`Options::unset("showtitle")`) combined with an unrelated
+            // document `:!notitle:` entry must still resolve to showing the
+            // title end-to-end (parity oracle: `test/document_test.rb`,
+            // "should be able to enable doctitle for embedded document",
+            // case `[{ 'showtitle' => false }, [':!notitle:']]`).
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "showtitle",
+                false,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Document Title\n:!notitle:\n\nbody\n");
+
+            assert!(parser.resolve_show_title(false));
+        }
+
+        #[test]
+        fn header_showtitle_entry_shows_title_when_notitle_is_api_hard_unset() {
+            // Issue #1148 (reopened): a hard-unset `notitle` lock
+            // (`Options::unset("notitle")`) combined with an unrelated
+            // document `:!showtitle:` entry must still resolve to showing the
+            // title -- this was a regression from 0.29.15 introduced while
+            // fixing the case above (parity oracle: same Ruby test, case
+            // `[{ 'notitle' => nil }, [':!showtitle:']]`).
+            let mut parser = Parser::default().with_intrinsic_attribute_bool(
+                "notitle",
+                false,
+                ModificationContext::ApiOnly,
+            );
+            let _ = parser.parse("= Document Title\n:!showtitle:\n\nbody\n");
+
+            assert!(parser.resolve_show_title(false));
         }
 
         #[test]

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -682,4 +682,75 @@ mod tests {
             InterpretedValue::Value("/some/dir".to_string())
         );
     }
+
+    mod resolve_show_title {
+        use std::{collections::HashMap, sync::Arc};
+
+        use crate::{
+            SafeMode,
+            document::InterpretedValue,
+            parser::{AllowableValue, AttributeValue, ModificationContext, ResolvedAttributes},
+        };
+
+        fn attrs(entries: &[(&str, InterpretedValue)]) -> ResolvedAttributes {
+            let mut attribute_values: HashMap<String, AttributeValue> = HashMap::new();
+            for (name, value) in entries {
+                attribute_values.insert(
+                    name.to_string(),
+                    AttributeValue {
+                        allowable_value: AllowableValue::Any,
+                        modification_context: ModificationContext::Anywhere,
+                        silent_when_locked: false,
+                        value: value.clone(),
+                    },
+                );
+            }
+
+            ResolvedAttributes::new(
+                Arc::new(attribute_values),
+                Arc::new(HashMap::new()),
+                HashMap::new(),
+                SafeMode::Secure,
+                None,
+                None,
+            )
+        }
+
+        #[test]
+        fn neither_present_uses_default() {
+            let empty = attrs(&[]);
+
+            assert!(empty.resolve_show_title(true));
+            assert!(!empty.resolve_show_title(false));
+        }
+
+        #[test]
+        fn set_showtitle_always_wins() {
+            let showtitle_set = attrs(&[("showtitle", InterpretedValue::Set)]);
+
+            assert!(showtitle_set.resolve_show_title(false));
+        }
+
+        #[test]
+        fn present_notitle_decides_when_showtitle_absent() {
+            let notitle_set = attrs(&[("notitle", InterpretedValue::Set)]);
+            let notitle_unset = attrs(&[("notitle", InterpretedValue::Unset)]);
+
+            assert!(!notitle_set.resolve_show_title(true));
+            assert!(notitle_unset.resolve_show_title(false));
+        }
+
+        #[test]
+        fn present_but_unset_showtitle_hides_when_notitle_absent() {
+            // This shape -- `showtitle` present and unset, with no `notitle`
+            // entry at all -- cannot arise from a normal document/API write
+            // (assigning `showtitle` always plants a `notitle` mirror; see
+            // `apply_title_visibility_linkage`), but a snapshot can still be
+            // constructed directly (as this test does), so the fallback must
+            // resolve it correctly too.
+            let showtitle_unset = attrs(&[("showtitle", InterpretedValue::Unset)]);
+
+            assert!(!showtitle_unset.resolve_show_title(true));
+        }
+    }
 }

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -433,6 +433,33 @@ impl ResolvedAttributes {
             .map(|a| a.value != InterpretedValue::Unset)
             .unwrap_or_else(|| self.resolve_datetime_attribute(name).is_some())
     }
+
+    /// Resolves whether a document title should be displayed, from the
+    /// `showtitle`/`notitle` attribute pair (which are complements).
+    ///
+    /// Mirrors [`Parser::resolve_show_title`](crate::Parser::resolve_show_title)
+    /// exactly, so a lookup here returns the same value the parser would report
+    /// after `parse`. See that method's doc comment for the full precedence
+    /// rules. This is the accessor a renderer holding only a [`Document`]
+    /// (e.g. an *embed* consumer with no [`Parser`] in hand) should use to
+    /// decide whether to emit the title, rather than re-deriving the toggle
+    /// from a direct read of `notitle` / `showtitle` -- see issue
+    /// asciidoc-rs/asciidoc-parser#1148, where a downstream re-implementation
+    /// of this logic repeatedly drifted out of sync with the parser's.
+    ///
+    /// [`Document`]: crate::Document
+    /// [`Parser`]: crate::Parser
+    pub(crate) fn resolve_show_title(&self, default_shown: bool) -> bool {
+        if self.is_attribute_set("showtitle") {
+            true
+        } else if self.has_attribute("notitle") {
+            !self.is_attribute_set("notitle")
+        } else if self.has_attribute("showtitle") {
+            false
+        } else {
+            default_shown
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes #1148.

The issue's reopening comment reports two title-visibility mismatches (a hard-unset `showtitle` API lock combined with a document `:!notitle:` entry, and the mirror case with `notitle`/`:!showtitle:`) that a downstream renderer (`asciidoc-html5`) still gets wrong against 0.29.17.

Investigation showed `Parser::resolve_show_title` (the parser's internal algorithm for resolving the `notitle`/`showtitle` toggle) already resolves *both* of these scenarios correctly — I added regression tests for each exact case (`header_notitle_entry_shows_title_when_showtitle_is_api_hard_unset` / `header_showtitle_entry_shows_title_when_notitle_is_api_hard_unset`) and they pass on current `main` without any change to that method's logic.

The problem is that `resolve_show_title` was `pub(crate)`-only. A downstream consumer has no way to ask the parser "should the title show?" — it can only read `notitle` / `showtitle` directly and re-derive the precedence itself. That precedence is genuinely subtle (the mirroring can leave one spelling's *raw stored value* looking inconsistent with the toggle's true resolved state — see the extensive doc comment on `apply_title_visibility_linkage`), and re-deriving it from scratch is exactly what has produced this issue's repeated regressions across #1143 → #1145 → #1148.

## Changes

* Promote `Parser::resolve_show_title` from `pub(crate)` to `pub`.
* Add a mirrored `pub fn show_title(&self, default_shown: bool) -> bool` on `Document` (backed by a new `ResolvedAttributes::resolve_show_title`, following the crate's existing pattern of mirroring `Parser` accessors on `Document`/`ResolvedAttributes` for the *embed* path — i.e. a caller with only a `Document`, no `Parser`, in hand).
* Add regression tests on both `Parser` and `Document` for the two scenarios from the issue's reopening comment.

Downstream renderers (like `asciidoc-html5`) can now call `document.show_title(default_shown)` directly instead of reimplementing the toggle logic.

## Test plan

- [x] `cargo test -p asciidoc-parser` — all 4708 tests pass, including new regression tests for both reopened scenarios
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo fmt -p asciidoc-parser -- --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01FcDstcwYNDMzmojQV5pZzY)_