### PR TITLE
feat: Recognize inter-document and document-as-a-whole cross-reference targets (inline-ast Phase 4, step 4b(ii) part 3c)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -982,6 +982,40 @@ Each phase is a reviewable unit with a clear exit gate.
   text – remain for a later increment (part 3c), which needs new `Ref` fields pinned against a
   consumer.
 
+  *Step 4b(ii) part 3c landed as (`Ref` grows a `derived` field, closing the inter-document half):*
+  part 3c turned out to split cleanly along its own two deferred forms – an inter-document/
+  document-as-a-whole target needs only a *destination* the node can carry opaquely (the exact
+  `DerivedReference` type [`ResolutionContext`](../../parser/src/parser/reference_resolver.rs)
+  already produces for the string pipeline's own non-catalog case), while an attribute-list-bearing
+  display text needs the node to parse and hold `window`/`role`/`xrefstyle`. The first needed no
+  "consumer" to pin its shape – it is a straight reuse of an existing, already-public type – so it
+  lands now; the second (part 3c's attribute-list half) remains deferred, still needing a real
+  consumer to pin how (or whether) `Ref` grows an `Attrlist<'src>`.
+  [`Ref`](../../parser/src/inlines/ref_node.rs) gains `derived: Option<DerivedReference>` –
+  `None` for a same-document reference (unchanged: still resolves through the catalog at the
+  cutover) and `always None` for a [`Link`](../../parser/src/inlines/ref_node.rs), populated only
+  for a cross-reference whose target carries its own destination. A new
+  `xref_target_and_derived` helper in
+  [`xref.rs`](../../parser/src/content/inline_builder/macros/xref.rs) mirrors
+  `InlineXrefReplacer::replace_append`'s own target-interpretation match *exactly* – including its
+  "a target naming this document, or a file included into it in full, is a same-document reference
+  after all" special case (`Parser::docname`/`Parser::catalog_include_is_full`) – so both the
+  `xref:` macro form and the `<<id>>` shorthand (which shares the helper, differing only in
+  `macro_form`) now recognize every target shape: a same-document id, an inter-document target
+  (`xref:other.adoc#frag[]`, `<<other#frag>>`), and the document-as-a-whole form (`xref:#[]`,
+  `<<>>`). [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) reconstructs
+  `XrefRenderParams.derived` straight from the node, so a derived-carrying reference now folds
+  through `render_xref`'s `(None, Some(derived))` branch instead of the unresolved fallback,
+  byte-for-byte identical to the string pipeline (`xrefstyle` stays `None` – it plays no part in
+  that branch, and the attribute-list half that would populate it for other cases is still
+  deferred). As throughout this module, this performs *no* recognition side effect and nothing is
+  wired into the parse path. A differential corpus extends the existing xref fixtures with
+  inter-document (with and without a fragment, and a non-AsciiDoc extension kept as-is) and
+  document-as-a-whole forms in both spellings, alongside a unit test pinning the
+  "target names this document" special case. The one remaining deferred xref form – a text
+  carrying an attribute list (part 3c's other half) – is unchanged, still pinned by its own
+  divergence test.
+
   *Step 4b(ii) part 4a landed as (`Macros` → `Anchor`, inline anchors):* the builder now recognizes
   **inline anchors** in both spellings – the `[[id]]` / `[[id,reftext]]` shorthand and the
   `anchor:id[reftext]` macro – as an [`Anchor`](../../parser/src/inlines/anchor.rs) node, folding
@@ -1407,9 +1441,12 @@ Each phase is a reviewable unit with a clear exit gate.
          - **part 3.** cross-references (`INLINE_XREF`) → `Ref{Xref}`, itself sliced:
            - ✅ **part 3a.** the same-document `xref:` macro form (`xref:id[text]`).
            - ✅ **part 3b.** the same-document `<<id>>` shorthand (`<<id>>` / `<<id,text>>`).
-           - **part 3c.** the node-blocked forms both spellings share – inter-document targets (a
-             *derived* destination) and an attribute-list text (an `Attrlist<'src>`) – which need
-             new `Ref` fields, pinned against a consumer.
+           - **part 3c.** the node-blocked forms both spellings share, split in two once landed:
+             - ✅ inter-document targets and the document-as-a-whole form (a *derived*
+               destination) – needed only an existing, already-public type (`Ref` gains
+               `derived: Option<DerivedReference>`), no consumer required to pin its shape.
+             - an attribute-list text (an `Attrlist<'src>`, for `window`/`role`/`xrefstyle`) –
+               still needs new `Ref` fields, pinned against a consumer.
          - **part 4.** `Anchor`, `IndexTerm`, `Footnote`, each its own sub-step (inline `Stem` is
            *not* a macros-step family – it is extracted at passthrough time, so it lands in step 5):
            - ✅ **part 4a.** inline anchors (`[[id]]` / `anchor:id[…]`, `INLINE_ANCHOR`) → `Anchor`.

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -542,6 +542,7 @@ mod tests {
             roles: vec![],
             window: None,
             resolved: None,
+            derived: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -352,15 +352,17 @@ fn fold_link(
 /// `render_xref` the string pipeline's macros step feeds at resolution time,
 /// reconstructing the [`XrefRenderParams`] from the node: the provided text is
 /// the fold of the children (empty children ⇒ no text, so the renderer emits
-/// the bracketed `[id]` fallback), and the target/window/roles come straight
-/// off the node.
+/// the bracketed `[id]` fallback), and the target/window/roles/derived come
+/// straight off the node.
 ///
-/// This increment recognizes only same-document references, which the additive
-/// builder leaves **unresolved** (no catalog-resolution pass runs) and which
-/// carry no *derived* destination – so the fold always takes `render_xref`'s
-/// unresolved branch, where `xrefstyle` and `derived` play no part. The cutover
-/// (design §5.2 Phase 4, step 6) wires resolution to the tree, at which point a
-/// resolved reference renders through its resolved destination.
+/// This increment recognizes both a same-document reference to a specific id
+/// (unresolved – no catalog-resolution pass runs, so `resolved` is always
+/// `None` here) and a target that carries its own destination without a
+/// catalog (`derived`, populated at build time – see the `Ref::derived` field
+/// docs): an inter-document target, and the empty target naming the current
+/// document as a whole. It does not yet parse an attribute-list-bearing
+/// display text, so `xrefstyle` is always `None`; the cutover (design §5.2
+/// Phase 4, step 6) wires catalog resolution to the tree.
 fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -386,7 +388,7 @@ fn fold_xref(
         window: reference.window.as_deref(),
         roles: &roles,
         xrefstyle: None,
-        derived: None,
+        derived: reference.derived.as_ref(),
         resolved: reference.resolved.as_ref(),
     };
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -278,6 +278,7 @@ fn build_inline_link_node<'src>(
         roles,
         window,
         resolved: None,
+        derived: None,
         location,
     });
 
@@ -532,6 +533,7 @@ pub(super) fn build_link_node<'src>(
         roles,
         window,
         resolved: None,
+        derived: None,
         location,
     }))
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -133,7 +133,7 @@ pub(super) fn apply_macros<'src>(
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
-    xref_macros_level(nodes, root)
+    xref_macros_level(nodes, root, parser)
 
     // Footnotes are **not** handled here. Every other family's recognition is
     // order-independent (no cross-node side effect), so it is safe for them to
@@ -261,6 +261,7 @@ mod tests {
             roles: vec![],
             window: None,
             resolved: None,
+            derived: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -2,15 +2,75 @@
 
 use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
 use crate::{
-    Span,
+    Parser, Span,
     content::{
         INLINE_XREF,
         inline_builder::quotes::{Piece, build_match_string, source_slice},
-        xref_target::{XrefTarget, interpret_xref_target},
+        xref_target::{
+            XrefTarget, interpret_xref_target, other_document_reference, this_document_reference,
+        },
     },
     inlines::{InlineNode, Ref, RefVariant},
+    parser::DerivedReference,
     strings::CowStr,
 };
+
+/// Interprets a cross-reference `target` and computes the pieces the [`Ref`]
+/// node needs to render it, mirroring
+/// [`InlineXrefReplacer::replace_append`](crate::content::macros)'s own target
+/// interpretation exactly so the fold reproduces the same bytes:
+///
+/// - a same-document reference to a specific id resolves through the catalog
+///   later, so it carries no *derived* destination (`derived: None`);
+/// - the empty target (`xref:#[]`, `<<>>`) names the current document as a
+///   whole, and a target naming another document – or a file that was
+///   included into this one in full, which is a reference within it after all
+///   – carries a destination *derived* from the target itself, computed here
+///   from the path attributes in effect at the reference (no catalog
+///   consulted).
+///
+/// The returned target is the node's `Ref::target` (see its field docs): the
+/// interpreted id for a same-document reference, the fragment for a
+/// same-document inclusion, or the raw target as written for a genuine
+/// inter-document reference.
+fn xref_target_and_derived(
+    raw_target: &str,
+    macro_form: bool,
+    parser: &Parser,
+) -> (String, Option<DerivedReference>) {
+    match interpret_xref_target(raw_target, macro_form) {
+        XrefTarget::SameDocument(id) if id.is_empty() => {
+            (id, Some(this_document_reference(parser)))
+        }
+
+        XrefTarget::SameDocument(id) => (id, None),
+
+        // A target that names *this* document, or a file that was included
+        // into it in full, is a reference within it after all.
+        XrefTarget::OtherDocument {
+            path,
+            source,
+            fragment,
+        } if source
+            && (parser.docname().as_deref() == Some(path.as_str())
+                || parser.catalog_include_is_full(&path)) =>
+        {
+            match fragment {
+                Some(fragment) => (fragment, None),
+                None => (String::new(), Some(this_document_reference(parser))),
+            }
+        }
+
+        XrefTarget::OtherDocument {
+            path,
+            source,
+            fragment,
+        } => {
+            let derived = other_document_reference(parser, &path, source, fragment.as_deref());
+            (raw_target.to_string(), Some(derived))
+        }
+    }
+}
 
 /// Matches `INLINE_XREF` at this level's escaped text, replacing each
 /// recognized `xref:` macro with the [`Ref`](InlineNode::Ref)`{Xref}` node it
@@ -18,6 +78,7 @@ use crate::{
 pub(super) fn xref_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -31,7 +92,7 @@ pub(super) fn xref_macros_level<'src>(
         return nodes;
     }
 
-    let matches = find_xref_matches(&s, &pieces, root);
+    let matches = find_xref_matches(&s, &pieces, root, parser);
 
     if matches.is_empty() {
         return nodes;
@@ -44,7 +105,12 @@ pub(super) fn xref_macros_level<'src>(
 /// form and the `<<id>>` shorthand – skipping any match that is not verbatim
 /// enough to slice from `'src` or that this increment defers (see
 /// [`build_xref_node`] and [`build_xref_shorthand_node`]).
-fn find_xref_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<MacroMatch<'src>> {
+fn find_xref_matches<'src>(
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
     for caps in INLINE_XREF.captures_iter(s) {
@@ -91,8 +157,8 @@ fn find_xref_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
         }
 
         let node = match &shorthand_inner {
-            Some(inner) => build_xref_shorthand_node(inner.clone(), &full, pieces, root),
-            None => build_xref_node(&caps, &full, pieces, root),
+            Some(inner) => build_xref_shorthand_node(inner.clone(), &full, pieces, root, parser),
+            None => build_xref_node(&caps, &full, pieces, root, parser),
         };
 
         match node {
@@ -104,9 +170,9 @@ fn find_xref_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
                 full,
             }),
 
-            // A form this increment defers (an inter-document target, an
-            // attribute-list-in-text macro, or a degenerate shorthand – see the
-            // two builders) is left as literal source for a later increment.
+            // A form this increment defers (an attribute-list-in-text macro or
+            // a degenerate shorthand – see the two builders) is left as
+            // literal source for a later increment.
             None => continue,
         }
     }
@@ -119,13 +185,17 @@ fn find_xref_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
 /// replacer does so the fold reproduces the same bytes. Returns `None` for a
 /// form this increment defers.
 ///
-/// The scope this builder claims is the **same-document** `xref:` macro form
-/// (`xref:id[]`, `xref:id[Reference Text]`); the `<<id>>` shorthand is built by
-/// [`build_xref_shorthand_node`]. Two macro-form targets are deferred, each to
-/// a later increment:
+/// The scope this builder claims is every macro-form target *except* a text
+/// carrying an attribute list; the `<<id>>` shorthand is built by
+/// [`build_xref_shorthand_node`]. A same-document reference to a specific id
+/// (`xref:install[]`) resolves through the catalog later (`derived: None`);
+/// the empty target (`xref:#[]`), a target naming another document
+/// (`xref:other.adoc#frag[]`), and a target naming this document (or a file
+/// included into it in full) all carry a destination *derived* from the
+/// target itself, computed by [`xref_target_and_derived`] exactly as the
+/// string replacer computes it – so this builder no longer defers any target
+/// shape. One form remains deferred to a later increment:
 ///
-/// - an **inter-document** target (`xref:other.adoc#frag[]`): its rendering
-///   needs a *derived* destination the [`Ref`] node does not carry;
 /// - a **text carrying an attribute list** (an `=`, for `window`/`role`/
 ///   `xrefstyle`): it is parsed as an [`Attrlist`](crate::attributes::Attrlist)
 ///   the node cannot hold yet, exactly as
@@ -147,27 +217,13 @@ fn build_xref_node<'src>(
     full: &std::ops::Range<usize>,
     pieces: &[Piece],
     root: Span<'src>,
+    parser: &Parser,
 ) -> Option<InlineNode<'src>> {
     // Group 3 is the `xref:` macro target; when it is absent the match is the
     // shorthand form, which this increment defers.
     let raw_target = caps.get(3)?.as_str();
 
-    // This increment recognizes only same-document references. An empty target
-    // (`xref:#[]`) points at the document as a whole – which carries a derived
-    // destination – and an inter-document target needs one too; both are
-    // deferred.
-    //
-    // The node's `target` is the *interpreted* id (a leading `#` stripped:
-    // `#install` → `install`), not the raw source spelling. This is deliberate:
-    // it is the value the renderer builds the `href` from and the value
-    // resolution keys on, so it matches both the string pipeline's rendering and
-    // the recorder tree's `target` (which stores the same interpreted value) –
-    // storing the raw `#install` would fold to `href="##install"` and break
-    // parity. See the `Ref::target` field docs.
-    let target = match interpret_xref_target(raw_target, true) {
-        XrefTarget::SameDocument(id) if !id.is_empty() => id,
-        _ => return None,
-    };
+    let (target, derived) = xref_target_and_derived(raw_target, true, parser);
 
     let raw_text = caps.get(4).map_or("", |m| m.as_str());
 
@@ -216,6 +272,7 @@ fn build_xref_node<'src>(
         roles: vec![],
         window: None,
         resolved: None,
+        derived,
         location,
     }))
 }
@@ -235,14 +292,16 @@ fn build_xref_node<'src>(
 /// provided" – the bracketed `[id]` fallback), and the whole `<<…>>` – its
 /// `CharRef` delimiters included – is the node's `location`.
 ///
-/// The scope this builder claims is the **same-document** shorthand
-/// (`<<id>>`, `<<id,Reference Text>>`). Three forms are deferred, each left as
-/// literal source for a later increment and pinned by a divergence test:
+/// The scope this builder claims is every shorthand target *except* one whose
+/// reference text is present but empty. A same-document shorthand
+/// (`<<install>>`) resolves through the catalog later (`derived: None`); an
+/// inter-document shorthand (`<<other#frag>>`) and the document-as-a-whole
+/// shorthand (`<<>>`, an empty id) both carry a destination *derived* from the
+/// target itself, computed by [`xref_target_and_derived`] exactly as the macro
+/// form's – so this builder no longer defers any target shape. One form
+/// remains deferred, left as literal source for a later increment and pinned
+/// by a divergence test:
 ///
-/// - an **inter-document** shorthand (`<<other#frag>>`): like the macro form,
-///   it needs a *derived* destination the [`Ref`] node does not carry;
-/// - a **document-as-a-whole** shorthand (`<<>>`, an empty id): it too resolves
-///   through a derived destination;
 /// - a **`<<id,>>` with an empty reference text**: the string replacer records
 ///   this as a *present-but-empty* text (rendering an empty `<a>…</a>`), which
 ///   an empty child vector cannot distinguish from "no text provided" – so the
@@ -262,6 +321,7 @@ fn build_xref_shorthand_node<'src>(
     full: &std::ops::Range<usize>,
     pieces: &[Piece],
     root: Span<'src>,
+    parser: &Parser,
 ) -> Option<InlineNode<'src>> {
     // The inner is verbatim (the caller checked), so its source slice's bytes
     // coincide with the match string's – a byte offset within `inner_data` maps
@@ -277,13 +337,7 @@ fn build_xref_shorthand_node<'src>(
         None => inner_data,
     };
 
-    // Only same-document shorthands are claimed. An inter-document target
-    // (`<<other#frag>>`) carries a derived destination, and an empty id
-    // (`<<>>`) names the document as a whole (also derived); both are deferred.
-    let target = match interpret_xref_target(raw_id.trim(), false) {
-        XrefTarget::SameDocument(id) if !id.is_empty() => id,
-        _ => return None,
-    };
+    let (target, derived) = xref_target_and_derived(raw_id.trim(), false, parser);
 
     let location = source_slice(pieces, full.clone(), root);
 
@@ -322,6 +376,7 @@ fn build_xref_shorthand_node<'src>(
         roles: vec![],
         window: None,
         resolved: None,
+        derived,
         location,
     }))
 }
@@ -383,10 +438,11 @@ mod tests {
         // For each fixture, folding the single-pass tree (all five steps)
         // reproduces the string pipeline's output byte-for-byte. This is the
         // differential corpus (design §5.3) that pins the cross-reference
-        // increment. Every fixture is a *verbatim*, same-document cross-reference
-        // in either spelling – the boundary this increment claims (an
-        // inter-document target, a document-as-a-whole reference, an
-        // attribute-list text, and a shorthand crossing a special/span are
+        // increment. Every fixture is a *verbatim* cross-reference in either
+        // spelling, whether it resolves through the catalog (same-document) or
+        // through a target-derived destination (inter-document, or the
+        // document-as-a-whole form) – the boundary this increment claims (an
+        // attribute-list text, and a shorthand crossing a special/span, are
         // deferred and live in divergence tests below).
         let fixtures = [
             // No cross-reference despite macro-ish characters.
@@ -399,6 +455,13 @@ mod tests {
             "xref:sect-one[Section One]",
             // An explicit same-document reference (`#id`).
             "xref:#install[Install]",
+            // An inter-document target – with and without a fragment, and a
+            // non-AsciiDoc extension kept as-is – and the document-as-a-whole
+            // form (an empty target).
+            "xref:other.adoc#frag[Elsewhere]",
+            "xref:other.adoc[]",
+            "xref:refcard.pdf[Reference Card]",
+            "xref:#[]",
             // An escaped `]` inside the text is unescaped.
             "xref:foo[a\\]b]",
             // A macro embedded in surrounding flow, and next to other constructs.
@@ -420,6 +483,11 @@ mod tests {
             "<<a.b.c>>",
             // The id and reference text are each trimmed around the comma.
             "<< spaced , Trimmed Text >>",
+            // An inter-document shorthand – with and without a fragment – and
+            // the document-as-a-whole shorthand (an empty id).
+            "<<other#frag,Elsewhere>>",
+            "<<other#>>",
+            "<<>>",
             // A shorthand embedded in surrounding flow, and next to other
             // constructs; and both spellings together.
             "See <<install>> now.",
@@ -635,39 +703,56 @@ mod tests {
     }
 
     #[test]
-    fn an_inter_document_xref_shorthand_is_a_documented_divergence() {
-        // An inter-document shorthand target (`other#frag`) renders through a
-        // *derived* destination the `Ref` node does not carry, so the builder
-        // defers it (left literal), exactly as it defers the inter-document
-        // `xref:` macro form.
+    fn an_inter_document_xref_shorthand_becomes_a_ref_node() {
+        // An inter-document shorthand target (`other#frag`) carries a *derived*
+        // destination computed from the target itself, exactly as the
+        // inter-document `xref:` macro form does.
         let source = "<<other#frag,Elsewhere>>";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an inter-document shorthand must be left unrecognized: {nodes:?}"
-        );
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "other#frag");
+        assert_eq!(link_text_of(reference), "Elsewhere");
+        assert_eq!(reference.resolved, None);
 
-        // The string pipeline, by contrast, *does* build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        #[allow(clippy::expect_used)]
+        let derived = reference
+            .derived
+            .as_ref()
+            .expect("an inter-document shorthand carries a derived destination");
+        assert_eq!(derived.href, "other.html#frag");
+        assert_eq!(derived.text, "other.html");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]
-    fn an_empty_xref_shorthand_is_a_documented_divergence() {
+    fn an_empty_xref_shorthand_becomes_a_ref_node() {
         // `<<>>` names the document as a whole: an empty id that resolves through
-        // a *derived* destination the `Ref` node does not carry, so the builder
-        // defers it (left literal), exactly as it defers the empty `xref:#[]`
-        // macro form.
+        // a *derived* destination computed from the document's own attributes,
+        // exactly as the empty `xref:#[]` macro form does.
         let source = "<<>>";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an empty shorthand must be left unrecognized: {nodes:?}"
-        );
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "");
+        assert!(reference.children.is_empty());
+        assert_eq!(reference.resolved, None);
 
-        // The string pipeline, by contrast, *does* build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        #[allow(clippy::expect_used)]
+        let derived = reference
+            .derived
+            .as_ref()
+            .expect("a document-as-a-whole shorthand carries a derived destination");
+        assert_eq!(derived.href, "#");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]
@@ -710,20 +795,36 @@ mod tests {
     }
 
     #[test]
-    fn an_inter_document_xref_is_a_documented_divergence() {
-        // An inter-document target (`other.adoc#frag`) renders through a
-        // *derived* destination the `Ref` node does not carry, so the single-pass
-        // builder defers it to a later increment (left literal).
+    fn an_inter_document_xref_becomes_a_ref_node() {
+        // An inter-document target (`other.adoc#frag`) carries a *derived*
+        // destination computed from the target itself – the AsciiDoc extension
+        // stripped, the output suffix substituted in – mirroring the string
+        // replacer's own target interpretation exactly.
         let source = "xref:other.adoc#frag[Elsewhere]";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an inter-document xref must be left unrecognized: {nodes:?}"
-        );
+        let reference = assert_xref(&nodes[0]);
 
-        // The string pipeline, by contrast, *does* build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        // Unlike a same-document reference, the node's target is the raw target
+        // as written, not an interpreted id (see the `Ref::target` field docs).
+        assert_eq!(reference.target.as_ref(), "other.adoc#frag");
+        assert_eq!(link_text_of(reference), "Elsewhere");
+        assert_eq!(reference.resolved, None);
+
+        #[allow(clippy::expect_used)]
+        let derived = reference
+            .derived
+            .as_ref()
+            .expect("an inter-document xref carries a derived destination");
+        assert_eq!(derived.href, "other.html#frag");
+        assert_eq!(derived.text, "other.html");
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert!(
+            folded.contains(r#"href="other.html#frag""#),
+            "folded: {folded}"
+        );
+        assert_eq!(folded, golden_xref(source));
     }
 
     #[test]
@@ -765,21 +866,51 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_same_document_xref_is_a_documented_divergence() {
+    fn an_empty_same_document_xref_becomes_a_ref_node() {
         // `xref:#[]` names the document as a whole: an empty same-document id
         // that resolves through a *derived* destination (`this_document_
-        // reference`) the `Ref` node does not carry, so the builder defers it to
-        // a later increment (left literal) exactly as it defers an inter-document
-        // target.
+        // reference`), computed from the document's own attributes without
+        // consulting any catalog.
         let source = "xref:#[]";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an empty same-document xref must be left unrecognized: {nodes:?}"
-        );
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "");
+        assert!(reference.children.is_empty());
+        assert_eq!(reference.resolved, None);
 
-        // The string pipeline, by contrast, *does* build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        #[allow(clippy::expect_used)]
+        let derived = reference
+            .derived
+            .as_ref()
+            .expect("a document-as-a-whole xref carries a derived destination");
+        assert_eq!(derived.href, "#");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn a_this_document_xref_target_is_treated_as_same_document() {
+        // A target naming *this* document by its own `docname` (or a file
+        // included into it in full) is a reference within it after all: the
+        // element it names is in the catalog being built right now, so the node
+        // carries the same-document target (the fragment) with no derived
+        // destination – exactly as an explicit `#id` shorthand does.
+        let parser = Parser::default().with_primary_file_name("mydoc.adoc");
+
+        let source = "xref:mydoc.adoc#install[Install]";
+        let root = Span::new(source);
+        let nodes = super::super::super::build(root, &parser);
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert_eq!(reference.derived, None);
+
+        let folded = super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+        assert!(folded.contains(r##"href="#install""##), "folded: {folded}");
+        assert_eq!(folded, golden_xref_with(source, &parser));
     }
 }

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -913,4 +913,30 @@ mod tests {
         assert!(folded.contains(r##"href="#install""##), "folded: {folded}");
         assert_eq!(folded, golden_xref_with(source, &parser));
     }
+
+    #[test]
+    fn a_fragmentless_this_document_xref_target_is_document_as_a_whole() {
+        // A target naming *this* document with no fragment (`xref:mydoc.adoc[]`)
+        // is, like the empty target (`xref:#[]`), a reference to the document as
+        // a whole: the same `this_document_reference` derived destination, not a
+        // same-document id to resolve through the catalog.
+        let parser = Parser::default().with_primary_file_name("mydoc.adoc");
+
+        let source = "xref:mydoc.adoc[Home]";
+        let root = Span::new(source);
+        let nodes = super::super::super::build(root, &parser);
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "");
+
+        #[allow(clippy::expect_used)]
+        let derived = reference
+            .derived
+            .as_ref()
+            .expect("a fragmentless self-reference carries a derived destination");
+        assert_eq!(derived.href, "#");
+
+        let folded = super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+        assert_eq!(folded, golden_xref_with(source, &parser));
+    }
 }

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -140,6 +140,7 @@ mod tests {
             roles: vec![],
             window: None,
             resolved: None,
+            derived: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -297,6 +297,7 @@ mod tests {
             roles: vec![],
             window: None,
             resolved: None,
+            derived: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -872,6 +872,7 @@ fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
                 roles: roles.iter().cloned().map(CowStr::from).collect(),
                 window: window.clone().map(CowStr::from),
                 resolved: None,
+                derived: None,
                 location: span,
             }),
 
@@ -923,6 +924,7 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             roles: roles.iter().cloned().map(CowStr::from).collect(),
             window: window.clone().map(CowStr::from),
             resolved: None,
+            derived: None,
             location: span,
         }),
 

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -163,6 +163,7 @@ mod tests {
                 roles: vec![],
                 window: None,
                 resolved: None,
+                derived: None,
                 location,
             }),
             InlineNode::Image(Image {

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -1,13 +1,20 @@
-use crate::{HasSpan, Span, inlines::InlineNode, parser::ResolvedReference, strings::CowStr};
+use crate::{
+    HasSpan, Span,
+    inlines::InlineNode,
+    parser::{DerivedReference, ResolvedReference},
+    strings::CowStr,
+};
 
 /// A link or cross-reference. ASG: `inlineRef`.
 ///
 /// The display text is held as child [`InlineNode`]s, so a formatted link text
 /// (`link:x[*bold*]`) is a tree. For a cross-reference, [`resolved`] is filled
 /// in by the resolution pass and remains `None` while unresolved or for a
-/// standalone (document-less) parse.
+/// standalone (document-less) parse; [`derived`] is filled in at build time
+/// instead, for a target that carries its own destination without any catalog.
 ///
 /// [`resolved`]: Self::resolved
+/// [`derived`]: Self::derived
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ref<'src> {
     /// Whether this is a link or a cross-reference.
@@ -40,6 +47,15 @@ pub struct Ref<'src> {
     /// resolution pass. `None` while unresolved, or for a standalone parse with
     /// no catalog.
     pub resolved: Option<ResolvedReference>,
+
+    /// For a cross-reference whose target names another document, or the
+    /// empty target naming the current document as a whole, the destination
+    /// derived from the target itself — computed once, at build time, without
+    /// consulting any catalog (mirroring the string pipeline's own target
+    /// interpretation). `None` for a same-document reference to a specific id,
+    /// which resolves through [`resolved`](Self::resolved) instead, and always
+    /// `None` for a [`Link`](RefVariant::Link).
+    pub derived: Option<DerivedReference>,
 
     /// The source location of the whole reference.
     pub location: Span<'src>,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2036,6 +2036,7 @@ fn unresolved_xref() -> InlineNode<'static> {
         roles: vec![],
         window: None,
         resolved: None,
+        derived: None,
         location: Span::new(""),
     })
 }
@@ -2060,6 +2061,7 @@ fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         roles: vec![],
         window: None,
         resolved: None,
+        derived: None,
         location: Span::new(""),
     })
 }


### PR DESCRIPTION
## Summary

This is the next step in the [inline AST migration](docs/design/inline-ast-architecture.md) — it closes the derived-destination half of the previously-deferred **step 4b(ii) part 3c**, the last item left unchecked under Phase 4's macro-recognition step list.

Parts 3a/3b (landed earlier) built a `Ref{Xref}` node for every *same-document* cross-reference in both the `xref:` macro form and the `<<id>>` shorthand, but deferred two target shapes because the `Ref` node had nowhere to put their rendering:

- an **inter-document** target (`xref:other.adoc#frag[]`, `<<other#frag>>`), and
- the **document-as-a-whole** form (`xref:#[]`, `<<>>`, an empty target).

Both render through a *derived* destination — computed from the target itself, without consulting any catalog — rather than through resolution. This PR closes that gap:

- [`Ref`](parser/src/inlines/ref_node.rs) gains `derived: Option<DerivedReference>`, reusing the exact `DerivedReference` type the string pipeline's own non-catalog resolution path already produces (`parser::reference_resolver::DerivedReference`) — no new type needed, so this required no "pin the shape against a consumer" step the attribute-list half of part 3c still does.
- A new `xref_target_and_derived` helper in [`xref.rs`](parser/src/content/inline_builder/macros/xref.rs) mirrors `InlineXrefReplacer::replace_append`'s own target-interpretation match exactly — including its "a target naming this document, or a file included into it in full, is a same-document reference after all" special case (`Parser::docname`/`Parser::catalog_include_is_full`) — so both the macro and shorthand builders (which share the helper) now recognize every target shape.
- [`fold_xref`](parser/src/content/inline_builder/fold.rs) reconstructs `XrefRenderParams.derived` from the node, so a derived-carrying reference folds through `render_xref`'s `(None, Some(derived))` branch byte-for-byte identical to the string pipeline.
- As throughout this module, this performs *no* recognition side effect and nothing is wired into the real parse path.

The remaining deferred xref form — a display text carrying an attribute list (`window=`, `role=`, `xrefstyle=`) — is unchanged and still pinned by its own divergence test; it needs new `Ref` fields whose shape should be pinned against a real consumer, per the design doc's own note.

The design doc is updated with this step's landed-as note and its "Next steps" checklist entry.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::macros::xref` — 21 tests: four former "documented divergence" tests are now positive `Ref`-node assertions (with `derived` checked field-by-field), a new unit test pins the "target names this document" special case, and the differential corpus gains inter-document/document-as-a-whole fixtures in both spellings.
- [x] `cargo test --workspace` — full suite green (4903 passed, 0 failed).
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean.
- [x] `cargo fmt --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzDdJdmeDmWc89bvy3PyZ6)_