### PR TITLE
feat: Recognize an attribute-list-bearing xref: display text in the single-pass inline builder (inline-ast Phase 4, step 4b(ii) part 3c)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1016,6 +1016,46 @@ Each phase is a reviewable unit with a clear exit gate.
   carrying an attribute list (part 3c's other half) – is unchanged, still pinned by its own
   divergence test.
 
+  *Step 4b(ii) part 3c (attribute-list half) landed as (`Ref` grows `xrefstyle`, closing the last
+  deferred xref form):* the `xref:` macro's own remaining deferred form – a bracketed text
+  carrying an attribute list (an `=`, for `window`/`role`/`xrefstyle`) – is now recognized.
+  [`xref_macro_text`](../../parser/src/content/inline_builder/macros/xref.rs) mirrors
+  `InlineXrefReplacer::replace_append`'s own text interpretation exactly: it parses the text – from
+  a newline-normalized copy, since the parse is not necessarily verbatim, exactly as the string
+  replacer parses that same normalized copy rather than a source slice – as an
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs) whose first positional attribute becomes the
+  display text and whose `window`/`role` named attributes populate the node's existing fields; a new
+  [`Ref::xrefstyle`](../../parser/src/inlines/ref_node.rs) field (`Option<XrefStyle>`) carries a
+  `xrefstyle=` override. As with the `<<other#frag>>` half, this needed no consumer to pin its
+  shape – `window`/`roles` already existed as plain fields (not an `Attrlist<'src>`) because
+  [`XrefRenderParams`](../../parser/src/parser/inline_substitution_renderer.rs) itself takes them
+  that way, not a borrowed attribute list, so the node stores exactly what the fold already needs.
+  When the attrlist parse finds no named attribute – the sole positional value is the whole
+  normalized text – the `=` was incidental (mirroring Asciidoctor's own
+  `extract_attributes_from_text` fallback); the text is then used as plain display text with no
+  named attributes, exactly as if it carried no `=` at all. The parsed positional text becomes a
+  *synthesized* `Text` child (no `'src` slice of its own, since it comes from the normalized,
+  attrlist-parsed copy) whose location falls back to the bracketed text's own span (design §4.4),
+  the same synthesized-value policy `apply_attribute_references` (step 5b) already established.
+
+  Landing this also closed a latent gap the fold carried since the cross-reference increment first
+  landed (part 3a): the *document-wide* `xrefstyle` attribute – which applies to every reference,
+  not only one carrying its own `xrefstyle=` override – was never applied at all, because
+  [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) hard-coded `xrefstyle: None`. It now
+  combines the node's own override with the document-wide default exactly as
+  `InlineXrefReplacer` does (`xrefstyle_override.or_else(|| document_xrefstyle(parser))`), reusing
+  the string pipeline's own [`document_xrefstyle`](../../parser/src/content/macros.rs) helper (now
+  shared `pub(crate)`) rather than a second implementation. The `<<id>>` shorthand has no
+  attribute-list text of its own – its node's `xrefstyle` override is always `None` – but still
+  observes the document-wide default through this same fold-time combination, closing the sub-step
+  in full: every form the design names for part 3c is now recognized. A differential corpus extends
+  the existing xref fixtures with `role=`/`window=`/`xrefstyle=` combinations, a positional-text-free
+  attribute list, and the incidental-`=` case (verified reachable in the builder's own verbatim-gated
+  matching, unlike the nested-macro-substitution route the string pipeline's own incidental case
+  takes); hand-built-node tests in `fold.rs` pin the document-wide-default and override-precedence
+  behavior directly, since neither is observable through an unresolved fold (the tree does not yet
+  reach catalog resolution – that remains step 6's job).
+
   *Step 4b(ii) part 4a landed as (`Macros` → `Anchor`, inline anchors):* the builder now recognizes
   **inline anchors** in both spellings – the `[[id]]` / `[[id,reftext]]` shorthand and the
   `anchor:id[reftext]` macro – as an [`Anchor`](../../parser/src/inlines/anchor.rs) node, folding
@@ -1609,26 +1649,28 @@ Each phase is a reviewable unit with a clear exit gate.
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
   3. ✅ `CharacterReplacements` → `CharRef::Replacement`, and `PostReplacement` → `LineBreak`.
-  4. `Macros`, sliced by construct family, each capturing the owned `Attrlist<'src>` it carries –
+  4. ✅ `Macros`, sliced by construct family, each capturing the owned `Attrlist<'src>` it carries –
      the step that makes nodes **self-describing** (and the one that finally unblocks
      `render_with`):
      - ✅ **4a.** `Image` / icon (`image:` / `icon:`).
-     - **4b.** the remaining families, each its own sub-step:
+     - ✅ **4b.** the remaining families, each its own sub-step:
        - ✅ **4b(i).** `Ui` (`kbd:` / `btn:` / `menu:`).
-       - **4b(ii).** `Ref` (links / cross-references), `Footnote`, `IndexTerm`, `Stem`, `Anchor`,
+       - ✅ **4b(ii).** `Ref` (links / cross-references), `Footnote`, `IndexTerm`, `Stem`, `Anchor`,
          itself sliced into parts:
          - ✅ **part 1.** the `link:`/`mailto:` macro (`INLINE_LINK_MACRO`) → `Ref{Link}`.
          - ✅ **part 2.** auto-links and formal-URL links (`INLINE_LINK`) → `Ref{Link}`.
-         - **part 3.** cross-references (`INLINE_XREF`) → `Ref{Xref}`, itself sliced:
+         - ✅ **part 3.** cross-references (`INLINE_XREF`) → `Ref{Xref}`, itself sliced:
            - ✅ **part 3a.** the same-document `xref:` macro form (`xref:id[text]`).
            - ✅ **part 3b.** the same-document `<<id>>` shorthand (`<<id>>` / `<<id,text>>`).
-           - **part 3c.** the node-blocked forms both spellings share, split in two once landed:
+           - ✅ **part 3c.** the node-blocked forms both spellings share, split in two once landed:
              - ✅ inter-document targets and the document-as-a-whole form (a *derived*
                destination) – needed only an existing, already-public type (`Ref` gains
                `derived: Option<DerivedReference>`), no consumer required to pin its shape.
-             - an attribute-list text (an `Attrlist<'src>`, for `window`/`role`/`xrefstyle`) –
-               still needs new `Ref` fields, pinned against a consumer.
-         - **part 4.** `Anchor`, `IndexTerm`, `Footnote`, each its own sub-step (inline `Stem` is
+             - ✅ an attribute-list text (`window`/`role` reuse `Ref`'s existing plain fields; a
+               new `Ref::xrefstyle: Option<XrefStyle>` field carries the macro-level override) –
+               needed no consumer to pin its shape, since `XrefRenderParams` itself takes plain
+               fields, not a borrowed `Attrlist<'src>`.
+         - ✅ **part 4.** `Anchor`, `IndexTerm`, `Footnote`, each its own sub-step (inline `Stem` is
            *not* a macros-step family – it is extracted at passthrough time, so it lands in step 5):
            - ✅ **part 4a.** inline anchors (`[[id]]` / `anchor:id[…]`, `INLINE_ANCHOR`) → `Anchor`.
            - ✅ **part 4b.** index terms (`((term))` / `(((primary, secondary)))` / `indexterm:[…]` /

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -543,6 +543,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -562,8 +562,10 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::test_support::{build_src, fold_html};
-    use super::fold_html as fold_html_with_parser;
+    use super::{
+        super::test_support::{build_src, fold_html},
+        fold_html as fold_html_with_parser,
+    };
     use crate::{
         Parser, Span,
         inlines::{CharRef, Image, InlineNode, Ref, RefVariant},

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -4,6 +4,7 @@ use super::{callouts::replacement_type_of, quotes::quote_type_of};
 use crate::{
     Parser,
     attributes::{Attrlist, AttrlistContext},
+    content::document_xrefstyle,
     inlines::{
         Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
         RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
@@ -360,9 +361,12 @@ fn fold_link(
 /// `None` here) and a target that carries its own destination without a
 /// catalog (`derived`, populated at build time – see the `Ref::derived` field
 /// docs): an inter-document target, and the empty target naming the current
-/// document as a whole. It does not yet parse an attribute-list-bearing
-/// display text, so `xrefstyle` is always `None`; the cutover (design §5.2
-/// Phase 4, step 6) wires catalog resolution to the tree.
+/// document as a whole. The effective `xrefstyle` is the node's own
+/// macro-level override if present, otherwise the document-wide `xrefstyle`
+/// attribute in effect for this reference – mirroring `InlineXrefReplacer`'s
+/// own `xrefstyle_override.or_else(|| document_xrefstyle(parser))` exactly
+/// (see the `Ref::xrefstyle` field docs); the cutover (design §5.2 Phase 4,
+/// step 6) wires catalog resolution to the tree.
 fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -382,12 +386,14 @@ fn fold_xref(
     // materialized into a `String` vector for the borrow.
     let roles: Vec<String> = reference.roles.iter().map(|r| r.to_string()).collect();
 
+    let xrefstyle = reference.xrefstyle.or_else(|| document_xrefstyle(parser));
+
     let params = XrefRenderParams {
         target: reference.target.as_ref(),
         provided_text,
         window: reference.window.as_deref(),
         roles: &roles,
-        xrefstyle: None,
+        xrefstyle,
         derived: reference.derived.as_ref(),
         resolved: reference.resolved.as_ref(),
     };
@@ -557,10 +563,14 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::test_support::{build_src, fold_html};
+    use super::fold_html as fold_html_with_parser;
     use crate::{
-        Span,
-        inlines::{CharRef, Image, InlineNode},
-        parser::HtmlSubstitutionRenderer,
+        Parser, Span,
+        inlines::{CharRef, Image, InlineNode, Ref, RefVariant},
+        parser::{
+            HtmlSubstitutionRenderer, ModificationContext, ResolvedReference, XrefSignifier,
+            XrefStyle,
+        },
         strings::CowStr,
     };
 
@@ -624,5 +634,78 @@ mod tests {
         let macro_built = fold_html(&build_src(location), &renderer);
 
         assert_eq!(fold_html(&[hand_built], &renderer), macro_built);
+    }
+
+    /// A resolved cross-reference to a target that carries a signifier (a
+    /// numbered/captioned element), with no explicit display text – the shape
+    /// `xrefstyle` formatting actually changes (design's `apply_xrefstyle`
+    /// only alters output when a signifier is present).
+    fn resolved_xref_with_signifier(xrefstyle: Option<XrefStyle>) -> InlineNode<'static> {
+        InlineNode::Ref(Ref {
+            variant: RefVariant::Xref,
+            target: CowStr::from("install"),
+            children: vec![],
+            roles: vec![],
+            window: None,
+            resolved: Some(ResolvedReference {
+                href: "#install".to_string(),
+                text: None,
+                signifier: Some(XrefSignifier {
+                    label: "Section 2".to_string(),
+                    emphasize: false,
+                }),
+            }),
+            derived: None,
+            xrefstyle,
+            location: Span::new(""),
+        })
+    }
+
+    #[test]
+    fn fold_xref_falls_back_to_the_document_wide_xrefstyle() {
+        // A node with no macro-level `xrefstyle` override still picks up the
+        // document-wide `xrefstyle` attribute in effect for the reference,
+        // mirroring `InlineXrefReplacer`'s own
+        // `xrefstyle_override.or_else(|| document_xrefstyle(parser))` (see the
+        // `Ref::xrefstyle` field docs) – this is the document-wide default a
+        // hand-built node with no override still observes.
+        let renderer = HtmlSubstitutionRenderer {};
+        let nodes = [resolved_xref_with_signifier(None)];
+
+        // With no document-wide `xrefstyle` set, the target's reference text
+        // (here `None`, so the bracketed fallback) is used verbatim.
+        let unstyled = fold_html_with_parser(&nodes, &renderer, &Parser::default());
+        assert!(!unstyled.contains("Section 2"), "folded: {unstyled}");
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "xrefstyle",
+            "full",
+            ModificationContext::Anywhere,
+        );
+
+        let styled = fold_html_with_parser(&nodes, &renderer, &parser);
+        assert!(styled.contains("Section 2, &#8220;"), "folded: {styled}");
+    }
+
+    #[test]
+    fn fold_xref_macro_level_xrefstyle_overrides_the_document_wide_default() {
+        // A macro-level `xrefstyle=` override (`Ref::xrefstyle`) wins over the
+        // document-wide `xrefstyle` attribute, exactly as
+        // `InlineXrefReplacer`'s own `xrefstyle_override` takes precedence.
+        let renderer = HtmlSubstitutionRenderer {};
+        let nodes = [resolved_xref_with_signifier(Some(XrefStyle::Short))];
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "xrefstyle",
+            "full",
+            ModificationContext::Anywhere,
+        );
+
+        let folded = fold_html_with_parser(&nodes, &renderer, &parser);
+
+        // `Short` shows only the signifier label, with none of `Full`'s
+        // quoted-title suffix.
+        assert!(folded.contains(">Section 2<"), "folded: {folded}");
+        assert!(!folded.contains("&#8220;"), "folded: {folded}");
     }
 }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -781,6 +781,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -629,6 +629,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -279,6 +279,7 @@ fn build_inline_link_node<'src>(
         window,
         resolved: None,
         derived: None,
+        xrefstyle: None,
         location,
     });
 
@@ -534,6 +535,7 @@ pub(super) fn build_link_node<'src>(
         window,
         resolved: None,
         derived: None,
+        xrefstyle: None,
         location,
     }))
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -315,6 +315,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -3,6 +3,7 @@
 use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
 use crate::{
     Parser, Span,
+    attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_XREF,
         inline_builder::quotes::{Piece, build_match_string, source_slice},
@@ -11,7 +12,7 @@ use crate::{
         },
     },
     inlines::{InlineNode, Ref, RefVariant},
-    parser::DerivedReference,
+    parser::{DerivedReference, XrefStyle},
     strings::CowStr,
 };
 
@@ -184,28 +185,23 @@ fn find_xref_matches<'src>(
 /// replacer does so the fold reproduces the same bytes. Returns `None` for a
 /// form this increment defers.
 ///
-/// The scope this builder claims is every macro-form target *except* a text
+/// The scope this builder claims is every macro-form target, including a text
 /// carrying an attribute list; the `<<id>>` shorthand is built by
-/// [`build_xref_shorthand_node`]. A same-document reference to a specific id
-/// (`xref:install[]`) resolves through the catalog later (`derived: None`);
-/// the empty target (`xref:#[]`), a target naming another document
+/// [`build_xref_shorthand_node`] and never carries one (see
+/// [`Ref::xrefstyle`]'s field docs). A same-document reference to a specific
+/// id (`xref:install[]`) resolves through the catalog later (`derived:
+/// None`); the empty target (`xref:#[]`), a target naming another document
 /// (`xref:other.adoc#frag[]`), and a target naming this document (or a file
 /// included into it in full) all carry a destination *derived* from the
 /// target itself, computed by [`xref_target_and_derived`] exactly as the
-/// string replacer computes it – so this builder no longer defers any target
-/// shape. One form remains deferred to a later increment:
-///
-/// - a **text carrying an attribute list** (an `=`, for `window`/`role`/
-///   `xrefstyle`): it is parsed as an [`Attrlist`](crate::attributes::Attrlist)
-///   the node cannot hold yet, exactly as
-///   [`build_link_node`](super::links::build_link_node) defers the analogous
-///   link form.
+/// string replacer computes it.
 ///
 /// The display text becomes the node's children as a single
 /// [`Text`](InlineNode::Text), so the fold recovers the provided text by
 /// folding the children and needs no build-time state; an empty text yields no
 /// children, which the fold reads as "no text provided" (the bracketed `[id]`
-/// fallback).
+/// fallback). See [`xref_macro_text`] for how a text carrying an attribute
+/// list (an `=`) is interpreted.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect – notably it does **not** register the reference for resolution,
@@ -225,55 +221,147 @@ fn build_xref_node<'src>(
     let (target, derived) = xref_target_and_derived(raw_target, true, parser);
 
     let raw_text = caps.get(4).map_or("", |m| m.as_str());
-
-    // A text carrying an attribute list (an `=`) is parsed from a
-    // newline-normalized copy of the text into named attributes (`window`,
-    // `role`, `xrefstyle`); it cannot be carried on the node yet, so defer the
-    // whole macro, mirroring the string replacer's `raw_text.contains('=')`
-    // branch and [`build_link_node`](super::links::build_link_node).
-    if raw_text.contains('=') {
-        return None;
-    }
+    let (children, window, roles, xrefstyle) =
+        xref_macro_text(raw_text, caps.get(4), pieces, root, parser);
 
     let location = source_slice(pieces, full.clone(), root);
-
-    let children = if raw_text.is_empty() {
-        vec![]
-    } else {
-        // The provided text becomes the node's children, located at the
-        // bracketed text.
-        #[allow(clippy::unwrap_used)]
-        let text_span = caps.get(4).unwrap();
-
-        let text_location = source_slice(pieces, text_span.start()..text_span.end(), root);
-
-        // An escaped bracket (`\]`) makes the logical text a computed (owned)
-        // value – a *synthesized* `Text` whose value need not coincide with its
-        // source, mirroring the string replacer's `raw_text.replace`. Without
-        // one the text is verbatim, so it borrows the very bytes its location
-        // covers (the builder's `'src`-borrowing goal).
-        let value = if raw_text.contains("\\]") {
-            CowStr::from(raw_text.replace("\\]", "]"))
-        } else {
-            CowStr::from(text_location.data())
-        };
-
-        vec![InlineNode::Text {
-            value,
-            location: text_location,
-        }]
-    };
 
     Some(InlineNode::Ref(Ref {
         variant: RefVariant::Xref,
         target: CowStr::from(target),
         children,
-        roles: vec![],
-        window: None,
+        roles,
+        window,
         resolved: None,
         derived,
+        xrefstyle,
         location,
     }))
+}
+
+/// Interprets the bracketed display text of an `xref:` macro, mirroring
+/// [`InlineXrefReplacer::replace_append`](crate::content::macros)'s own text
+/// interpretation exactly so the fold reproduces the same bytes: a text
+/// carrying an `=` is parsed – from a newline-normalized copy, since the parse
+/// is not necessarily verbatim (mirroring the string replacer, which parses
+/// the same normalized copy rather than a source slice) – as an
+/// [`Attrlist`], whose first positional attribute becomes the display text
+/// and whose `window`/`role`/`xrefstyle` named attributes are honored. If the
+/// attrlist parse finds no named attribute – the sole positional value is the
+/// whole normalized text – the `=` was incidental (e.g. an already-rendered
+/// inner macro such as `xref:sec[image:...[]]`, whose HTML contains `=` and
+/// `"`), not a real attribute list; the text is then used as plain text with
+/// no named attributes, matching Asciidoctor's `extract_attributes_from_text`.
+///
+/// Returns the display-text children, the window, the roles, and the
+/// `xrefstyle` override (`None` unless the macro carries its own `xrefstyle=`
+/// attribute; the document-wide default is applied later, at fold time – see
+/// [`Ref::xrefstyle`]'s field docs).
+fn xref_macro_text<'src>(
+    raw_text: &str,
+    text_span: Option<regex::Match<'_>>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> (
+    Vec<InlineNode<'src>>,
+    Option<CowStr<'src>>,
+    Vec<CowStr<'src>>,
+    Option<XrefStyle>,
+) {
+    if raw_text.is_empty() {
+        return (vec![], None, vec![], None);
+    }
+
+    if raw_text.contains('=') {
+        let normalized = raw_text.replace('\n', " ");
+        let attrlist = Attrlist::parse(Span::new(&normalized), parser, AttrlistContext::Inline)
+            .item
+            .item;
+
+        let first = attrlist.nth_attribute(1).map(|a| a.value().to_string());
+
+        if first.as_deref() != Some(normalized.as_str()) {
+            let window = attrlist
+                .named_attribute("window")
+                .map(|a| CowStr::from(a.value().to_string()));
+
+            let roles = attrlist
+                .roles()
+                .iter()
+                .map(|r| CowStr::from(r.to_string()))
+                .collect();
+
+            let xrefstyle = attrlist
+                .named_attribute("xrefstyle")
+                .map(|a| XrefStyle::parse(a.value()));
+
+            let children = match first.filter(|s| !s.is_empty()) {
+                None => vec![],
+                Some(text) => {
+                    // `text_span` is always `Some` here: it is `None` only
+                    // when `raw_text` is empty, which returns above before
+                    // reaching this branch.
+                    #[allow(clippy::unwrap_used)]
+                    let span = text_span.unwrap();
+
+                    vec![InlineNode::Text {
+                        value: CowStr::from(text),
+                        // The parsed positional attribute is a synthesized
+                        // value with no `'src` slice of its own (it comes
+                        // from the normalized, attrlist-parsed copy, not the
+                        // source directly); it falls back to the bracketed
+                        // text's own span (design §4.4), mirroring the
+                        // synthesized-value location policy
+                        // `apply_attribute_references` already establishes.
+                        location: source_slice(pieces, span.start()..span.end(), root),
+                    }]
+                }
+            };
+
+            return (children, window, roles, xrefstyle);
+        }
+
+        // The `=` was incidental; fall through to plain-text handling.
+    }
+
+    (
+        plain_xref_text(raw_text, text_span, pieces, root),
+        None,
+        vec![],
+        None,
+    )
+}
+
+/// Builds the display-text children for a text with no attribute list (or one
+/// whose `=` was incidental), mirroring the string replacer's own
+/// `raw_text.replace("\\]", "]")` unescape.
+fn plain_xref_text<'src>(
+    raw_text: &str,
+    text_span: Option<regex::Match<'_>>,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    #[allow(clippy::unwrap_used)]
+    let span = text_span.unwrap();
+
+    let text_location = source_slice(pieces, span.start()..span.end(), root);
+
+    // An escaped bracket (`\]`) makes the logical text a computed (owned)
+    // value – a *synthesized* `Text` whose value need not coincide with its
+    // source, mirroring the string replacer's `raw_text.replace`. Without one
+    // the text is verbatim, so it borrows the very bytes its location covers
+    // (the builder's `'src`-borrowing goal).
+    let value = if raw_text.contains("\\]") {
+        CowStr::from(raw_text.replace("\\]", "]"))
+    } else {
+        CowStr::from(text_location.data())
+    };
+
+    vec![InlineNode::Text {
+        value,
+        location: text_location,
+    }]
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a `<<id>>` shorthand
@@ -376,6 +464,7 @@ fn build_xref_shorthand_node<'src>(
         window: None,
         resolved: None,
         derived,
+        xrefstyle: None,
         location,
     }))
 }
@@ -393,7 +482,7 @@ mod tests {
         Parser, Span,
         content::{Content, SubstitutionStep},
         inlines::{InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
-        parser::HtmlSubstitutionRenderer,
+        parser::{HtmlSubstitutionRenderer, XrefStyle},
     };
 
     /// The string pipeline's output through the **macros** step for `source`,
@@ -463,6 +552,19 @@ mod tests {
             "xref:#[]",
             // An escaped `]` inside the text is unescaped.
             "xref:foo[a\\]b]",
+            // A text carrying an attribute list (an `=`): the first positional
+            // attribute is the display text, and `window`/`role`/`xrefstyle`
+            // named attributes are honored.
+            "xref:install[Installation,role=hl]",
+            "xref:install[Installation,window=_blank]",
+            "xref:install[Installation,role=hl,window=_blank,xrefstyle=full]",
+            // An attribute list with no positional text at all: no display
+            // text, only the named attributes.
+            "xref:install[role=hl]",
+            // An `=` that is not a real attribute list: no valid attribute
+            // name precedes it, so the attrlist parse yields one positional
+            // value spanning the whole text – the incidental case.
+            "xref:install[=text]",
             // A macro embedded in surrounding flow, and next to other constructs.
             "See xref:install[the guide] for details.",
             "*bold* then xref:x[X] and _em_",
@@ -847,21 +949,97 @@ mod tests {
     }
 
     #[test]
-    fn an_xref_attribute_list_is_a_documented_divergence() {
-        // An `xref:` text carrying an `=` splits into an attribute list (here a
-        // role), which the string replacer parses from a newline-normalized copy
-        // of the text – not from `'src`. The builder cannot carry that as an
-        // `Attrlist<'src>` yet, so it defers the whole macro (left literal).
-        let source = "xref:install[Installation,role=hl]";
+    fn an_xref_attribute_list_text_populates_window_role_and_xrefstyle() {
+        // An `xref:` text carrying an `=` splits into an attribute list: the
+        // first positional attribute becomes the display text, and the
+        // `window`/`role`/`xrefstyle` named attributes populate the node's own
+        // fields, parsed from a newline-normalized copy of the text (mirroring
+        // `InlineXrefReplacer`'s own attrlist parse).
+        let source = "xref:install[Installation,role=hl,window=_blank,xrefstyle=full]";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list-in-text xref must be left unrecognized: {nodes:?}"
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert_eq!(link_text_of(reference), "Installation");
+        assert_eq!(
+            reference
+                .roles
+                .iter()
+                .map(|r| r.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["hl"]
+        );
+        assert_eq!(reference.window.as_deref(), Some("_blank"));
+        assert_eq!(reference.xrefstyle, Some(XrefStyle::Full));
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn an_xref_attribute_list_with_no_positional_text_has_no_children() {
+        // An attribute list with no positional value at all (only named
+        // attributes) yields no display text – the same "no text provided"
+        // fallback an empty `xref:id[]` uses – but still honors the named
+        // attributes.
+        let source = "xref:install[role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert!(reference.children.is_empty());
+        assert_eq!(
+            reference
+                .roles
+                .iter()
+                .map(|r| r.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["hl"]
         );
 
-        // The string pipeline, by contrast, applies the role.
-        assert!(golden_xref(source).contains(r#"class="hl""#));
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn an_xref_shorthand_never_carries_an_xrefstyle_override() {
+        // The `<<id>>` shorthand has no attribute-list text of its own (see the
+        // `Ref::xrefstyle` field docs): its node's `xrefstyle` override is
+        // always `None`, even though the document-wide default can still apply
+        // at fold time.
+        let nodes = build_src(Span::new("<<install,Install Now>>"));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.xrefstyle, None);
+    }
+
+    #[test]
+    fn an_incidental_equals_in_xref_text_is_not_an_attribute_list() {
+        // `=text` contains an `=`, but no valid attribute name precedes it (an
+        // attribute name cannot start with `=`), so the attrlist parse finds
+        // one positional value spanning the *whole* text rather than a named
+        // attribute – the `=` was incidental, mirroring
+        // `InlineXrefReplacer`'s own `extract_attributes_from_text` fallback.
+        // The text is then used as plain display text with no named
+        // attributes, exactly as if it carried no `=` at all.
+        let source = "xref:install[=text]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert_eq!(link_text_of(reference), "=text");
+        assert!(reference.roles.is_empty());
+        assert_eq!(reference.window, None);
+        assert_eq!(reference.xrefstyle, None);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -141,6 +141,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -298,6 +298,7 @@ mod tests {
             window: None,
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -873,6 +873,7 @@ fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
                 window: window.clone().map(CowStr::from),
                 resolved: None,
                 derived: None,
+                xrefstyle: None,
                 location: span,
             }),
 
@@ -925,6 +926,7 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             window: window.clone().map(CowStr::from),
             resolved: None,
             derived: None,
+            xrefstyle: None,
             location: span,
         }),
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1779,7 +1779,7 @@ struct InlineXrefReplacer<'p, 'x> {
 /// An unset attribute yields `None` (the target's reftext is used verbatim). A
 /// set-but-empty value (`:xrefstyle:`) and any unrecognized value both resolve
 /// to [`XrefStyle::Basic`], mirroring Asciidoctor.
-fn document_xrefstyle(parser: &Parser) -> Option<XrefStyle> {
+pub(crate) fn document_xrefstyle(parser: &Parser) -> Option<XrefStyle> {
     match parser.attribute_value("xrefstyle") {
         InterpretedValue::Value(value) => Some(XrefStyle::parse(&value)),
         InterpretedValue::Set => Some(XrefStyle::Basic),

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -20,8 +20,8 @@ pub(crate) use macros::{
     INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
     INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
     NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
-    normalize_footnote_text, normalize_index_text, normalize_text_lf_escaped_bracket,
-    split_kbd_keys, strip_see_and_seealso,
+    document_xrefstyle, normalize_footnote_text, normalize_index_text,
+    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -164,6 +164,7 @@ mod tests {
                 window: None,
                 resolved: None,
                 derived: None,
+                xrefstyle: None,
                 location,
             }),
             InlineNode::Image(Image {

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -1,7 +1,7 @@
 use crate::{
     HasSpan, Span,
     inlines::InlineNode,
-    parser::{DerivedReference, ResolvedReference},
+    parser::{DerivedReference, ResolvedReference, XrefStyle},
     strings::CowStr,
 };
 
@@ -56,6 +56,17 @@ pub struct Ref<'src> {
     /// which resolves through [`resolved`](Self::resolved) instead, and always
     /// `None` for a [`Link`](RefVariant::Link).
     pub derived: Option<DerivedReference>,
+
+    /// For a cross-reference, the `xrefstyle=` override supplied via the
+    /// macro's own attribute-list text (`xref:id[text,xrefstyle=full]`).
+    /// `None` when the macro carries no such override — which does *not*
+    /// mean the target's reference text is used verbatim: the fold still
+    /// falls back to the document-wide `xrefstyle` attribute in effect for
+    /// this reference, mirroring `InlineXrefReplacer`'s own
+    /// `xrefstyle_override.or_else(|| document_xrefstyle(parser))`. Always
+    /// `None` for a [`Link`](RefVariant::Link) and for the `<<id>>` shorthand,
+    /// which has no attribute-list text of its own.
+    pub xrefstyle: Option<XrefStyle>,
 
     /// The source location of the whole reference.
     pub location: Span<'src>,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2037,6 +2037,7 @@ fn unresolved_xref() -> InlineNode<'static> {
         window: None,
         resolved: None,
         derived: None,
+        xrefstyle: None,
         location: Span::new(""),
     })
 }
@@ -2062,6 +2063,7 @@ fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         window: None,
         resolved: None,
         derived: None,
+        xrefstyle: None,
         location: Span::new(""),
     })
 }


### PR DESCRIPTION
## Summary

This is the next step in the [inline AST migration](docs/design/inline-ast-architecture.md) — it closes the attribute-list half of **step 4b(ii) part 3c**, the last item left unchecked under Phase 4's macro-recognition step list (step 4, `Macros`, is now checked off in full).

Part 3c's derived-destination half (inter-document/document-as-a-whole targets) landed in #1163. The remaining deferred form was a bracketed `xref:` display text carrying an attribute list — `xref:id[text,role=hl,window=_blank,xrefstyle=full]` — which needed somewhere on the node to put `window`/`role`/`xrefstyle`.

- [`xref_macro_text`](parser/src/content/inline_builder/macros/xref.rs) mirrors `InlineXrefReplacer::replace_append`'s own text interpretation exactly: it parses the text — from a newline-normalized copy, since the parse is not necessarily verbatim, exactly as the string replacer parses that same normalized copy rather than a source slice — as an `Attrlist`, whose first positional attribute becomes the display text and whose `window`/`role` named attributes populate `Ref`'s existing plain fields.
- A new [`Ref::xrefstyle: Option<XrefStyle>`](parser/src/inlines/ref_node.rs) field carries the macro-level `xrefstyle=` override. Unlike the link family's own deferred attribute-list form, this needed no "pin the shape against a consumer" step: `window`/`role` already existed as plain fields (not a borrowed `Attrlist<'src>`) because `XrefRenderParams` itself takes them that way.
- When the attrlist parse finds no named attribute — the sole positional value is the whole normalized text — the `=` was incidental (mirroring Asciidoctor's own `extract_attributes_from_text` fallback); the text is then used as plain display text. This is verified reachable in the builder's own verbatim-gated matching (`xref:install[=text]`, since no valid attribute name can start with `=`) — a different route than the nested-macro-substitution case the string pipeline's own incidental case takes, but a real one.
- The parsed positional text becomes a *synthesized* `Text` child (no `'src` slice of its own) whose location falls back to the bracketed text's own span (design §4.4), the same synthesized-value policy `apply_attribute_references` (step 5b) already established.

Landing this also fixes a latent gap the fold carried since the cross-reference increment first landed: the **document-wide** `xrefstyle` attribute — which applies to every reference, not only one carrying its own override — was never applied at all, because `fold_xref` hard-coded `xrefstyle: None`. It now combines the node's own override with the document-wide default exactly as `InlineXrefReplacer` does (`xrefstyle_override.or_else(|| document_xrefstyle(parser))`), reusing the string pipeline's own `document_xrefstyle` helper (now shared `pub(crate)`). The `<<id>>` shorthand has no attribute-list text of its own — its node's override is always `None` — but still observes the document-wide default through this same fold-time combination.

As throughout this module, this performs *no* recognition side effect and nothing is wired into the real parse path. The design doc is updated with this step's landed-as note, and step 4's checklist entries are now fully checked off.

## Test plan

- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::macros::xref` — 25 tests: the former "documented divergence" test is now a positive `Ref`-node assertion, new unit tests pin the attribute-list extraction, the no-positional-text case, the incidental-`=` case, and the shorthand's always-`None` override; the differential corpus gains `role=`/`window=`/`xrefstyle=` fixtures.
- [x] `cargo test -p asciidoc-parser --lib content::inline_builder::fold` — new hand-built-node tests pin the document-wide-default and override-precedence behavior directly, since neither is observable through an unresolved fold (the tree does not yet reach catalog resolution — that remains step 6's job).
- [x] `cargo test --workspace` — full suite green (4954 passed, 0 failed).
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo llvm-cov` — no newly-uncovered lines in changed files beyond an idiomatic test-assertion panic arm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASR2XXgH29KjAhkoRsZNhW)_