### PR TITLE
feat: Recognize character replacements inside expanded attribute values

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1301,6 +1301,57 @@ Each phase is a reviewable unit with a clear exit gate.
   deferred – a missing attribute under `Drop`/`DropLine`, and a construct inside an expanded value – remain
   outstanding.
 
+  *Follow-up landed as (a character replacement inside an expanded value):* the *construct inside an
+  expanded value* half of 5b's own deferred pair is closed for
+  [`apply_character_replacements`](../../parser/src/content/inline_builder/char_replacements.rs) (the
+  *macro* half remains deferred – see below). The shared match-string builder,
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs), previously treated *any*
+  non-verbatim node – a rendered span exactly as much as a synthesized (attribute-expanded) `Text` run – as
+  one opaque placeholder, which is why a `(C)` inside `{note}` (`"(C) 2024"`) stayed unrecognized: the
+  `Text` node's `value` differs from `location.data()`, so it fell through to that opaque case. It now
+  splits a synthesized run into its own [`Piece`](../../parser/src/content/inline_builder/quotes.rs) kind –
+  contributing the run's own `value` bytes to the match string (so a pattern sweep can match inside it) but
+  flagged [`synthesized`](../../parser/src/content/inline_builder/quotes.rs), since those bytes have no
+  honest `'src` counterpart. [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) slices a
+  synthesized piece's *value* (not its `location`) to the overlap and keeps the whole original `location` as
+  every resulting fragment's coarse fallback span (design §4.4 – the same policy
+  [`split_attribute_value`](../../parser/src/content/inline_builder/attribute_refs.rs) already gives every
+  fragment of an expansion), and [`source_slice`](../../parser/src/content/inline_builder/quotes.rs) gained
+  a start/end [`Bias`](../../parser/src/content/inline_builder/quotes.rs) so a boundary landing *inside* a
+  synthesized piece falls back to that piece's whole node span while a boundary landing exactly on one of
+  its own edges still resolves honestly (critically, to whatever construct comes immediately *after* it,
+  not back into the synthesized run – see below).
+
+  Because [`build_match_string`] is shared by every step in this module, this fix is also what keeps a
+  *macro* family's own verbatim gate correctly rejecting a synthesized run now that it is no longer
+  atomic: [`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs) (every macro
+  family's own gate) and a new, narrower
+  [`range_overlaps_synthesized`](../../parser/src/content/inline_builder/quotes.rs) (for the two macro
+  families – the index-term shorthand and `indexterm2:[…]` – whose own recognition boundary was a bespoke
+  opaque-span check rather than `range_is_verbatim`, since neither needs an honest `'src` slice for its
+  *output*, only for deciding whether its *shown text* is reconstructable) both now reject a synthesized
+  piece explicitly, so a macro inside an expanded value remains a documented divergence exactly as before,
+  pinned by the existing (and one new, index-term) divergence test.
+
+  Auditing every other consumer of the boundary-mapping helpers surfaced two real bugs, both fixed as part
+  of this same follow-up rather than left as new divergences: (1) a boundary landing *exactly* on a
+  synthesized piece's own edge was initially resolved via the same coarse whole-node-span fallback as an
+  interior boundary, which is wrong whenever the piece's match-string length differs from its source
+  length (the whole reason a piece is synthesized in the first place) – a construct recognized
+  *immediately after* a synthesized run (e.g. a second `image:` macro right after an `{sp}` attribute
+  reference) had its own location wrongly swallow the synthesized run's source bytes, corrupting an
+  unrelated node's `is_icon` classification in one differential-corpus fixture; the fix skips that
+  boundary to whichever piece comes next (or the past-the-last-piece fallback) instead of letting the
+  synthesized piece claim it. (2) [`apply_footnotes`](../../parser/src/content/inline_builder/footnotes.rs)
+  keeps its *own* copy of `emit_range`'s verbatim-slicing logic for the gaps around a recognized footnote
+  ([`emit_range_recursing_footnotes`], which additionally recurses into a `Styled`/`Ref` child in place of
+  cloning it whole); this copy had not been updated in step with `emit_range`'s own synthesized branch, so
+  a plain attribute reference sitting beside (not inside) a footnote – reachable through the ordinary
+  pipeline, since `apply_attribute_references` runs well before `apply_footnotes` – produced a corrupted,
+  truncated `Text` value. Both are pinned by regression tests reproducing the exact fixture shapes that
+  caught them, alongside unit tests exercising the fixed boundary-mapping helpers directly. This step is
+  **additive**: nothing is wired into the parse path.
+
   *Step 5c landed as (`Callouts` → `Callout`, verbatim-group content):* a new
   [`apply_callouts`](../../parser/src/content/inline_builder.rs) step recognizes a trailing callout
   token (`<1>`, `<.>`, or `<!--1-->` for XML) in literal, listing, and source blocks as a

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -33,26 +33,32 @@ use crate::{
 /// by [`split_attribute_value`] exactly like a plain reference's value);
 /// `counter2` advances silently and splices nothing.
 ///
-/// Two forms are still deferred, each documented and pinned by a divergence
-/// test: a reference to a **missing** attribute under
-/// [`AttributeMissing::Drop`] / [`AttributeMissing::DropLine`] (whose output
-/// *removes* content, unlike leaving the reference literal – the behavior this
-/// step *does* reproduce, since it is also what [`AttributeMissing::Skip`] (the
-/// default) and [`AttributeMissing::Warn`] do); and a construct (a character
-/// replacement, a macro) *inside* an expanded value, which
-/// [`apply_character_replacements`](super::char_replacements::apply_character_replacements)
-/// and [`apply_macros`](super::macros::apply_macros) would recognize per design
-/// §3.4.1 but do not yet – a spliced value is a synthesized run with no `'src`
-/// slice of its own, and [`build_match_string`] (shared by those two steps and
-/// by [`apply_quotes`](super::quotes::apply_quotes)) only treats a verbatim
-/// [`Text`](InlineNode::Text) node (`value == location.data()`) as literal
-/// content; it does not yet look inside a synthesized one, so such a node is
-/// one opaque piece to them, exactly like an already-built
-/// [`Styled`](crate::inlines::Styled) span. Both remaining forms are left
-/// **unrecognized**: no match is produced for the first, and no further node
-/// is produced for the second, so the surrounding gap logic reproduces the
-/// source text unchanged, exactly as an unrecognized macro is left for a
-/// later increment.
+/// One form is still deferred, documented and pinned by a divergence test: a
+/// reference to a **missing** attribute under [`AttributeMissing::Drop`] /
+/// [`AttributeMissing::DropLine`] (whose output *removes* content, unlike
+/// leaving the reference literal – the behavior this step *does* reproduce,
+/// since it is also what [`AttributeMissing::Skip`] (the default) and
+/// [`AttributeMissing::Warn`] do). It is left **unrecognized**: no match is
+/// produced, so the surrounding gap logic reproduces the source text
+/// unchanged, exactly as an unrecognized macro is left for a later increment.
+///
+/// A **character replacement** *inside* an expanded value ((C) → © and
+/// friends) is, by contrast, recognized: [`build_match_string`] (shared by
+/// [`apply_character_replacements`](super::char_replacements::apply_character_replacements),
+/// [`apply_macros`](super::macros::apply_macros), and
+/// [`apply_quotes`](super::quotes::apply_quotes)) now contributes a
+/// synthesized run's own `value` to the match string too – flagged
+/// [`synthesized`](super::quotes::Piece::synthesized) rather than opaque –
+/// so `apply_character_replacements`'s pattern sweep, still ahead in the
+/// effective order, can match inside it exactly as it would over any other
+/// run (a follow-up to this step, closing the gap this doc comment used to
+/// describe). A **macro** *inside* an expanded value remains deferred,
+/// though: a macro node bakes its target/attribute list straight from an
+/// honest `'src` slice, which a synthesized run – its bytes have no source
+/// counterpart of their own – cannot supply; see
+/// [`range_is_verbatim`](super::macros::image::range_is_verbatim), which
+/// every macro family gates recognition on, and which rejects a synthesized
+/// piece for exactly this reason.
 ///
 /// [`AttributeMissing::Drop`]: crate::content::AttributeMissing::Drop
 /// [`AttributeMissing::DropLine`]: crate::content::AttributeMissing::DropLine
@@ -418,11 +424,10 @@ fn rebuild_attribute_level<'src>(
 /// content that design §3.4.1 says
 /// [`apply_character_replacements`](super::char_replacements::apply_character_replacements) and [`apply_macros`](super::macros::apply_macros) (still ahead in the
 /// effective order) should recognize normally (a `(C)` in the value becomes
-/// a `CharRef`, a `link:` in it becomes a `Ref`); this increment does not yet
-/// reach that (see [`apply_attribute_references`]'s doc comment for why), so
-/// the resulting `Text` node's value stays untouched by those later steps for
-/// now, but is shaped so a later increment only needs to extend
-/// [`build_match_string`], not this splitting.
+/// a `CharRef`, a `link:` in it becomes a `Ref`) – true today for the former
+/// (a follow-up to this step extended [`build_match_string`] to look inside a
+/// synthesized run, so no change was needed here), still deferred for the
+/// latter (see [`apply_attribute_references`]'s doc comment for why).
 ///
 /// Both node kinds carry the reference's own `location` as their coarse
 /// fallback span (design §4.4: a synthesized value has no source of its own).
@@ -678,28 +683,72 @@ mod tests {
     }
 
     #[test]
-    fn a_replacement_inside_an_expanded_value_is_a_documented_divergence() {
+    fn a_replacement_inside_an_expanded_value_is_recognized() {
         // Design §3.4.1 says `replacements` still runs over an expanded
-        // value, so a `(C)` inside it should become a `CharRef`. It does not
-        // yet: a synthesized `Text` node's `value` differs from
-        // `location.data()`, so `build_match_string` (shared by
-        // `apply_character_replacements` and `apply_macros`) treats it as one
-        // opaque piece – the same "not verbatim" boundary every macro family
-        // already documents for content it cannot slice from `'src`. Lifting
-        // this needs `build_match_string` itself to look inside a synthesized
-        // run, tracked as a follow-up to this increment.
+        // value, so a `(C)` inside it becomes a `CharRef` – closing the gap
+        // `build_match_string` documented as a follow-up: a synthesized
+        // `Text` piece now contributes its own `value` to the match string
+        // (flagged [`synthesized`](super::super::quotes::Piece::synthesized)
+        // rather than opaque), so `apply_character_replacements`'s pattern
+        // sweep can match inside it exactly as it would over any other run.
         let parser = parser_with_attribute("note", "(C) 2024");
         let nodes = build(Span::new("{note}"), &parser, None);
 
         assert!(
             nodes
                 .iter()
-                .all(|n| !matches!(n, InlineNode::CharRef { .. })),
-            "a replacement inside a spliced value must not yet be recognized: {nodes:?}"
+                .any(|n| matches!(n, InlineNode::CharRef { .. })),
+            "a replacement inside a spliced value must be recognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, *does* recognize it.
-        assert_eq!(golden_attributes_with("{note}", &parser), "&#169; 2024");
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_attributes_with("{note}", &parser),
+        );
+    }
+
+    #[test]
+    fn a_replacement_straddling_a_synthesized_and_a_real_piece_is_recognized() {
+        // The em-dash-without-space rule (`(\w)--`) needs its leading word
+        // character from one piece and its `--` from the next – exercised
+        // here across the boundary between a synthesized (attribute-expanded)
+        // piece and the real, verbatim text that follows it, the case that
+        // first exposed `s_to_src`'s own edge-vs-interior bug (see
+        // `quotes::tests::s_to_src_resolves_a_synthesized_pieces_own_edges_exactly`).
+        let parser = parser_with_attribute("word", "hello");
+        let source = "{word}--world";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_attributes_with(source, &parser),
+        );
+    }
+
+    #[test]
+    fn a_construct_immediately_after_a_synthesized_run_keeps_its_own_location() {
+        // Regression coverage for the bug the `{sp}`-then-`image:` fixture in
+        // `macros::image::tests::matches_the_golden_pipelines_registration_for_a_broad_fixture_set`
+        // first caught: a construct recognized by a *later* step
+        // (`apply_character_replacements`, standing in for any step that
+        // shares `build_match_string`) immediately after a synthesized piece
+        // must not have its own location swallow the synthesized run's
+        // source bytes.
+        let parser = parser_with_attribute("word", "hello");
+        let nodes = build(Span::new("{word}(C)"), &parser, None);
+
+        let replacement = nodes
+            .iter()
+            .find(|n| matches!(n, InlineNode::CharRef { .. }))
+            .unwrap_or_else(|| panic!("expected a CharRef among {nodes:?}"));
+
+        match replacement {
+            InlineNode::CharRef { location, .. } => {
+                assert_eq!(location.data(), "(C)", "{nodes:?}");
+            }
+
+            other => panic!("expected CharRef, got {other:?}"),
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -20,8 +20,16 @@ use crate::{
 /// **escaped** text (built by [`build_match_string`], where a
 /// [`CharRef::Special`] contributes its canonical entity) – which is exactly
 /// why the arrow (`-&gt;`, `&lt;-`) and entity (`&amp;copy;`) rules can
-/// straddle a `Text`/`CharRef` boundary. `root` is the whole-content source
-/// span; every leaf's precise `location` is sliced from it.
+/// straddle a `Text`/`CharRef` boundary, and, since a
+/// [`synthesized`](super::quotes::Piece::synthesized) run (an
+/// attribute-expanded value) contributes its own `value` there too, why they
+/// can straddle a `Text`/synthesized-`Text` boundary as well (design §3.4.1) –
+/// pinned by
+/// `attribute_refs::tests::a_replacement_straddling_a_synthesized_and_a_real_piece_is_recognized`.
+/// `root` is the whole-content source span; every leaf's precise `location`
+/// is sliced from it – or, for a leaf recognized *inside* a synthesized run,
+/// falls back to that run's own whole span (design §4.4), since its bytes
+/// have no honest source counterpart of their own.
 pub(super) fn apply_character_replacements<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -185,9 +185,9 @@ fn rebuild_footnote_level<'src>(
 /// [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref) piece's
 /// children with [`apply_footnotes`] instead of cloning the node whole – the
 /// piece that makes [`apply_footnotes`] a true whole-tree, source-order walk
-/// rather than a single level pass. Every other aspect (slicing a verbatim
-/// [`Text`](InlineNode::Text) run at the overlap, an empty range emitting
-/// nothing) is identical.
+/// rather than a single level pass. Every other aspect (slicing a verbatim or
+/// synthesized [`Text`](InlineNode::Text) run at the overlap, an empty range
+/// emitting nothing) is identical.
 fn emit_range_recursing_footnotes<'src>(
     nodes: &[InlineNode<'src>],
     pieces: &[Piece],
@@ -231,17 +231,29 @@ fn emit_range_recursing_footnotes<'src>(
             continue;
         }
 
-        // A verbatim text run: slice it to the overlap.
+        // A verbatim or synthesized text run: slice it to the overlap (see
+        // [`emit_range`]'s own synthesized branch).
         let lo = range.start.max(p_start) - p_start;
         let hi = range.end.min(p_end) - p_start;
 
-        if let InlineNode::Text { location, .. } = node {
-            let sliced = location.slice(lo..hi);
+        if let InlineNode::Text { value, location } = node {
+            if piece.synthesized {
+                let Some(sliced) = value.get(lo..hi) else {
+                    continue;
+                };
 
-            out.push(InlineNode::Text {
-                value: CowStr::from(sliced.data()),
-                location: sliced,
-            });
+                out.push(InlineNode::Text {
+                    value: CowStr::from(sliced.to_string()),
+                    location: *location,
+                });
+            } else {
+                let sliced = location.slice(lo..hi);
+
+                out.push(InlineNode::Text {
+                    value: CowStr::from(sliced.data()),
+                    location: sliced,
+                });
+            }
         }
     }
 }
@@ -615,6 +627,90 @@ mod tests {
 
             other => panic!("expected a Footnote, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn emit_range_recursing_footnotes_skips_a_synthesized_piece_whose_declared_length_overruns_its_value()
+     {
+        // The same defensive posture as
+        // `quotes::tests::emit_range_skips_a_synthesized_piece_whose_declared_length_overruns_its_value`,
+        // exercised directly against this module's own copy of the
+        // synthesized-slicing branch (see `emit_range_recursing_footnotes`'s
+        // own doc comment for why it duplicates `emit_range` rather than
+        // calling it).
+        use super::{Piece, emit_range_recursing_footnotes};
+        use crate::Parser;
+
+        let location = Span::new("{x}");
+
+        let node = InlineNode::Text {
+            value: CowStr::from("ab"),
+            location,
+        };
+
+        let piece = Piece {
+            node_index: 0,
+            s_start: 0,
+            s_len: 5, // overruns "ab"'s 2 bytes
+            src_offset: location.byte_offset(),
+            src_len: location.data().len(),
+            atomic: false,
+            synthesized: true,
+        };
+
+        let mut out = Vec::new();
+        emit_range_recursing_footnotes(
+            std::slice::from_ref(&node),
+            std::slice::from_ref(&piece),
+            0..5,
+            location,
+            &Parser::default(),
+            &mut out,
+        );
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    #[test]
+    fn an_attribute_reference_beside_a_footnote_keeps_its_resolved_value() {
+        // Regression test: `emit_range_recursing_footnotes` (used for every
+        // *gap* around a recognized footnote, not the footnote's own content –
+        // see `footnote_content_children`) has its own copy of `emit_range`'s
+        // verbatim-slicing logic, and until it also special-cased a
+        // `synthesized` piece (see `quotes::Piece::synthesized`), it applied a
+        // match-string-coordinate range straight to the node's *source*
+        // `location` – valid for a verbatim run (whose `s_len` and source
+        // length agree) but not for a synthesized one (an attribute
+        // expansion), where they can differ. Concretely, `{product}`
+        // (9 source bytes) expanding to `"Widget"` (6 bytes) corrupted the gap
+        // *before* a sibling footnote into a truncated slice of the raw
+        // source (`"{produ"`) instead of the resolved value.
+        use crate::{
+            Parser,
+            content::{Content, SubstitutionGroup, inline_builder::build},
+            parser::ModificationContext,
+        };
+
+        // Two *independent* parsers (design §5.3's discipline, established by
+        // this module's own differential corpus below): `build` and the real
+        // pipeline each advance the footnote registry for real, so sharing
+        // one parser would double-count the footnote's assigned number.
+        let configure = || {
+            Parser::default().with_intrinsic_attribute(
+                "product",
+                "Widget",
+                ModificationContext::Anywhere,
+            )
+        };
+
+        let source = "The {product} is great, footnote:[x] right?";
+        let nodes = build(Span::new(source), &configure(), None);
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+        let mut golden = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut golden, &configure(), None);
+
+        assert_eq!(folded, golden.rendered_str(), "{nodes:#?}");
+        assert!(folded.contains("Widget"), "{folded:?}");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -90,9 +90,16 @@ fn find_image_matches<'src>(
 }
 
 /// Reports whether every piece overlapping the match-string range `range` is a
-/// verbatim [`Text`](InlineNode::Text) run (non-atomic). Only then does the
-/// range map one-to-one onto contiguous source, so its captures can slice
-/// `'src` directly.
+/// verbatim [`Text`](InlineNode::Text) run (non-atomic, non-synthesized). Only
+/// then does the range map one-to-one onto contiguous source, so its captures
+/// can slice `'src` directly. A [`synthesized`](Piece::synthesized) piece
+/// (an attribute-expanded value, a `counter` directive) is rejected here too:
+/// [`apply_character_replacements`](super::super::char_replacements::apply_character_replacements)
+/// can recognize a construct inside one (it produces a leaf needing no `'src`
+/// slice of its own – design §4.4's coarse fallback), but a macro node bakes
+/// its target/attribute list straight from source, so it still needs a real
+/// `'src` slice a synthesized run cannot provide – the same boundary an
+/// escaped-special or a rendered span already documents.
 pub(in crate::content::inline_builder) fn range_is_verbatim(
     pieces: &[Piece],
     range: &std::ops::Range<usize>,
@@ -106,7 +113,7 @@ pub(in crate::content::inline_builder) fn range_is_verbatim(
             continue;
         }
 
-        if piece.atomic {
+        if piece.atomic || piece.synthesized {
             return false;
         }
     }

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -6,7 +6,9 @@ use crate::{
     Span,
     content::{
         INLINE_INDEXTERM,
-        inline_builder::quotes::{Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+        inline_builder::quotes::{
+            Piece, SPAN_PLACEHOLDER, build_match_string, range_overlaps_synthesized, source_slice,
+        },
         normalize_index_text, strip_see_and_seealso,
     },
     inlines::{IndexTerm, InlineNode},
@@ -240,8 +242,10 @@ fn build_indexterm_macro_match<'src>(
     let (node, rendered_nonempty) = if is_visible {
         // A visible flow term crossing an opaque span cannot be reconstructed
         // from this level's escaped string (a span is a placeholder here, not
-        // its markup), so it is deferred.
-        if arg.contains(SPAN_PLACEHOLDER) {
+        // its markup), so it is deferred; one crossing a synthesized run (an
+        // attribute expansion) is deferred too – design §3.4.1 leaves a macro
+        // *inside* such a run for a later increment.
+        if arg.contains(SPAN_PLACEHOLDER) || range_overlaps_synthesized(pieces, &full) {
             return None;
         }
 
@@ -371,8 +375,10 @@ fn build_indexterm_shorthand_match<'src>(
 
     let (node, rendered_nonempty) = if visible {
         // A visible term crossing an opaque span cannot be reconstructed from
-        // the escaped string; defer it (see [`find_indexterm_matches`]).
-        if term_src.contains(SPAN_PLACEHOLDER) {
+        // the escaped string; defer it (see [`find_indexterm_matches`]), and
+        // likewise for one crossing a synthesized run (see the macro form's
+        // own check above).
+        if term_src.contains(SPAN_PLACEHOLDER) || range_overlaps_synthesized(pieces, &full) {
             return None;
         }
 
@@ -741,6 +747,97 @@ mod tests {
 
         // The string pipeline, by contrast, shows the first positional term.
         assert_eq!(golden_macros(source), "Coffee");
+    }
+
+    #[test]
+    fn a_visible_term_inside_an_expanded_value_is_a_documented_divergence() {
+        // A visible term whose shown text crosses a *synthesized* run (an
+        // attribute expansion) cannot be reconstructed from this level's
+        // escaped match string any more honestly than one crossing a rendered
+        // span can – its bytes have no source counterpart of their own – so
+        // `range_overlaps_synthesized` defers it too, the same boundary every
+        // other macro family draws around a synthesized run (see
+        // `attribute_refs::apply_attribute_references`'s own doc comment).
+        // Unlike a *character replacement* inside such a run – recognized as
+        // of this increment, since its leaf needs no `'src` slice of its own –
+        // an index term's macro-family recognition is still deferred.
+        use crate::{
+            Parser,
+            content::{Content, SubstitutionGroup, inline_builder::build},
+            parser::{HtmlSubstitutionRenderer, ModificationContext},
+        };
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "term",
+            "coffee",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "x (({term})) y";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "a term crossing a synthesized run must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, recognizes it (the attribute
+        // expands before the index-term shorthand is matched), showing the
+        // term text in place of the whole shorthand.
+        let mut golden = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(folded, "x ((coffee)) y", "builder output for {source:?}");
+        assert_eq!(
+            golden.rendered_str(),
+            "x coffee y",
+            "golden output for {source:?}"
+        );
+        assert_ne!(folded, golden.rendered_str());
+    }
+
+    #[test]
+    fn a_visible_macro_term_inside_an_expanded_value_is_a_documented_divergence() {
+        // The same boundary as
+        // `a_visible_term_inside_an_expanded_value_is_a_documented_divergence`,
+        // for the `indexterm2:[…]` *macro* spelling – its own, separate
+        // `range_overlaps_synthesized` call site in
+        // `build_indexterm_macro_match`.
+        use crate::{
+            Parser,
+            content::{Content, SubstitutionGroup, inline_builder::build},
+            parser::{HtmlSubstitutionRenderer, ModificationContext},
+        };
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "term",
+            "coffee",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "x indexterm2:[{term}] y";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "a macro term crossing a synthesized run must be left unrecognized: {nodes:?}"
+        );
+
+        let mut golden = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(
+            folded, "x indexterm2:[coffee] y",
+            "builder output for {source:?}"
+        );
+        assert_eq!(
+            golden.rendered_str(),
+            "x coffee y",
+            "golden output for {source:?}"
+        );
+        assert_ne!(folded, golden.rendered_str());
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -41,13 +41,15 @@
 //!   resolves *and advances* the named counter via [`Parser::counter`], the
 //!   same required side effect [`apply_footnotes`] performs for footnote
 //!   numbering. A missing-attribute reference under `AttributeMissing::Drop` /
-//!   `::DropLine` is deferred (see [`apply_attribute_references`] for why); so
-//!   is a construct *inside* an expanded value that
-//!   [`apply_character_replacements`]/[`apply_macros`] would otherwise
-//!   recognize – the value is a synthesized, non-`'src` run, and
-//!   [`build_match_string`](quotes::build_match_string) does not yet look
-//!   inside one (the same "not verbatim" boundary a macro over a rendered span
-//!   already documents).
+//!   `::DropLine` is deferred (see [`apply_attribute_references`] for why). A
+//!   character replacement *inside* an expanded value ((C) → ©, `--`, …) is
+//!   recognized, a follow-up increment having taught
+//!   [`build_match_string`](quotes::build_match_string) to look inside a
+//!   [`synthesized`](quotes::Piece::synthesized) run instead of treating it as
+//!   opaque; a **macro** inside one remains deferred (a macro node needs an
+//!   honest `'src` slice for its target/attribute list, which a synthesized
+//!   run's bytes – no source counterpart of their own – cannot supply; see
+//!   [`range_is_verbatim`](macros::image::range_is_verbatim)).
 //! - [`apply_character_replacements`] recognizes [character replacements] –
 //!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities – replacing
 //!   each with a [`CharRef::Replacement`](crate::inlines::CharRef::Replacement)

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -81,10 +81,22 @@ pub(super) struct Piece {
     pub(super) src_len: usize,
 
     /// Whether the piece is indivisible. Only a verbatim
-    /// [`Text`](InlineNode::Text) run can be split by a match boundary;
-    /// everything else ([`CharRef`](InlineNode::CharRef) entities, opaque
-    /// spans) is atomic.
+    /// [`Text`](InlineNode::Text) run or a [`synthesized`](Self::synthesized)
+    /// one can be split by a match boundary; everything else
+    /// ([`CharRef`](InlineNode::CharRef) entities, opaque spans) is atomic.
     pub(super) atomic: bool,
+
+    /// Whether the piece is a [`Text`](InlineNode::Text) run whose `value`
+    /// was synthesized (an attribute expansion, a `counter` directive, …) –
+    /// its `value` differs from `location.data()`, so unlike a verbatim run
+    /// its match-string bytes do **not** correspond one-to-one with source
+    /// bytes. It contributes its `value` to the match string so a later step
+    /// (design §3.4.1: character replacements, macros) can still recognize a
+    /// construct inside it, but a match landing here has no honest `'src`
+    /// slice: [`emit_range`] slices the node's *value* instead of its
+    /// location, and [`s_to_src`] falls back to the piece's whole node span
+    /// (design §4.4's coarse fallback) rather than a proportional one.
+    pub(super) synthesized: bool,
 }
 
 /// Matches `sub` once at this level, wrapping each accepted match in a
@@ -115,11 +127,19 @@ fn match_level<'src>(
 /// Reconstructs the escaped match string for a level and the [`Piece`] map back
 /// to its nodes.
 ///
-/// A [`Text`](InlineNode::Text) run contributes its (special-free) value; a
-/// [`CharRef`](InlineNode::CharRef) contributes its canonical entity, so the
-/// boundary classes the quote patterns key off (`&`, `;`) see exactly what the
-/// string pipeline's escaped text presents; every other node contributes a
-/// single opaque [`SPAN_PLACEHOLDER`].
+/// A verbatim [`Text`](InlineNode::Text) run contributes its (special-free)
+/// value; a [`CharRef`](InlineNode::CharRef) contributes its canonical entity,
+/// so the boundary classes the quote patterns key off (`&`, `;`) see exactly
+/// what the string pipeline's escaped text presents; a *synthesized*
+/// `Text` run (design §3.4.1 – an attribute expansion, a `counter` directive)
+/// contributes its `value` too, so [`apply_character_replacements`]
+/// (design §3.4.1: `replacements` still runs over an expanded value) can
+/// recognize a construct inside it, but is flagged
+/// [`synthesized`](Piece::synthesized) since those bytes have no honest
+/// `'src` counterpart; every other node contributes a single opaque
+/// [`SPAN_PLACEHOLDER`].
+///
+/// [`apply_character_replacements`]: super::char_replacements::apply_character_replacements
 pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece>) {
     let mut s = String::new();
     let mut pieces = Vec::with_capacity(nodes.len());
@@ -138,6 +158,25 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                     src_offset: location.byte_offset(),
                     src_len: location.data().len(),
                     atomic: false,
+                    synthesized: false,
+                });
+            }
+
+            InlineNode::Text { value, location } => {
+                // A synthesized run (its value has no `'src` slice of its
+                // own): still splittable for matching purposes, but any
+                // resulting node falls back to this node's whole `location`
+                // (design §4.4) rather than a proportional slice of it.
+                s.push_str(value);
+
+                pieces.push(Piece {
+                    node_index,
+                    s_start,
+                    s_len: value.len(),
+                    src_offset: location.byte_offset(),
+                    src_len: location.data().len(),
+                    atomic: false,
+                    synthesized: true,
                 });
             }
 
@@ -155,13 +194,14 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                     src_offset: location.byte_offset(),
                     src_len: location.data().len(),
                     atomic: true,
+                    synthesized: false,
                 });
             }
 
             other => {
-                // A span from an earlier sub (or any node with a synthesized
-                // value) is opaque: a single placeholder that a quote pattern
-                // sees as one boundary character.
+                // A span from an earlier sub (or any other synthesized-value
+                // node, e.g. a `Raw` leaf) is opaque: a single placeholder
+                // that a quote pattern sees as one boundary character.
                 s.push(SPAN_PLACEHOLDER);
 
                 let location = other.span();
@@ -173,12 +213,36 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                     src_offset: location.byte_offset(),
                     src_len: location.data().len(),
                     atomic: true,
+                    synthesized: false,
                 });
             }
         }
     }
 
     (s, pieces)
+}
+
+/// Reports whether any piece overlapping the match-string range `range` is
+/// [`synthesized`](Piece::synthesized). A macro family that reconstructs its
+/// *shown* text straight from the match string (rather than needing an honest
+/// `'src` slice – e.g. an index term's `arg`/`term_src`, already checked
+/// against [`SPAN_PLACEHOLDER`] for a crossed span) still needs this check
+/// too: a synthesized run's bytes have no source counterpart, and design
+/// §3.4.1 leaves recognizing a macro *inside* one for a later increment (see
+/// [`apply_attribute_references`](super::attribute_refs::apply_attribute_references)'s
+/// doc comment) – distinct from [`range_is_verbatim`](super::macros::image::range_is_verbatim),
+/// which a family needing to *slice* `'src` (a target, an `Attrlist<'src>`)
+/// uses instead and which already rejects a synthesized piece outright.
+pub(in crate::content::inline_builder) fn range_overlaps_synthesized(
+    pieces: &[Piece],
+    range: &std::ops::Range<usize>,
+) -> bool {
+    pieces.iter().any(|piece| {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        piece.synthesized && p_end > range.start && p_start < range.end
+    })
 }
 
 /// The canonical special-character entity a [`CharRef::Special`] contributes to
@@ -527,17 +591,33 @@ pub(super) fn emit_range<'src>(
             continue;
         }
 
-        // A verbatim text run: slice it to the overlap.
+        // A verbatim or synthesized text run: slice it to the overlap.
         let lo = range.start.max(p_start) - p_start;
         let hi = range.end.min(p_end) - p_start;
 
-        if let InlineNode::Text { location, .. } = node {
-            let sliced = location.slice(lo..hi);
+        if let InlineNode::Text { value, location } = node {
+            if piece.synthesized {
+                // No `'src` slice exists for these bytes: slice the node's
+                // *value* instead, keeping the whole original `location` as
+                // the coarse fallback span (design §4.4) – the same policy
+                // `split_attribute_value` already applies to every fragment
+                // of an expanded value.
+                let Some(sliced) = value.get(lo..hi) else {
+                    continue;
+                };
 
-            out.push(InlineNode::Text {
-                value: CowStr::from(sliced.data()),
-                location: sliced,
-            });
+                out.push(InlineNode::Text {
+                    value: CowStr::from(sliced.to_string()),
+                    location: *location,
+                });
+            } else {
+                let sliced = location.slice(lo..hi);
+
+                out.push(InlineNode::Text {
+                    value: CowStr::from(sliced.data()),
+                    location: sliced,
+                });
+            }
         }
     }
 }
@@ -545,29 +625,60 @@ pub(super) fn emit_range<'src>(
 /// Maps a match-string range back to its source [`Span`], sliced from `root`.
 ///
 /// A boundary inside a verbatim [`Text`](InlineNode::Text) run maps one-to-one
-/// (its match text is its source text); a boundary inside an atomic piece snaps
-/// to the nearer edge (it never legitimately falls there).
+/// (its match text is its source text); a boundary inside an atomic or
+/// [`synthesized`](Piece::synthesized) piece has no such honest source
+/// position, so it falls back to that piece's own edges (design §4.4) –
+/// snapping to the *nearer* one for an atomic piece (it never legitimately
+/// falls there), or to the edge [`Bias`] names for a synthesized one, so a
+/// range wholly inside a synthesized run maps to that run's *whole* node span
+/// regardless of exactly where the range's boundaries land in it – the same
+/// coarse policy [`split_attribute_value`](super::attribute_refs::split_attribute_value)
+/// already gives every fragment of an expanded value.
 pub(super) fn source_slice<'src>(
     pieces: &[Piece],
     range: std::ops::Range<usize>,
     root: Span<'src>,
 ) -> Span<'src> {
-    let start = s_to_src(pieces, range.start);
-    let end = s_to_src(pieces, range.end);
+    let start = s_to_src(pieces, range.start, Bias::Start);
+    let end = s_to_src(pieces, range.end, Bias::End);
 
     let base = root.byte_offset();
     root.slice(start.saturating_sub(base)..end.saturating_sub(base))
 }
 
+/// Which edge of a piece [`s_to_src`] falls back to when a boundary lands
+/// inside a [`synthesized`](Piece::synthesized) piece, matching whether the
+/// boundary is a range's start or end.
+#[derive(Clone, Copy)]
+enum Bias {
+    Start,
+    End,
+}
+
 /// Maps a single match-string byte offset back to an absolute source byte
-/// offset.
-fn s_to_src(pieces: &[Piece], x: usize) -> usize {
+/// offset. `bias` only matters for a boundary landing inside a `synthesized`
+/// piece; an atomic piece keeps its own nearer-edge snap regardless of it.
+fn s_to_src(pieces: &[Piece], x: usize, bias: Bias) -> usize {
     for piece in pieces {
         let p_start = piece.s_start;
         let p_end = piece.s_start + piece.s_len;
 
         if x < p_start {
             break;
+        }
+
+        // A boundary exactly at the *end* of a synthesized piece belongs to
+        // whatever comes next, not to this piece: unlike a verbatim piece
+        // (whose `s_len` and `src_len` always agree, so its own end edge and
+        // the next piece's start edge are numerically the same value either
+        // way), a synthesized piece's `value` generally has a *different*
+        // byte length than its source span, so the plain linear mapping below
+        // is only honest at this piece's own `p_start` (a zero delta) – never
+        // at `p_end`. Skipping to the next piece (or the past-the-last-piece
+        // fallback, if there is none) lets that boundary resolve correctly
+        // instead.
+        if piece.synthesized && x == p_end {
+            continue;
         }
 
         if x <= p_end {
@@ -578,6 +689,18 @@ fn s_to_src(pieces: &[Piece], x: usize) -> usize {
                     piece.src_offset
                 } else {
                     piece.src_offset + piece.src_len
+                };
+            }
+
+            // A boundary strictly *inside* a synthesized piece (not on its
+            // `p_start` edge – already excluded `p_end` above, and `p_start`
+            // is exact via the plain mapping just like a verbatim piece) has
+            // no honest source position, so it falls back to the edge `bias`
+            // names (design §4.4's coarse fallback).
+            if piece.synthesized && x > p_start {
+                return match bias {
+                    Bias::Start => piece.src_offset,
+                    Bias::End => piece.src_offset + piece.src_len,
                 };
             }
 
@@ -749,12 +872,13 @@ mod tests {
 
     #[test]
     fn s_to_src_guards_are_defensive() {
-        use super::{Piece, s_to_src};
+        use super::{Bias, Piece, s_to_src};
 
         // In practice every boundary `s_to_src` maps falls on a literal
         // delimiter (a text position), so the atomic-snap, before-first, and
         // past-last branches are defensive. Exercise them directly to document
-        // the intended fallback.
+        // the intended fallback. Bias is irrelevant to an atomic piece, so
+        // `Bias::Start` is used throughout.
         let atomic = Piece {
             node_index: 0,
             s_start: 0,
@@ -762,14 +886,15 @@ mod tests {
             src_offset: 10,
             src_len: 1,
             atomic: true,
+            synthesized: false,
         };
 
         // A boundary inside an atomic piece snaps to the nearer edge.
-        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 1), 10);
-        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 3), 11);
+        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 1, Bias::Start), 10);
+        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 3, Bias::Start), 11);
 
         // A boundary past the last piece falls back to the source end.
-        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 9), 11);
+        assert_eq!(s_to_src(std::slice::from_ref(&atomic), 9, Bias::Start), 11);
 
         // A boundary before the first piece begins breaks out to the same
         // fallback.
@@ -778,10 +903,104 @@ mod tests {
             ..atomic
         };
 
-        assert_eq!(s_to_src(std::slice::from_ref(&offset), 0), 11);
+        assert_eq!(s_to_src(std::slice::from_ref(&offset), 0, Bias::Start), 11);
 
         // No pieces (an empty level) anchors at the source start.
-        assert_eq!(s_to_src(&[], 0), 0);
+        assert_eq!(s_to_src(&[], 0, Bias::Start), 0);
+    }
+
+    #[test]
+    fn s_to_src_biases_a_synthesized_piece_to_its_whole_node_span() {
+        use super::{Bias, Piece, s_to_src};
+
+        // A boundary landing *strictly inside* a synthesized piece (its
+        // match-string bytes have no honest source counterpart, since its
+        // `s_len` here – 9 – differs from its `src_len` – 10) falls back to
+        // the whole node span: its start edge (100) for a `Bias::Start`
+        // boundary, its end edge (110) for a `Bias::End` one.
+        //
+        // Its own two edges (`x == 0`, `x == 9`) are a distinct case, pinned
+        // by `s_to_src_resolves_a_synthesized_pieces_own_edges_exactly`
+        // below: `p_start` already has an honest position (delta zero) and
+        // `p_end` is skipped to whatever comes next, so *neither* runs
+        // through this bias fallback – only interior positions like `3` do.
+        let synthesized = Piece {
+            node_index: 0,
+            s_start: 0,
+            s_len: 9,
+            src_offset: 100,
+            src_len: 10,
+            atomic: false,
+            synthesized: true,
+        };
+
+        assert_eq!(
+            s_to_src(std::slice::from_ref(&synthesized), 3, Bias::Start),
+            100
+        );
+        assert_eq!(
+            s_to_src(std::slice::from_ref(&synthesized), 3, Bias::End),
+            110
+        );
+    }
+
+    #[test]
+    fn s_to_src_resolves_a_synthesized_pieces_own_edges_exactly() {
+        use super::{Bias, Piece, s_to_src};
+
+        // A boundary landing exactly on a synthesized piece's own start or
+        // end edge has an honest position regardless of `bias` – unlike an
+        // interior boundary (see the test above), it never falls back to the
+        // coarse whole-node span. This is what keeps a construct recognized
+        // *immediately after* a synthesized run (e.g. a second `image:` macro
+        // right after an `{sp}` attribute reference) from having its node's
+        // location wrongly swallow the synthesized run's own source bytes –
+        // a real regression this test reproduces at the `Piece` level
+        // (see `image::tests::matches_the_golden_pipelines_registration_for_a_broad_fixture_set`
+        // for the end-to-end fixture that first caught it).
+        fn synthesized_piece() -> Piece {
+            Piece {
+                node_index: 0,
+                s_start: 5,
+                s_len: 9, // match-string range [5, 14)
+                src_offset: 100,
+                src_len: 10, // source range [100, 110)
+                atomic: false,
+                synthesized: true,
+            }
+        }
+
+        // A lone synthesized piece: its own start edge is exact for both
+        // biases; its own end edge has no *next* piece to defer to, so it
+        // falls back to the past-the-last-piece anchor, which for this piece
+        // alone is its own end – numerically the same as the whole-node-span
+        // fallback here, but arrived at without going through `Bias` at all.
+        let pieces = [synthesized_piece()];
+        assert_eq!(s_to_src(&pieces, 5, Bias::Start), 100);
+        assert_eq!(s_to_src(&pieces, 5, Bias::End), 100);
+        assert_eq!(s_to_src(&pieces, 14, Bias::Start), 110);
+        assert_eq!(s_to_src(&pieces, 14, Bias::End), 110);
+
+        // With a verbatim piece immediately following (the common case – a
+        // recognized construct starting right where the synthesized run
+        // ends), the shared boundary (`x == 14`) resolves through the
+        // *following* piece's own honest linear mapping instead, giving the
+        // same edge value (110) as the piece-alone case above, but arrived
+        // at correctly rather than by the synthesized piece's own (invalid,
+        // since `s_len != src_len` for it) linear mapping.
+        let following = Piece {
+            node_index: 1,
+            s_start: 14,
+            s_len: 4,
+            src_offset: 110,
+            src_len: 4,
+            atomic: false,
+            synthesized: false,
+        };
+        let pieces = [synthesized_piece(), following];
+        assert_eq!(s_to_src(&pieces, 14, Bias::Start), 110);
+        assert_eq!(s_to_src(&pieces, 14, Bias::End), 110);
+        assert_eq!(s_to_src(&pieces, 16, Bias::Start), 112);
     }
 
     #[test]
@@ -797,11 +1016,49 @@ mod tests {
             src_offset: 0,
             src_len: 1,
             atomic: true,
+            synthesized: false,
         };
 
         let mut out = Vec::new();
         emit_range(&[], std::slice::from_ref(&piece), 0..1, &mut out);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn emit_range_skips_a_synthesized_piece_whose_declared_length_overruns_its_value() {
+        use super::{Piece, emit_range};
+        use crate::{Span, inlines::InlineNode, strings::CowStr};
+
+        // A synthesized piece's `s_len` is expected to equal its node's
+        // `value.len()` (how `build_match_string` constructs one); a piece
+        // declaring a longer `s_len` than its node's actual `value` – an
+        // internal invariant slip – is skipped rather than panicking, the
+        // same defensive posture as a stale `node_index` above.
+        let location = Span::new("{x}");
+
+        let node = InlineNode::Text {
+            value: CowStr::from("ab"),
+            location,
+        };
+
+        let piece = Piece {
+            node_index: 0,
+            s_start: 0,
+            s_len: 5, // overruns "ab"'s 2 bytes
+            src_offset: location.byte_offset(),
+            src_len: location.data().len(),
+            atomic: false,
+            synthesized: true,
+        };
+
+        let mut out = Vec::new();
+        emit_range(
+            std::slice::from_ref(&node),
+            std::slice::from_ref(&piece),
+            0..5,
+            &mut out,
+        );
+        assert!(out.is_empty(), "{out:?}");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -230,7 +230,8 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
 /// too: a synthesized run's bytes have no source counterpart, and design
 /// §3.4.1 leaves recognizing a macro *inside* one for a later increment (see
 /// [`apply_attribute_references`](super::attribute_refs::apply_attribute_references)'s
-/// doc comment) – distinct from [`range_is_verbatim`](super::macros::image::range_is_verbatim),
+/// doc comment) – distinct from
+/// [`range_is_verbatim`](super::macros::image::range_is_verbatim),
 /// which a family needing to *slice* `'src` (a target, an `Attrlist<'src>`)
 /// uses instead and which already rejects a synthesized piece outright.
 pub(in crate::content::inline_builder) fn range_overlaps_synthesized(
@@ -632,8 +633,9 @@ pub(super) fn emit_range<'src>(
 /// falls there), or to the edge [`Bias`] names for a synthesized one, so a
 /// range wholly inside a synthesized run maps to that run's *whole* node span
 /// regardless of exactly where the range's boundaries land in it – the same
-/// coarse policy [`split_attribute_value`](super::attribute_refs::split_attribute_value)
-/// already gives every fragment of an expanded value.
+/// coarse policy `split_attribute_value` (in
+/// [`attribute_refs`](super::attribute_refs)) already gives every fragment of
+/// an expanded value.
 pub(super) fn source_slice<'src>(
     pieces: &[Piece],
     range: std::ops::Range<usize>,


### PR DESCRIPTION
## Summary

Closes the "construct inside an expanded value" half of Phase 4 step 5b's own deferred pair, for `apply_character_replacements`: a `(C)` (or any other typographic replacement) inside an attribute-expanded value like `{note}` now becomes a `CharRef`, matching design §3.4.1.

- `build_match_string` (shared by every step in `inline_builder`) now splits a synthesized (attribute-expanded) `Text` run into its own `Piece` kind that contributes the run's own `value` bytes to the match string — rather than an opaque placeholder — so a pattern sweep (character replacements) can match inside it. The piece is flagged `synthesized`, since those bytes have no honest `'src` counterpart.
- `emit_range` and `source_slice`/`s_to_src` gained matching synthesized-aware handling: a fragment recognized inside a synthesized run slices the run's *value* (not its `location`) and keeps the whole original `location` as its coarse fallback span (design §4.4 — the same policy `split_attribute_value` already uses).
- The **macro** half of the same deferred pair (e.g. a `link:` inside an expanded value) stays deferred: `range_is_verbatim` and a new, narrower `range_overlaps_synthesized` (for the two index-term matchers, whose own boundary check didn't route through `range_is_verbatim`) both now reject a synthesized piece explicitly, since a macro node needs an honest `'src` slice a synthesized run can't supply.
- Auditing every consumer of the new boundary-mapping code surfaced and fixed two real bugs along the way (not new divergences — both are corrected):
  1. A boundary landing *exactly* on a synthesized piece's own edge was initially treated the same as an interior boundary, which is wrong whenever the piece's match-string length differs from its source length. A construct recognized *immediately after* a synthesized run (e.g. a second `image:` macro right after an `{sp}` attribute reference) could have its own location wrongly swallow the synthesized run's source bytes.
  2. `apply_footnotes` keeps its own duplicate copy of `emit_range`'s verbatim-slicing logic for the gaps around a recognized footnote; it hadn't been updated in step, so a plain attribute reference sitting *beside* (not inside) a footnote produced a corrupted, truncated `Text` value.

Both bugs are pinned by regression tests reproducing the exact fixture shapes that caught them, alongside direct unit tests of the fixed boundary-mapping helpers.

This step is **additive**: nothing is wired into a real parse path (per design §5.2's phase gates — the single-pass builder still runs alongside, not in place of, the authoritative string pipeline).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` (clean)
- [x] `cargo test --workspace` (4969 passed, 0 failed)
- [x] `cargo llvm-cov` — every newly-uncovered line in a changed file was either closed with a new test or is an accepted `other => panic!(...)` test-assertion fallback
- [x] Design doc (`docs/design/inline-ast-architecture.md`) updated with a new "Follow-up landed as" entry under Phase 4 step 5b

---
_Generated by [Claude Code](https://claude.ai/code/session_017NuV5cXSVtFjjxUPhjYD6b)_