### PR TITLE
feat: Recognize a pass: macro's explicit substitution list in the single-pass inline builder (inline-ast Phase 4, step 5d part 3)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1304,6 +1304,53 @@ Each phase is a reviewable unit with a clear exit gate.
   (`pass:c,q[…]`), which still needs a richer subtree than a single `Raw` leaf can hold. This step is
   **additive**: nothing is wired into the parse path.
 
+  *Step 5d part 3 landed as (a `pass:` macro with an explicit substitution list → `Raw`, the last of 5d's
+  four deferred forms):* the one form step 5a and part 4 both name as outstanding,
+  [`build_pass_macro_subs_value`](../../parser/src/content/inline_builder/passthrough_step.rs), is
+  recognized – but not, in the end, via a richer node subtree. Prototyping that shape first (threading the
+  resolved [`SubstitutionGroup::Custom`] steps through this module's own transducers, the way the legacy
+  `x-` compatibility marker's body already does via [`apply_normal_subs`](../../parser/src/content/inline_builder/passthrough_step.rs))
+  surfaced a real bug, **pre-existing** in the already-landed `x-` marker path and independent of this
+  step: [`apply_passthroughs`] runs *first* in [`build`](../../parser/src/content/inline_builder/mod.rs),
+  so anything it splices is still visited by every one of `build`'s own later steps. That visit is a safe
+  no-op for `Quotes` (delimiters are consumed, so a second pass finds nothing left) and
+  `SpecialCharacters`/`CharacterReplacements`/`PostReplacement` (their own output is atomic or already
+  stripped of what they match on) – but **not** for `Macros`: a link or cross-reference node's display
+  text is *literal* text that reads exactly like the source it came from (by design, so the fold can
+  recover it with no build-time state), so a second `Macros` pass recognizes it all over again and nests
+  a second `Ref` inside the first. A prototype fixture (`[x-]++https://example.org++`, exercising the
+  already-merged step 5d part 2) reproduces this today: `<code><a href="…"><a href="…">…</a></a></code>`,
+  doubled. A list omitting a step `build`'s own fixed order still runs unconditionally (e.g. `pass:q[…]`,
+  which never asks for `SpecialCharacters`) fails the opposite way: content the author's list deliberately
+  left raw gets escaped anyway by `build`'s own later `SpecialCharacters` step. Solving this properly – so
+  a spliced subtree is visited by *exactly* the steps its own resolved list named, once – is a splice-time
+  protection mechanism this additive, pre-cutover module does not yet have; it is squarely the cutover's
+  job (step 6, which does not splice mid-`build` at all).
+
+  Given that, this increment takes the same shape every other deferred-until-now form in this file
+  eventually adopts once it becomes tractable: the resolved list's body is rendered through the **real,
+  string-based** substitution pipeline ([`SubstitutionGroup::apply`], via the passthrough step's own
+  [`passthrough_text`](../../parser/src/content/inline_builder/passthrough_step.rs) helper already used for
+  `++…++`/`$$…$$`/the bare unconstrained form) – exactly the call `PassthroughRestoreReplacer` makes for a
+  stored `Passthrough` – producing an already-final HTML string that becomes a single
+  [`Raw`](../../parser/src/inlines/inline_node.rs) leaf's `value` verbatim, folding through the identical
+  byte-for-byte output the string pipeline produces. A `Raw` leaf is *opaque* to every one of `build`'s own
+  later steps (never descended into, never re-matched), so it sidesteps both failure modes above
+  regardless of which steps the author's list names or omits, and in which order – the list is applied
+  once, by the real pipeline, and never touched again. An unrecognized substitution name in the list (e.g.
+  `pass:bogus[…]`) is silently skipped – any recognized names are still honored – mirroring
+  `SubstitutionGroup::from_custom_string`/`InlinePassMacroReplacer`'s own resolution; this additive pass
+  does not yet raise the string pipeline's own `InvalidSubstitutionTypeForPassthroughMacro` warning for
+  it, deferring that side effect to the cutover like every other macro family's own catalog/warning side
+  effect, since it does not change the fold's output bytes. An escaped closing bracket (`pass:c[a\]b]`)
+  unescapes before rendering, the same treatment every other `pass:[…]` bracket content gets – no longer a
+  deferred corner the way a structured-children shape (a footnote's own content) would have forced. A
+  differential corpus pins single- and multi-step lists (applied in the order given, not the *normal*
+  effective order), an unrecognized name skipped alongside a recognized one, an empty resolved list (the
+  content spliced back completely untouched), a list naming `Macros` (folding through real rendered
+  markup), and the escape/unescape forms. This step is **additive**: nothing is wired into the parse path.
+  Landing it closes out step 5d and, with it, step 5 in full.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1337,12 +1384,14 @@ Each phase is a reviewable unit with a clear exit gate.
        `pass:[…]`) → `Raw`.
      - ✅ **5b.** `AttributeReferences` (expanded-value splicing, §3.4.1).
      - ✅ **5c.** `Callouts` (verbatim-group content – literal, listing, and source blocks).
-     - **5d.** the deferred forms `5a` documents, itself sliced into parts:
+     - ✅ **5d.** the deferred forms `5a` documents, itself sliced into parts:
        - ✅ **part 1.** inline STEM (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) → `Stem`
          (an explicit substitution list, `stem:c,q[…]`, is itself deferred).
        - ✅ **part 2.** an attribute-list-prefixed passthrough (`[quotes]++text++`, `` [x-]`text` ``,
          `[attrs]+text+`).
-       - **part 3.** a `pass:` macro carrying an explicit substitution list (`pass:c,q[…]`).
+       - ✅ **part 3.** a `pass:` macro carrying an explicit substitution list (`pass:c,q[…]`) → `Raw`,
+         rendered through the real substitution pipeline rather than a node subtree (see the step's own
+         landed-as note for why).
        - ✅ **part 4.** the bare unconstrained `+text+` form.
   6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make
      `rendered_html()` a fold, delete the three production sentinel systems (§4.2), and retire

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -125,8 +125,10 @@
 //!   passthrough (`stem:[+++<b>x</b>+++]`) is never deferred – the `Raw` is
 //!   spliced into the node's value verbatim, unlike every other macro family's
 //!   "crosses an already-recognized construct" boundary. A macro carrying an
-//!   explicit substitution list (`stem:c,q[…]`) is deferred, the same reason
-//!   `pass:c,q[…]` is deferred.
+//!   explicit substitution list (`stem:c,q[…]`) is deferred – STEM's own
+//!   increment hasn't yet picked up the same
+//!   `passthrough_text`-through-the-real-pipeline treatment that resolved the
+//!   analogous `pass:c,q[…]` form (see [`apply_passthroughs`]'s doc comment).
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -91,10 +91,21 @@ use crate::{
 /// reusing the same kept-prefix [`MacroMatch`] sub-range the auto-link
 /// increment introduced.
 ///
-/// A **`pass:` macro carrying an explicit substitution list** (`pass:c,q[…]`,
-/// whose content would need a richer subtree than a single `Raw` leaf – the
-/// same reason a footnote's content is structured children rather than a
-/// literal value) remains deferred. Inline STEM (`stem:[…]`, `asciimath:[…]`,
+/// A **`pass:` macro carrying an explicit substitution list**
+/// (`pass:c,q[…]`) folds through [`build_pass_macro_subs_value`], the same
+/// [`Raw`](InlineNode::Raw) shape [`build_passthrough_node`] gives every
+/// other `pass:`/delimiter form: `text` runs through the real, string-based
+/// substitution pipeline under the resolved
+/// [`SubstitutionGroup::Custom`] list (mirroring
+/// `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call), producing
+/// an already-final HTML string that becomes the leaf's `value` verbatim.
+/// See [`build_pass_macro_subs_value`]'s own doc comment for why a `Raw`
+/// leaf – not a richer node subtree built from this module's own
+/// transducers – is the shape this increment needs: the resolved list can
+/// name any of the six steps in any order, and only an opaque leaf is immune
+/// to [`build`](super::build)'s own later steps reprocessing (or, for a step
+/// the list omits, wrongly applying to) that same content a second time.
+/// Inline STEM (`stem:[…]`, `asciimath:[…]`,
 /// `latexmath:[…]`) is an implicit
 /// passthrough too, but folds through its own [`Stem`](InlineNode::Stem) node
 /// rather than `Raw`, so it is recognized by its own step,
@@ -196,10 +207,9 @@ fn apply_bare_attrlisted_pass_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
-/// Finds every passthrough at this level, skipping the deferred forms
-/// [`apply_passthroughs`] documents: a `pass:` macro carrying an explicit
-/// substitution list, and an attribute-list-prefixed match whose *bracket* is
-/// escaped (`\[attrs]++text++`) – the one remaining documented divergence. A
+/// Finds every passthrough at this level, skipping the one form
+/// [`apply_passthroughs`] still documents as deferred: an attribute-list-
+/// prefixed match whose *bracket* is escaped (`\[attrs]++text++`). A
 /// *delimiter* escape (`[attrs]\++text++`) is not deferred: it becomes an
 /// [`Unescape`](MacroMatchKind::Unescape) that drops one backslash and leaves
 /// the rest literal, exactly like an unattrlisted delimiter escape.
@@ -224,12 +234,6 @@ fn find_passthrough_matches<'src>(
         // reason every other family keeps it: a future caller of this
         // function over a non-seed level must not silently mis-slice.
         if !range_is_verbatim(pieces, &full) {
-            continue;
-        }
-
-        // A `pass:` macro carrying an explicit substitution list
-        // (`pass:c,q[…]`) is deferred.
-        if caps.get(14).is_some() {
             continue;
         }
 
@@ -506,23 +510,86 @@ fn build_passthrough_node<'src>(
         };
     }
 
-    // The bare `pass:[…]` macro (no explicit substitution list):
-    // `SubstitutionGroup::None` applies nothing, and an escaped closing
-    // bracket (`\]`) unescapes, mirroring the string replacer's
+    // The `pass:` macro (no delimiters). With an **explicit substitution
+    // list** (`pass:c,q[…]`, group 14), the body is rendered through the
+    // real substitution pipeline under the resolved `SubstitutionGroup::
+    // Custom` list – see [`build_pass_macro_subs_value`] for why this (and
+    // not a richer node subtree) is the safe shape for this increment.
+    // Without one (the bare `pass:[…]` form), `SubstitutionGroup::None`
+    // applies nothing. Either way, an escaped closing bracket (`\]`)
+    // unescapes first, mirroring the string replacer's
     // `text.replace("\\]", "]")` – the same treatment every other macro
     // family's bracket content gets.
     #[allow(clippy::unwrap_used)]
     let m = caps.get(15).unwrap();
     let content = source_slice(pieces, m.start()..m.end(), root);
     let raw = content.data();
+    let unescaped = raw.contains("\\]").then(|| raw.replace("\\]", "]"));
 
-    let value = if raw.contains("\\]") {
-        CowStr::from(raw.replace("\\]", "]"))
+    let value = if let Some(subs_list) = caps.get(14) {
+        let text = unescaped.as_deref().unwrap_or(raw);
+        CowStr::from(build_pass_macro_subs_value(
+            text,
+            subs_list.as_str(),
+            parser,
+        ))
+    } else if let Some(unescaped) = unescaped {
+        CowStr::from(unescaped)
     } else {
         CowStr::from(raw)
     };
 
     InlineNode::Raw { value, location }
+}
+
+/// Computes the rendered `value` for a `pass:` macro carrying an **explicit
+/// substitution list** (`pass:c,q[…]`) – the one deferred form 5a documented
+/// that a bare `SubstitutionGroup::None`/`::Verbatim` treatment cannot cover,
+/// since the list can name *any* of the six named steps, in any order and
+/// combination the author writes.
+///
+/// A naive extension would thread `text` through this module's own node
+/// transducers under the resolved step list, the way the legacy `x-`
+/// compatibility marker's body does ([`apply_normal_subs`]). That shape does
+/// not work here: [`build`](super::build) always runs its own fixed *normal*
+/// order over the level this passthrough is embedded in, so any structural
+/// node (`Styled`, `Ref`, …) this construct's own resolved subset produced
+/// would be visited *again* by whichever of `build`'s six steps come after
+/// this one – and unlike `Quotes` (whose delimiters are consumed, so a
+/// second pass finds nothing left to match) or `SpecialCharacters` (whose
+/// `CharRef` leaves are atomic), a macro's own display text is not
+/// idempotent under a second pass: a `Ref{Link}`'s display children are
+/// literal text that *looks* exactly like the source URL, so a second
+/// `Macros` pass would recognize it all over again and nest a nested link
+/// inside it. A resolved list omitting a step `build`'s own fixed order
+/// still runs (e.g. `pass:q[<b>]`, which never asks for
+/// `SpecialCharacters`) has the same problem in reverse: `build`'s own
+/// unconditional `SpecialCharacters` step would escape content the author's
+/// list deliberately left raw.
+///
+/// [`passthrough_text`] – already used for `++…++`/`$$…$$`/the bare
+/// unconstrained form – sidesteps both failure modes: it renders `text`
+/// through the **real, string-based** substitution pipeline
+/// ([`SubstitutionGroup::apply`], the same call
+/// `PassthroughRestoreReplacer` makes for a stored `Passthrough`), producing
+/// an already-final HTML string, then this function's caller wraps it in a
+/// single [`Raw`](InlineNode::Raw) leaf. A `Raw` leaf is *opaque* to every
+/// later step in this module (never descended into, never re-matched –
+/// design §4.2's passthrough-as-leaf convention), so it is immune to both
+/// failure modes above: nothing in `build`'s own remaining steps can touch
+/// it, whether or not the author's list included that step.
+///
+/// An unrecognized substitution name in the list (e.g. `pass:bogus[…]`) is
+/// silently skipped – any recognized names are still honored – mirroring
+/// [`SubstitutionGroup::from_custom_string`]/`InlinePassMacroReplacer`'s own
+/// resolution. Unlike the string pipeline, this additive pass does not yet
+/// raise the `InvalidSubstitutionTypeForPassthroughMacro` warning for it,
+/// deferring that side effect to the cutover exactly as every other macro
+/// family defers its own catalog/warning side effect (design §5.2 Phase 4
+/// step 6), since it does not change the fold's output bytes.
+fn build_pass_macro_subs_value(text: &str, subs_list: &str, parser: &Parser) -> String {
+    let (subs, _invalid) = SubstitutionGroup::from_custom_string(None, subs_list);
+    passthrough_text(text, &subs, parser)
 }
 
 /// Builds one [`Styled`] node from a verbatim, unescaped, attribute-listed
@@ -964,6 +1031,20 @@ mod tests {
             "pass:[]",
             r"pass:[a\]b]",
             "pass:[*not quotes*]",
+            // The `pass:` macro with an explicit substitution list: a single
+            // step, several steps (applied in the order given, not the
+            // normal order), an unrecognized name skipped alongside a
+            // recognized one, an empty resolved body, and an escape.
+            "pass:c[<b>]",
+            "pass:q[*bold*]",
+            "pass:c,q[<b> *bold*]",
+            "pass:q,c[<b> *bold*]",
+            "pass:m[https://example.org]",
+            "pass:a[{missing-attr}]",
+            "pass:bogus[<b>]",
+            "pass:c,bogus[<b>]",
+            "pass:c[]",
+            r"\pass:c[<b>]",
             // Multiple passthroughs, and passthroughs beside ordinary quoted
             // text (proving the surrounding text is still substituted
             // normally).
@@ -1434,23 +1515,146 @@ mod tests {
     }
 
     #[test]
-    fn a_pass_macro_with_an_explicit_subs_list_is_a_documented_divergence() {
-        // `pass:c[…]` names an explicit substitution list, which would need a
-        // richer subtree than a single `Raw` leaf can hold (the same reason a
-        // footnote's content is structured children rather than a literal
-        // value) – deferred to a later increment.
+    fn a_pass_macro_with_a_special_characters_subs_list_is_a_raw_node() {
+        // `pass:c[…]` resolves to `Custom([SpecialCharacters])`: the body is
+        // rendered through the real pipeline under just that one step (see
+        // `build_pass_macro_subs_value`), so `<`/`>` are already escaped in
+        // the leaf's `value` – a single opaque `Raw` node, not `CharRef`
+        // leaves this builder's own `SpecialCharacters` transducer would
+        // produce.
         let source = "pass:c[<b>]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "&lt;b&gt;");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_pass_macro_with_a_quotes_subs_list_renders_the_markup() {
+        // `pass:q[…]` resolves to `Custom([Quotes])`: rendered through the
+        // real pipeline, so the leaf's `value` already carries the
+        // `<strong>` markup `Quotes` produced – unescaped, since `Raw`'s
+        // fold emits `value` verbatim.
+        let source = "pass:q[*bold*]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "<strong>bold</strong>");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_pass_macro_with_a_macros_subs_list_renders_a_nested_macro() {
+        // `pass:m[…]` resolves to `Custom([Macros])`: rendered through the
+        // real pipeline (which itself extracts passthroughs/STEM ahead of
+        // `Macros`, `run_pipeline`'s own gate), so the leaf's `value` already
+        // carries the rendered `<a href="…">` markup.
+        let source = "pass:m[https://example.org]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(
+            &nodes[0],
+            r#"<a href="https://example.org" class="bare">https://example.org</a>"#,
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_pass_macro_with_multiple_subs_applies_them_in_the_order_given() {
+        // `pass:q,c[…]` resolves to `Custom([Quotes, SpecialCharacters])` –
+        // the order the author wrote, not the *normal* effective order
+        // (which always runs `SpecialCharacters` first). `Quotes` runs
+        // first here, wrapping `*bold*` in a literal `<strong>…</strong>`;
+        // `SpecialCharacters` then runs *second* and escapes every `<`/`>`
+        // it finds – tags included, since it has no way to tell them apart
+        // from `<b>`'s own literal angle brackets. This is the documented
+        // gotcha of naming `specialcharacters` after a step that emits
+        // markup, reproduced byte-for-byte from the real pipeline.
+        let nodes = build_src(Span::new("pass:q,c[<b> *bold*]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "&lt;b&gt; &lt;strong&gt;bold&lt;/strong&gt;");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs("pass:q,c[<b> *bold*]")
+        );
+    }
+
+    #[test]
+    fn a_pass_macro_with_an_unrecognized_subs_name_skips_it() {
+        // An unrecognized name resolves to zero steps – rather than
+        // invalidating the whole list – mirroring
+        // `SubstitutionGroup::from_custom_string`/`InlinePassMacroReplacer`'s
+        // own "skip and keep going" resolution. With no steps at all the
+        // rendered `value` is the content completely untouched (not even
+        // special characters are escaped).
+        let source = "pass:bogus[<b>]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "<b>");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_recognized_name_beside_an_unrecognized_one_is_still_honored() {
+        // `pass:c,bogus[…]` resolves to the same `Custom([SpecialCharacters])`
+        // as `pass:c[…]` alone – the unrecognized name is skipped, not fatal
+        // to the rest of the list.
+        let nodes = build_src(Span::new("pass:c,bogus[<b>]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "&lt;b&gt;");
+    }
+
+    #[test]
+    fn an_escaped_pass_macro_with_a_subs_list_stays_literal() {
+        // `\pass:c[…]` drops the single backslash and reconstructs the whole
+        // `pass:c[…]` text literally, mirroring `InlinePassMacroReplacer`'s
+        // own `caps.get(13)` branch (which re-emits `pass:`, the subs list,
+        // and the bracketed content exactly as written).
+        let source = r"\pass:c[<b>]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
-            "a pass: macro with an explicit subs list must be left unrecognized: {nodes:?}"
+            "an escaped passthrough must not apply its subs list: {nodes:?}"
         );
 
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        let golden = golden_passthroughs(source);
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
 
-        assert_ne!(folded, golden);
+    #[test]
+    fn a_pass_macro_subs_list_unescapes_an_escaped_closing_bracket() {
+        // `pass:c[a\]b]`: the same `text.replace("\\]", "]")` unescape every
+        // other `pass:[…]` bracket content gets, applied before the resolved
+        // list renders it.
+        let nodes = build_src(Span::new(r"pass:c[a\]b]"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw(&nodes[0], "a]b");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -59,10 +59,13 @@ use crate::{
 /// mirroring every other macro family's escape handling.
 ///
 /// One form is deferred, documented and pinned by a divergence test: a macro
-/// carrying an **explicit substitution list** (`stem:c,q[…]`, whose content
-/// would need a richer subtree than a single `Stem` leaf can hold – the same
-/// reason a `pass:` macro with an explicit list is deferred). This step is
-/// **additive**: nothing is wired into the parse path.
+/// carrying an **explicit substitution list** (`stem:c,q[…]`) – the
+/// analogous `pass:c,q[…]` form is no longer deferred (it renders through
+/// the real substitution pipeline and folds through a single opaque `Raw`
+/// leaf, immune to reprocessing by this builder's own later steps – see
+/// `passthrough_step::apply_passthroughs`'s doc comment), but this
+/// increment hasn't yet picked up the same treatment for `Stem`. This step
+/// is **additive**: nothing is wired into the parse path.
 ///
 /// [`Passthroughs::extract_from`]: crate::content::Passthroughs::extract_from
 /// [`InlineStemMacroReplacer`]: crate::content::passthroughs
@@ -443,9 +446,10 @@ mod tests {
 
     #[test]
     fn a_stem_macro_with_an_explicit_subs_list_is_a_documented_divergence() {
-        // `stem:c[…]` names an explicit substitution list, which would need a
-        // richer subtree than a single `Stem` leaf can hold (the same reason
-        // `pass:c[…]` is deferred) – deferred to a later increment.
+        // `stem:c[…]` names an explicit substitution list. The analogous
+        // `pass:c[…]` form is handled (see `passthrough_step`'s
+        // `build_pass_macro_subs_value`), but `Stem` hasn't picked up the
+        // same treatment yet – deferred to a later increment.
         let source = "stem:c[a < b]";
         let nodes = build_src(Span::new(source));
 


### PR DESCRIPTION
## Summary

This is the next step in the [inline AST migration](docs/design/inline-ast-architecture.md) (Phase 4, step 5d part 3): the single-pass inline builder now recognizes a **`pass:` macro carrying an explicit substitution list** (`pass:c,q[…]`) — the last of the four forms step 5a deferred, closing out step 5d and step 5 in full.

- `pass:c,q[…]` folds through a single [`Raw`](parser/src/inlines/inline_node.rs) leaf: its body is rendered through the **real, string-based** substitution pipeline under the resolved `SubstitutionGroup::Custom` list (via the passthrough step's own `passthrough_text` helper, already used for `++…++`/`$$…$$`/the bare unconstrained form), exactly mirroring `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call — so the output is byte-for-byte identical.
- **A node-subtree shape was prototyped first and abandoned.** The obvious extension is to thread the resolved steps through this module's own transducers — the same shape the legacy `x-` compatibility marker's body already uses (`apply_normal_subs`). That doesn't work here: [`apply_passthroughs`](parser/src/content/inline_builder/passthrough_step.rs) runs *first* in `build`, so anything it splices is still visited by every one of `build`'s own later steps. That revisit is a safe no-op for `Quotes`/`SpecialCharacters`/`CharacterReplacements`/`PostReplacement` (their own output is idempotent under a second pass), but **not** for `Macros`: a link or cross-reference node's display text is literal text that reads exactly like the source it came from, so a second `Macros` pass recognizes it all over again and nests a second `Ref` inside the first. A list omitting a step `build`'s own fixed order still runs unconditionally (e.g. `pass:q[…]`, which never asks for `SpecialCharacters`) fails the opposite way — content the author deliberately left raw gets escaped anyway.
- This surfaced a **pre-existing bug**, independent of this change, in the already-merged `x-` marker path (step 5d part 2): `[x-]++https://example.org++` double-wraps its own link (`<code><a href="…"><a href="…">…</a></a></code>`). Fixing that properly needs a splice-time "visited by exactly the steps its own list named, once" protection this additive, pre-cutover module doesn't have — squarely the cutover's job (step 6). Left as a documented, out-of-scope discovery rather than patched here.
- Folding through an opaque `Raw` leaf sidesteps the whole problem for *this* construct: a `Raw` leaf is never descended into or re-matched by any of this builder's steps, regardless of which steps the author's list names or omits, or in what order.
- An unrecognized substitution name (`pass:bogus[…]`) is silently skipped, mirroring `SubstitutionGroup::from_custom_string`/`InlinePassMacroReplacer`'s own resolution; this additive pass doesn't yet raise the string pipeline's `InvalidSubstitutionTypeForPassthroughMacro` warning for it, deferred to the cutover like every other macro family's own catalog/warning side effect. An escaped closing bracket (`pass:c[a\]b]`) unescapes before rendering — no longer a deferred corner, since it's handled the same way as every other `pass:[…]` bracket.

The design doc is updated with this step's landed-as note (including the double-processing finding) and the checklist now shows step 5 fully done.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::passthrough_step` — new structural and parity tests (single/multi-step lists in author order, unrecognized names, empty resolved lists, a `Macros`-naming list, escapes), plus an extended differential corpus.
- [x] `cargo test --workspace` — full suite green (4898 passed, 0 failed).
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean.
- [x] `cargo fmt --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeopiacXb7F3iHxpMp23bD)_