### PR TITLE
feat: Compose the staged inline-builder side effects into one entry point (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1540,6 +1540,47 @@ Each phase is a reviewable unit with a clear exit gate.
   unwired building block; step 6 itself – swapping the recorder for the builder, the fold, the sentinel
   deletions, and calling each staged function exactly once per parse – remains fully outstanding.
 
+  *Step 6 prep landed as (a combined entry point for every staged side effect, plus a link-registration-order
+  fix it surfaced):* with all three families' side effects staged individually, the cutover's own job of
+  "calling each staged function exactly once per parse" needed one more piece: a single entry point that
+  composes them in the right relative order, since the two link-recognizing families and the image/anchor
+  families all write into catalogs and warnings the cutover must get right *together*, not just individually.
+  [`apply_macro_side_effects`](../../parser/src/content/inline_builder/macros/mod.rs) is that entry point –
+  it calls [`apply_image_side_effects`](../../parser/src/content/inline_builder/macros/image.rs), then
+  [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs), then
+  [`apply_ref_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs) – the same relative
+  order the string pipeline's own macro passes run in (§4.1) – so that when more than one family's side
+  effect touches the *same* shared list (concretely, [`Parser::record_substitution_warning`](../../parser/src/parser/parser.rs)'s
+  one shared warnings list, which both the image family's dangerous-scheme warning and the anchor family's
+  duplicate-id warning write to) the combined call lands them in the golden pipeline's own order. A new
+  differential corpus exercises the composed call directly – a fixture mixing an image, both link forms, and
+  an anchor in one content, and a fixture whose image and anchor *both* warn, asserting the two warnings land
+  in image-then-anchor order against an independent golden parser (the same two-independent-parsers
+  discipline every prior staged function's own corpus uses).
+
+  Building that composed differential corpus surfaced a genuine ordering bug in the already-staged
+  [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs): the string pipeline
+  registers a link's target when its *own* replacer's pass matches it, and the auto-link/formal-URL pass
+  (`INLINE_LINK`) and the `link:`/`mailto:` macro pass (`INLINE_LINK_MACRO`) are two separate, sequential
+  whole-string passes (§4.1) – so the catalog ends up in **family-pass order, not true source order**: every
+  auto-link/formal-URL link registers before every `link:`/`mailto:` macro, regardless of which appears first
+  in the source (already pinned, independently of this module, by
+  `catalog_records_link_targets_when_catalog_assets_enabled` in `tests/asciidoctor_rb/substitutions_test.rs`).
+  The originally-staged function instead made one tree walk in document order, which is only ever correct by
+  coincidence – a content that interleaves the two forms out of that relative order (`link:b.html[B] then
+  https://a.example`) diverges: document order would register `b.html` first, but the golden catalog is
+  `["https://a.example", "b.html"]`. No existing test exercised mixed forms in one content, so this had gone
+  unnoticed. The fix makes two passes over the tree – every auto-link/formal-URL match first, then every
+  `link:`/`mailto:` macro match – distinguishing the two from a node's own `location` alone (a `link:`/
+  `mailto:` match's location always starts with its literal prefix, and the auto-link pass never builds a
+  node for `INLINE_LINK`'s own link-macro branch, deferring that whole form to the macro pass – see
+  [`inline_link_level`](../../parser/src/content/inline_builder/macros/links.rs)'s own doc comment – so this
+  is a reliable signal, not a heuristic, and needs no new node field). A new test pins the interleaved case
+  directly against the golden pipeline, and the broad differential fixture set gains an interleaved fixture
+  too. As with every prior increment in this module, nothing here is wired into a real parse path – calling
+  [`apply_macro_side_effects`] for real still waits for the single-pass builder to replace the recorder as
+  `Content`'s tree source, which remains step 6's own, still fully outstanding, job.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -221,8 +221,9 @@ fn build_anchor_reftext<'src>(
 /// see [`attributes_of`](super::super::quotes::attributes_of)'s own note).
 ///
 /// Every macro family this module recognizes defers exactly this kind of side
-/// effect (see [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
-/// own note): while the additive builder runs *alongside* the authoritative
+/// effect (see
+/// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
+/// s own note): while the additive builder runs *alongside* the authoritative
 /// string pipeline – each against its own, independent [`Parser`] – performing
 /// it from every additive pass would risk double-counting a registration once
 /// the two paths ever share one `Parser`. This function is the last of the
@@ -234,8 +235,8 @@ fn build_anchor_reftext<'src>(
 /// their own `Parser`.
 ///
 /// `source` is the whole original content span being processed, used – like
-/// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
-/// own `source` parameter – to locate the duplicate-id warning exactly as
+/// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
+/// s own `source` parameter – to locate the duplicate-id warning exactly as
 /// [`InlineAnchorReplacer`](crate::content::macros) does (against the
 /// content's own span, not the individual anchor's).
 ///

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -550,8 +550,9 @@ pub(super) fn build_link_node<'src>(
 /// needed.
 ///
 /// Every macro family this module recognizes defers exactly this kind of side
-/// effect (see [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'s
-/// own note): while the additive builder runs *alongside* the authoritative
+/// effect (see
+/// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
+/// s own note): while the additive builder runs *alongside* the authoritative
 /// string pipeline – each against its own, independent [`Parser`] – performing
 /// it from every additive pass would risk double-counting a registration once
 /// the two paths ever share one `Parser`. This function is that deferred piece

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -562,6 +562,32 @@ pub(super) fn build_link_node<'src>(
 /// real parse yet – it is exercised only by this module's own tests, against
 /// their own `Parser`.
 ///
+/// # Registration order across the two link forms
+///
+/// The string pipeline registers a link's target *when its own replacer's
+/// regex pass matches it* – `InlineLinkReplacer` (auto-links and formal-URL
+/// links, `INLINE_LINK`'s non-angle branch) runs as one whole-string pass, then
+/// `InlineLinkMacroReplacer` (`link:`/`mailto:`, `INLINE_LINK_MACRO`) runs as a
+/// *second*, later pass – exactly the order [`inline_link_level`] and
+/// [`link_macro_level`] apply the two families in. So the catalog ends up in
+/// **family-pass order, not true source order**: every auto-link/formal-URL
+/// link in the content registers before every `link:`/`mailto:` macro in it,
+/// regardless of which appears first in the source (see
+/// `catalog_records_link_targets_when_catalog_assets_enabled` in
+/// `tests/asciidoctor_rb/substitutions_test.rs`, which pins this exact
+/// behavior). A single tree walk in document order would get this wrong for a
+/// content that interleaves the two forms out of that relative order (for
+/// example `link:b.html[B] then https://a.example`, which the golden pipeline
+/// registers as `["https://a.example", "b.html"]`, not `["b.html",
+/// "https://a.example"]`), so this function makes **two** passes over the
+/// tree – all auto-link/formal-URL matches first, then all `link:`/`mailto:`
+/// macro matches – rather than one. [`link_form`] tells the two apart from the
+/// node's own `location` (a `link:`/`mailto:` macro's location always starts
+/// with its literal prefix; [`inline_link_level`] never builds a node for
+/// `INLINE_LINK`'s own link-macro branch, deferring that whole form to
+/// [`link_macro_level`] – see [`inline_link_level`]'s own doc comment – so this
+/// is a reliable, no-recomputation signal, not a heuristic).
+///
 /// Recurses into every container a `Ref` node can be nested inside –
 /// [`Styled`](InlineNode::Styled), another [`Ref`](InlineNode::Ref) (a link's
 /// own display children, or a cross-reference's), and
@@ -572,26 +598,58 @@ pub(super) fn build_link_node<'src>(
 /// but its children are still walked, since a formatted cross-reference text
 /// could itself carry a nested link.
 pub(crate) fn apply_link_side_effects(nodes: &[InlineNode<'_>], parser: &Parser) {
+    register_links_of_form(nodes, parser, LinkForm::AutoOrFormal);
+    register_links_of_form(nodes, parser, LinkForm::Macro);
+}
+
+/// Which of the two link-recognizing passes built a [`Ref`](InlineNode::Ref)
+/// node – see [`apply_link_side_effects`]'s own "Registration order" note.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum LinkForm {
+    /// An auto-link or formal-URL link, built by [`inline_link_level`].
+    AutoOrFormal,
+
+    /// A `link:`/`mailto:` macro, built by [`link_macro_level`].
+    Macro,
+}
+
+/// Walks `nodes`, registering only the [`Ref`](InlineNode::Ref)`{Link}` nodes
+/// of the given `form`, in document order.
+fn register_links_of_form(nodes: &[InlineNode<'_>], parser: &Parser, form: LinkForm) {
     for node in nodes {
         match node {
             InlineNode::Ref(reference) => {
-                if reference.variant == RefVariant::Link {
+                if reference.variant == RefVariant::Link && link_form(reference) == form {
                     parser.register_link(reference.target.to_string());
                 }
 
-                apply_link_side_effects(&reference.children, parser);
+                register_links_of_form(&reference.children, parser, form);
             }
 
             InlineNode::Styled(styled) => {
-                apply_link_side_effects(&styled.children, parser);
+                register_links_of_form(&styled.children, parser, form);
             }
 
             InlineNode::Footnote(footnote) => {
-                apply_link_side_effects(&footnote.children, parser);
+                register_links_of_form(&footnote.children, parser, form);
             }
 
             _ => {}
         }
+    }
+}
+
+/// Tells which pass built a link [`Ref`](InlineNode::Ref) node from its own
+/// `location`: only [`link_macro_level`] ever builds a node whose matched
+/// source starts with a literal `link:`/`mailto:` prefix (see
+/// [`apply_link_side_effects`]'s own doc comment).
+fn link_form(reference: &Ref<'_>) -> LinkForm {
+    let text = reference.location.data();
+
+    if text.starts_with("link:") || text.starts_with("mailto:") {
+        LinkForm::Macro
+    } else {
+        LinkForm::AutoOrFormal
     }
 }
 
@@ -1255,6 +1313,31 @@ mod tests {
     }
 
     #[test]
+    fn registers_interleaved_forms_in_family_pass_order_not_source_order() {
+        // `link:b.html[B]` appears first in the source, but the golden
+        // pipeline's `link:`/`mailto:` pass runs *after* its auto-link/
+        // formal-URL pass (see `apply_link_side_effects`'s own "Registration
+        // order" doc note), so `https://a.example` – which appears second –
+        // registers first. A single document-order tree walk would get this
+        // backwards; the two-pass split must reproduce it.
+        let source = "link:b.html[B] then https://a.example then link:c.html[C]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(
+            parser.catalog().links(),
+            ["https://a.example", "b.html", "c.html"]
+        );
+
+        // The golden string pipeline agrees.
+        let golden_parser = Parser::default().with_catalog_assets(true);
+        golden_macros_with(source, &golden_parser);
+        assert_eq!(golden_parser.catalog().links(), parser.catalog().links());
+    }
+
+    #[test]
     fn does_not_register_a_cross_reference_as_a_link() {
         // A cross-reference is also a `Ref` node, but only a `Link` variant has
         // an asset-catalog entry.
@@ -1308,6 +1391,10 @@ mod tests {
             "link:https://example.org[Example]",
             "\\link:index.html[Docs]",
             "link:a.html[A]{sp}link:b.html[B]",
+            // Interleaved forms, out of source order relative to the family
+            // passes that register them (see `apply_link_side_effects`'s own
+            // "Registration order" doc note).
+            "link:b.html[B]{sp}then{sp}https://a.example",
         ];
 
         for fixture in fixtures {

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -285,11 +285,13 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::apply_macros;
+    use super::{super::test_support::golden_macros_with, apply_macro_side_effects, apply_macros};
     use crate::{
         Parser, Span,
+        content::inline_builder::build,
         inlines::{InlineNode, Ref, RefVariant},
         strings::CowStr,
+        warnings::WarningType,
     };
 
     #[test]
@@ -336,16 +338,6 @@ mod tests {
             other => panic!("expected the Ref to survive, got {other:?}"),
         }
     }
-}
-
-#[cfg(test)]
-mod side_effects_tests {
-    #![allow(clippy::indexing_slicing)]
-    #![allow(clippy::panic)]
-    #![allow(clippy::unwrap_used)]
-
-    use super::{super::test_support::golden_macros_with, apply_macro_side_effects};
-    use crate::{Parser, Span, content::inline_builder::build, warnings::WarningType};
 
     #[test]
     fn registers_every_family_from_a_single_call() {

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -148,10 +148,10 @@ pub(super) fn apply_macros<'src>(
 
 /// The eventual cutover's single entry point (design §5.2, Phase 4 step 6) for
 /// **every** recognition side effect the macro families above defer –
-/// composing [`image::apply_image_side_effects`], [`links::apply_link_side_effects`],
-/// and [`anchors::apply_ref_side_effects`], each staged and tested as its own
-/// standalone building block, into the one call the cutover makes exactly once
-/// per parse.
+/// composing [`image::apply_image_side_effects`],
+/// [`links::apply_link_side_effects`], and [`anchors::apply_ref_side_effects`],
+/// each staged and tested as its own standalone building block, into the one
+/// call the cutover makes exactly once per parse.
 ///
 /// # Ordering
 ///
@@ -344,8 +344,7 @@ mod side_effects_tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::test_support::golden_macros_with;
-    use super::apply_macro_side_effects;
+    use super::{super::test_support::golden_macros_with, apply_macro_side_effects};
     use crate::{Parser, Span, content::inline_builder::build, warnings::WarningType};
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1,9 +1,9 @@
 //! The macros substitution step, split by macro family.
 
-mod anchors;
+pub(super) mod anchors;
 pub(super) mod image;
 mod indexterm;
-mod links;
+pub(super) mod links;
 mod ui;
 mod xref;
 
@@ -146,6 +146,57 @@ pub(super) fn apply_macros<'src>(
     // other family at every level.
 }
 
+/// The eventual cutover's single entry point (design §5.2, Phase 4 step 6) for
+/// **every** recognition side effect the macro families above defer –
+/// composing [`image::apply_image_side_effects`], [`links::apply_link_side_effects`],
+/// and [`anchors::apply_ref_side_effects`], each staged and tested as its own
+/// standalone building block, into the one call the cutover makes exactly once
+/// per parse.
+///
+/// # Ordering
+///
+/// The three are called in the same relative order the string pipeline's own
+/// macro passes run in (image/icon, …, links, …, anchors, …– see
+/// [`apply_macros`]'s own doc comment): image, then link, then anchor/ref.
+/// This is not cosmetic – it is what keeps this function's output identical to
+/// the golden pipeline's whenever more than one family's side effect touches
+/// the *same* shared list. Concretely, [`Parser::record_substitution_warning`]
+/// appends to one shared warnings list, and both
+/// [`image::apply_image_side_effects`]'s dangerous-link-scheme warning and
+/// [`anchors::apply_ref_side_effects`]'s duplicate-id warning write to it – a
+/// content whose image triggers the first and whose anchor triggers the
+/// second must see the image warning recorded first, exactly as it would from
+/// the string pipeline's own image-then-anchor pass order. (The asset/ref
+/// catalogs the three write to are otherwise disjoint from one another –
+/// images, links, and refs are three separate lists – so this ordering does
+/// not, by itself, need to hold *within* a single catalog; see
+/// [`links::apply_link_side_effects`]'s own doc comment for the finer-grained
+/// ordering *within* the link family that the golden pipeline also requires.)
+///
+/// Index terms, cross-references, and footnotes are not part of this
+/// function: index terms and cross-references perform no recognition side
+/// effect at all (an index term has no catalog in the HTML backend; a
+/// cross-reference is resolved, not registered), and a footnote's one
+/// required side effect – its assigned number – is not deferred in the first
+/// place (see [`apply_footnotes`](super::footnotes::apply_footnotes)'s own doc
+/// comment); it already runs during [`build`](super::build), not here.
+///
+/// As with each of the three functions it composes, **nothing here is wired
+/// into a real parse path yet** – it is exercised only by this module's own
+/// tests, against their own `Parser`. `source` and `leading_anchor_registered`
+/// are threaded straight through to
+/// [`anchors::apply_ref_side_effects`] – see its own doc comment for both.
+pub(crate) fn apply_macro_side_effects(
+    nodes: &[InlineNode<'_>],
+    parser: &Parser,
+    source: Span<'_>,
+    leading_anchor_registered: bool,
+) {
+    image::apply_image_side_effects(nodes, parser, source);
+    links::apply_link_side_effects(nodes, parser);
+    anchors::apply_ref_side_effects(nodes, parser, source, leading_anchor_registered);
+}
+
 /// One recognized macro match at a level, in absolute match-string byte
 /// offsets. Shared across the macro families (image/icon, UI, and later
 /// increments), which differ only in how they *build* a match's node.
@@ -284,5 +335,94 @@ mod tests {
 
             other => panic!("expected the Ref to survive, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod side_effects_tests {
+    #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::super::test_support::golden_macros_with;
+    use super::apply_macro_side_effects;
+    use crate::{Parser, Span, content::inline_builder::build, warnings::WarningType};
+
+    #[test]
+    fn registers_every_family_from_a_single_call() {
+        let source =
+            "image:a.png[] link:b.html[B] https://c.example [[anchor-id]] xref:anchor-id[]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build(Span::new(source), &parser);
+
+        apply_macro_side_effects(&nodes, &parser, Span::new(source), false);
+
+        let catalog = parser.catalog();
+        assert_eq!(
+            catalog
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect::<Vec<_>>(),
+            ["a.png"]
+        );
+        assert_eq!(catalog.links(), ["https://c.example", "b.html"]);
+        assert!(catalog.contains_id("anchor-id"));
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registrations_and_warning_order_for_mixed_families() {
+        // A content that exercises every family this function composes in one
+        // go: an image whose `link=` targets a dangerous scheme (a warning
+        // from the image family) *before* a duplicate anchor id (a warning
+        // from the anchor family) – the golden pipeline's own image-then-
+        // anchor pass order (`apply_macros`'s own doc comment) must land the
+        // two warnings in that order, not the reverse. Each side uses its own
+        // *independent* parser (design §5.3's two-independent-parsers
+        // discipline, established by the image increment's own differential
+        // corpus).
+        let source = "image:x.png[alt,link=javascript:alert(1)] then [[dup]] and [[dup]]";
+
+        let builder_parser = Parser::default().with_catalog_assets(true);
+        let nodes = build(Span::new(source), &builder_parser);
+        apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
+
+        let golden_parser = Parser::default().with_catalog_assets(true);
+        golden_macros_with(source, &golden_parser);
+
+        assert_eq!(
+            builder_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect::<Vec<_>>(),
+            golden_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect::<Vec<_>>(),
+        );
+
+        let builder_warnings: Vec<_> = builder_parser
+            .drain_substitution_warnings_since(0)
+            .into_iter()
+            .map(|w| w.warning)
+            .collect();
+        let golden_warnings: Vec<_> = golden_parser
+            .drain_substitution_warnings_since(0)
+            .into_iter()
+            .map(|w| w.warning)
+            .collect();
+
+        assert_eq!(builder_warnings, golden_warnings);
+        assert_eq!(
+            builder_warnings,
+            [
+                WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
+                WarningType::DuplicateId("dup".to_string()),
+            ]
+        );
     }
 }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -162,14 +162,16 @@
 //! the additive builder still runs *alongside* the authoritative string
 //! pipeline (each against its own, independent [`Parser`]), so performing one
 //! here today would risk double-counting a registration once the two paths
-//! ever share a `Parser`. [`apply_image_side_effects`] is the first of these
-//! to be written: it re-attaches the `image:`/`icon:` family's own deferred
-//! side effects (`register_image`, the `link=` dangerous-scheme/self-href
-//! warning) as a function that walks an already-built tree, staged as its own
-//! reviewable building block for the cutover (design §5.2, Phase 4 step 6).
-//! It is exercised only by its own tests, against their own `Parser` – calling
-//! it for real means invoking it exactly once per parse, after the
-//! single-pass builder replaces the recorder as `Content`'s tree source.
+//! ever share a `Parser`. Each family's own deferred side effects are staged
+//! as their own reviewable building block – `register_image` and the `link=`
+//! dangerous-scheme/self-href warning for `image:`/`icon:`, `register_link`
+//! for the four link-macro forms, and the `register_ref` pair for anchors and
+//! id-carrying attributed spans – and [`apply_macro_side_effects`] composes
+//! all three, in the string pipeline's own family-pass order, into the single
+//! call the eventual cutover makes exactly once per parse (design §5.2, Phase
+//! 4 step 6). It is exercised only by its own tests (and its constituents'
+//! own), against their own `Parser` – calling it for real still waits for the
+//! single-pass builder to replace the recorder as `Content`'s tree source.
 //!
 //! # A note on quote nesting
 //!
@@ -223,7 +225,7 @@ use macros::apply_macros;
 // yet called from any real parse path, so – like `fold_html` above – reachable
 // only via `cfg(test)` callers and future external callers today.
 #[allow(unused_imports)]
-pub(crate) use macros::image::apply_image_side_effects;
+pub(crate) use macros::apply_macro_side_effects;
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -220,12 +220,12 @@ use char_replacements::apply_character_replacements;
 #[allow(unused_imports)]
 pub(crate) use fold::fold_html;
 use footnotes::apply_footnotes;
-use macros::apply_macros;
 // Staged for the eventual cutover (see this module's own doc comment); not
 // yet called from any real parse path, so – like `fold_html` above – reachable
 // only via `cfg(test)` callers and future external callers today.
 #[allow(unused_imports)]
 pub(crate) use macros::apply_macro_side_effects;
+use macros::apply_macros;
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;


### PR DESCRIPTION
## Summary

Continues the `inline-ast` Phase 4 "step 6 prep" line of work (#1165, #1166, #1167), which staged the recognition side effects (`register_image`, `register_link`, `register_ref`, and their associated warnings) that the single-pass inline builder's macro families defer until the eventual cutover.

- Adds `apply_macro_side_effects` (`parser/src/content/inline_builder/macros/mod.rs`), the single entry point the cutover will call exactly once per parse. It composes the three previously-staged, previously-unreachable-outside-their-own-tests functions (`apply_image_side_effects`, `apply_link_side_effects`, `apply_ref_side_effects`) in the same relative order the string pipeline's own macro passes run in — image, then link, then anchor — so cross-family shared state (concretely, the shared substitution-warnings list, which both the image family's dangerous-scheme warning and the anchor family's duplicate-id warning write to) lands in the golden pipeline's own order.
- Re-exports it from `inline_builder::mod` in place of the narrower `apply_image_side_effects` re-export, and widens `anchors`/`links` from private to `pub(super)` so the combinator can reach them.
- Building the combined differential corpus surfaced a genuine, previously-untested ordering bug in the already-merged `apply_link_side_effects`: the golden string pipeline registers a link's target in **family-pass order, not source order** — the auto-link/formal-URL pass and the `link:`/`mailto:` macro pass are two separate, sequential whole-string passes, so every auto-link/formal-URL link registers before every `link:`/`mailto:` macro regardless of which appears first in the source (this exact behavior is independently pinned by `catalog_records_link_targets_when_catalog_assets_enabled` in `tests/asciidoctor_rb/substitutions_test.rs`). The originally-staged function did one document-order tree walk, which is only correct by coincidence when the two forms don't interleave — no existing test caught this. Fixed with a two-pass walk that distinguishes the two forms from a node's own `location` alone (a `link:`/`mailto:` node's location always starts with its literal prefix; the auto-link pass never builds a node for that branch), with a new regression test and an added fixture in the broad differential corpus pinning the interleaved case against the golden pipeline directly.
- Updates the design doc (`docs/design/inline-ast-architecture.md`) with a new "Step 6 prep" entry describing both pieces.

As with every prior increment in this module, **nothing is wired into a real parse path** — `apply_macro_side_effects` is exercised only by its own tests, against their own `Parser`. Calling it for real still waits for the single-pass builder to replace the recorder as `Content`'s tree source (step 6 itself, which remains fully outstanding).

## Test plan

- [x] `cargo test -p asciidoc-parser content::inline_builder::` — 279 passed, including the new combinator tests and the link-ordering regression test
- [x] `cargo test --workspace` — 4943 passed, 0 failed
- [x] `cargo fmt --check -p asciidoc-parser`
- [x] `cargo clippy --all-features --all-targets -p asciidoc-parser -- -Dwarnings`
- [x] `cargo doc -p asciidoc-parser --no-deps --document-private-items` (checks intra-doc links)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABLNyHzHR6eRRSvhiFYzMt)_