### PR TITLE
feat: Recognize the hardbreaks block option in the single-pass inline builder (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1669,6 +1669,25 @@ Each phase is a reviewable unit with a clear exit gate.
   – not just its individual steps – reproduces the real production pipeline's output, ahead of step 6's own
   wiring work. As with every prior increment, nothing here is wired into a real parse path.
 
+  *Step 6 prep landed as (the `hardbreaks` option, closing a real cutover blocker):* auditing `build`'s
+  vocabulary against a corpus-wide differential run (rather than the hand-picked fixtures every prior corpus
+  in this module uses) surfaced that the `hardbreaks` block option was not just an unclaimed form like the
+  others this module documents as deferred, but a **real blocker**: golden tests already exercise it (design
+  §5.4's oracle), so cutting over `Content` to `build` while it stayed unhandled would have silently regressed
+  them, not merely left a construct unrecognized. [`apply_post_replacements`](../../parser/src/content/inline_builder/post_replacements.rs)
+  now takes the enclosing block's own `Attrlist` (`build` itself gains the same `Option<&Attrlist<'src>>`
+  parameter, threaded through from its caller – every other step ignores it) and, when
+  `parser.is_attribute_set("hardbreaks-option")` or the attrlist's own `%hardbreaks` option is set, runs a new
+  `apply_hardbreaks` in place of the default ` +`-only form: every line ending in the level's own match string
+  becomes a break, a redundant trailing ` +` is stripped rather than doubled, and the level's own last line
+  (nothing follows its `\n`) never gets one – mirroring the string pipeline's own `lines()`-split, per-line
+  `render_line_break`, rejoin exactly. Both forms now share one `emit_breaks` tail. A differential corpus pins
+  the block-attrlist and document-attribute forms of the option, a redundant-` +`-stripping fixture, a
+  single-line no-op, and recursion into a quoted span, against the real `SubstitutionGroup::Normal` pipeline;
+  the whole-pipeline combined-constructs corpus above gains a hardbreaks-plus-attribute-reference-plus-span
+  fixture too. As with every increment before it, this is purely additive: `build`'s new parameter is `None`
+  at every existing call site, so no real parse path is touched.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -1744,6 +1763,11 @@ Each phase is a reviewable unit with a clear exit gate.
        byte-for-byte – see the step's own "landed as" note above. Wiring `build` into `Content` in
        place of the recorder, and calling `apply_macro_side_effects` for real, remain this step's
        own job.
+     - ✅ **prep (hardbreaks).** The `hardbreaks` block option – identified as a real cutover
+       blocker, not merely an unclaimed form, since golden tests already exercise it – is now
+       recognized by `apply_post_replacements`, which takes the enclosing block's `Attrlist` for
+       it; see the step's own "landed as" note above. `build`'s new `Attrlist` parameter is `None`
+       at every existing call site, so this is unwired like every other prep piece.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -541,7 +541,7 @@ mod tests {
                 );
 
             let folded = fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &HtmlSubstitutionRenderer {},
             );
 
@@ -560,7 +560,7 @@ mod tests {
             let parser = parser_with_attribute(name, value);
 
             let folded = fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &HtmlSubstitutionRenderer {},
             );
 
@@ -579,7 +579,7 @@ mod tests {
 
         for fixture in ["before{flag-on}after", "before{flag-off}after"] {
             let folded = fold_html(
-                &build(Span::new(fixture), &bool_parser),
+                &build(Span::new(fixture), &bool_parser, None),
                 &HtmlSubstitutionRenderer {},
             );
 
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn a_reference_to_a_set_attribute_expands_to_a_text_node() {
         let parser = parser_with_attribute("greeting", "Hello");
-        let nodes = build(Span::new("say {greeting}!"), &parser);
+        let nodes = build(Span::new("say {greeting}!"), &parser, None);
 
         // [Text("say "), Text("Hello") (synthesized), Text("!")].
         assert_eq!(nodes.len(), 3);
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn a_reference_to_a_missing_attribute_stays_literal() {
-        let nodes = build(Span::new("{undefined-thing}"), &Parser::default());
+        let nodes = build(Span::new("{undefined-thing}"), &Parser::default(), None);
 
         assert_eq!(nodes.len(), 1);
         assert_text(&nodes[0], "{undefined-thing}", 1, 1);
@@ -634,7 +634,7 @@ mod tests {
             ("\\{name\\}", "{name}"),
             ("\\{counter:x}", "{counter:x}"),
         ] {
-            let nodes = build(Span::new(source), &Parser::default());
+            let nodes = build(Span::new(source), &Parser::default(), None);
 
             assert!(
                 nodes.iter().all(|n| matches!(n, InlineNode::Text { .. })),
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     fn a_reference_expanding_to_a_special_character_becomes_raw() {
         let parser = parser_with_attribute("tag", "<b>");
-        let nodes = build(Span::new("{tag}"), &parser);
+        let nodes = build(Span::new("{tag}"), &parser, None);
 
         // The expansion splits into `Raw("<")`, `Text("b")`, `Raw(">")` –
         // design §3.4.1's mix of node kinds, since `specialcharacters` has
@@ -689,7 +689,7 @@ mod tests {
         // this needs `build_match_string` itself to look inside a synthesized
         // run, tracked as a follow-up to this increment.
         let parser = parser_with_attribute("note", "(C) 2024");
-        let nodes = build(Span::new("{note}"), &parser);
+        let nodes = build(Span::new("{note}"), &parser, None);
 
         assert!(
             nodes
@@ -708,7 +708,7 @@ mod tests {
         // `a_replacement_inside_an_expanded_value_is_a_documented_divergence`,
         // for the macros step.
         let parser = parser_with_attribute("linktext", "link:https://example.org[Example]");
-        let nodes = build(Span::new("see {linktext} now"), &parser);
+        let nodes = build(Span::new("see {linktext} now"), &parser, None);
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
@@ -721,7 +721,7 @@ mod tests {
     #[test]
     fn a_reference_inside_a_span_is_recognized() {
         let parser = parser_with_attribute("greeting", "Hello");
-        let nodes = build(Span::new("*{greeting}*"), &parser);
+        let nodes = build(Span::new("*{greeting}*"), &parser, None);
 
         assert_eq!(nodes.len(), 1);
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -772,7 +772,7 @@ mod tests {
 
         for fixture in fixtures {
             let folded = fold_html(
-                &build(Span::new(fixture), &Parser::default()),
+                &build(Span::new(fixture), &Parser::default(), None),
                 &HtmlSubstitutionRenderer {},
             );
 
@@ -786,7 +786,11 @@ mod tests {
 
     #[test]
     fn a_counter_directive_advances_and_displays_the_new_value() {
-        let nodes = build(Span::new("{counter:n}-{counter:n}"), &Parser::default());
+        let nodes = build(
+            Span::new("{counter:n}-{counter:n}"),
+            &Parser::default(),
+            None,
+        );
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
@@ -797,7 +801,11 @@ mod tests {
 
     #[test]
     fn a_counter2_directive_advances_without_displaying() {
-        let nodes = build(Span::new("{counter2:n}{counter:n}"), &Parser::default());
+        let nodes = build(
+            Span::new("{counter2:n}{counter:n}"),
+            &Parser::default(),
+            None,
+        );
 
         // `counter2:n` advances the counter to `1` and splices no node;
         // `counter:n` then advances it again and displays `2`.
@@ -811,7 +819,7 @@ mod tests {
 
     #[test]
     fn a_counter_directive_with_a_seed_starts_from_it() {
-        let nodes = build(Span::new("{counter:n:9}"), &Parser::default());
+        let nodes = build(Span::new("{counter:n:9}"), &Parser::default(), None);
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
@@ -830,7 +838,11 @@ mod tests {
         // the source – reversing the numbering. `resolve_counters` fixes this
         // by resolving every directive, across the whole tree, in one
         // document-order pass first.
-        let nodes = build(Span::new("{counter:n} *{counter:n}*"), &Parser::default());
+        let nodes = build(
+            Span::new("{counter:n} *{counter:n}*"),
+            &Parser::default(),
+            None,
+        );
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
@@ -840,7 +852,11 @@ mod tests {
 
         // The reverse arrangement (the span comes first in the source) must
         // stay correct too.
-        let nodes = build(Span::new("*{counter:n}* {counter:n}"), &Parser::default());
+        let nodes = build(
+            Span::new("*{counter:n}* {counter:n}"),
+            &Parser::default(),
+            None,
+        );
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
@@ -860,7 +876,7 @@ mod tests {
         );
 
         let source = "before {undefined-thing} after";
-        let nodes = build(Span::new(source), &parser);
+        let nodes = build(Span::new(source), &parser, None);
 
         // Left unrecognized: the reference stays literal rather than being
         // dropped.
@@ -883,7 +899,7 @@ mod tests {
         );
 
         let source = "a line with {undefined-thing} in it";
-        let nodes = build(Span::new(source), &parser);
+        let nodes = build(Span::new(source), &parser, None);
 
         // Left unrecognized: the whole line is not dropped (this step has no
         // line-granularity concept; the string pipeline's line-drop mode is

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -628,7 +628,7 @@ mod tests {
     /// Builds the single-pass tree for `source` against `parser` (unlike
     /// [`build_src`], which always uses its own fresh default parser).
     fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
-        build(source, parser)
+        build(source, parser, None)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -387,7 +387,7 @@ mod tests {
 
         for fixture in fixtures {
             let folded = crate::content::inline_builder::fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &renderer,
                 &parser,
             );
@@ -544,7 +544,7 @@ mod tests {
     /// Builds the single-pass tree for `source` against `parser` (unlike
     /// [`build_src`], which always uses its own fresh default parser).
     fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
-        build(source, parser)
+        build(source, parser, None)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -762,7 +762,7 @@ mod tests {
 
         for fixture in fixtures {
             let folded = crate::content::inline_builder::fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &renderer,
                 &parser,
             );
@@ -1043,7 +1043,7 @@ mod tests {
 
         for fixture in fixtures {
             let folded = crate::content::inline_builder::fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &renderer,
                 &parser,
             );
@@ -1274,7 +1274,7 @@ mod tests {
     /// Builds the single-pass tree for `source` against `parser` (unlike
     /// [`build_src`], which always uses its own fresh default parser).
     fn build_with<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
-        build(source, parser)
+        build(source, parser, None)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -345,7 +345,7 @@ mod tests {
         let source =
             "image:a.png[] link:b.html[B] https://c.example [[anchor-id]] xref:anchor-id[]";
         let parser = Parser::default().with_catalog_assets(true);
-        let nodes = build(Span::new(source), &parser);
+        let nodes = build(Span::new(source), &parser, None);
 
         apply_macro_side_effects(&nodes, &parser, Span::new(source), false);
 
@@ -376,7 +376,7 @@ mod tests {
         let source = "image:x.png[alt,link=javascript:alert(1)] then [[dup]] and [[dup]]";
 
         let builder_parser = Parser::default().with_catalog_assets(true);
-        let nodes = build(Span::new(source), &builder_parser);
+        let nodes = build(Span::new(source), &builder_parser, None);
         apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
 
         let golden_parser = Parser::default().with_catalog_assets(true);

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -294,7 +294,7 @@ mod tests {
 
     /// Builds the single-pass tree for `source` under [`experimental_parser`].
     fn build_ui(source: Span<'_>) -> Vec<InlineNode<'_>> {
-        build(source, &experimental_parser())
+        build(source, &experimental_parser(), None)
     }
 
     #[test]
@@ -347,7 +347,7 @@ mod tests {
 
         for fixture in fixtures {
             let folded = crate::content::inline_builder::fold_html(
-                &build(Span::new(fixture), &parser),
+                &build(Span::new(fixture), &parser, None),
                 &renderer,
                 &parser,
             );

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1080,7 +1080,7 @@ mod tests {
 
         let source = "xref:mydoc.adoc#install[Install]";
         let root = Span::new(source);
-        let nodes = super::super::super::build(root, &parser);
+        let nodes = super::super::super::build(root, &parser, None);
 
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.target.as_ref(), "install");
@@ -1101,7 +1101,7 @@ mod tests {
 
         let source = "xref:mydoc.adoc[Home]";
         let root = Span::new(source);
-        let nodes = super::super::super::build(root, &parser);
+        let nodes = super::super::super::build(root, &parser, None);
 
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.target.as_ref(), "");

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -69,7 +69,7 @@
 //!   [`Ui`](InlineNode::Ui), [`Ref`](InlineNode::Ref),
 //!   [`Anchor`](InlineNode::Anchor), or [`IndexTerm`](InlineNode::IndexTerm)
 //!   node. An image node
-//!   captures its own owned [`Attrlist`](crate::attributes::Attrlist) – the step that makes a macro node
+//!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. Each family reuses the shared pattern the string step

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -140,7 +140,12 @@
 //!   comment), except a `Stem` node already has a single `value` field to hold
 //!   the result, so no richer subtree is needed.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
-//!   into a [`LineBreak`](InlineNode::LineBreak) leaf.
+//!   into a [`LineBreak`](InlineNode::LineBreak) leaf. Under the block-wide
+//!   `hardbreaks` option – the enclosing block's own `attrlist`, or the
+//!   document's `hardbreaks-option` attribute – it instead turns *every* line
+//!   ending into a break, stripping a redundant trailing ` +` rather than
+//!   doubling it, mirroring [`apply_post_replacements`]'s own string-pipeline
+//!   counterpart exactly.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
 //!   through an
 //!   [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
@@ -236,7 +241,7 @@ use quotes::apply_quotes;
 use special_chars::apply_special_characters;
 use stem_step::apply_stem;
 
-use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
+use crate::{Parser, Span, attributes::Attrlist, inlines::InlineNode, strings::CowStr};
 
 /// Builds the inline tree for `source` in a single forward pass.
 ///
@@ -245,10 +250,17 @@ use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 /// text to process, so a caller controls precisely what is built; reconciling
 /// with a block's line filtering and joining is a later increment's concern.
 ///
-/// `parser` is consulted only to parse the attribute list of an attributed
-/// quote (`[.role]#…#`); a caller with no document context can pass a default
-/// [`Parser`].
-pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
+/// `parser` is consulted to parse the attribute list of an attributed quote
+/// (`[.role]#…#`) and to read the document-wide `hardbreaks-option`
+/// attribute; a caller with no document context can pass a default
+/// [`Parser`]. `attrlist` is the enclosing block's own attribute list (for
+/// its `hardbreaks` option, [`apply_post_replacements`]'s only consumer of
+/// it today); a caller with no block context can pass `None`.
+pub(crate) fn build<'src>(
+    source: Span<'src>,
+    parser: &Parser,
+    attrlist: Option<&Attrlist<'src>>,
+) -> Vec<InlineNode<'src>> {
     let seed = vec![InlineNode::Text {
         value: CowStr::from(source.data()),
         location: source,
@@ -285,7 +297,7 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
     // `apply_macros` as an ordinary level pass.
     let nodes = apply_footnotes(nodes, source, parser);
 
-    apply_post_replacements(nodes, source)
+    apply_post_replacements(nodes, source, parser, attrlist)
 }
 
 /// A whole-pipeline differential corpus: [`build`] against the *real*,
@@ -316,8 +328,7 @@ pub(crate) fn build<'src>(source: Span<'src>, parser: &Parser) -> Vec<InlineNode
 /// inside the vocabulary [`build`] already covers – it avoids the forms still
 /// documented as deferred elsewhere in this module (e.g. an attribute value
 /// that itself embeds a construct `CharacterReplacements`/`Macros` would
-/// recognize, or the `hardbreaks` option, which needs the block attribute
-/// list `build` does not yet take).
+/// recognize).
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -341,7 +352,7 @@ mod tests {
     /// Builds and folds the single-pass tree for `source` – the same [`build`]
     /// a real cutover would call – through the built-in HTML renderer.
     fn built(source: &str, parser: &Parser) -> String {
-        let nodes = build(Span::new(source), parser);
+        let nodes = build(Span::new(source), parser, None);
         fold_html(&nodes, &HtmlSubstitutionRenderer {}, parser)
     }
 
@@ -444,6 +455,22 @@ mod tests {
             "First footnote:[a {product} note] then footnote:[b unrelated note], \
              and finally <<see-also>>.",
             with_product,
+        );
+
+        // The document-wide `hardbreaks-option` attribute breaking every
+        // line, one of which carries a quoted span and an attribute
+        // reference.
+        assert_parity_with(
+            "Line one uses *{product}*.\nLine two is plain.\nLine three too.",
+            || {
+                Parser::default()
+                    .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+                    .with_intrinsic_attribute_bool(
+                        "hardbreaks-option",
+                        true,
+                        ModificationContext::Anywhere,
+                    )
+            },
         );
     }
 }

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -784,7 +784,7 @@ fn split_old_behavior_attrlist(attrlist: Span<'_>) -> (Span<'_>, bool) {
 /// numbering-order reasons, design §5.2 step 4b(ii) part 4c) – so this
 /// delegates to it directly rather than re-deriving a subset.
 fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
-    super::build(text, parser)
+    super::build(text, parser, None)
 }
 
 /// Runs `text` through the real substitution pipeline under `subs`, returning

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -1,20 +1,23 @@
 //! The post-replacements substitution step (hard line breaks).
 
-use super::quotes::{build_match_string, emit_range, source_slice};
-use crate::{Span, content::hard_line_break_pattern, inlines::InlineNode};
+use super::quotes::{Piece, build_match_string, emit_range, source_slice};
+use crate::{
+    Parser, Span, attributes::Attrlist, content::hard_line_break_pattern, inlines::InlineNode,
+};
 
 /// The post-replacement substitution, as a node transducer: a line ending in
 /// ` +` has that ` +` replaced by a [`LineBreak`](InlineNode::LineBreak) leaf,
 /// the line content before it staying in place.
 ///
-/// Only the default hard-line-break form is handled here. The block-wide
-/// `hardbreaks` option – which turns *every* line ending into a break – needs
-/// the block's attribute list and the document's `hardbreaks-option` attribute,
-/// neither yet threaded into the builder, so it is deferred to the cutover
-/// (design §5.2 Phase 4, step 6).
+/// Under the block-wide `hardbreaks` option – set on `attrlist` (the block's
+/// own attribute list) or via the document's `hardbreaks-option` attribute –
+/// [`apply_hardbreaks`] runs instead: *every* line ending becomes a break, not
+/// only one already marked with ` +`.
 pub(super) fn apply_post_replacements<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    parser: &Parser,
+    attrlist: Option<&Attrlist<'src>>,
 ) -> Vec<InlineNode<'src>> {
     // Descend into spans/refs first, matching the string pipeline's
     // whole-string pass.
@@ -22,18 +25,25 @@ pub(super) fn apply_post_replacements<'src>(
         .into_iter()
         .map(|node| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_post_replacements(styled.children, root);
+                styled.children = apply_post_replacements(styled.children, root, parser, attrlist);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_post_replacements(reference.children, root);
+                reference.children =
+                    apply_post_replacements(reference.children, root, parser, attrlist);
                 InlineNode::Ref(reference)
             }
 
             other => other,
         })
         .collect();
+
+    if parser.is_attribute_set("hardbreaks-option")
+        || attrlist.is_some_and(|attrlist| attrlist.has_option("hardbreaks"))
+    {
+        return apply_hardbreaks(nodes, root);
+    }
 
     let (s, pieces) = build_match_string(&nodes);
 
@@ -62,21 +72,63 @@ pub(super) fn apply_post_replacements<'src>(
         return nodes;
     }
 
+    emit_breaks(&nodes, &pieces, &s, &breaks, root)
+}
+
+/// The `hardbreaks` form of the post-replacement substitution: every line
+/// ending (`\n`) in the level's match string becomes a break, mirroring the
+/// string pipeline's own `line.ends_with(" +")`-stripping, line-by-line
+/// rejoin exactly – a trailing ` +` is stripped rather than kept *and*
+/// doubled, and the level's *last* line (nothing follows its own `\n`, since
+/// there is none) never gets one, matching the string pipeline leaving the
+/// popped last line unbroken.
+fn apply_hardbreaks<'src>(nodes: Vec<InlineNode<'src>>, root: Span<'src>) -> Vec<InlineNode<'src>> {
+    let (s, pieces) = build_match_string(&nodes);
+
+    if !s.contains('\n') {
+        return nodes;
+    }
+
+    let breaks: Vec<std::ops::Range<usize>> = s
+        .match_indices('\n')
+        .map(|(nl, _)| {
+            if s.get(nl.saturating_sub(2)..nl) == Some(" +") {
+                nl - 2..nl
+            } else {
+                nl..nl
+            }
+        })
+        .collect();
+
+    emit_breaks(&nodes, &pieces, &s, &breaks, root)
+}
+
+/// Shared tail of both post-replacement forms: replaces each `breaks` range
+/// (already ordered, non-overlapping, over the level's match string `s`) with
+/// a [`LineBreak`](InlineNode::LineBreak) leaf, keeping everything between and
+/// around them.
+fn emit_breaks<'src>(
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    s: &str,
+    breaks: &[std::ops::Range<usize>],
+    root: Span<'src>,
+) -> Vec<InlineNode<'src>> {
     let mut out = Vec::new();
     let mut cursor = 0usize;
 
     for br in breaks {
-        emit_range(&nodes, &pieces, cursor..br.start, &mut out);
+        emit_range(nodes, pieces, cursor..br.start, &mut out);
 
         out.push(InlineNode::LineBreak {
-            location: source_slice(&pieces, br.clone(), root),
+            location: source_slice(pieces, br.clone(), root),
         });
 
         cursor = br.end;
     }
 
     if cursor < s.len() {
-        emit_range(&nodes, &pieces, cursor..s.len(), &mut out);
+        emit_range(nodes, pieces, cursor..s.len(), &mut out);
     }
 
     out
@@ -93,9 +145,11 @@ mod tests {
         apply_post_replacements,
     };
     use crate::{
-        Span,
+        Parser, Span,
+        attributes::{Attrlist, AttrlistContext},
+        content::{Content, SubstitutionGroup},
         inlines::{InlineNode, Ref, RefVariant},
-        parser::HtmlSubstitutionRenderer,
+        parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
     };
 
@@ -145,7 +199,7 @@ mod tests {
             location: loc,
         });
 
-        let out = apply_post_replacements(vec![reference], loc);
+        let out = apply_post_replacements(vec![reference], loc, &Parser::default(), None);
 
         match &out[0] {
             InlineNode::Ref(reference) => {
@@ -160,5 +214,70 @@ mod tests {
 
             other => panic!("expected Ref, got {other:?}"),
         }
+    }
+
+    /// Runs `source` through the real, public `SubstitutionGroup::Normal`
+    /// pipeline (the golden oracle), and through [`super::super::build`] +
+    /// [`fold_html`] (the candidate), under a document configured by
+    /// `parser` and a block `attrlist` parsed from `attrlist_src`.
+    fn assert_hardbreaks_parity(source: &str, attrlist_src: &str, parser: &Parser) {
+        let attrlist = if attrlist_src.is_empty() {
+            None
+        } else {
+            Some(
+                Attrlist::parse(Span::new(attrlist_src), parser, AttrlistContext::Block)
+                    .item
+                    .item,
+            )
+        };
+
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, attrlist.as_ref());
+        let golden = content.rendered_str().to_string();
+
+        let nodes = super::super::build(Span::new(source), parser, attrlist.as_ref());
+        let built = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+        assert_eq!(golden, built, "hardbreaks fold diverged for {source:?}");
+    }
+
+    #[test]
+    fn hardbreaks_option_on_the_block_breaks_every_line() {
+        assert_hardbreaks_parity(
+            "line one\nline two\nline three",
+            "%hardbreaks",
+            &Parser::default(),
+        );
+    }
+
+    #[test]
+    fn hardbreaks_option_strips_a_redundant_trailing_plus() {
+        // A line already ending in ` +` is not double-broken.
+        assert_hardbreaks_parity("line one +\nline two", "%hardbreaks", &Parser::default());
+    }
+
+    #[test]
+    fn hardbreaks_option_on_a_single_line_breaks_nothing() {
+        assert_hardbreaks_parity("just one line", "%hardbreaks", &Parser::default());
+    }
+
+    #[test]
+    fn hardbreaks_option_document_attribute_breaks_every_line() {
+        let parser = Parser::default().with_intrinsic_attribute_bool(
+            "hardbreaks-option",
+            true,
+            ModificationContext::Anywhere,
+        );
+
+        assert_hardbreaks_parity("line one\nline two", "", &parser);
+    }
+
+    #[test]
+    fn hardbreaks_recurses_into_a_quoted_span() {
+        assert_hardbreaks_parity(
+            "*line one\nline two*\nline three",
+            "%hardbreaks",
+            &Parser::default(),
+        );
     }
 }

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -25,10 +25,11 @@ pub(super) fn fold_html(nodes: &[InlineNode<'_>], renderer: &HtmlSubstitutionRen
     super::fold_html(nodes, renderer, &Parser::default())
 }
 
-/// Builds the single-pass tree for `source` with a default parser (the
-/// parser is consulted only for attributed-quote attribute lists).
+/// Builds the single-pass tree for `source` with a default parser and no
+/// block attribute list (the parser is consulted only for attributed-quote
+/// attribute lists and the document-wide `hardbreaks-option` attribute).
 pub(super) fn build_src(source: Span<'_>) -> Vec<InlineNode<'_>> {
-    build(source, &Parser::default())
+    build(source, &Parser::default(), None)
 }
 
 /// Seeds the whole-source [`Text`](InlineNode::Text) node the transducer


### PR DESCRIPTION
## Summary

This continues the `inline-ast` branch's Phase 4 "step 6" cutover prep (see `docs/design/inline-ast-architecture.md` §5.2). All of step 6's macro-family side-effect prep work (image/link/anchor registrations, the combined entry point, and a whole-pipeline differential corpus) had already landed. This closes the next concrete blocker found while auditing what still stands between the additive single-pass builder (`inline_builder::build`) and a real cutover of `Content` onto it: the block-wide `hardbreaks` option.

Unlike the builder's other documented "deferred forms" (each a construct that's simply left unrecognized until a later increment, with no output regression), `hardbreaks` was a **real blocker**: golden `.rendered_html()` tests already exercise it (`tests/asciidoc_lang/blocks/hard_line_breaks.rs`, `tests/asciidoctor_rb/paragraphs_test.rs`, `substitutions_test.rs`), and `fold_html` has no fallback path to the string pipeline for unrecognized constructs — so cutting `Content` over to the builder while this stayed unhandled would have silently regressed those golden assertions rather than merely leaving a construct unrecognized.

- `inline_builder::build()` and `apply_post_replacements` now take the enclosing block's own `Attrlist` (`Option<&Attrlist<'src>>`), the piece the design doc's own step-3 landing note flagged as still needed.
- When `parser.is_attribute_set("hardbreaks-option")` or the block's own `%hardbreaks` option is set, a new `apply_hardbreaks` runs in place of the default ` +`-only form: every line ending in the level's own match string becomes a break, a redundant trailing ` +` is stripped rather than doubled, and the level's own last line never gets one — mirroring the string pipeline's own `lines()`-split, per-line `render_line_break`, rejoin exactly. Both forms now share one `emit_breaks` tail.
- A differential corpus pins the block-attrlist and document-attribute forms of the option, redundant-` +`-stripping, a single-line no-op, and recursion into a quoted span, against the real `SubstitutionGroup::Normal` pipeline; the existing whole-pipeline combined-constructs corpus gains a hardbreaks-plus-attribute-reference-plus-span fixture too.
- The design doc's Phase 4 narrative and step-6 checklist are updated to record this landing, per this repo's usual practice for the branch.

As with every prior increment in this module, this is purely additive: nothing is wired into a real parse path. `build`'s new `Attrlist` parameter is `None` at every existing call site (mechanically updated across ~25 call sites), so the string pipeline and `Content::inlines()` (the Strategy-A tree) are untouched.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo test --workspace` — 4960 passed, 0 failed
- [x] `cargo llvm-cov -p asciidoc-parser --lib` — new code covered; the two uncovered lines in `post_replacements.rs` are pre-existing-style `other => panic!(...)` fallback arms inside test assertions (expected per this repo's coverage policy)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWNqat5kVqTkXgQr4UwByF)_