### PR TITLE
feat: Stage the image macro's deferred registration and link-scheme warning side effects (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1464,6 +1464,36 @@ Each phase is a reviewable unit with a clear exit gate.
   markup), and the escape/unescape forms. This step is **additive**: nothing is wired into the parse path.
   Landing it closes out step 5d and, with it, step 5 in full.
 
+  *Step 6 prep landed as (the image family's deferred recognition side effects, staged):* with step 5 done,
+  every macro family the recorder covers now has a single-pass counterpart, but each one still skips the
+  **recognition side effect** its string-pipeline replacer performs at the same point – registering an id,
+  link, or image target in the document catalog, or recording a warning – deferring it "to the cutover"
+  (step 6, below). Step 6 itself bundles a lot: swapping the recorder for the builder inside `Content`,
+  making `rendered_html()` a fold, deleting the three sentinel systems, retiring the `with_inline_tree`
+  flag, *and* re-attaching every deferred side effect all at once. Re-attaching the image family's own two
+  side effects – [`register_image`](../../parser/src/parser/parser.rs) (for `image:`, gated on
+  `catalog_assets`) and the `link=` dangerous-scheme/self-href warning `InlineImageMacroReplacer` records –
+  turns out not to need the cutover itself: it is a standalone function,
+  [`apply_image_side_effects`](../../parser/src/content/inline_builder/macros/image.rs), that walks an
+  already-built tree and reads each [`Image`](../../parser/src/inlines/image.rs) node's own stored `target`
+  and `attrs` instead of a regex capture, mirroring `InlineImageMacroReplacer::replace_append`'s own
+  `link=self`/`link=`-scheme rejection logic (`link_self_resolves_to_src`, `has_dangerous_scheme`,
+  `has_dangerous_self_href`, `is_uri_ish`) exactly. It recurses into every container an `Image` node can be
+  nested inside – a `Styled` span, a `Ref`, or a `Footnote`'s own children – so a nested or footnote-embedded
+  image is found too. Landing it now, ahead of the rest of step 6, gives the eventual cutover one fewer thing
+  to get right in one leap: this piece is already written, tested against a broad fixture set (including a
+  differential comparison against the golden string pipeline's own registrations, using the same
+  two-independent-parsers discipline the footnote increment established), and reviewed on its own. As with
+  every additive increment before it, **nothing is wired into a real parse path** – the function is called
+  only by its own tests, against their own `Parser` – so calling it for real still waits for step 6, when it
+  can be invoked exactly once per parse without double-counting a registration. A new
+  [`Parser::catalog`](../../parser/src/parser/parser.rs) test-only accessor was added alongside it, so a test
+  can inspect a `Parser`'s own live catalog directly (the registrations this function performs) without a
+  full `Document` parse, whose own `Document::catalog()` is a separate, later snapshot. The remaining
+  deferred side effects – an attributed span's and an anchor's own `register_ref` (plus the anchor's
+  duplicate-id warning and the bibliography-anchor form), and `register_link` for the four link-macro forms –
+  are unstaged and remain step 6's own work, alongside everything else step 6 bundles.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1519,6 +1549,11 @@ Each phase is a reviewable unit with a clear exit gate.
      the dangerous-scheme substitution warning. Doing this at the cutover (rather than in the
      additive passes, which run *alongside* the authoritative string pipeline) is what avoids
      double-counting each registration.
+     - ✅ **prep.** The image family's own two side effects (`register_image`, the `link=`
+       dangerous-scheme/self-href warning) are already written and tested as a standalone,
+       unwired function, [`apply_image_side_effects`](../../parser/src/content/inline_builder/macros/image.rs)
+       – see the step's own "landed as" note above. Calling it for real is still this step's job;
+       the anchor/attributed-span `register_ref` pair and `register_link` remain unstaged.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -65,12 +65,12 @@ use crate::{
 /// (so a later sub can match *inside* an earlier span – design note on
 /// [`apply_quotes`](super::quotes::apply_quotes)). Left uncorrected, that
 /// would advance a directive nested in an earlier-positioned span *after* one
-/// that sits later in the same source but outside any span. [`resolve_counters`]
-/// runs first, as a dedicated pass that interleaves this level's own matches
-/// with a `Styled` sibling's nested ones by source position, and records each
-/// directive's resolved value keyed by its absolute source byte offset; the
-/// splicing recursion then looks values up by that same key regardless of the
-/// order it happens to visit levels in.
+/// that sits later in the same source but outside any span.
+/// [`resolve_counters`] runs first, as a dedicated pass that interleaves this
+/// level's own matches with a `Styled` sibling's nested ones by source
+/// position, and records each directive's resolved value keyed by its absolute
+/// source byte offset; the splicing recursion then looks values up by that same
+/// key regardless of the order it happens to visit levels in.
 pub(super) fn apply_attribute_references<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -10,7 +10,9 @@ use crate::{
         normalize_text_lf_escaped_bracket,
     },
     inlines::{Image, InlineNode},
+    parser::{has_dangerous_scheme, has_dangerous_self_href, is_uri_ish},
     strings::CowStr,
+    warnings::WarningType,
 };
 
 /// Matches `INLINE_IMAGE_MACRO` at this level's escaped text, replacing each
@@ -185,6 +187,101 @@ fn build_image_node<'src>(
         attrs: Some(attrlist),
         location,
     })
+}
+
+/// Performs the recognition side effects the string pipeline's own
+/// `InlineImageMacroReplacer` attaches to an `image:`/`icon:` match –
+/// registering the image target in the document's asset catalog (`image:`
+/// only, and only when [`catalog_assets`](Parser::with_catalog_assets) is
+/// enabled) and recording the `link=` dangerous-scheme/self-href warning –
+/// by walking an already-built tree and reading each
+/// [`Image`](InlineNode::Image) node's own stored fields instead of a regex
+/// capture.
+///
+/// Every macro family this module recognizes defers exactly this kind of
+/// side effect (see this file's own `register_image` note, and the anchor,
+/// link, and footnote increments' own): while the additive builder runs
+/// *alongside* the authoritative string pipeline – each against its own,
+/// independent [`Parser`] – performing it from every additive pass would risk
+/// double-counting a registration once the two paths ever share one `Parser`.
+/// This function is that deferred piece, staged as its own building block for
+/// the eventual cutover (design §5.2, Phase 4 step 6): re-attaching it for
+/// real means calling it exactly once per parse, after the single-pass
+/// builder replaces the recorder as `Content`'s tree source, so nothing here
+/// is wired into a real parse yet – it is exercised only by this module's own
+/// tests, against their own `Parser`.
+///
+/// Recurses into every container an `Image` node can be nested inside –
+/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref), and
+/// [`Footnote`](InlineNode::Footnote) children – mirroring exactly where
+/// [`apply_macros`](super::apply_macros) and the footnote increment's own
+/// `emit_range` can place one.
+pub(crate) fn apply_image_side_effects(
+    nodes: &[InlineNode<'_>],
+    parser: &Parser,
+    source: Span<'_>,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Image(image) => {
+                if !image.is_icon {
+                    parser.register_image(
+                        image.target.to_string(),
+                        parser
+                            .attribute_value("imagesdir")
+                            .as_maybe_str()
+                            .map(str::to_owned),
+                    );
+                }
+
+                if let Some(rejected) = rejected_link_target(image, parser) {
+                    parser.record_substitution_warning(
+                        source,
+                        WarningType::UnsafeLinkSchemeRejected(rejected.to_owned()),
+                    );
+                }
+            }
+
+            InlineNode::Styled(styled) => {
+                apply_image_side_effects(&styled.children, parser, source);
+            }
+
+            InlineNode::Ref(reference) => {
+                apply_image_side_effects(&reference.children, parser, source);
+            }
+
+            InlineNode::Footnote(footnote) => {
+                apply_image_side_effects(&footnote.children, parser, source);
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// Mirrors `InlineImageMacroReplacer::link_self_resolves_to_src`: whether
+/// `link=self` on this image/icon node resolves to a real `src` the renderer
+/// promotes into the anchor `href` (an icon has one only in image-icon mode –
+/// icons enabled and not font-based).
+fn link_self_resolves_to_src(image: &Image<'_>, parser: &Parser) -> bool {
+    !image.is_icon
+        || (parser.is_attribute_set("icons")
+            && parser.attribute_value("icons").as_maybe_str() != Some("font"))
+}
+
+/// Mirrors `InlineImageMacroReplacer::replace_append`'s own `link=`
+/// rejection check, returning the target string the renderer would refuse to
+/// promote into an `href`, if any.
+fn rejected_link_target<'a>(image: &'a Image<'_>, parser: &Parser) -> Option<&'a str> {
+    let link = image.attrs.as_ref()?.named_attribute("link")?;
+
+    if link.value() == "self" {
+        (link_self_resolves_to_src(image, parser)
+            && has_dangerous_self_href(&image.target, is_uri_ish(&image.target)))
+        .then_some(image.target.as_ref())
+    } else {
+        has_dangerous_scheme(link.value()).then_some(link.value())
+    }
 }
 
 #[cfg(test)]
@@ -437,5 +534,241 @@ mod tests {
     /// so a test can drive [`apply_macros`] directly.
     fn build_through_special_and_replacements(source: Span<'_>) -> Vec<InlineNode<'_>> {
         apply_character_replacements(build_through_quotes(source), source)
+    }
+
+    // ---- `apply_image_side_effects` (staged for the eventual cutover) -----
+
+    use super::apply_image_side_effects;
+    use crate::warnings::WarningType;
+
+    /// Builds the single-pass tree for `source` against `parser` (unlike
+    /// [`build_src`], which always uses its own fresh default parser).
+    fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
+        build(source, parser)
+    }
+
+    #[test]
+    fn registers_an_image_target_when_catalog_assets_is_enabled() {
+        let source = "image:sunset.jpg[Sunset]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        let catalog = parser.catalog();
+        let images = catalog.images();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].target, "sunset.jpg");
+    }
+
+    #[test]
+    fn does_not_register_an_icon_as_an_image() {
+        // `icon:` shares the `Image` node with `image:`, but only `image:` is
+        // registered in the asset catalog – mirroring
+        // `InlineImageMacroReplacer`'s own `caps[0].starts_with("image:")`
+        // gate.
+        let source = "icon:home[]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        assert!(parser.catalog().images().is_empty());
+    }
+
+    #[test]
+    fn registration_is_a_no_op_when_catalog_assets_is_disabled() {
+        // `catalog_assets` defaults to off; `register_image` is then a no-op,
+        // mirroring the string pipeline's own `Parser::register_image`.
+        let source = "image:sunset.jpg[Sunset]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        assert!(parser.catalog().images().is_empty());
+    }
+
+    #[test]
+    fn registers_an_image_nested_inside_a_styled_span_and_a_footnote() {
+        // An `Image` node can be nested inside a `Styled` span (matched inside
+        // a rendered span, mirroring the string pipeline) or captured whole
+        // into a `Footnote`'s own children (the footnote increment's own
+        // `emit_range`); both containers must be walked.
+        let source = "*see image:a.png[]* and footnote:[see image:b.png[]]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        let catalog = parser.catalog();
+        let images = catalog.images();
+        assert_eq!(images.len(), 2);
+        assert_eq!(images[0].target, "a.png");
+        assert_eq!(images[1].target, "b.png");
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
+        // Each fixture uses its own pair of *independent* parsers (design
+        // §5.3's two-independent-parsers discipline, already established by
+        // the footnote increment's own differential corpus): one that the
+        // additive builder builds against and this function then walks, one
+        // that the real string pipeline (`golden_macros_with`) runs against
+        // directly. Because neither path is wired into the other, comparing
+        // their two catalogs after the fact is the whole test.
+        let fixtures = [
+            "image:sunset.jpg[Sunset]",
+            "icon:home[]",
+            "image:sunset.jpg[Sunset]{sp}image:other.png[]",
+            "image without a bracket image:foo.png stays literal",
+            "\\image:sunset.jpg[Sunset]",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = Parser::default().with_catalog_assets(true);
+            let nodes = build_with(Span::new(fixture), &builder_parser);
+            apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
+
+            let golden_parser = Parser::default().with_catalog_assets(true);
+            golden_macros_with(fixture, &golden_parser);
+
+            let got: Vec<_> = builder_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+            let want: Vec<_> = golden_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+
+            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+        }
+    }
+
+    #[test]
+    fn records_the_dangerous_scheme_warning_for_an_explicit_link_target() {
+        let source = "image:safe.png[alt,link=javascript:alert(1)]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string())
+        );
+    }
+
+    #[test]
+    fn records_the_dangerous_scheme_warning_case_insensitively() {
+        let source = "image:safe.png[alt,link=JavaScript:alert(1)]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn does_not_warn_for_a_safe_explicit_link_target() {
+        let source = "image:safe.png[alt,link=https://example.org]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        assert_eq!(parser.substitution_warnings_len(), before);
+    }
+
+    #[test]
+    fn records_the_warning_for_a_dangerous_image_target_promoted_by_link_self() {
+        // `link=self` resolves the anchor `href` to the image's own `src`
+        // (`target`); a dangerous target is rejected exactly as an explicit
+        // `link=` value would be.
+        let source = "image:javascript:alert(1)[alt,link=self]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string())
+        );
+    }
+
+    #[test]
+    fn does_not_warn_for_link_self_on_a_safe_image_target() {
+        let source = "image:safe.png[alt,link=self]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        assert_eq!(parser.substitution_warnings_len(), before);
+    }
+
+    #[test]
+    fn records_the_warning_for_a_dangerous_icon_target_promoted_by_link_self_in_image_icon_mode() {
+        // An `icon:` target only promotes into a live `href` in image-icon
+        // mode (`icons` set, not `font`); with `icons` unset (the default) an
+        // icon has no `src` at all, so `link=self` stays the literal `self`
+        // and nothing is rejected – see the companion
+        // `does_not_warn_for_link_self_on_a_font_icon` test for that case.
+        use crate::parser::ModificationContext;
+
+        let source = "icon:javascript:alert(1)[link=self]";
+        let parser =
+            Parser::default().with_intrinsic_attribute("icons", "", ModificationContext::ApiOnly);
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string())
+        );
+    }
+
+    #[test]
+    fn does_not_warn_for_link_self_on_a_font_icon() {
+        // A font icon has no `src`, so `link=self` resolves to the literal
+        // `self` (harmless) rather than the dangerous target – nothing is
+        // rejected, mirroring
+        // `font_icon_link_self_with_dangerous_target_keeps_literal_self_without_warning`
+        // in `parser/src/tests/security.rs`.
+        use crate::parser::ModificationContext;
+
+        let source = "icon:javascript:alert(1)[link=self]";
+        let parser = Parser::default().with_intrinsic_attribute(
+            "icons",
+            "font",
+            ModificationContext::ApiOnly,
+        );
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        assert_eq!(parser.substitution_warnings_len(), before);
     }
 }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -609,6 +609,39 @@ mod tests {
     }
 
     #[test]
+    fn registers_an_image_nested_inside_a_refs_display_children() {
+        // A `Ref`'s display children can hold an `Image` too – `apply_macros`
+        // itself descends into a `Ref`'s own children before matching at its
+        // level (see `apply_macros_recognizes_a_macro_inside_reference_children`
+        // in `macros/mod.rs`'s own tests), so a hand-built `Ref` exercises the
+        // same container here.
+        use crate::inlines::{Ref, RefVariant};
+
+        let root = Span::new("image:a.png[]");
+        let image = build_with(root, &Parser::default());
+        assert_eq!(image.len(), 1);
+
+        let reference = InlineNode::Ref(Ref {
+            variant: RefVariant::Link,
+            target: CowStr::from("https://example.org"),
+            children: image,
+            roles: vec![],
+            window: None,
+            resolved: None,
+            derived: None,
+            location: root,
+        });
+
+        let parser = Parser::default().with_catalog_assets(true);
+        apply_image_side_effects(std::slice::from_ref(&reference), &parser, root);
+
+        let catalog = parser.catalog();
+        let images = catalog.images();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].target, "a.png");
+    }
+
+    #[test]
     fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
         // Each fixture uses its own pair of *independent* parsers (design
         // §5.3's two-independent-parsers discipline, already established by

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -23,11 +23,10 @@ use crate::{
 /// - a same-document reference to a specific id resolves through the catalog
 ///   later, so it carries no *derived* destination (`derived: None`);
 /// - the empty target (`xref:#[]`, `<<>>`) names the current document as a
-///   whole, and a target naming another document – or a file that was
-///   included into this one in full, which is a reference within it after all
-///   – carries a destination *derived* from the target itself, computed here
-///   from the path attributes in effect at the reference (no catalog
-///   consulted).
+///   whole, and a target naming another document – or a file that was included
+///   into this one in full, which is a reference within it after all – carries
+///   a destination *derived* from the target itself, computed here from the
+///   path attributes in effect at the reference (no catalog consulted).
 ///
 /// The returned target is the node's `Ref::target` (see its field docs): the
 /// interpreted id for a same-document reference, the fragment for a

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -154,6 +154,23 @@
 //! attribute expansion, and passthroughs, at which point it can replace the
 //! recorder, make `rendered_html()` a fold, and retire the sentinel systems.
 //!
+//! # Staging the cutover's recognition side effects
+//!
+//! Every macro family above deliberately skips a **recognition side effect**
+//! the string pipeline performs at the same point – registering an id, link,
+//! or image target in the document catalog, or recording a warning – because
+//! the additive builder still runs *alongside* the authoritative string
+//! pipeline (each against its own, independent [`Parser`]), so performing one
+//! here today would risk double-counting a registration once the two paths
+//! ever share a `Parser`. [`apply_image_side_effects`] is the first of these
+//! to be written: it re-attaches the `image:`/`icon:` family's own deferred
+//! side effects (`register_image`, the `link=` dangerous-scheme/self-href
+//! warning) as a function that walks an already-built tree, staged as its own
+//! reviewable building block for the cutover (design §5.2, Phase 4 step 6).
+//! It is exercised only by its own tests, against their own `Parser` – calling
+//! it for real means invoking it exactly once per parse, after the
+//! single-pass builder replaces the recorder as `Content`'s tree source.
+//!
 //! # A note on quote nesting
 //!
 //! The string pipeline realizes nesting by running the ordered [`quote_subs`]
@@ -202,6 +219,11 @@ use char_replacements::apply_character_replacements;
 pub(crate) use fold::fold_html;
 use footnotes::apply_footnotes;
 use macros::apply_macros;
+// Staged for the eventual cutover (see this module's own doc comment); not
+// yet called from any real parse path, so – like `fold_html` above – reachable
+// only via `cfg(test)` callers and future external callers today.
+#[allow(unused_imports)]
+pub(crate) use macros::image::apply_image_side_effects;
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1607,6 +1607,17 @@ impl Parser {
         }
     }
 
+    /// Returns the parser's own live catalog, for tests that inspect a
+    /// registration recorded via [`register_image`](Self::register_image) or
+    /// [`register_link`](Self::register_link) directly against this `Parser`,
+    /// without going through a full [`Document`](crate::document::Document)
+    /// parse (whose own [`catalog`](crate::document::Document::catalog) is a
+    /// separate, later snapshot).
+    #[cfg(test)]
+    pub(crate) fn catalog(&self) -> std::cell::Ref<'_, crate::document::Catalog> {
+        self.catalog.borrow()
+    }
+
     /// Registers a callout number defined by a verbatim block.
     ///
     /// Takes `&self` so it can be called from the callouts substitution step,


### PR DESCRIPTION
## Summary

With Phase 4 step 5 now complete (#1164), every macro family the recorder covers has a single-pass counterpart in the additive inline builder — but each one still skips the **recognition side effect** its string-pipeline replacer performs at the same point (registering an id/link/image target in the document catalog, or recording a warning). Per `docs/design/inline-ast-architecture.md`, those are deferred to the cutover (step 6), because the additive builder currently runs *alongside* the authoritative string pipeline — each against its own, independent `Parser` — so performing a side effect from an additive pass today would risk double-counting a registration once the two paths ever share one.

Step 6 as scoped bundles a lot in one leap: swapping the recorder for the single-pass builder inside `Content`, making `rendered_html()` a fold, deleting the three sentinel systems, retiring the `with_inline_tree` opt-in flag, *and* re-attaching every deferred side effect all at once. This PR lands one piece of that ahead of the rest, as its own reviewable, additive increment (following the same discipline every prior Phase 4 PR used): `apply_image_side_effects` walks an already-built tree and, for each `Image` node, calls `register_image` (`image:` only, gated on `catalog_assets`) and records the same `link=` dangerous-scheme/self-href warning `InlineImageMacroReplacer` does — mirroring its `link_self_resolves_to_src`/`has_dangerous_scheme`/`has_dangerous_self_href` logic exactly, and recursing into every container an `Image` node can be nested inside (a `Styled` span, a `Ref`, or a `Footnote`'s own children).

Like every prior Phase 4 increment, **nothing here is wired into a real parse path** — the function is exercised only by its own tests, against their own `Parser`. Calling it for real still waits for step 6, when it can be invoked exactly once per parse without double-counting.

## Changes

- `parser/src/content/inline_builder/macros/image.rs`: new `apply_image_side_effects` function (plus `link_self_resolves_to_src`/`rejected_link_target` helpers) and a broad test suite — catalog registration (enabled/disabled, `image:` vs `icon:`, nested inside a `Styled` span and a `Footnote`), a differential comparison against the golden string pipeline's own registrations (the footnote increment's two-independent-parsers discipline), and the dangerous-scheme/self-href warning cases mirrored from `parser/src/tests/security.rs`.
- `parser/src/parser/parser.rs`: new `#[cfg(test)] pub(crate) fn Parser::catalog()` accessor so a test can inspect a `Parser`'s own live catalog directly (the registrations `apply_image_side_effects` performs), without a full `Document` parse — `Document::catalog()` is a separate, later snapshot.
- `parser/src/content/inline_builder/mod.rs`: module-doc note on staging cutover side effects, and a `pub(crate) use` re-export (unwired, mirroring `fold_html`'s own note).
- `docs/design/inline-ast-architecture.md`: records this as a "step 6 prep" landed-as note, and checks off a sub-item under step 6 in the Phase 4 step list.

## Test plan

- [x] `cargo test -p asciidoc-parser` — full suite passes (4922 passed, 0 failed)
- [x] `cargo clippy --all-features --all-targets -- -Dwarnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean for the files this PR touches (the same two unrelated files already showing pre-existing formatting drift on `inline-ast`, per #1164's own test plan, are left untouched)
- [x] `cargo doc -p asciidoc-parser --no-deps` — clean, no broken intra-doc links
- [x] New tests in `image.rs` pin: registration on/off `catalog_assets`, `image:` vs `icon:`, nesting inside `Styled`/`Footnote`, a fixture-set differential comparison against the golden string pipeline's own catalog, and the `link=` warning cases (explicit dangerous scheme, case-insensitivity, `link=self` promoting a dangerous image/icon target, and the font-icon no-warning case) mirrored from `parser/src/tests/security.rs`

Marking as **draft** since this stages part of step 6 rather than closing out a fully-scoped design-doc step on its own — happy to adjust scope per review (e.g. folding in `register_link` for the link-macro family too, or holding this until step 6 proper).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CxWpqSRUgvHCuC6WLUsNHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxWpqSRUgvHCuC6WLUsNHJ)_