### PR TITLE
feat: Recognize the anchor/attributed-span register_ref pair in the single-pass inline builder (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1512,6 +1512,34 @@ Each phase is a reviewable unit with a clear exit gate.
   (plus the anchor's duplicate-id warning and the bibliography-anchor form) – is unstaged and remains step
   6's own work.
 
+  *Step 6 prep landed as (the anchor and attributed-span family's deferred `register_ref`, staged – the
+  last of step 6's unstaged registrations):* [`apply_ref_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs)
+  is a standalone function that walks an already-built tree and, for each [`Anchor`](../../parser/src/inlines/anchor.rs)
+  node and each id-carrying [`Styled`](../../parser/src/inlines/styled.rs) span, calls
+  [`register_ref`](../../parser/src/parser/parser.rs) under `RefType::Anchor` – reading the node's own
+  stored `id`/`reftext` instead of a regex capture. It reproduces the two divergent behaviors the string
+  pipeline's two call sites give this one catalog side effect: an inline anchor additionally raises the
+  duplicate-id warning `InlineAnchorReplacer` records (an attributed span's own registration stays silently
+  non-fatal, mirroring the quotes step's own `let _ = register_ref(...)`), and a shorthand `[[id]]`
+  immediately preceded by a `[` – the inner anchor of a `[[[id]]]` sequence appearing *outside* a
+  bibliography list item – is recognized (already, by the existing node builder) but never registered,
+  mirroring `InlineAnchorReplacer`'s own `is_bibliography_inner` check (recomputed here from the node's own
+  source span rather than a haystack index, since the tree walk has no regex capture to read it from). The
+  true bibliography-anchor construct itself (`[[[label]]]` inside a bibliography list item, `RefType::Bibliography`)
+  is a separate, list-item-gated pass (`INLINE_BIBLIO_ANCHOR`) this builder does not yet recognize as its own
+  node at all; that remains out of scope here, same as before. A description-list term's own leading-anchor
+  pre-registration (`DefinedTerm::substitute`, `apply_macros_with_leading_anchor_registered`) is mirrored by
+  a `leading_anchor_registered` parameter, so wiring this function in at that call site can suppress the same
+  duplicate-id warning the string pipeline suppresses there. It recurses into every container an id-bearing
+  node can be nested inside – a `Styled` span, a `Ref`'s own display children, or a `Footnote`'s own children
+  – mirroring the image and link increments' own recursion. As with those, **nothing is wired into a real
+  parse path** – the function is exercised only by its own tests, against their own `Parser` – so calling it
+  for real still waits for step 6. A broad differential corpus compares its registrations against the golden
+  string pipeline's own, using the same two-independent-parsers discipline the image increment established.
+  With this landed, every recognition side effect step 5's macro families skip is now staged as its own
+  unwired building block; step 6 itself – swapping the recorder for the builder, the fold, the sentinel
+  deletions, and calling each staged function exactly once per parse – remains fully outstanding.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1574,8 +1602,12 @@ Each phase is a reviewable unit with a clear exit gate.
      - ✅ **prep (links).** `register_link` for the four link-macro forms is likewise staged as a
        standalone, unwired function,
        [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs) – see the
-       step's own "landed as" note above. Calling it for real is still this step's job; the
-       anchor/attributed-span `register_ref` pair remains unstaged.
+       step's own "landed as" note above.
+     - ✅ **prep (anchors).** The anchor/attributed-span `register_ref` pair – the last of step 6's
+       unstaged registrations – is likewise staged as a standalone, unwired function,
+       [`apply_ref_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs) – see the
+       step's own "landed as" note above. Every deferred recognition side effect is now staged;
+       calling each one for real, exactly once per parse, remains this step's own job.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -2,13 +2,15 @@
 
 use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
 use crate::{
-    Span,
+    Parser, Span,
     content::{
         INLINE_ANCHOR,
         inline_builder::quotes::{Piece, build_match_string, source_slice},
     },
+    document::RefType,
     inlines::{Anchor, InlineNode},
     strings::CowStr,
+    warnings::WarningType,
 };
 
 /// Matches `INLINE_ANCHOR` at this level's escaped text, replacing each
@@ -205,6 +207,151 @@ fn build_anchor_reftext<'src>(
     Some(vec![child])
 }
 
+/// Performs the recognition side effects the string pipeline attaches to an
+/// assigned id at two distinct points – `InlineAnchorReplacer` (an inline
+/// anchor, `[[id]]` / `anchor:id[…]`) and the attributed-quote handling in
+/// [`SubstitutionStep::Quotes`](crate::content::SubstitutionStep::Quotes)
+/// (`[#id]#…#`) – by walking an already-built tree and reading each
+/// [`Anchor`](InlineNode::Anchor) node's own stored `id`/`reftext` and each
+/// [`Styled`](crate::inlines::Styled) span's own optional `id`, instead of a
+/// regex capture. Both register the id in the document's reference catalog
+/// under [`RefType::Anchor`] so a later cross-reference can resolve against
+/// it; only the inline-anchor form also raises a duplicate-id warning (the
+/// attributed-span form is silently non-fatal in the string pipeline too –
+/// see [`attributes_of`](super::super::quotes::attributes_of)'s own note).
+///
+/// Every macro family this module recognizes defers exactly this kind of side
+/// effect (see [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
+/// own note): while the additive builder runs *alongside* the authoritative
+/// string pipeline – each against its own, independent [`Parser`] – performing
+/// it from every additive pass would risk double-counting a registration once
+/// the two paths ever share one `Parser`. This function is the last of the
+/// deferred registrations, staged as its own building block for the eventual
+/// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
+/// calling it exactly once per parse, after the single-pass builder replaces
+/// the recorder as `Content`'s tree source, so nothing here is wired into a
+/// real parse yet – it is exercised only by this module's own tests, against
+/// their own `Parser`.
+///
+/// `source` is the whole original content span being processed, used – like
+/// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
+/// own `source` parameter – to locate the duplicate-id warning exactly as
+/// [`InlineAnchorReplacer`](crate::content::macros) does (against the
+/// content's own span, not the individual anchor's).
+///
+/// `leading_anchor_registered` mirrors
+/// [`apply_macros_with_leading_anchor_registered`](super::apply_macros)'s own
+/// parameter: a description-list term pre-registers its own leading
+/// `[[id]]`/`[[id,reftext]]` before running the macros pass (see
+/// `DefinedTerm::substitute` in `blocks::list_item_marker`), so – once this
+/// function is wired in for real at the same call site – passing `true` there
+/// suppresses the duplicate-id warning this function would otherwise raise
+/// for that very same anchor, which sits at byte offset `0` of `source`.
+/// Every other caller passes `false`.
+///
+/// Recurses into every container an id-bearing node can be nested inside –
+/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref), and
+/// [`Footnote`](InlineNode::Footnote) children – mirroring exactly where the
+/// image and link increments' own side-effect functions recurse.
+pub(crate) fn apply_ref_side_effects(
+    nodes: &[InlineNode<'_>],
+    parser: &Parser,
+    source: Span<'_>,
+    leading_anchor_registered: bool,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Anchor(anchor) => {
+                if !is_bibliography_inner(anchor, source) {
+                    let reftext = anchor_reftext_str(anchor);
+
+                    if parser
+                        .register_ref(&anchor.id, reftext, RefType::Anchor)
+                        .is_err()
+                        && !(leading_anchor_registered
+                            && anchor.location.byte_offset() == source.byte_offset())
+                    {
+                        parser.record_substitution_warning(
+                            source,
+                            WarningType::DuplicateId(anchor.id.to_string()),
+                        );
+                    }
+                }
+            }
+
+            InlineNode::Styled(styled) => {
+                if let Some(id) = &styled.id {
+                    let _ = parser.register_ref(id, None, RefType::Anchor);
+                }
+
+                apply_ref_side_effects(&styled.children, parser, source, leading_anchor_registered);
+            }
+
+            InlineNode::Ref(reference) => {
+                apply_ref_side_effects(
+                    &reference.children,
+                    parser,
+                    source,
+                    leading_anchor_registered,
+                );
+            }
+
+            InlineNode::Footnote(footnote) => {
+                apply_ref_side_effects(
+                    &footnote.children,
+                    parser,
+                    source,
+                    leading_anchor_registered,
+                );
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// The reference text `str` a built [`Anchor`] node's `reftext` carries, when
+/// it is populated (a single verbatim [`Text`](InlineNode::Text) child – see
+/// [`build_anchor_reftext`]), mirroring the `Option<&str>`
+/// [`register_ref`](Parser::register_ref) itself expects.
+fn anchor_reftext_str<'a>(anchor: &'a Anchor<'_>) -> Option<&'a str> {
+    match anchor.reftext.as_deref() {
+        Some([InlineNode::Text { value, .. }]) => Some(value.as_ref()),
+        _ => None,
+    }
+}
+
+/// Mirrors `InlineAnchorReplacer`'s own `is_bibliography_inner` check: a
+/// shorthand `[[id]]` anchor immediately preceded by a `[` in the source is
+/// the inner anchor of a bibliography-style `[[[id]]]` sequence appearing
+/// *outside* a bibliography list item (a genuine bibliography anchor there is
+/// consumed whole by a separate, list-item-gated pass this builder does not
+/// yet recognize as its own node – `INLINE_BIBLIO_ANCHOR`, see
+/// [`content::macros`](crate::content::macros)). Asciidoctor's own
+/// inline-anchor *scan* excludes a `[[id]]` preceded by a `[`, so it renders
+/// the anchor (already handled by [`build_anchor_node`], which does not
+/// exclude this case – see its own doc) but never catalogs the id; this
+/// mirrors that by skipping only the registration, not the recognition. See
+/// #769.
+fn is_bibliography_inner(anchor: &Anchor<'_>, source: Span<'_>) -> bool {
+    if !anchor.location.data().starts_with("[[") {
+        return false;
+    }
+
+    let Some(local_offset) = anchor
+        .location
+        .byte_offset()
+        .checked_sub(source.byte_offset())
+    else {
+        return false;
+    };
+
+    local_offset
+        .checked_sub(1)
+        .and_then(|i| source.data().as_bytes().get(i))
+        == Some(&b'[')
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -212,10 +359,10 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::super::test_support::{
-        assert_styled, assert_text, build_src, fold_html, golden_macros,
+        assert_styled, assert_text, build_src, fold_html, golden_macros, golden_macros_with,
     };
     use crate::{
-        Span,
+        Parser, Span,
         inlines::{Anchor, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -473,5 +620,217 @@ mod tests {
 
         // The consumed span does not render into the flow.
         assert!(!folded.contains("<strong>"), "folded: {folded}");
+    }
+
+    // ---- `apply_ref_side_effects` (staged for the eventual cutover) -------
+
+    use super::apply_ref_side_effects;
+    use crate::{content::inline_builder::build, document::RefType, warnings::WarningType};
+
+    /// Builds the single-pass tree for `source` against `parser` (unlike
+    /// [`build_src`], which always uses its own fresh default parser).
+    fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
+        build(source, parser)
+    }
+
+    #[test]
+    fn registers_an_anchor_id_in_the_catalog() {
+        let source = "[[install]]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        let catalog = parser.catalog();
+        assert!(catalog.contains_id("install"));
+        assert_eq!(catalog.get_ref("install").unwrap().reftext, None);
+    }
+
+    #[test]
+    fn registers_an_anchors_reftext() {
+        let source = "[[install,Installation]]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        let catalog = parser.catalog();
+        assert_eq!(
+            catalog.get_ref("install").unwrap().reftext.as_deref(),
+            Some("Installation")
+        );
+    }
+
+    #[test]
+    fn records_a_duplicate_id_warning_for_a_repeated_anchor() {
+        let source = "[[a]] [[a]]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        // The first registration wins; the catalog holds one entry.
+        assert_eq!(parser.catalog().ids().collect::<Vec<_>>(), ["a"]);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::DuplicateId("a".to_string())
+        );
+    }
+
+    #[test]
+    fn registers_an_attributed_spans_id() {
+        // `[#anchor]*bold*` assigns an id to the span via its attribute list
+        // (see `attributes_of`'s own note on this deferred registration).
+        let source = "[#anchor]*bold*";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        assert!(parser.catalog().contains_id("anchor"));
+    }
+
+    #[test]
+    fn an_attributed_spans_duplicate_id_is_silently_non_fatal() {
+        // Unlike an inline anchor, a duplicate id assigned via an attributed
+        // span raises no warning, mirroring the string pipeline's own
+        // `let _ = register_ref(...)` in `SubstitutionStep::Quotes`.
+        let source = "[#dup]*a* [#dup]*b*";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        assert_eq!(parser.substitution_warnings_len(), before);
+        assert_eq!(parser.catalog().ids().collect::<Vec<_>>(), ["dup"]);
+    }
+
+    #[test]
+    fn does_not_register_the_inner_anchor_of_a_bibliography_style_triple_bracket() {
+        // The `[[id]]` inside `[[[id]]]` is recognized as an `Anchor` node
+        // (see the differential corpus above), but – outside a bibliography
+        // list item – the string pipeline renders it without cataloging its
+        // id (`is_bibliography_inner`); this mirrors that.
+        let source = "[[[id]]]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        assert!(!parser.catalog().contains_id("id"));
+    }
+
+    #[test]
+    fn leading_anchor_registered_suppresses_the_warning_for_the_anchor_at_the_start() {
+        // Mirrors `DefinedTerm::substitute`'s own pre-registration dance: the
+        // id is already registered by the time this pass runs, and – because
+        // the anchor sits at byte offset `0` of `source` – the
+        // `leading_anchor_registered` flag suppresses the warning the second
+        // (redundant) registration attempt would otherwise raise.
+        let source = "[[install]]";
+        let parser = Parser::default();
+        parser
+            .register_ref("install", None, RefType::Anchor)
+            .unwrap();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), true);
+
+        assert_eq!(parser.substitution_warnings_len(), before);
+    }
+
+    #[test]
+    fn leading_anchor_registered_still_warns_for_an_anchor_not_at_the_start() {
+        // The suppression is specific to the anchor at offset `0`; a
+        // duplicate anywhere else still warns even with the flag set.
+        let source = "x [[install]]";
+        let parser = Parser::default();
+        parser
+            .register_ref("install", None, RefType::Anchor)
+            .unwrap();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), true);
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::DuplicateId("install".to_string())
+        );
+    }
+
+    #[test]
+    fn registers_ids_nested_inside_a_styled_span_a_ref_and_a_footnote() {
+        use crate::inlines::{Ref, RefVariant};
+
+        let root = Span::new("[[nested]]");
+        let anchor = build_with(root, &Parser::default());
+        assert_eq!(anchor.len(), 1);
+
+        let reference = InlineNode::Ref(Ref {
+            variant: RefVariant::Link,
+            target: CowStr::from("https://example.org"),
+            children: anchor,
+            roles: vec![],
+            window: None,
+            resolved: None,
+            derived: None,
+            location: root,
+        });
+
+        let source = "*see [[a]]* and footnote:[see [[b]]]";
+        let parser = Parser::default();
+        let mut nodes = build_with(Span::new(source), &parser);
+        nodes.push(reference);
+
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        assert_eq!(
+            parser.catalog().ids().collect::<Vec<_>>(),
+            ["a", "b", "nested"]
+        );
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
+        // Each fixture uses its own pair of *independent* parsers (design
+        // §5.3's two-independent-parsers discipline, already established by
+        // the image increment's own differential corpus): one that the
+        // additive builder builds against and this function then walks, one
+        // that the real string pipeline (`golden_macros_with`, which also
+        // runs the `Quotes` step and so exercises the attributed-span
+        // registration too) runs against directly.
+        let fixtures = [
+            "[[install]]",
+            "[[install,Installation]]",
+            "anchor:install[Installation]",
+            "[#free_the_world]#free the world#",
+            "[[a]] [[a]]",
+            "[[[id]]]",
+            "*see [[x]]* and footnote:[see [[y]]]",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = Parser::default();
+            let nodes = build_with(Span::new(fixture), &builder_parser);
+            apply_ref_side_effects(&nodes, &builder_parser, Span::new(fixture), false);
+
+            let golden_parser = Parser::default();
+            golden_macros_with(fixture, &golden_parser);
+
+            assert_eq!(
+                builder_parser.catalog().ids().collect::<Vec<_>>(),
+                golden_parser.catalog().ids().collect::<Vec<_>>(),
+                "registered ids diverged for {fixture:?}"
+            );
+        }
     }
 }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -338,13 +338,10 @@ fn is_bibliography_inner(anchor: &Anchor<'_>, source: Span<'_>) -> bool {
         return false;
     }
 
-    let Some(local_offset) = anchor
-        .location
-        .byte_offset()
-        .checked_sub(source.byte_offset())
-    else {
-        return false;
-    };
+    // `anchor.location` always falls within `source` (every node this builder
+    // produces slices from the same root it was built against), so this is
+    // never a subtraction underflow.
+    let local_offset = anchor.location.byte_offset() - source.byte_offset();
 
     local_offset
         .checked_sub(1)


### PR DESCRIPTION
## Summary

Continues the `inline-ast` feature branch's Phase 4 "step 6 prep" work (see `docs/design/inline-ast-architecture.md` §5.2), following the same pattern #1165 (image side effects) and #1166 (link side effects) established.

Every macro family the single-pass inline builder recognizes still skips the **recognition side effect** its string-pipeline counterpart performs at the same point — because the additive builder runs *alongside* the authoritative string pipeline, each against its own independent `Parser`, so performing a registration from the additive pass today would risk double-counting once the two paths ever share a `Parser`. #1165 and #1166 staged the image and link families' own deferred registrations as standalone, unwired functions; this PR stages the **last** of them — the anchor/attributed-span `register_ref` pair.

- `apply_ref_side_effects` (`parser/src/content/inline_builder/macros/anchors.rs`) walks an already-built tree and, for each `Anchor` node and each id-carrying `Styled` span, calls `register_ref` under `RefType::Anchor`, reading the node's own stored `id`/`reftext` instead of a regex capture.
- It reproduces the two divergent behaviors the string pipeline's two call sites give this one catalog side effect:
  - an inline anchor additionally raises the duplicate-id warning `InlineAnchorReplacer` records;
  - an attributed span's own registration stays silently non-fatal, mirroring the quotes step's own `let _ = register_ref(...)`.
- A shorthand `[[id]]` immediately preceded by `[` — the inner anchor of a `[[[id]]]` sequence appearing *outside* a bibliography list item — is recognized (already, by the existing node builder) but never registered, mirroring `InlineAnchorReplacer`'s own `is_bibliography_inner` check (recomputed here from the node's own source span, since the tree walk has no regex capture to read it from). The true bibliography-anchor construct (`[[[label]]]` inside a bibliography list item) remains a separate, list-item-gated pass this builder does not yet recognize as its own node — out of scope here.
- A `leading_anchor_registered` parameter mirrors `apply_macros_with_leading_anchor_registered`'s own flag, so wiring this function in at the description-list-term call site (`DefinedTerm::substitute`) can later suppress the same duplicate-id warning the string pipeline suppresses there.
- Recurses into every container an id-bearing node can be nested inside (`Styled`, `Ref`, `Footnote` children), matching the image/link increments' own recursion.

As with #1165/#1166, **nothing is wired into a real parse path** — the function is exercised only by its own tests, against their own `Parser`. A broad differential corpus compares its registrations against the golden string pipeline's own, using the same two-independent-parsers discipline.

With this landed, every recognition side effect step 5's macro families skip is now staged as its own unwired building block; step 6 itself (swapping the recorder for the builder, the fold, the sentinel deletions, and calling each staged function exactly once per parse) remains fully outstanding.

Also updates `docs/design/inline-ast-architecture.md` to record this increment, matching the "landed as" narrative style already established for the image and link preps.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::macros::anchors` — 20 tests pass, including the new differential corpus and duplicate-id/bibliography-inner/leading-anchor coverage.
- [x] `cargo test -p asciidoc-parser --lib` — full suite (4940 tests) passes.
- [x] `cargo clippy -p asciidoc-parser --lib --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0117Jv5FKd8PwCPJ7ixMwTQk)_