### PR TITLE
feat: Recognize a link's attribute-list-bearing display text in the single-pass inline builder (inline-ast Phase 4, step 4b(ii) follow-up)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -923,6 +923,45 @@ Each phase is a reviewable unit with a clear exit gate.
   into the parse path. Cross-references (`Ref{Xref}`), footnotes, index terms, STEM, and anchors
   remain later sub-steps.
 
+  *Follow-up landed as (the link family's own attribute-list-bearing display text, closing
+  `Ref{Link}`'s last deferred form):* both link-recognizing passes now recognize a display text
+  carrying an `=` (`link:x[text,role=hl]`, `https://x[text,role=hl]`) and a `mailto:` text
+  carrying a `,` subject/body (`mailto:x[Team,Hello there]`) – the pair step 4b(ii) itself defers,
+  and the mirror of the `xref:` macro's own attribute-list text (part 3c below). Unlike that xref
+  form, a link's attribute list cannot be reduced to a few plain fields: `render_link` reads an
+  `id`, a `title`, and the `nofollow`/`noopener` options straight off the `Attrlist` itself (not
+  just `roles`/`window`, which `XrefRenderParams` alone needs), so `Ref` gains an
+  `attrs: Option<Attrlist<'src>>` field – `None` unless a `Link`'s display text carried its own
+  attribute list, always `None` for an `Xref`. This is also what step 4b(ii)'s own deferral notes
+  as the blocker ("deferred until the node can hold an `Attrlist<'src>`"): the string replacers
+  parse the attrlist from a *newline-normalized copy* of the text (so a multi-line
+  `link[Foo\nBar,role=x]` reads as `Foo Bar`), which cannot become an honestly-borrowed
+  `Attrlist<'src>` – but when the text has **no embedded newline**, that copy is byte-identical to
+  the bracketed text's own `'src` slice, so the node can parse the *real* source span instead and
+  carry a genuine borrow. A text that does embed a newline still needs the synthesized copy the
+  node cannot hold, so that one narrow form remains deferred (pinned by its own divergence test,
+  for both the `=` and `,` cases). Both call sites reuse
+  [`extract_attributes_from_text`](../../parser/src/content/macros.rs) (now shared `pub(crate)`,
+  its own signature relaxed from `&'src Span<'src>` to `Span<'src>` since `Span` is `Copy` and the
+  reference added nothing the by-value form doesn't already give a caller building a node with the
+  *same* `'src` as its input) and
+  [`encode_uri_component`](../../parser/src/content/macros.rs) (likewise now shared `pub(crate)`,
+  for the `mailto:` subject/body encoding), so the interpretation – including the "incidental `=`"
+  fallback (`extract_attributes_from_text`'s own guard) and, for the `link:`/`mailto:` macro form,
+  the exact unconditional-adoption behavior `InlineLinkMacroReplacer` has and
+  `InlineLinkReplacer` does not (see the two call sites' own doc comments) – is reused byte-for-byte
+  rather than re-derived. [`fold_link`](../../parser/src/content/inline_builder/fold.rs) now passes
+  the node's own `attrs` through to `render_link` when present, falling back to the empty attrlist
+  every other link already folds through. A display or reference text crossing a rendered span
+  (`link:x[*bold*]`, `xref:id[*bold*]`, `<<id,*bold*>>`) remains a **separate**, still-fully-open
+  boundary for every reference-bearing family (not touched by this follow-up): by the time macros
+  run, `*bold*` is already a `Styled` node, not text, so recognizing it would need the node's
+  display text to become structured children – the shape a footnote's own content already has –
+  which no reference family has yet grown; each now carries its own divergence test pinning this
+  (previously only the `<<id,*bold*>>` shorthand had one). Differential corpora extend the existing
+  link/formal-URL fixtures with `role=`/multi-attribute and mailto subject/body combinations,
+  alongside the incidental-`=` case and the multi-line divergence.
+
   *Step 4b(ii) part 3a landed as (`Macros` → `Ref{Xref}`, the same-document `xref:` macro form):*
   the builder now recognizes the **`xref:` cross-reference macro** (`xref:id[]`,
   `xref:id[Reference Text]`), each as a [`Ref`](../../parser/src/inlines/ref_node.rs)`{Xref}` node.

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -552,6 +552,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -312,9 +312,11 @@ fn fold_ui(
 /// the string pipeline's macros step calls, reconstructing the
 /// [`LinkRenderParams`] from the node: the display text is the fold of the
 /// children, the extra roles (`bare`) ride on the node's `roles`, and the
-/// target/window come straight off the node. The attribute list is empty
-/// because this increment recognizes only the attribute-list-free link forms
-/// (see `link_macro_level`).
+/// target/window come straight off the node. The attribute list is the
+/// node's own [`Ref::attrs`] when its display text carried one (an `id`, a
+/// `title`, a `role=`/`window=`/`nofollow`/`noopener` — see that field's own
+/// docs for why `render_link` needs the real list, not just `roles`/`window`),
+/// or an empty one otherwise.
 fn fold_link(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -324,16 +326,25 @@ fn fold_link(
     let mut link_text = String::new();
     fold_into_html(&reference.children, renderer, parser, &mut link_text);
 
-    // A link built by this increment carries no attribute list; fold through an
-    // empty one, sliced (empty) from the node's own location so its lifetime
-    // matches.
-    let attrlist = Attrlist::parse(
-        reference.location.slice(0..0),
-        parser,
-        AttrlistContext::Inline,
-    )
-    .item
-    .item;
+    // Sliced (empty) from the node's own location so its lifetime matches when
+    // no attribute list was parsed.
+    let empty_attrlist;
+
+    let attrlist: &Attrlist<'_> = match &reference.attrs {
+        Some(attrs) => attrs,
+
+        None => {
+            empty_attrlist = Attrlist::parse(
+                reference.location.slice(0..0),
+                parser,
+                AttrlistContext::Inline,
+            )
+            .item
+            .item;
+
+            &empty_attrlist
+        }
+    };
 
     let extra_roles: Vec<&str> = reference.roles.iter().map(|r| r.as_ref()).collect();
 
@@ -342,7 +353,7 @@ fn fold_link(
         link_text,
         extra_roles,
         window: reference.window.as_deref(),
-        attrlist: &attrlist,
+        attrlist,
         parser,
     };
 
@@ -659,6 +670,7 @@ mod tests {
             }),
             derived: None,
             xrefstyle,
+            attrs: None,
             location: Span::new(""),
         })
     }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -782,6 +782,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -637,6 +637,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -42,7 +42,7 @@ use crate::{
 ///   / title / window) is deferred, exactly as [`link_macro_level`] defers it:
 ///   the attribute list is parsed from a newline-normalized *copy* of the text,
 ///   so it cannot ride on the node as an
-///   [`Attrlist`](crate::attributes::Attrlist)`<'src>` yet.
+///   [`Attrlist`]`<'src>` yet.
 /// - A **non-verbatim match** – a URL crossing an escaped special
 ///   ([`CharRef`](InlineNode::CharRef)) or a rendered
 ///   [`Styled`](crate::inlines::Styled) span – is deferred exactly as the image
@@ -354,7 +354,7 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 ///   (its `subject`/`body`) or an `=` in a `link:` text (roles / id / title /
 ///   window) – is deferred, because that attribute list is parsed from a
 ///   newline-normalized *copy* of the text (not from `'src`) and so cannot be
-///   carried as an [`Attrlist`](crate::attributes::Attrlist)`<'src>` on the
+///   carried as an [`Attrlist`]`<'src>` on the
 ///   node yet.
 /// - **A non-verbatim match** – a macro whose target or text crosses an escaped
 ///   special ([`CharRef`](InlineNode::CharRef)) or a rendered

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -41,8 +41,7 @@ use crate::{
 /// - A **formal text carrying an attribute list** (an `=` selecting roles / id
 ///   / title / window) is deferred, exactly as [`link_macro_level`] defers it:
 ///   the attribute list is parsed from a newline-normalized *copy* of the text,
-///   so it cannot ride on the node as an
-///   [`Attrlist`]`<'src>` yet.
+///   so it cannot ride on the node as an [`Attrlist`]`<'src>` yet.
 /// - A **non-verbatim match** – a URL crossing an escaped special
 ///   ([`CharRef`](InlineNode::CharRef)) or a rendered
 ///   [`Styled`](crate::inlines::Styled) span – is deferred exactly as the image
@@ -354,8 +353,7 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 ///   (its `subject`/`body`) or an `=` in a `link:` text (roles / id / title /
 ///   window) – is deferred, because that attribute list is parsed from a
 ///   newline-normalized *copy* of the text (not from `'src`) and so cannot be
-///   carried as an [`Attrlist`]`<'src>` on the
-///   node yet.
+///   carried as an [`Attrlist`]`<'src>` on the node yet.
 /// - **A non-verbatim match** – a macro whose target or text crosses an escaped
 ///   special ([`CharRef`](InlineNode::CharRef)) or a rendered
 ///   [`Styled`](crate::inlines::Styled) span (`link:a&b[]`, `link:x[*bold*]`) –
@@ -1017,6 +1015,27 @@ mod tests {
             "mailto:team@example.org?subject=Hello%20there"
         );
         assert_eq!(link_text_of(reference), "Team");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_mailto_text_with_a_quoted_comma_and_no_subject_is_not_encoded() {
+        // A comma inside a quoted positional value (`"Full, Name"`) is not a
+        // subject/body separator: `extract_attributes_from_text` still parses
+        // only *one* positional attribute, so `nth_attribute(2)` is `None` and
+        // no `?subject=` is appended – the target stays the bare address,
+        // exactly as the golden pipeline leaves it.
+        let source = "mailto:team@example.org[\"Full, Name\"]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "mailto:team@example.org");
+        assert!(!reference.target.contains("subject="));
+        assert_eq!(link_text_of(reference), "Full, Name");
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3,8 +3,10 @@
 use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
 use crate::{
     Parser, Span,
+    attributes::Attrlist,
     content::{
-        INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
+        INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF, encode_uri_component,
+        extract_attributes_from_text,
         inline_builder::quotes::{Piece, build_match_string, source_slice},
     },
     inlines::{InlineNode, Ref, RefVariant},
@@ -228,15 +230,40 @@ fn build_inline_link_node<'src>(
 
     let mut window: Option<CowStr<'src>> = None;
     let mut bare = false;
+    let mut attrs: Option<Attrlist<'src>> = None;
 
     let link_text = if let Some(mut link_text) = link_text {
         link_text = link_text.replace("\\]", "]");
 
-        // A text carrying an `=` splits into an attribute list, parsed from a
-        // newline-normalized copy of the text (not from `'src`); defer the whole
-        // macro until the node can carry an `Attrlist<'src>`.
+        // A text carrying an `=` splits into an attribute list. `InlineLink
+        // Replacer` parses it from a newline-normalized *copy* of the text;
+        // when the text has no embedded newline that copy is byte-identical
+        // to the bracketed text's own `'src` slice, so the node can carry the
+        // real, honestly-borrowed `Attrlist<'src>` `render_link` needs
+        // (`Ref::attrs`'s own field docs explain why `roles`/`window` alone
+        // are not enough). A text that *does* embed a newline still needs a
+        // synthesized (owned) copy the node cannot hold yet, so that one form
+        // remains deferred.
         if link_text.contains('=') {
-            return None;
+            #[allow(clippy::unwrap_used)]
+            let range = text_location_range.clone().unwrap();
+            let text_span = source_slice(pieces, range, root);
+
+            if text_span.data().contains('\n') {
+                return None;
+            }
+
+            let (lt, parsed) = extract_attributes_from_text(text_span, parser, None);
+
+            // Mirrors `InlineLinkReplacer`'s own guard: only adopt the parsed
+            // result when a real named attribute actually split off from the
+            // text (otherwise the `=` was incidental and `extract_attributes_
+            // from_text` already returned the text unchanged with an empty
+            // attrlist, matching this fallthrough).
+            if lt != text_span.data() {
+                link_text = lt.replace("\\\"", "\"");
+                attrs = Some(parsed);
+            }
         }
 
         if link_text.ends_with('^') {
@@ -277,6 +304,7 @@ fn build_inline_link_node<'src>(
         children,
         roles,
         window,
+        attrs,
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -447,7 +475,7 @@ pub(super) fn build_link_node<'src>(
     let is_mailto = caps.get(1).is_some();
     let target_str = caps.get(3).map_or("", |m| m.as_str());
 
-    let target = if is_mailto {
+    let mut target = if is_mailto {
         format!("mailto:{target_str}")
     } else {
         target_str.to_string()
@@ -462,21 +490,65 @@ pub(super) fn build_link_node<'src>(
     }
 
     let mut window: Option<CowStr<'src>> = None;
+    let mut attrs: Option<Attrlist<'src>> = None;
 
-    let mut link_text = caps
-        .get(5)
-        .map_or_else(String::new, |m| m.as_str().to_string());
+    let raw_text_m = caps.get(5);
+    let mut link_text = raw_text_m.map_or_else(String::new, |m| m.as_str().to_string());
 
     if !link_text.is_empty() {
-        // An attribute list embedded in the text (`mailto:` subject/body via a
-        // comma, or `link:` roles/id/title via an `=`) is parsed from a
-        // newline-normalized copy of the text, so it cannot be carried as an
-        // `Attrlist<'src>` on the node yet; defer the whole macro.
-        if (is_mailto && link_text.contains(',')) || (!is_mailto && link_text.contains('=')) {
-            return None;
-        }
-
         link_text = link_text.replace("\\]", "]");
+
+        // An attribute list embedded in the text (`mailto:` subject/body via a
+        // comma, or `link:` roles/id/title via an `=`) is parsed by
+        // `InlineLinkMacroReplacer` from a newline-normalized *copy* of the
+        // (pre-`\]`-unescape) bracketed text; when that text has no embedded
+        // newline the copy is byte-identical to the bracket's own `'src`
+        // slice, so the node can carry the real `Attrlist<'src>` `render_link`
+        // needs (`Ref::attrs`'s own field docs). A text that *does* embed a
+        // newline still needs a synthesized copy the node cannot hold yet, so
+        // that one form remains deferred.
+        if is_mailto {
+            if link_text.contains(',') {
+                #[allow(clippy::unwrap_used)]
+                let m = raw_text_m.unwrap();
+                let text_span = source_slice(pieces, m.start()..m.end(), root);
+
+                if text_span.data().contains('\n') {
+                    return None;
+                }
+
+                let (lt, parsed) = extract_attributes_from_text(text_span, parser, None);
+                link_text = lt;
+
+                if let Some(target_attr) = parsed.nth_attribute(2) {
+                    target = format!(
+                        "{target}?subject={subject}",
+                        subject = encode_uri_component(target_attr.value())
+                    );
+
+                    if let Some(body) = parsed.nth_attribute(3) {
+                        target = format!(
+                            "{target}&amp;body={body}",
+                            body = encode_uri_component(body.value())
+                        );
+                    }
+                }
+
+                attrs = Some(parsed);
+            }
+        } else if link_text.contains('=') {
+            #[allow(clippy::unwrap_used)]
+            let m = raw_text_m.unwrap();
+            let text_span = source_slice(pieces, m.start()..m.end(), root);
+
+            if text_span.data().contains('\n') {
+                return None;
+            }
+
+            let (lt, parsed) = extract_attributes_from_text(text_span, parser, None);
+            link_text = lt;
+            attrs = Some(parsed);
+        }
 
         if link_text.ends_with('^') {
             link_text.truncate(link_text.len() - 1);
@@ -533,6 +605,7 @@ pub(super) fn build_link_node<'src>(
         children,
         roles,
         window,
+        attrs,
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -679,10 +752,11 @@ mod tests {
         // For each fixture, folding the single-pass tree (all five steps)
         // reproduces the string pipeline's output byte-for-byte. This is the
         // differential corpus (design §5.3) that pins the `link:`/`mailto:`
-        // macro increment. Every fixture is a *verbatim*, attribute-list-free
-        // `link:`/`mailto:` macro – the boundary this increment claims (a URL
-        // target, an attribute list in the text, or a special character inside
-        // the macro is deferred and lives in a divergence test below).
+        // macro increment. Every fixture is a *verbatim* `link:`/`mailto:`
+        // macro – the boundary this increment claims (a URL target, a
+        // multi-line attribute-list text, a display text crossing a rendered
+        // span, or a special character inside the macro is deferred and lives
+        // in a divergence test below).
         let fixtures = [
             // No link macro despite macro-ish characters.
             "plain text with a colon: but no bracket",
@@ -696,9 +770,20 @@ mod tests {
             "link:index.html[Open^]",
             // An escaped `]` inside the text is unescaped.
             "link:index.html[a\\]b]",
+            // A text carrying an attribute list (an `=`): the first positional
+            // attribute is the display text, and the named `role` attribute is
+            // honored. The `^` suffix still applies after the attrlist split.
+            "link:index.html[Docs,role=hl]",
+            "link:index.html[Docs,role=hl^]",
+            // An `=` that is not a real attribute list (the incidental case).
+            "link:index.html[=text]",
             // mailto: labeled and bare (bare shows the address).
             "mailto:hello@example.org[Email us]",
             "mailto:hello@example.org[]",
+            // A `mailto:` text carrying a `,` encodes a subject (and, with a
+            // second `,`, a body) into the target.
+            "mailto:team@example.org[Team,Hello there]",
+            "mailto:team@example.org[Team,Hello,Body text]",
             // Degenerate empty targets: a bare link/mailto with no display text.
             "link:[]",
             "mailto:[]",
@@ -893,38 +978,105 @@ mod tests {
     }
 
     #[test]
-    fn a_link_text_attribute_list_is_a_documented_divergence() {
+    fn a_link_text_attribute_list_populates_the_nodes_attrs() {
         // A `link:` text carrying an `=` splits into an attribute list (here a
-        // role), which the string replacer parses from a newline-normalized copy
-        // of the text – not from `'src`. The builder cannot carry that as an
-        // `Attrlist<'src>` yet, so it defers the whole macro (left literal),
-        // pending the increment that adds an attribute list to the link node.
+        // role): the first positional attribute becomes the display text, and
+        // the parsed `Attrlist<'src>` rides on the node's own `attrs` field, so
+        // the fold reproduces the role exactly as the string replacer does.
         let source = "link:index.html[Docs,role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "index.html");
+        assert_eq!(link_text_of(reference), "Docs");
+        assert_eq!(
+            reference
+                .attrs
+                .as_ref()
+                .and_then(|a| a.roles().into_iter().next()),
+            Some("hl")
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_mailto_subject_and_body_are_encoded_into_the_target() {
+        // A `mailto:` text carrying a `,` encodes a `subject` (and optional
+        // `body`) into the target, mirroring `InlineLinkMacroReplacer`'s own
+        // `extract_attributes_from_text` handling exactly.
+        let source = "mailto:team@example.org[Team,Hello there]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(
+            reference.target.as_ref(),
+            "mailto:team@example.org?subject=Hello%20there"
+        );
+        assert_eq!(link_text_of(reference), "Team");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_mailto_subject_with_a_body_is_encoded_into_the_target() {
+        let source = "mailto:team@example.org[Team,Hello,Body text]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(
+            reference.target.as_ref(),
+            "mailto:team@example.org?subject=Hello&amp;body=Body%20text"
+        );
+        assert_eq!(link_text_of(reference), "Team");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_link_text_attribute_list_over_a_multi_line_text_is_a_documented_divergence() {
+        // A text carrying an `=`/`,` still needs a real `'src` slice with no
+        // embedded newline to carry the parsed `Attrlist<'src>` honestly (see
+        // `build_link_node`'s own doc comment); a multi-line attribute-list
+        // text is deferred, exactly as the crossed-special/rendered-span forms
+        // are.
+        let source = "link:index.html[Docs\nmore,role=hl]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list-in-text link must be left unrecognized: {nodes:?}"
+            "a multi-line attribute-list-in-text link must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, applies the role.
+        // The string pipeline, by contrast, joins the lines with a space and
+        // applies the role.
         assert!(golden_macros(source).contains(r#"class="hl""#));
     }
 
     #[test]
-    fn a_mailto_subject_is_a_documented_divergence() {
-        // A `mailto:` text carrying a `,` encodes a `subject` (and optional
-        // `body`) into the target – the same attribute-list-from-a-copy handling
-        // the builder defers.
-        let source = "mailto:team@example.org[Team,Hello there]";
+    fn a_mailto_subject_over_a_multi_line_text_is_a_documented_divergence() {
+        // The same multi-line boundary as
+        // `a_link_text_attribute_list_over_a_multi_line_text_is_a_documented_divergence`,
+        // for a `mailto:` text carrying a subject/body.
+        let source = "mailto:team@example.org[Team,Hello\nthere]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a mailto with a subject must be left unrecognized: {nodes:?}"
+            "a multi-line mailto subject must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, encodes the subject into the href.
+        // The string pipeline, by contrast, joins the lines with a space and
+        // encodes the subject.
         assert!(golden_macros(source).contains("subject="));
     }
 
@@ -948,10 +1100,10 @@ mod tests {
         // For each fixture, folding the single-pass tree (all five steps)
         // reproduces the string pipeline's output byte-for-byte. This is the
         // differential corpus (design §5.3) that pins the auto-link / formal-URL
-        // link increment. Every fixture is a *verbatim*, attribute-list-free
-        // link – the boundary this increment claims (an angle form, a URL
-        // crossing a special, or an attribute-list text is deferred and lives in
-        // a divergence test below).
+        // link increment. Every fixture is a *verbatim* link – the boundary
+        // this increment claims (an angle form, a URL crossing a special, a
+        // multi-line attribute-list text, or a display text crossing a
+        // rendered span is deferred and lives in a divergence test below).
         let fixtures = [
             // No auto-link despite a colon or a `//`.
             "plain text with a colon: but no scheme",
@@ -986,6 +1138,13 @@ mod tests {
             "https://example.org[^]",
             // An escaped `]` inside the text is unescaped.
             "https://example.org[a\\]b]",
+            // A text carrying an attribute list (an `=`): the first positional
+            // attribute is the display text, and the named `role` attribute is
+            // honored.
+            "https://example.org[Example,role=hl]",
+            "https://example.org[Example,role=hl^]",
+            // An `=` that is not a real attribute list (the incidental case).
+            "https://example.org[=text]",
             // A bare scheme with nothing left after trimming is left literal by
             // both (a `://`-only rejection).
             "http://; is not a link",
@@ -1250,21 +1409,90 @@ mod tests {
     }
 
     #[test]
-    fn a_formal_url_link_attribute_list_is_a_documented_divergence() {
-        // A formal URL text carrying an `=` splits into an attribute list (here a
-        // role), which the string replacer parses from a newline-normalized copy
-        // of the text – not from `'src`. The builder cannot carry that as an
-        // `Attrlist<'src>` yet, so it defers the whole macro (left literal).
+    fn a_formal_url_link_attribute_list_populates_the_nodes_attrs() {
+        // A formal URL text carrying an `=` splits into an attribute list
+        // (here a role): the first positional attribute becomes the display
+        // text, and the parsed `Attrlist<'src>` rides on the node's own
+        // `attrs` field, so the fold reproduces the role exactly as the
+        // string replacer does.
         let source = "https://example.org[Example,role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "https://example.org");
+        assert_eq!(link_text_of(reference), "Example");
+        assert_eq!(
+            reference
+                .attrs
+                .as_ref()
+                .and_then(|a| a.roles().into_iter().next()),
+            Some("hl")
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_formal_url_link_attribute_list_over_a_multi_line_text_is_a_documented_divergence() {
+        // The same multi-line boundary `build_link_node` documents: an
+        // honest `'src` slice is available only when the bracketed text has
+        // no embedded newline.
+        let source = "https://example.org[Example\nmore,role=hl]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list-in-text link must be left unrecognized: {nodes:?}"
+            "a multi-line attribute-list-in-text link must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, applies the role.
+        // The string pipeline, by contrast, joins the lines with a space and
+        // applies the role.
         assert!(golden_macros(source).contains(r#"class="hl""#));
+    }
+
+    #[test]
+    fn an_incidental_equals_in_link_text_is_not_an_attribute_list() {
+        // `=text` contains an `=`, but no valid attribute name precedes it, so
+        // the attrlist parse yields one positional value spanning the *whole*
+        // text rather than a named attribute – the `=` was incidental,
+        // mirroring `InlineLinkReplacer`'s own `extract_attributes_from_text`
+        // fallback (the same case `xref`'s own part 3c increment pins).
+        let source = "https://example.org[=text]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(link_text_of(reference), "=text");
+        assert!(reference.attrs.is_none() || reference.attrs.as_ref().unwrap().roles().is_empty());
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_link_display_text_over_a_rendered_span_is_a_documented_divergence() {
+        // The macros step matches over *escaped, already-rendered* text, so a
+        // display text containing a quoted span (`*bold*`) has already become
+        // a `Styled` node by the time macros run – an opaque piece the node's
+        // single `Text` child cannot absorb without becoming structured
+        // children (the same shape a footnote's own content needs). Left
+        // unrecognized for a later increment.
+        let source = "link:https://example.org[with *bold* text]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a display text crossing a rendered span must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, *does* build a link here, with the
+        // span rendered inside the anchor text.
+        assert!(golden_macros(source).contains("<a href"));
+        assert!(golden_macros(source).contains("<strong>bold</strong>"));
     }
 
     // ---- `apply_link_side_effects` (staged for the eventual cutover) ------

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -316,6 +316,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -235,6 +235,7 @@ fn build_xref_node<'src>(
         resolved: None,
         derived,
         xrefstyle,
+        attrs: None,
         location,
     }))
 }
@@ -465,6 +466,7 @@ fn build_xref_shorthand_node<'src>(
         resolved: None,
         derived,
         xrefstyle: None,
+        attrs: None,
         location,
     }))
 }
@@ -946,6 +948,27 @@ mod tests {
 
         // The string pipeline, by contrast, *does* build a reference here.
         assert!(golden_xref(source).contains("<a href"));
+    }
+
+    #[test]
+    fn an_xref_macro_display_text_over_a_rendered_span_is_a_documented_divergence() {
+        // The macro form's own version of the boundary
+        // `an_xref_shorthand_over_a_rendered_span_is_a_documented_divergence`
+        // pins for the shorthand: a display text containing a quoted span
+        // (`*bold*`) has already become a `Styled` node by the time macros
+        // run, which the node's single `Text` child cannot absorb.
+        let source = "xref:sec[with *bold* reftext]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a display text crossing a rendered span must be left unrecognized: {nodes:?}"
+        );
+
+        // The string pipeline, by contrast, *does* build a reference here,
+        // with the span rendered inside the anchor text.
+        assert!(golden_xref(source).contains("<a href"));
+        assert!(golden_xref(source).contains("<strong>bold</strong>"));
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -74,17 +74,31 @@
 //!   captures its own owned [`Attrlist`] – the step that makes a macro node
 //!   *self-describing*; a link or cross-reference node bakes its computed display
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
-//!   build-time state. Each family reuses the shared pattern the string step
+//!   build-time state. A link whose display text carried its own attribute list
+//!   (`link:x[text,role=hl]`) likewise carries the parsed
+//!   [`Attrlist`](crate::attributes::Attrlist) on [`Ref::attrs`](crate::inlines::Ref::attrs)
+//!   – needed because `render_link` reads more out of it than `roles`/`window`
+//!   alone (an `id`, a `title`, the `nofollow`/`noopener` options) – recognized
+//!   whenever that text has no embedded newline, so it can be sliced honestly
+//!   from `'src` rather than a synthesized copy; a `mailto:` text's own
+//!   comma-delimited subject/body is encoded straight into the target, the same
+//!   way. Each family reuses the shared pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`](crate::content::INLINE_IMAGE_MACRO), [`INLINE_KBD_BTN_MACRO`](crate::content::INLINE_KBD_BTN_MACRO),
 //!   [`INLINE_MENU_MACRO`](crate::content::INLINE_MENU_MACRO), [`INLINE_LINK_MACRO`](crate::content::INLINE_LINK_MACRO), [`INLINE_LINK`](crate::content::INLINE_LINK),
 //!   [`INLINE_XREF`](crate::content::INLINE_XREF), [`INLINE_ANCHOR`](crate::content::INLINE_ANCHOR), [`INLINE_INDEXTERM`](crate::content::INLINE_INDEXTERM)), builds
 //!   `'src`-borrowing nodes for verbatim macros only (see [`apply_macros`] for
 //!   the boundary the escaped-content case defers), and – for the UI macros – is
 //!   recognized only under the `experimental` document attribute, exactly as the
-//!   string step gates them. The cross-reference pass claims the same-document
-//!   form in both spellings (`xref:id[text]` and `<<id>>` / `<<id,text>>`);
-//!   inter-document targets, a document-as-a-whole reference, and an
-//!   attribute-list text are deferred. An anchor renders from its id alone, so it
+//!   string step gates them. The cross-reference pass claims the same-document,
+//!   inter-document, and document-as-a-whole target forms in both spellings
+//!   (`xref:id[text]` and `<<id>>` / `<<id,text>>`), and the `xref:` macro's own
+//!   attribute-list text; only the shorthand's own `,>`-empty-text form remains
+//!   deferred. A display/reference text crossing a rendered span
+//!   (`link:x[*bold*]`, `xref:id[*bold*]`, `<<id,*bold*>>`) remains deferred for
+//!   every reference-bearing family, since a rendered span is an opaque piece
+//!   the node's single `Text` child cannot absorb without becoming structured
+//!   children (the shape a footnote's own content already needs). An anchor
+//!   renders from its id alone, so it
 //!   is *always* recognized (never deferred): only a non-verbatim reference text
 //!   – which does not reach the flow – leaves the node's `reftext` unpopulated.
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
@@ -380,6 +394,120 @@ mod tests {
 
     fn assert_parity(source: &str) {
         assert_parity_with(source, Parser::default);
+    }
+
+    /// A broad, general-purpose sweep of inline fixtures – reusing the shape
+    /// of the Phase 1 byte-parity corpus
+    /// ([`NORMAL_CORPUS`](crate::tests::inline_recorder)) that pins the
+    /// Strategy-A recorder – run against `build` + `fold_html` instead. Unlike
+    /// the hand-picked combined-constructs corpus above, this one is not
+    /// curated to stay inside `build`'s claimed vocabulary, so it is exactly
+    /// the kind of audit that caught the `hardbreaks` cutover blocker (see the
+    /// design doc's own "step 6 prep" note on that increment): a fixture here
+    /// that turns out to diverge is either a real, previously-unknown blocker
+    /// (fix it) or a form some other increment already documents as deferred
+    /// (drop it from this sweep and make sure it has its own divergence test
+    /// instead – e.g. a link/xref display text crossing a rendered span).
+    #[test]
+    fn fold_matches_the_real_pipeline_across_a_broad_general_purpose_sweep() {
+        let fixtures = [
+            "",
+            "plain text with no constructs",
+            "text with trailing spaces   and   runs",
+            "a < b && c > d",
+            "1 < 2 & 3 > 0",
+            "<>&",
+            "One *word* is strong.",
+            "An _emphasized_ phrase.",
+            "Some `monospaced` text.",
+            "A #highlighted# span.",
+            "H~2~O and E = mc^2^.",
+            "A bold *phrase of text* here.",
+            "Bold c**hara**cter**s** in a word.",
+            "un__frac__tured emphasis",
+            "a##b##c",
+            "*a _b_ c*",
+            "*bold _and italic_ mix*",
+            "_*strong inside emphasis*_",
+            "[.myrole]#roled text#",
+            "[#anchor]#anchored#",
+            "[.a.b]#multi role#",
+            "*a < b* and _c > d_",
+            "code `x < y && z` here",
+            "\"`double`\" and '`single`' quotes",
+            "(C) (R) (TM)",
+            "An em -- dash and an ellipsis...",
+            "arrows -> => <- <=",
+            "Sam's apostrophe",
+            "named &amp; numeric &#8217; entities",
+            "plain {backend} attribute",
+            "See https://example.org for details.",
+            "A link:https://example.org[example] link.",
+            "mailto:a@b.com[email me]",
+            "an image:photo.png[Alt Text] inline",
+            "image:pic.png[Scaled,200,100]",
+            "see <<target>> for more",
+            "see <<target,the target>> now",
+            "xref:other.adoc#frag[Other] doc",
+            "A claim.footnote:[the evidence]",
+            "Named.footnote:disc[a discussion] then footnote:disc[].",
+            "A claim.footnote:[the *strong* evidence and a link:https://e.org[source]]",
+            "Two notes.footnote:[first] and again.footnote:[second]",
+            "Press kbd:[Ctrl+T] now.",
+            "Press kbd:[Ctrl,Shift,N] now.",
+            "Click btn:[Save] please.",
+            "Choose menu:File[Save As > PDF].",
+            "A flow ((visible term)) here.",
+            "A concealed (((primary,secondary))) term.",
+            "[[the-anchor]]Anchored paragraph.",
+            "first line +\nsecond line",
+            "*bold* _em_ `code` (C) https://x.y[link] <<ref>> image:i.png[i]",
+            "A mix of {backend}, *bold < text*, and a footnote:[with `code`].",
+            r"a \*not bold* b",
+            r"an \_not emphasized_ here",
+            r"literal \`backtick\` text",
+            "*a _b `c` d_ e*",
+            "*one* *two* *three*",
+            "_a_ and _b_ and _c_",
+            "`code with *stars* inside`",
+            "pre**mid**post and a__b__c",
+            "x^sup^y and p~sub~q",
+            "[.role1.role2#the-id]#decorated#",
+            "[#only-id]#text#",
+            "`a < b > c & d`",
+            "(C) then (R) then (TM) end",
+            "First... then -- and -> arrows <-",
+            "a &amp; b and &#8482; and &copy;",
+            "an {undefined-attr} reference",
+            "link:https://example.org[Example,role=external,window=_blank]",
+            "https://example.org[Example^]",
+            "a https://example.org[] bare-macro link",
+            "visit https://example.org/path?q=1 now",
+            "image:a.png[An image with spaces,role=thumb]",
+            "before image:b.svg[Vector] after",
+            "<<a>> and <<b>> and <<c,C text>>",
+            "a ((flow term)) and (((c1, c2, c3))) end",
+            "indexterm:[primary, secondary]",
+            "indexterm2:[shown]",
+            "[[mid-anchor]] after the anchor",
+            "text before anchor:named[Ref Text] and after",
+            "a +++<b>raw</b>+++ passthrough",
+            "inline pass:[<i>x</i>] macro",
+            "math $$a < b$$ here",
+            "a +literal *stars*+ b",
+            "line one +\nline two +\nline three",
+            "stem:[a < b] expression",
+            "asciimath:[a < b] inline",
+            "latexmath:[x < y] inline",
+            "an icon:home[] icon",
+            "icon:star[2x,role=gold] rated",
+            "   ",
+            "a\nb\nc",
+        ];
+
+        for fixture in fixtures {
+            assert_parity(fixture);
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -76,7 +76,7 @@
 //!   text into [`Text`](InlineNode::Text) children so its fold needs no
 //!   build-time state. A link whose display text carried its own attribute list
 //!   (`link:x[text,role=hl]`) likewise carries the parsed
-//!   [`Attrlist`](crate::attributes::Attrlist) on [`Ref::attrs`](crate::inlines::Ref::attrs)
+//!   [`Attrlist`] on [`Ref::attrs`](crate::inlines::Ref::attrs)
 //!   – needed because `render_link` reads more out of it than `roles`/`window`
 //!   alone (an `id`, a `title`, the `nofollow`/`noopener` options) – recognized
 //!   whenever that text has no embedded newline, so it can be sliced honestly

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -196,6 +196,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -299,6 +299,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: loc,
         });
 

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -874,6 +874,7 @@ fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
                 resolved: None,
                 derived: None,
                 xrefstyle: None,
+                attrs: None,
                 location: span,
             }),
 
@@ -927,6 +928,7 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             resolved: None,
             derived: None,
             xrefstyle: None,
+            attrs: None,
             location: span,
         }),
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1142,7 +1142,7 @@ impl Replacer for InlineLinkReplacer<'_> {
             link_text = link_text.replace("\\]", "]");
 
             if link_text.contains('=') {
-                let (lt, attrs) = extract_attributes_from_text(&span_for_attrlist, self.0, None);
+                let (lt, attrs) = extract_attributes_from_text(span_for_attrlist, self.0, None);
 
                 // Only adopt the parsed result when a real named attribute split
                 // off (the positional value differs from the whole text).
@@ -1307,7 +1307,7 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
             if let Some(_mailto) = mailto {
                 if link_text.contains(',') {
                     let (lt, attrs) =
-                        extract_attributes_from_text(&span_for_attrlist, self.parser, None);
+                        extract_attributes_from_text(span_for_attrlist, self.parser, None);
 
                     link_text = lt;
 
@@ -1329,7 +1329,7 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
                 }
             } else if link_text.contains('=') {
                 let (lt, attrs) =
-                    extract_attributes_from_text(&span_for_attrlist, self.parser, None);
+                    extract_attributes_from_text(span_for_attrlist, self.parser, None);
                 link_text = lt;
 
                 attrlist = Some(attrs);
@@ -1389,12 +1389,18 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
 ///
 /// Precondition: Any new-line characters (`\n`) must be replaced with spaces
 /// prior to calling this function.
-fn extract_attributes_from_text<'src>(
-    text: &'src Span<'src>,
+///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) can parse a link's
+/// attribute-list-bearing display text with the *exact* same interpretation
+/// this string step uses, changing only the recognition *sink* (a node field
+/// instead of a `LinkRenderParams::attrlist` borrow).
+pub(crate) fn extract_attributes_from_text<'src>(
+    text: Span<'src>,
     parser: &Parser,
     default_text: Option<&str>,
 ) -> (String, Attrlist<'src>) {
-    let attrlist_maw = Attrlist::parse(*text, parser, AttrlistContext::Inline);
+    let attrlist_maw = Attrlist::parse(text, parser, AttrlistContext::Inline);
     let attrs = attrlist_maw.item.item;
 
     if let Some(resolved_text) = attrs.nth_attribute(1) {
@@ -1455,7 +1461,11 @@ const CGI_ESCAPE_SET: &AsciiSet = &CONTROLS
     .add(b'|')
     .add(b'}');
 
-fn encode_uri_component(s: &str) -> String {
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) can encode a `mailto:`
+/// subject/body into the target exactly as this string step does when
+/// recognizing a `mailto:` macro's own comma-delimited attribute-list text.
+pub(crate) fn encode_uri_component(s: &str) -> String {
     // First escape with percent-encoding.
     let encoded = utf8_percent_encode(s, CGI_ESCAPE_SET).to_string();
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -20,8 +20,9 @@ pub(crate) use macros::{
     INLINE_ANCHOR, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
     INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
     NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
-    document_xrefstyle, normalize_footnote_text, normalize_index_text,
-    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
+    document_xrefstyle, encode_uri_component, extract_attributes_from_text,
+    normalize_footnote_text, normalize_index_text, normalize_text_lf_escaped_bracket,
+    split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -165,6 +165,7 @@ mod tests {
                 resolved: None,
                 derived: None,
                 xrefstyle: None,
+                attrs: None,
                 location,
             }),
             InlineNode::Image(Image {

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -1,5 +1,6 @@
 use crate::{
     HasSpan, Span,
+    attributes::Attrlist,
     inlines::InlineNode,
     parser::{DerivedReference, ResolvedReference, XrefStyle},
     strings::CowStr,
@@ -67,6 +68,17 @@ pub struct Ref<'src> {
     /// `None` for a [`Link`](RefVariant::Link) and for the `<<id>>` shorthand,
     /// which has no attribute-list text of its own.
     pub xrefstyle: Option<XrefStyle>,
+
+    /// For a [`Link`](RefVariant::Link) whose display text carried its own
+    /// attribute list (`link:x[text,role=hl]`, `https://x[text,role=hl]`),
+    /// the parsed list — needed because `render_link` reads more out of it
+    /// than `roles`/`window` alone (an `id`, a `title`, the `nofollow` /
+    /// `noopener` options), unlike a cross-reference's own attribute-list
+    /// text, whose `window`/`role`/`xrefstyle` the plain fields above already
+    /// cover in full. `None` when the link carries no attribute-list text
+    /// (or the `=` was incidental — see `extract_attributes_from_text`), and
+    /// always `None` for an [`Xref`](RefVariant::Xref).
+    pub attrs: Option<Attrlist<'src>>,
 
     /// The source location of the whole reference.
     pub location: Span<'src>,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2038,6 +2038,7 @@ fn unresolved_xref() -> InlineNode<'static> {
         resolved: None,
         derived: None,
         xrefstyle: None,
+        attrs: None,
         location: Span::new(""),
     })
 }
@@ -2064,6 +2065,7 @@ fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         resolved: None,
         derived: None,
         xrefstyle: None,
+        attrs: None,
         location: Span::new(""),
     })
 }


### PR DESCRIPTION
## Summary

Closes the last deferred form of the `Ref{Link}` family in the [inline-ast](docs/design/inline-ast-architecture.md) single-pass builder: a `link:`/`mailto:` macro or auto-link/formal-URL link whose display text carries its own attribute list (`link:x[text,role=hl]`, `https://x[text,role=hl]`), or, for `mailto:`, a comma-delimited subject/body (`mailto:x[Team,Hello there]`).

- `Ref` gains an `attrs: Option<Attrlist<'src>>` field. Unlike the `xref:` macro's own attribute-list text (closed earlier in part 3c), a link's attribute list can't be reduced to a few plain fields — `render_link` reads an `id`, a `title`, and the `nofollow`/`noopener` options straight off the `Attrlist` itself — so the node now carries the real, honestly-borrowed list.
- Recognized whenever the bracketed text has **no embedded newline**, so it can be sliced directly from `'src` rather than needing a synthesized (owned) copy the node can't hold; a multi-line attribute-list text remains a documented, tested divergence.
- Both call sites reuse the string pipeline's own `extract_attributes_from_text`/`encode_uri_component` helpers (now shared `pub(crate)`, with `extract_attributes_from_text`'s signature relaxed from `&'src Span<'src>` to `Span<'src>` since `Span` is `Copy`), so the interpretation — including the "incidental `=`" fallback and the macro-vs-formal-link unconditional-adoption difference between `InlineLinkMacroReplacer` and `InlineLinkReplacer` — is reused byte-for-byte rather than re-derived.
- `fold_link` now folds through the node's own `attrs` when present.

A corpus-wide differential sweep against the real substitution pipeline (reusing the Phase 1 byte-parity fixture list from `inline_recorder.rs`, kept as a new permanent `fold_matches_the_real_pipeline_across_a_broad_general_purpose_sweep` test) surfaced this gap and, separately, confirmed that a link/xref display text crossing a *rendered span* (`link:x[*bold*]`) is a distinct, still-open boundary — now pinned by its own divergence test for every reference-bearing family (previously only the `<<id,*bold*>>` shorthand had one).

Design doc updated with a "Follow-up landed as" note under step 4b(ii).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` (clean)
- [x] `cargo test --workspace` (4977 passed)
- [x] `cargo llvm-cov` reviewed for newly-touched lines; remaining gaps are either defensive/unreachable fallbacks or pre-existing coverage-tool artifacts on closing braces, consistent with the rest of the codebase


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJWGRaBXzh5DxTMi82KXow)_