### PR TITLE
feat: Stage the link family's deferred register_link side effect (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1494,6 +1494,24 @@ Each phase is a reviewable unit with a clear exit gate.
   duplicate-id warning and the bibliography-anchor form), and `register_link` for the four link-macro forms –
   are unstaged and remain step 6's own work, alongside everything else step 6 bundles.
 
+  *Step 6 prep landed as (the link family's deferred `register_link`, staged):* the same treatment, applied
+  to the second of step 6's unstaged registrations. [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs)
+  is a standalone function that walks an already-built tree and, for each [`Ref`](../../parser/src/inlines/ref_node.rs)`{Link}`
+  node, calls [`register_link`](../../parser/src/parser/parser.rs) with the node's own stored `target` –
+  no recomputation needed, since `target` already holds exactly the string the string pipeline's four link
+  replacers (the `link:`/`mailto:` macro, the auto-link, and the formal-URL link – the bare e-mail form is a
+  later increment, not yet built by this module) register. A cross-reference is also a `Ref` node but is
+  never registered, mirroring the string pipeline's own link-only catalog. It recurses into every container
+  a `Ref` node can be nested inside – a `Styled` span, another `Ref`'s own display children (so a link
+  nested in a cross-reference's text, or vice versa, is found too), or a `Footnote`'s own children –
+  mirroring the image increment's own recursion. As with the image side effects, **nothing is wired into a
+  real parse path** – the function is exercised only by its own tests, against their own `Parser` – so
+  calling it for real still waits for step 6. A broad differential corpus compares its registrations against
+  the golden string pipeline's own, using the same two-independent-parsers discipline the image increment
+  established. The remaining deferred side effect – an attributed span's and an anchor's own `register_ref`
+  (plus the anchor's duplicate-id warning and the bibliography-anchor form) – is unstaged and remains step
+  6's own work.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1552,8 +1570,12 @@ Each phase is a reviewable unit with a clear exit gate.
      - ✅ **prep.** The image family's own two side effects (`register_image`, the `link=`
        dangerous-scheme/self-href warning) are already written and tested as a standalone,
        unwired function, [`apply_image_side_effects`](../../parser/src/content/inline_builder/macros/image.rs)
-       – see the step's own "landed as" note above. Calling it for real is still this step's job;
-       the anchor/attributed-span `register_ref` pair and `register_link` remain unstaged.
+       – see the step's own "landed as" note above.
+     - ✅ **prep (links).** `register_link` for the four link-macro forms is likewise staged as a
+       standalone, unwired function,
+       [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs) – see the
+       step's own "landed as" note above. Calling it for real is still this step's job; the
+       anchor/attributed-span `register_ref` pair remains unstaged.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -538,6 +538,63 @@ pub(super) fn build_link_node<'src>(
     }))
 }
 
+/// Performs the recognition side effect the string pipeline's four link
+/// replacers (`InlineLinkReplacer`'s angle/formal/bare branches and
+/// `InlineLinkMacroReplacer`, plus `InlineEmailReplacer`'s own registration for
+/// the bare e-mail form this module does not yet build) attach to a matched
+/// link – registering the target in the document's asset catalog – by walking
+/// an already-built tree and reading each [`Ref`](InlineNode::Ref)`{Link}`
+/// node's own stored `target` instead of a regex capture. `target` already
+/// holds exactly the string the string pipeline registers (see
+/// [`build_inline_link_node`] and [`build_link_node`]), so no recomputation is
+/// needed.
+///
+/// Every macro family this module recognizes defers exactly this kind of side
+/// effect (see [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
+/// own note): while the additive builder runs *alongside* the authoritative
+/// string pipeline – each against its own, independent [`Parser`] – performing
+/// it from every additive pass would risk double-counting a registration once
+/// the two paths ever share one `Parser`. This function is that deferred piece
+/// for the link family, staged as its own building block for the eventual
+/// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
+/// calling it exactly once per parse, after the single-pass builder replaces
+/// the recorder as `Content`'s tree source, so nothing here is wired into a
+/// real parse yet – it is exercised only by this module's own tests, against
+/// their own `Parser`.
+///
+/// Recurses into every container a `Ref` node can be nested inside –
+/// [`Styled`](InlineNode::Styled), another [`Ref`](InlineNode::Ref) (a link's
+/// own display children, or a cross-reference's), and
+/// [`Footnote`](InlineNode::Footnote) children – mirroring exactly where
+/// [`apply_macros`](super::apply_macros) and the footnote increment's own
+/// `emit_range` can place one. A cross-reference node itself is not
+/// registered – only a [`Link`](RefVariant::Link) has an asset-catalog entry –
+/// but its children are still walked, since a formatted cross-reference text
+/// could itself carry a nested link.
+pub(crate) fn apply_link_side_effects(nodes: &[InlineNode<'_>], parser: &Parser) {
+    for node in nodes {
+        match node {
+            InlineNode::Ref(reference) => {
+                if reference.variant == RefVariant::Link {
+                    parser.register_link(reference.target.to_string());
+                }
+
+                apply_link_side_effects(&reference.children, parser);
+            }
+
+            InlineNode::Styled(styled) => {
+                apply_link_side_effects(&styled.children, parser);
+            }
+
+            InlineNode::Footnote(footnote) => {
+                apply_link_side_effects(&footnote.children, parser);
+            }
+
+            _ => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -1147,5 +1204,125 @@ mod tests {
 
         // The string pipeline, by contrast, applies the role.
         assert!(golden_macros(source).contains(r#"class="hl""#));
+    }
+
+    // ---- `apply_link_side_effects` (staged for the eventual cutover) ------
+
+    use super::apply_link_side_effects;
+
+    /// Builds the single-pass tree for `source` against `parser` (unlike
+    /// [`build_src`], which always uses its own fresh default parser).
+    fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
+        build(source, parser)
+    }
+
+    #[test]
+    fn registers_a_link_macro_target_when_catalog_assets_is_enabled() {
+        let source = "link:index.html[Docs]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        let catalog = parser.catalog();
+        let links = catalog.links();
+        assert_eq!(links, ["index.html"]);
+    }
+
+    #[test]
+    fn registers_a_mailto_target_with_its_scheme() {
+        let source = "mailto:hello@example.org[Email us]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(parser.catalog().links(), ["mailto:hello@example.org"]);
+    }
+
+    #[test]
+    fn registers_an_auto_link_and_a_formal_url_link_target() {
+        let source = "https://example.org and https://example.org/docs[Docs]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(
+            parser.catalog().links(),
+            ["https://example.org", "https://example.org/docs"]
+        );
+    }
+
+    #[test]
+    fn does_not_register_a_cross_reference_as_a_link() {
+        // A cross-reference is also a `Ref` node, but only a `Link` variant has
+        // an asset-catalog entry.
+        let source = "xref:intro[Introduction]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert!(parser.catalog().links().is_empty());
+    }
+
+    #[test]
+    fn registration_is_a_no_op_when_catalog_assets_is_disabled() {
+        let source = "link:index.html[Docs]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert!(parser.catalog().links().is_empty());
+    }
+
+    #[test]
+    fn registers_a_link_nested_inside_a_styled_span_and_a_footnote() {
+        let source = "*see link:a.html[]* and footnote:[see link:b.html[]]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(parser.catalog().links(), ["a.html", "b.html"]);
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
+        // Each fixture uses its own pair of *independent* parsers (design
+        // §5.3's two-independent-parsers discipline, already established by
+        // the image increment's own differential corpus): one that the
+        // additive builder builds against and this function then walks, one
+        // that the real string pipeline (`golden_macros_with`) runs against
+        // directly. Because neither path is wired into the other, comparing
+        // their two catalogs after the fact is the whole test.
+        let fixtures = [
+            "link:index.html[Docs]",
+            "link:[]",
+            "mailto:hello@example.org[Email us]",
+            "mailto:[]",
+            "https://example.org",
+            "https://example.org[Example]",
+            "link:https://example.org[Example]",
+            "\\link:index.html[Docs]",
+            "link:a.html[A]{sp}link:b.html[B]",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = Parser::default().with_catalog_assets(true);
+            let nodes = build_with(Span::new(fixture), &builder_parser);
+            apply_link_side_effects(&nodes, &builder_parser);
+
+            let golden_parser = Parser::default().with_catalog_assets(true);
+            golden_macros_with(fixture, &golden_parser);
+
+            assert_eq!(
+                builder_parser.catalog().links(),
+                golden_parser.catalog().links(),
+                "registered links diverged for {fixture:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Per `docs/design/inline-ast-architecture.md`, Phase 4 step 5 (all transducer steps through the passthrough/STEM increments) is complete, and the most recent landed increment (#1165) staged the **image** family's deferred recognition side effects (`register_image`, the `link=` dangerous-scheme warning) as a standalone, unwired function ahead of the full cutover (step 6). The design doc explicitly named the two remaining unstaged side effects: an anchor/attributed-span `register_ref` pair, and `register_link` for the four link-macro forms.

This PR stages the second of those: `register_link`.

- Adds `apply_link_side_effects` in `parser/src/content/inline_builder/macros/links.rs`, following the exact shape `apply_image_side_effects` established: it walks an already-built `InlineNode` tree and, for each `Ref{Link}` node (covering all four link forms the builder already recognizes — the `link:`/`mailto:` macro, the bare auto-link, and the formal-URL link), calls `Parser::register_link` with the node's own stored `target`. No recomputation is needed: `target` already holds exactly the string the string pipeline's replacers register.
- A cross-reference is also a `Ref` node but is never registered — only `RefVariant::Link` has an asset-catalog entry — though its children are still walked, since a formatted cross-reference's display text could itself carry a nested link.
- Recurses into every container a `Ref` can be nested inside (`Styled`, another `Ref`'s own children, `Footnote`), mirroring the image increment's recursion.
- As with every additive increment in this module, **nothing is wired into a real parse path** — the function is exercised only by its own tests, against their own `Parser`. Wiring it in for real (exactly once per parse, so it doesn't double-count alongside the string pipeline's own registration) remains step 6's job.
- Adds a differential test comparing this function's registrations against the golden string pipeline's own, using the same two-independent-parsers discipline the image increment established, plus unit tests for each link form, nesting (styled span, footnote), the `catalog_assets` gate, and the cross-reference exclusion.
- Updates `docs/design/inline-ast-architecture.md` to record the increment and narrow the step 6 checklist's remaining scope to just the anchor/attributed-span `register_ref` pair.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib` — all 4930 tests pass (0 failed)
- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::macros::links` — new tests pass alongside the existing link-family suite
- [x] `cargo test -p asciidoc-parser --doc` — passes
- [x] `cargo clippy -p asciidoc-parser --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check -p asciidoc-parser` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvhBwhGwfbWdrPuhAscnSj)_