### PR TITLE
feat: Add a whole-pipeline differential corpus for the single-pass inline builder (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1645,6 +1645,30 @@ Each phase is a reviewable unit with a clear exit gate.
   [`apply_macro_side_effects`] for real still waits for the single-pass builder to replace the recorder as
   `Content`'s tree source, which remains step 6's own, still fully outstanding, job.
 
+  *Step 6 prep landed as (a whole-pipeline differential corpus against the real `SubstitutionGroup::apply`
+  entry point):* every differential corpus landed so far (one per step/family) hand-chains only the
+  [`SubstitutionStep`]s that step's own increment covers – skipping `AttributeReferences` unless the fixture
+  needs it, and never running passthrough extraction/restore or deferred cross-reference finalization
+  alongside the other steps. That pins each step in isolation, but it had never exercised the *fully
+  assembled* pipeline [`SubstitutionGroup::Normal::apply`](../../parser/src/content/substitution_group.rs)
+  runs in production – passthrough/STEM extraction, every step in true order, passthrough restore, and
+  deferred-reference finalization, all against one `Content` – which is exactly what [`build`] (this
+  module's own single call) must reproduce once the cutover wires it in. A new differential corpus, in
+  [`inline_builder`](../../parser/src/content/inline_builder.rs)'s own test module, closes that gap: each
+  fixture calls the real, public `SubstitutionGroup::Normal.apply` as the golden and `build` + `fold_html`
+  as the candidate, and – unlike every prior corpus, each scoped to one family – **combines** several
+  construct families in one piece of content (quotes wrapping an attribute reference, a footnote whose own
+  text carries a nested attribute reference, a passthrough beside an image macro, a `counter` directive
+  beside a formatted span carrying an attribute reference and a STEM expression, an inline anchor beside an
+  index term, escaped constructs beside a live attribute reference, …), so a boundary-crossing interaction
+  between two steps that individually pass would still be caught. As with every prior corpus, a fixture stays
+  inside the vocabulary `build` already covers, avoiding the forms still documented as deferred elsewhere in
+  this module (an attribute value that itself embeds a construct `CharacterReplacements`/`Macros` would
+  recognize, the `hardbreaks` option, a menu's `>` submenu form, …). Every fixture passed without needing a
+  code change, giving the first real, end-to-end confirmation that the fully assembled single-pass builder
+  – not just its individual steps – reproduces the real production pipeline's output, ahead of step 6's own
+  wiring work. As with every prior increment, nothing here is wired into a real parse path.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1715,6 +1739,11 @@ Each phase is a reviewable unit with a clear exit gate.
        [`apply_ref_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs) – see the
        step's own "landed as" note above. Every deferred recognition side effect is now staged;
        calling each one for real, exactly once per parse, remains this step's own job.
+     - ✅ **prep (whole-pipeline parity).** A combined, multi-family differential corpus confirms
+       `build` reproduces the real, public `SubstitutionGroup::Normal::apply` entry point
+       byte-for-byte – see the step's own "landed as" note above. Wiring `build` into `Content` in
+       place of the recorder, and calling `apply_macro_side_effects` for real, remain this step's
+       own job.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1654,7 +1654,7 @@ Each phase is a reviewable unit with a clear exit gate.
   runs in production – passthrough/STEM extraction, every step in true order, passthrough restore, and
   deferred-reference finalization, all against one `Content` – which is exactly what [`build`] (this
   module's own single call) must reproduce once the cutover wires it in. A new differential corpus, in
-  [`inline_builder`](../../parser/src/content/inline_builder.rs)'s own test module, closes that gap: each
+  [`inline_builder`](../../parser/src/content/inline_builder/mod.rs)'s own test module, closes that gap: each
   fixture calls the real, public `SubstitutionGroup::Normal.apply` as the golden and `build` + `fold_html`
   as the candidate, and – unlike every prior corpus, each scoped to one family – **combines** several
   construct families in one piece of content (quotes wrapping an attribute reference, a footnote whose own

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -299,17 +299,18 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
 /// passthrough extraction/restore or deferred cross-reference finalization
 /// alongside the other steps. That is enough to pin each step in isolation,
 /// but it never exercises the *fully assembled* pipeline
-/// [`SubstitutionGroup::Normal.apply`](crate::content::SubstitutionGroup::apply)
-/// runs in production – passthrough/STEM extraction, every step in true
-/// order, passthrough restore, and deferred-reference finalization, all
-/// against one `Content` – which is exactly what [`build`] (this module's own
-/// single call) must reproduce once the cutover (design §5.2, Phase 4 step 6)
-/// wires it in. This closes that gap: each fixture below mixes constructs
-/// that were previously verified only in separate, single-family corpora
-/// (quotes nested around an attribute reference, a footnote whose text itself
-/// carries an attribute reference, a passthrough beside a macro, a counter
-/// directive beside a formatted span, …), so a boundary-crossing interaction
-/// between two steps that individually pass would still be caught here.
+/// [`SubstitutionGroup::Normal.
+/// apply`](crate::content::SubstitutionGroup::apply) runs in production –
+/// passthrough/STEM extraction, every step in true order, passthrough restore,
+/// and deferred-reference finalization, all against one `Content` – which is
+/// exactly what [`build`] (this module's own single call) must reproduce once
+/// the cutover (design §5.2, Phase 4 step 6) wires it in. This closes that gap:
+/// each fixture below mixes constructs that were previously verified only in
+/// separate, single-family corpora (quotes nested around an attribute
+/// reference, a footnote whose text itself carries an attribute reference, a
+/// passthrough beside a macro, a counter directive beside a formatted span, …),
+/// so a boundary-crossing interaction between two steps that individually pass
+/// would still be caught here.
 ///
 /// As with every other corpus in this module, a fixture is chosen to stay
 /// inside the vocabulary [`build`] already covers – it avoids the forms still

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -287,3 +287,162 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
 
     apply_post_replacements(nodes, source)
 }
+
+/// A whole-pipeline differential corpus: [`build`] against the *real*,
+/// public [`SubstitutionGroup::apply`] entry point, over fixtures that
+/// **combine** several construct families in one piece of content.
+///
+/// Every other differential corpus in this module (each landed alongside its
+/// own step, e.g. [`test_support::golden_macros`]) hand-chains only the
+/// [`SubstitutionStep`]s that step's own increment covers, skipping
+/// `AttributeReferences` unless the fixture needs it, and never runs
+/// passthrough extraction/restore or deferred cross-reference finalization
+/// alongside the other steps. That is enough to pin each step in isolation,
+/// but it never exercises the *fully assembled* pipeline
+/// [`SubstitutionGroup::Normal.apply`](crate::content::SubstitutionGroup::apply)
+/// runs in production – passthrough/STEM extraction, every step in true
+/// order, passthrough restore, and deferred-reference finalization, all
+/// against one `Content` – which is exactly what [`build`] (this module's own
+/// single call) must reproduce once the cutover (design §5.2, Phase 4 step 6)
+/// wires it in. This closes that gap: each fixture below mixes constructs
+/// that were previously verified only in separate, single-family corpora
+/// (quotes nested around an attribute reference, a footnote whose text itself
+/// carries an attribute reference, a passthrough beside a macro, a counter
+/// directive beside a formatted span, …), so a boundary-crossing interaction
+/// between two steps that individually pass would still be caught here.
+///
+/// As with every other corpus in this module, a fixture is chosen to stay
+/// inside the vocabulary [`build`] already covers – it avoids the forms still
+/// documented as deferred elsewhere in this module (e.g. an attribute value
+/// that itself embeds a construct `CharacterReplacements`/`Macros` would
+/// recognize, or the `hardbreaks` option, which needs the block attribute
+/// list `build` does not yet take).
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::build;
+    use crate::{
+        Parser, Span,
+        content::{Content, SubstitutionGroup, inline_builder::fold_html},
+        parser::{HtmlSubstitutionRenderer, ModificationContext},
+    };
+
+    /// Runs `source` through the real, public `SubstitutionGroup::Normal`
+    /// pipeline, exactly as a real block's content is substituted in
+    /// production.
+    fn golden(source: &str, parser: &Parser) -> String {
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        content.rendered_str().to_string()
+    }
+
+    /// Builds and folds the single-pass tree for `source` – the same [`build`]
+    /// a real cutover would call – through the built-in HTML renderer.
+    fn built(source: &str, parser: &Parser) -> String {
+        let nodes = build(Span::new(source), parser);
+        fold_html(&nodes, &HtmlSubstitutionRenderer {}, parser)
+    }
+
+    /// Asserts that `source` folds identically whether taken through the real
+    /// production pipeline or through the single-pass builder, under a
+    /// document configured by `configure`.
+    ///
+    /// `configure` is called once per side rather than sharing one `Parser`
+    /// between them: `golden`'s `SubstitutionGroup::apply` and `built`'s
+    /// `build` each advance document counters (footnote numbers,
+    /// `{counter:...}` values) for real, so sharing a parser would double
+    /// them. Two independently-built parsers, identically configured, see
+    /// the same fixture in the same left-to-right order and so stay in
+    /// lockstep – the same two-independent-parsers discipline this module's
+    /// other differential corpora already use (see e.g. `footnotes.rs`).
+    fn assert_parity_with(source: &str, configure: impl Fn() -> Parser) {
+        assert_eq!(
+            golden(source, &configure()),
+            built(source, &configure()),
+            "fold diverged from the real pipeline for {source:?}"
+        );
+    }
+
+    fn assert_parity(source: &str) {
+        assert_parity_with(source, Parser::default);
+    }
+
+    #[test]
+    fn fold_matches_the_real_pipeline_across_combined_constructs() {
+        let with_product = || {
+            Parser::default().with_intrinsic_attribute(
+                "product",
+                "Widget",
+                ModificationContext::Anywhere,
+            )
+        };
+
+        // Quotes wrapping an attribute reference: the quotes step matches
+        // `*...*` before the reference expands, so the splice must still
+        // reach inside the already-built `Styled` span.
+        assert_parity_with("The {product} is *fast* and reliable.", with_product);
+
+        // A cross-reference and a footnote in the same sentence, the
+        // footnote's own text carrying a nested attribute reference.
+        assert_parity_with(
+            "See <<intro>> for details.footnote:[Also check the {product} docs.]",
+            with_product,
+        );
+
+        // A delimited passthrough beside a quoted span and an image macro.
+        assert_parity("+++<u>raw</u>+++ combined with *bold* and image:foo.png[Alt Text].");
+
+        // Inline STEM beside a quoted span and a character replacement.
+        assert_parity("Equation stem:[x^2+y^2=z^2] appears in *bold* text with (C) 2024.");
+
+        // UI macros (kbd/menu, gated on `experimental`) beside a quoted span.
+        assert_parity_with(
+            "kbd:[Ctrl+Alt+Del] opens the *Task Manager* via menu:File[Save].",
+            || {
+                Parser::default().with_intrinsic_attribute_bool(
+                    "experimental",
+                    true,
+                    ModificationContext::Anywhere,
+                )
+            },
+        );
+
+        // Several link forms and a cross-reference in one sentence.
+        assert_parity(
+            "Visit https://example.org[the site] or mailto:a@example.org[email us], \
+             then see <<conclusion,the conclusion>>.",
+        );
+
+        // A `counter` directive beside a quoted span carrying an attribute
+        // reference and a STEM expression – the ordering fix documented in
+        // this module's `attribute_refs.rs` follow-up note.
+        assert_parity_with(
+            "{counter:step}. Step one uses *{product}* and stem:[x+1].",
+            with_product,
+        );
+
+        // An inline anchor, a quoted span, an index term, and an attribute
+        // reference together.
+        assert_parity_with(
+            "[[custom-id]]Anchored *text* referencing ((index term)) and {product}.",
+            with_product,
+        );
+
+        // Escaped constructs (quotes, a character replacement) beside a live
+        // attribute reference.
+        assert_parity_with(
+            r"An escaped \*not bold\* attribute {product} and \(C) not replaced.",
+            with_product,
+        );
+
+        // Multiple footnotes (numbered in document order) and a
+        // cross-reference, one footnote's text carrying an attribute
+        // reference.
+        assert_parity_with(
+            "First footnote:[a {product} note] then footnote:[b unrelated note], \
+             and finally <<see-also>>.",
+            with_product,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new differential corpus, in `inline_builder`'s own test module, that
  runs fixtures through the **real, public `SubstitutionGroup::Normal::apply`**
  entry point (the golden) and compares against `build()` + `fold_html()` (the
  single-pass builder's own fold).
- Every prior differential corpus landed alongside a single step/family
  hand-chains only the `SubstitutionStep`s that increment covers — skipping
  `AttributeReferences` unless the fixture needs it, and never running
  passthrough extraction/restore or deferred cross-reference finalization
  alongside the other steps. None of them exercise the **fully assembled**
  pipeline production actually runs. This corpus closes that gap.
- Each fixture deliberately **combines** several construct families in one
  piece of content — quotes wrapping an attribute reference, a footnote whose
  own text carries a nested attribute reference, a passthrough beside an
  image macro, a `counter` directive beside a formatted span carrying an
  attribute reference and a STEM expression, an inline anchor beside an index
  term, escaped constructs beside a live attribute reference, multiple
  footnotes plus a cross-reference — so a boundary-crossing interaction
  between two steps that individually pass would still be caught here. Every
  fixture avoids the forms still documented elsewhere in this module as
  deferred (an attribute value embedding a construct `CharacterReplacements`/
  `Macros` would recognize, the `hardbreaks` option, a menu's `>` submenu
  form, …).
- **Every fixture passed without needing a code change** — the first
  end-to-end confirmation that the fully assembled single-pass builder (not
  just its individual steps, each already pinned by its own corpus)
  reproduces the real production pipeline's output. This directly de-risks
  step 6's own remaining, still-outstanding work: swapping the recorder for
  `build()` as `Content`'s tree source.
- Updates `docs/design/inline-ast-architecture.md` with a new "landed as"
  note and checklist entry for this step-6 prep piece, matching the style of
  every prior increment's own note.
- **Nothing is wired into a real parse path.** This is purely additive,
  test-only code — no production behavior changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo test --workspace` — 4955 passed, 0 failed
- [x] `cargo llvm-cov -p asciidoc-parser --lib` — `content/inline_builder/mod.rs`
      at 100% line/region/function coverage (no new non-test code was added)


---
_Generated by [Claude Code](https://claude.ai/code/session_013mmmhfcZeTNBPPXf9pj4Bv)_