### PR TITLE
feat: Swap the single-pass builder in as Content's tree source (inline-ast Phase 4, step 6, first half)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /semver-checks/target/
 /target/
 Cargo.lock
+lcov*.info

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1890,6 +1890,59 @@ Each phase is a reviewable unit with a clear exit gate.
   identically through `build_from_value` — remains a later increment's job, alongside the rest of step
   6's own wiring work. As with every prior increment, nothing here is wired into the parse path.
 
+  *Step 6, first half, landed as (the tree-source swap: the single-pass builder replaces the
+  recorder as `Content`'s tree source):* with every prep piece in place, the swap each of them
+  named as "this step's own job" is done.
+  [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) no longer runs the
+  Strategy-A recording pass at all: when tree building is enabled
+  ([`Parser::with_inline_tree`](../../parser/src/parser/parser.rs)), it snapshots the
+  **pre-substitution content value** and a clone of the parser before the authoritative pass runs
+  – the same counter-safe discipline the recorder used, so footnote numbers and `{counter:…}`
+  values come out identical to the authoritative output – then builds the tree with a new
+  group-aware entry point,
+  [`build_for_group`](../../parser/src/content/inline_builder/mod.rs), and stores it on
+  [`Content::inlines`](../../parser/src/content/content.rs). `build_for_group` mirrors
+  `run_pipeline`'s own step selection exactly: passthrough/STEM extraction runs first **iff** the
+  group's steps include `Macros` or the group is `Header` (the same gate `run_pipeline` places on
+  `Passthroughs::extract_from`), then each of the group's
+  [`steps()`](../../parser/src/content/substitution_group.rs) runs in the group's own order, each
+  recast as its node transducer – so a `subs=` custom list, the verbatim group's `Callouts`, the
+  header/attribute-entry-value groups' two-step list, and the empty `Pass`/`None` lists (whose
+  tree is the untouched seed) all follow the string pipeline's own selection, pinned by new
+  per-group parity and structure tests. `build_from_value` is now the `Normal`-group special case
+  of this entry point.
+
+  What the swap changes for a tree consumer: every node now carries its **honest, precise span**
+  (issue #944's precision stage, with the documented §4.4 coarse fallback for synthesized values)
+  and macro nodes are **self-describing** (their own `Attrlist<'src>`, `derived`, `xrefstyle`) –
+  the recorder's whole-content-span, `attrs: None` tree is gone from production. The fold-parity
+  guarantee is now scoped to the builder's claimed vocabulary: a form documented as deferred
+  (e.g. a display text crossing a rendered span) is left as **literal text** in the tree – never
+  a wrong node – where the recorder, recovering structure from rendered output, could represent
+  it. That scoping surfaced in exactly one production seam: the positional cross-reference
+  resolution mirror (`mirror_tree_xref_resolution`), whose count-parity debug assertions assumed
+  the tree holds one node per deferred segment. The mirror now **counts each list's slots first
+  and skips a list whose count diverges** – leaving those nodes in their honest unresolved state
+  rather than assigning destinations positionally onto the wrong nodes – pinned by new tests for
+  both the block-level and footnote-embedded skip paths. The recorder's stateful-renderer hazard
+  (its debug assertion, and the "requires a side-effect-free renderer" caveat on
+  `with_inline_tree`) retires with the second rendering pass itself: the builder consults the
+  configured renderer only where a node's *value* is defined as already-substituted text (a
+  delimited passthrough's or STEM expression's body), so a stateful custom renderer now gets a
+  logical, unpolluted tree – repinned by the corresponding test.
+
+  The recorder ([`inline_tree`](../../parser/src/content/inline_tree.rs)) is not deleted but
+  **retired to test-only oracle machinery** (`#[cfg(test)]`), exactly the §4.1 bring-up-oracle
+  role: the differential harness drives it directly, and the structural cross-check
+  ([`inline_builder_recorder_parity`](../../parser/src/tests/inline_builder_recorder_parity.rs))
+  now builds its recorder side by driving that machinery itself – the production accessor returns
+  the builder's tree, so reading `Content::inlines()` for both sides would compare the builder to
+  itself – keeping the two independent constructions honestly comparable. The remainder of step 6
+  is unchanged and still outstanding: making `rendered_html()` an authoritative fold of this
+  tree, calling `apply_macro_side_effects` for real (which must wait for the fold, since until
+  then the string pipeline still performs every registration), deleting the three production
+  sentinel systems, and retiring the `with_inline_tree` flag.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2006,6 +2059,14 @@ Each phase is a reviewable unit with a clear exit gate.
        divergence` test #1177 added is now a parity test instead of a divergence test, per its own
        "if lifted, fold this into a parity corpus" note. Wiring `build`/`build_from_value` into
        `Content` in place of the recorder remains this step's own job.
+     - ✅ **first half: the tree-source swap.** `SubstitutionGroup::apply` builds each content's
+       tree with the single-pass builder – via the new group-aware
+       [`build_for_group`](../../parser/src/content/inline_builder/mod.rs), mirroring
+       `run_pipeline`'s own step selection per substitution group – in place of the Strategy-A
+       recording pass, which is retired to test-only oracle machinery; see the step's own
+       "landed as" note above. The remaining half – `rendered_html()` as an authoritative fold,
+       `apply_macro_side_effects` called for real, the sentinel deletions, and the flag's
+       retirement – is still outstanding.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -87,7 +87,7 @@ pub struct Content<'src> {
 
     /// The inline AST for this content: the structured representation of its
     /// inline nodes, built by the single-pass builder
-    /// ([`inline_builder`](crate::content::inline_builder)) directly from the
+    /// (the crate-internal `inline_builder` module) directly from the
     /// pre-substitution source, in parallel with the substitution pass that
     /// produced [`rendered`](Self::rendered).
     ///
@@ -405,14 +405,14 @@ impl<'src> Content<'src> {
     /// [`Parser`](crate::Parser) (see
     /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
     /// slice otherwise. The tree is built by the single-pass builder
-    /// ([`inline_builder`](crate::content::inline_builder)) directly from the
+    /// (the crate-internal `inline_builder` module) directly from the
     /// pre-substitution source, so each node carries its own precise source
     /// [`Span`] (a node born from a transformation, such as an attribute
     /// expansion, falls back to a documented coarser span) and a macro node
     /// carries its own parsed attribute list. The fold of the tree reproduces
     /// [`rendered_html`](Self::rendered_html) byte-for-byte across the
     /// builder's supported vocabulary; a small set of forms is documented as
-    /// deferred (see the [`inline_builder`](crate::content::inline_builder)
+    /// deferred (documented in the `inline_builder`
     /// module), each left as literal text in the tree rather than a wrong
     /// node. The tree is not yet the canonical representation (see the
     /// [inline AST architecture design], Phase 4 step 6).

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -86,13 +86,16 @@ pub struct Content<'src> {
     passthroughs: Vec<Passthrough>,
 
     /// The inline AST for this content: the structured representation of its
-    /// inline nodes, folded from the same substitution pass that produced
-    /// [`rendered`](Self::rendered).
+    /// inline nodes, built by the single-pass builder
+    /// ([`inline_builder`](crate::content::inline_builder)) directly from the
+    /// pre-substitution source, in parallel with the substitution pass that
+    /// produced [`rendered`](Self::rendered).
     ///
-    /// This is a **derived artifact** – a projection of the rendered content,
-    /// not an independent source of truth (yet; see the [inline AST
-    /// architecture] design, Phase 2). It is populated only when inline-tree
-    /// building is enabled on the [`Parser`](crate::Parser)
+    /// This is a **derived artifact** – built alongside the rendered content,
+    /// which remains the source of truth (making the tree canonical, with
+    /// `rendered_html()` a fold of it, is the remaining half of the [inline
+    /// AST architecture] design's step 6). It is populated only when
+    /// inline-tree building is enabled on the [`Parser`](crate::Parser)
     /// ([`with_inline_tree`](crate::Parser::with_inline_tree)); otherwise it is
     /// empty and the default parse path is byte- and performance-identical to
     /// before. Because it is derived, it is deliberately excluded from
@@ -401,10 +404,18 @@ impl<'src> Content<'src> {
     /// This is populated only when inline-tree building is enabled on the
     /// [`Parser`](crate::Parser) (see
     /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
-    /// slice otherwise. The tree is a projection of the rendered content – the
-    /// fold of the tree reproduces [`rendered_html`](Self::rendered_html)
-    /// byte-for-byte – and is not yet the canonical representation (see the
-    /// [inline AST architecture design], Phase 2).
+    /// slice otherwise. The tree is built by the single-pass builder
+    /// ([`inline_builder`](crate::content::inline_builder)) directly from the
+    /// pre-substitution source, so each node carries its own precise source
+    /// [`Span`] (a node born from a transformation, such as an attribute
+    /// expansion, falls back to a documented coarser span) and a macro node
+    /// carries its own parsed attribute list. The fold of the tree reproduces
+    /// [`rendered_html`](Self::rendered_html) byte-for-byte across the
+    /// builder's supported vocabulary; a small set of forms is documented as
+    /// deferred (see the [`inline_builder`](crate::content::inline_builder)
+    /// module), each left as literal text in the tree rather than a wrong
+    /// node. The tree is not yet the canonical representation (see the
+    /// [inline AST architecture design], Phase 4 step 6).
     ///
     /// Cross-references in the tree carry their resolved destination once a
     /// full [`Parser::parse`](crate::Parser::parse) has resolved the document's
@@ -420,8 +431,8 @@ impl<'src> Content<'src> {
         &self.inlines
     }
 
-    /// Installs the inline AST built for this content by the recording pass
-    /// (see [`inline_tree`](crate::content::inline_tree)).
+    /// Installs the inline AST built for this content by the single-pass
+    /// builder (see [`inline_builder`](crate::content::inline_builder)).
     pub(crate) fn set_inlines(&mut self, inlines: Vec<InlineNode<'src>>) {
         self.inlines = inlines;
     }
@@ -681,27 +692,24 @@ impl<'src> Content<'src> {
             return;
         }
 
-        let mut next = 0;
-        assign_tree_xrefs(&mut self.inlines, block_ordered, &mut next);
+        // The correlation is positional, so it requires the tree to hold
+        // exactly one node per segment. The single-pass builder leaves a
+        // documented set of divergent forms unrecognized (e.g. a display text
+        // crossing a rendered span – see the `inline_builder` module), so the
+        // tree can legitimately hold *fewer* cross-reference nodes than the
+        // string pipeline deferred. When the counts differ the positional
+        // pairing is unknowable; the mirror is skipped for that list – leaving
+        // its nodes in their honest unresolved state – rather than assigning
+        // destinations to the wrong nodes.
+        if count_tree_xrefs(&self.inlines) == block_ordered.len() {
+            let mut next = 0;
+            assign_tree_xrefs(&mut self.inlines, block_ordered, &mut next);
+        }
 
-        // Each block-level segment must line up with exactly one tree node. A
-        // mismatch means the recording pass and the authoritative pass
-        // enumerated cross-references differently, which would silently misplace
-        // a resolved destination; catch that in debug/test builds.
-        debug_assert_eq!(
-            next,
-            block_ordered.len(),
-            "inline tree cross-reference count diverged from the resolved segments",
-        );
-
-        let mut next = 0;
-        assign_footnote_tree_xrefs(&mut self.inlines, footnote_ordered, &mut next);
-
-        debug_assert_eq!(
-            next,
-            footnote_ordered.len(),
-            "inline tree footnote cross-reference count diverged from the re-homed segments",
-        );
+        if count_footnote_tree_xrefs(&self.inlines) == footnote_ordered.len() {
+            let mut next = 0;
+            assign_footnote_tree_xrefs(&mut self.inlines, footnote_ordered, &mut next);
+        }
     }
 
     /// Rebuilds [`Content::rendered`] from the deferred template and the
@@ -767,6 +775,44 @@ pub(crate) fn footnote_tree_xrefs(
         .filter(|(index, _)| !template.contains(&Content::xref_placeholder(*index)))
         .map(|(_, xref)| xref.resolved.clone())
         .collect()
+}
+
+/// Counts the [`Xref`](RefVariant::Xref) nodes an [`assign_tree_xrefs`] walk
+/// over `nodes` would visit – i.e. the block-level cross-reference slots of the
+/// tree, excluding footnote subtrees (which [`count_footnote_tree_xrefs`]
+/// covers). Used to verify the positional correlation before assigning.
+fn count_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
+    nodes
+        .iter()
+        .map(|node| match node {
+            InlineNode::Ref(reference) => {
+                usize::from(reference.variant == RefVariant::Xref)
+                    + count_tree_xrefs(&reference.children)
+            }
+
+            InlineNode::Styled(styled) => count_tree_xrefs(&styled.children),
+
+            _ => 0,
+        })
+        .sum()
+}
+
+/// Counts the [`Xref`](RefVariant::Xref) nodes an
+/// [`assign_footnote_tree_xrefs`] walk over `nodes` would visit – i.e. the
+/// cross-reference slots inside the tree's footnote subtrees.
+fn count_footnote_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
+    nodes
+        .iter()
+        .map(|node| match node {
+            InlineNode::Footnote(footnote) => count_tree_xrefs(&footnote.children),
+
+            InlineNode::Ref(reference) => count_footnote_tree_xrefs(&reference.children),
+
+            InlineNode::Styled(styled) => count_footnote_tree_xrefs(&styled.children),
+
+            _ => 0,
+        })
+        .sum()
 }
 
 /// Walks an inline node slice in document order and installs each

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -49,7 +49,7 @@ use crate::{
 /// does not call `Parser::register_callout`, deferring the callout catalog's
 /// validation to the cutover (design §5.2 Phase 4, step 6), exactly as the
 /// image and link increments defer their own catalog registrations.
-fn apply_callouts<'src>(
+pub(super) fn apply_callouts<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -452,7 +452,7 @@ fn fold_anchor(
 /// the string pipeline's bytes exactly.
 ///
 /// The node's `terms` mirrors what the
-/// [`inline_tree`](crate::content::inline_tree) recorder stores – the single
+/// (test-only) `inline_tree` recorder stores – the single
 /// shown term for a visible node, empty for a concealed one; the richer
 /// primary/secondary/tertiary structure the field can hold is left to a re-flow
 /// consumer to pin (the field is provisional, per the node's Phase-0 note),

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the first brick of "Strategy B" (design §4.1): rather than recover
 //! the tree from a post-substitution *marked string* – the
-//! [`inline_tree`](crate::content::inline_tree) recorder's "Strategy A" – each
+//! `inline_tree` recorder's "Strategy A", now test-only – each
 //! substitution step is recast as a **transducer** over a node list,
 //! `Vec<InlineNode<'src>> -> Vec<InlineNode<'src>>`, that refines the tree in
 //! place. Two properties fall out that Strategy A cannot offer:
@@ -166,13 +166,12 @@
 //!   spliced into the node's value verbatim, unlike every other macro family's
 //!   "crosses an already-recognized construct" boundary. A macro carrying an
 //!   explicit substitution list (`stem:c,q[…]`) is recognized too: the list
-//!   resolves to a [`SubstitutionGroup`](crate::content::SubstitutionGroup) the
-//!   expression runs through in place of the bare macro's
-//!   [`SubstitutionGroup::Stem`](crate::content::SubstitutionGroup::Stem) – the
-//!   same `passthrough_text`-through-the-real-pipeline treatment that resolves
-//!   the analogous `pass:c,q[…]` form (see [`apply_passthroughs`]'s doc
-//!   comment), except a `Stem` node already has a single `value` field to hold
-//!   the result, so no richer subtree is needed.
+//!   resolves to a [`SubstitutionGroup`] the expression runs through in place
+//!   of the bare macro's [`SubstitutionGroup::Stem`] – the same
+//!   `passthrough_text`-through-the-real-pipeline treatment that resolves the
+//!   analogous `pass:c,q[…]` form (see [`apply_passthroughs`]'s doc comment),
+//!   except a `Stem` node already has a single `value` field to hold the
+//!   result, so no richer subtree is needed.
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf. Under the block-wide
 //!   `hardbreaks` option – the enclosing block's own `attrlist`, or the
@@ -184,7 +183,7 @@
 //!   through an
 //!   [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
 //!   – the first fold over the *public* [`InlineNode`] tree (the recorder's
-//!   [`fold_into`] folds an intermediate representation, not the public tree).
+//!   `fold_into` folds an intermediate representation, not the public tree).
 //!
 //! [quoted text]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
 //! [character replacements]:
@@ -242,7 +241,6 @@
 //! pipeline's match-through-rendered-tags behavior for pathological cross-span
 //! inputs; the differential corpus (§5.3) pins the cases this increment claims.
 //!
-//! [`fold_into`]: crate::content::inline_tree
 //! [`Text`]: InlineNode::Text
 //! [`quote_subs`]: crate::content::quote_subs
 
@@ -387,12 +385,12 @@ pub(crate) fn build_from_value<'src>(
 ///   [`Macros`](SubstitutionStep::Macros) or the group is
 ///   [`Header`](SubstitutionGroup::Header) – the same condition `run_pipeline`
 ///   gates `Passthroughs::extract_from` on.
-/// - Each of the group's [`steps()`](SubstitutionGroup::steps) then runs in
-///   the group's own order, each recast as its node transducer. The
+/// - Each of the group's [`steps()`](SubstitutionGroup::steps) then runs in the
+///   group's own order, each recast as its node transducer. The
 ///   [`Macros`](SubstitutionStep::Macros) step runs [`apply_macros`] and then
 ///   [`apply_footnotes`] – footnotes are part of the string pipeline's macros
-///   step, but are their own transducer here so numbering follows true
-///   source order (see [`apply_footnotes`]'s doc comment).
+///   step, but are their own transducer here so numbering follows true source
+///   order (see [`apply_footnotes`]'s doc comment).
 ///
 /// A group whose steps are empty ([`Pass`](SubstitutionGroup::Pass) /
 /// [`None`](SubstitutionGroup::None), or an empty custom list) yields the

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -190,31 +190,42 @@
 //! [character replacements]:
 //!     https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
 //!
-//! It is **additive and non-regressing**: nothing here is wired into the parse
-//! path yet, so the authoritative string pipeline and the Strategy-A
-//! [`Content::inlines`](crate::content::Content::inlines) tree are untouched.
-//! Later increments extend the transducer to the remaining macro families,
-//! attribute expansion, and passthroughs, at which point it can replace the
-//! recorder, make `rendered_html()` a fold, and retire the sentinel systems.
+//! This module is now **the production tree source**: when inline-tree
+//! building is enabled ([`Parser::with_inline_tree`](crate::Parser)),
+//! `SubstitutionGroup::apply` calls [`build_for_group`] – the group-aware
+//! entry point mirroring its own `run_pipeline` step selection – over the
+//! pre-substitution content value, against a counter-safe clone of the
+//! parser, and stores the result on
+//! [`Content::inlines`](crate::content::Content::inlines). This replaced the
+//! Strategy-A recorder (`content::inline_tree`, now test-only oracle
+//! machinery) as the design's step 6 tree-source swap. The authoritative
+//! rendered string is still produced by the string pipeline; making
+//! `rendered_html()` a fold of this tree – and deleting the three production
+//! sentinel systems – is the remaining half of the cutover. A form documented
+//! as deferred elsewhere in this module is left as literal text in the tree
+//! (never a wrong node), so the fold-parity guarantee is scoped to the
+//! claimed vocabulary.
 //!
 //! # Staging the cutover's recognition side effects
 //!
 //! Every macro family above deliberately skips a **recognition side effect**
 //! the string pipeline performs at the same point – registering an id, link,
 //! or image target in the document catalog, or recording a warning – because
-//! the additive builder still runs *alongside* the authoritative string
-//! pipeline (each against its own, independent [`Parser`]), so performing one
-//! here today would risk double-counting a registration once the two paths
-//! ever share a `Parser`. Each family's own deferred side effects are staged
-//! as their own reviewable building block – `register_image` and the `link=`
-//! dangerous-scheme/self-href warning for `image:`/`icon:`, `register_link`
-//! for the four link-macro forms, and the `register_ref` pair for anchors and
-//! id-carrying attributed spans – and [`apply_macro_side_effects`] composes
-//! all three, in the string pipeline's own family-pass order, into the single
-//! call the eventual cutover makes exactly once per parse (design §5.2, Phase
-//! 4 step 6). It is exercised only by its own tests (and its constituents'
-//! own), against their own `Parser` – calling it for real still waits for the
-//! single-pass builder to replace the recorder as `Content`'s tree source.
+//! the builder still runs *alongside* the authoritative string pipeline
+//! (against a counter-safe clone of the parser, whose mutations are
+//! discarded), so performing one here today would double-count the
+//! registration the string pipeline already performs. Each family's own
+//! deferred side effects are staged as their own reviewable building block –
+//! `register_image` and the `link=` dangerous-scheme/self-href warning for
+//! `image:`/`icon:`, `register_link` for the four link-macro forms, and the
+//! `register_ref` pair for anchors and id-carrying attributed spans – and
+//! [`apply_macro_side_effects`] composes all three, in the string pipeline's
+//! own family-pass order, into the single call the cutover's remaining half
+//! makes exactly once per parse (design §5.2, Phase 4 step 6): once
+//! `rendered_html()` is a fold of this tree, the string pipeline no longer
+//! performs the registrations and this call takes over. Until then it is
+//! exercised only by its own tests (and its constituents' own), against
+//! their own `Parser`.
 //!
 //! # A note on quote nesting
 //!
@@ -235,8 +246,10 @@
 //! [`Text`]: InlineNode::Text
 //! [`quote_subs`]: crate::content::quote_subs
 
-// The transducer framework is deliberately broader than the single step wired
-// up so far; later Strategy-B increments consume the rest.
+// The fold ([`fold_html`]) and the staged recognition side effects
+// ([`apply_macro_side_effects`] and its constituents) are consumed only by
+// tests until the authoritative-fold half of the cutover wires them into
+// `Content` (design §5.2, Phase 4 step 6).
 #![allow(dead_code)]
 
 mod attribute_refs;
@@ -255,17 +268,17 @@ mod stem_step;
 mod test_support;
 
 use attribute_refs::apply_attribute_references;
+use callouts::apply_callouts;
 use char_replacements::apply_character_replacements;
-// Reachable only via `cfg(test)` callers and future external callers today
-// (mirroring the crate-wide `#![allow(dead_code)]` above), so unlike the
-// other step re-exports below (each consumed by `build`), this one is not
-// itself consumed within this module.
+// Consumed only by `cfg(test)` callers and future external callers until the
+// authoritative-fold half of the cutover wires it into `Content`.
 #[allow(unused_imports)]
 pub(crate) use fold::fold_html;
 use footnotes::apply_footnotes;
-// Staged for the eventual cutover (see this module's own doc comment); not
-// yet called from any real parse path, so – like `fold_html` above – reachable
-// only via `cfg(test)` callers and future external callers today.
+// Staged for the eventual authoritative-fold half of the cutover (see this
+// module's own doc comment); not yet called from any real parse path, so –
+// unlike the step re-exports below – reachable only via `cfg(test)` callers
+// and future external callers today.
 #[allow(unused_imports)]
 pub(crate) use macros::apply_macro_side_effects;
 use macros::apply_macros;
@@ -275,7 +288,13 @@ use quotes::apply_quotes;
 use special_chars::apply_special_characters;
 use stem_step::apply_stem;
 
-use crate::{Parser, Span, attributes::Attrlist, inlines::InlineNode, strings::CowStr};
+use crate::{
+    Parser, Span,
+    attributes::Attrlist,
+    content::{SubstitutionGroup, SubstitutionStep},
+    inlines::InlineNode,
+    strings::CowStr,
+};
 
 /// Builds the inline tree for `source` in a single forward pass.
 ///
@@ -346,40 +365,101 @@ pub(crate) fn build_from_value<'src>(
     parser: &Parser,
     attrlist: Option<&Attrlist<'src>>,
 ) -> Vec<InlineNode<'src>> {
-    let seed = vec![InlineNode::Text { value, location }];
+    build_for_group(
+        &SubstitutionGroup::Normal,
+        value,
+        location,
+        parser,
+        attrlist,
+    )
+}
+
+/// Builds the inline tree from an already-computed content **value** under the
+/// substitution group that governs the content – the group-aware counterpart
+/// of [`build_from_value`], mirroring the step selection
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup)'s own
+/// `run_pipeline` makes for the string.
+///
+/// The mapping reproduces `run_pipeline` exactly:
+///
+/// - Passthrough (and, with it, inline-STEM) extraction runs first, ahead of
+///   every step, **iff** the group's steps include
+///   [`Macros`](SubstitutionStep::Macros) or the group is
+///   [`Header`](SubstitutionGroup::Header) – the same condition `run_pipeline`
+///   gates `Passthroughs::extract_from` on.
+/// - Each of the group's [`steps()`](SubstitutionGroup::steps) then runs in
+///   the group's own order, each recast as its node transducer. The
+///   [`Macros`](SubstitutionStep::Macros) step runs [`apply_macros`] and then
+///   [`apply_footnotes`] – footnotes are part of the string pipeline's macros
+///   step, but are their own transducer here so numbering follows true
+///   source order (see [`apply_footnotes`]'s doc comment).
+///
+/// A group whose steps are empty ([`Pass`](SubstitutionGroup::Pass) /
+/// [`None`](SubstitutionGroup::None), or an empty custom list) yields the
+/// untouched seed: a single [`Text`](InlineNode::Text) node holding `value`,
+/// exactly as the string pipeline leaves such content's text unchanged.
+pub(crate) fn build_for_group<'src>(
+    group: &SubstitutionGroup,
+    value: CowStr<'src>,
+    location: Span<'src>,
+    parser: &Parser,
+    attrlist: Option<&Attrlist<'src>>,
+) -> Vec<InlineNode<'src>> {
+    let steps = group.steps();
+
+    let mut nodes = vec![InlineNode::Text { value, location }];
 
     // Passthroughs are extracted before every other step (mirroring
     // `Passthroughs::extract_from`, which the string pipeline runs ahead of
-    // its own step loop), so their content is never touched by
-    // specialcharacters, quotes, replacements, or macros.
-    let nodes = apply_passthroughs(seed, location, parser);
+    // its own step loop, under the same group condition), so their content is
+    // never touched by specialcharacters, quotes, replacements, or macros.
+    if steps.contains(&SubstitutionStep::Macros) || group == &SubstitutionGroup::Header {
+        nodes = apply_passthroughs(nodes, location, parser);
 
-    // Inline STEM is an implicit passthrough too, extracted last (mirroring
-    // `Passthroughs::extract_from`'s own ordering) so a passthrough
-    // placeholder nested inside a STEM expression survives.
-    let nodes = apply_stem(nodes, location, parser);
+        // Inline STEM is an implicit passthrough too, extracted last
+        // (mirroring `Passthroughs::extract_from`'s own ordering) so a
+        // passthrough placeholder nested inside a STEM expression survives.
+        nodes = apply_stem(nodes, location, parser);
+    }
 
-    let nodes = apply_special_characters(nodes);
-    let nodes = apply_quotes(nodes, location, parser);
+    for step in steps {
+        nodes = match step {
+            SubstitutionStep::SpecialCharacters => apply_special_characters(nodes),
 
-    // Attribute references sit here in the *normal* effective order
-    // (specialcharacters → quotes → attributes → replacements → macros,
-    // design §3.4.1): by this point `<`/`>`/`&` are already `CharRef` leaves
-    // and quoted spans are already `Styled` nodes, and whatever this step
-    // splices in is exactly what `apply_character_replacements` and
-    // `apply_macros` – still ahead – see and refine.
-    let nodes = apply_attribute_references(nodes, location, parser);
+            SubstitutionStep::Quotes => apply_quotes(nodes, location, parser),
 
-    let nodes = apply_character_replacements(nodes, location);
-    let nodes = apply_macros(nodes, location, parser);
+            // In the *normal* effective order (specialcharacters → quotes →
+            // attributes → replacements → macros, design §3.4.1), by this
+            // point `<`/`>`/`&` are already `CharRef` leaves and quoted spans
+            // are already `Styled` nodes, and whatever this step splices in
+            // is exactly what the steps still ahead see and refine.
+            SubstitutionStep::AttributeReferences => {
+                apply_attribute_references(nodes, location, parser)
+            }
 
-    // Footnotes are their own step, run once over the *whole* tree after
-    // every other macro family has been resolved at every level – see
-    // `apply_footnotes`'s doc comment for why this cannot be folded into
-    // `apply_macros` as an ordinary level pass.
-    let nodes = apply_footnotes(nodes, location, parser);
+            SubstitutionStep::CharacterReplacements => {
+                apply_character_replacements(nodes, location)
+            }
 
-    apply_post_replacements(nodes, location, parser, attrlist)
+            SubstitutionStep::Macros => {
+                // Footnotes are their own transducer, run once over the
+                // *whole* tree after every other macro family has been
+                // resolved at every level – see `apply_footnotes`'s doc
+                // comment for why this cannot be folded into `apply_macros`
+                // as an ordinary level pass.
+                let nodes = apply_macros(nodes, location, parser);
+                apply_footnotes(nodes, location, parser)
+            }
+
+            SubstitutionStep::PostReplacement => {
+                apply_post_replacements(nodes, location, parser, attrlist)
+            }
+
+            SubstitutionStep::Callouts => apply_callouts(nodes, location, parser, attrlist),
+        };
+    }
+
+    nodes
 }
 
 /// A whole-pipeline differential corpus: [`build`] against the *real*,
@@ -732,6 +812,205 @@ mod tests {
                 "fold diverged from the real pipeline for synthesized value {filtered:?} \
                  (location {source:?})"
             );
+        }
+    }
+
+    /// The group-aware entry point ([`build_for_group`]) against the real
+    /// pipeline, for the substitution groups whose step lists differ from
+    /// [`SubstitutionGroup::Normal`] – pinning both the per-group step
+    /// selection and the passthrough-extraction gate (`Macros` in the steps,
+    /// or the `Header` group), which mirror `run_pipeline`'s own.
+    mod build_for_group {
+        #![allow(clippy::unwrap_used)]
+
+        use super::super::{build_for_group, fold_html};
+        use crate::{
+            Parser, Span,
+            content::{Content, SubstitutionGroup},
+            inlines::InlineNode,
+            parser::{HtmlSubstitutionRenderer, ModificationContext},
+            strings::CowStr,
+        };
+
+        fn parser_with_product() -> Parser {
+            Parser::default().with_intrinsic_attribute(
+                "product",
+                "Widget",
+                ModificationContext::Anywhere,
+            )
+        }
+
+        fn build_group<'src>(
+            group: &SubstitutionGroup,
+            source: &'src str,
+            parser: &Parser,
+        ) -> Vec<InlineNode<'src>> {
+            build_for_group(group, CowStr::from(source), Span::new(source), parser, None)
+        }
+
+        /// Runs `source` through the real pipeline under `group` and asserts
+        /// the group-aware tree folds to the same bytes.
+        fn assert_group_parity(group: &SubstitutionGroup, source: &str) {
+            let golden_parser = parser_with_product();
+            let mut content = Content::from(Span::new(source));
+            group.apply(&mut content, &golden_parser, None);
+            let golden = content.rendered_str().to_string();
+
+            let built_parser = parser_with_product();
+            let nodes = build_group(group, source, &built_parser);
+            let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+
+            assert_eq!(
+                built, golden,
+                "group-aware fold diverged from the real pipeline for {source:?} under {group:?}"
+            );
+        }
+
+        #[test]
+        fn header_group_extracts_passthroughs_and_expands_attributes() {
+            // The header group runs special characters and attribute
+            // references only – but, uniquely among the non-`Macros` groups,
+            // it *does* extract passthroughs (`run_pipeline`'s own gate).
+            let source = "v pass:[<raw>] {product} *plain* < end";
+            let parser = parser_with_product();
+            let nodes = build_group(&SubstitutionGroup::Header, source, &parser);
+
+            // The pass macro was extracted (a `Raw` leaf) …
+            assert!(
+                nodes.iter().any(
+                    |n| matches!(n, InlineNode::Raw { value, .. } if value.as_ref() == "<raw>")
+                ),
+                "expected the pass macro's Raw leaf: {nodes:?}"
+            );
+
+            // … the attribute reference expanded …
+            assert!(
+                nodes
+                    .iter()
+                    .any(|n| matches!(n, InlineNode::Text { value, .. } if value.as_ref().contains("Widget"))),
+                "expected the expanded attribute value: {nodes:?}"
+            );
+
+            // … and the quotes step did not run.
+            assert!(
+                !nodes.iter().any(|n| matches!(n, InlineNode::Styled(_))),
+                "the quotes step must not run for the header group: {nodes:?}"
+            );
+
+            assert_group_parity(&SubstitutionGroup::Header, source);
+        }
+
+        #[test]
+        fn attribute_entry_value_group_does_not_extract_passthroughs() {
+            // The attribute-entry-value group runs the same two steps as the
+            // header group but does *not* extract passthroughs, so a
+            // `pass:[…]` stays literal text – mirroring `run_pipeline`'s
+            // extraction gate exactly.
+            let source = "v pass:[x] {product}";
+            let parser = parser_with_product();
+            let nodes = build_group(&SubstitutionGroup::AttributeEntryValue, source, &parser);
+
+            assert!(
+                !nodes.iter().any(|n| matches!(n, InlineNode::Raw { .. })),
+                "a pass macro must stay literal for the attribute-entry-value group: {nodes:?}"
+            );
+
+            assert_group_parity(&SubstitutionGroup::AttributeEntryValue, source);
+        }
+
+        #[test]
+        fn pass_and_none_groups_yield_the_untouched_seed() {
+            let source = "<b>raw</b> *not bold* {product}";
+            let parser = parser_with_product();
+
+            for group in [SubstitutionGroup::Pass, SubstitutionGroup::None] {
+                let nodes = build_group(&group, source, &parser);
+
+                assert!(
+                    matches!(
+                        nodes.as_slice(),
+                        [InlineNode::Text { value, .. }] if value.as_ref() == source
+                    ),
+                    "expected the untouched single text run under {group:?}: {nodes:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn stem_group_applies_special_characters_only() {
+            let source = "*a* < {product}";
+            let parser = parser_with_product();
+            let nodes = build_group(&SubstitutionGroup::Stem, source, &parser);
+
+            // `<` became a CharRef; `*a*` and `{product}` stayed literal.
+            assert!(
+                nodes
+                    .iter()
+                    .any(|n| matches!(n, InlineNode::CharRef { .. })),
+                "expected the escaped special character: {nodes:?}"
+            );
+            assert!(
+                !nodes.iter().any(|n| matches!(n, InlineNode::Styled(_))),
+                "the quotes step must not run for the stem group: {nodes:?}"
+            );
+
+            assert_group_parity(&SubstitutionGroup::Stem, source);
+        }
+
+        #[test]
+        fn a_custom_list_runs_exactly_the_named_steps_in_order() {
+            // `subs=quotes` alone: `*bold*` is recognized, `<` stays literal
+            // text (never escaped), and `{product}` stays unexpanded.
+            let (group, invalid) = SubstitutionGroup::from_custom_string(None, "quotes");
+            assert!(invalid.is_empty());
+
+            let source = "keep *bold* and a < b with {product}";
+            let parser = parser_with_product();
+            let nodes = build_group(&group, source, &parser);
+
+            assert!(
+                nodes.iter().any(|n| matches!(n, InlineNode::Styled(_))),
+                "expected the quoted span: {nodes:?}"
+            );
+            assert!(
+                !nodes
+                    .iter()
+                    .any(|n| matches!(n, InlineNode::CharRef { .. })),
+                "the special-characters step must not run for subs=quotes: {nodes:?}"
+            );
+            assert!(
+                nodes
+                    .iter()
+                    .any(|n| matches!(n, InlineNode::Text { value, .. } if value.as_ref().contains("{product}"))),
+                "the attribute reference must stay literal for subs=quotes: {nodes:?}"
+            );
+        }
+
+        #[test]
+        fn a_custom_list_including_macros_extracts_passthroughs() {
+            // A custom list naming `macros` triggers passthrough extraction
+            // (the same `steps.contains(Macros)` gate `run_pipeline` uses), so
+            // a `+++…+++` passthrough is a `Raw` leaf even under a custom
+            // list.
+            let (group, invalid) = SubstitutionGroup::from_custom_string(None, "macros");
+            assert!(invalid.is_empty());
+
+            let source = "a +++<u>raw</u>+++ and image:pic.png[Alt]";
+            let parser = parser_with_product();
+            let nodes = build_group(&group, source, &parser);
+
+            assert!(
+                nodes.iter().any(
+                    |n| matches!(n, InlineNode::Raw { value, .. } if value.as_ref() == "<u>raw</u>")
+                ),
+                "expected the passthrough's Raw leaf: {nodes:?}"
+            );
+            assert!(
+                nodes.iter().any(|n| matches!(n, InlineNode::Image(_))),
+                "expected the image macro's node: {nodes:?}"
+            );
+
+            assert_group_parity(&group, source);
         }
     }
 

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -1,11 +1,18 @@
-//! Builds the inline AST as a **live artifact of a parsed [`Content`]**.
+//! Builds an inline AST by **recording the string pipeline's own renderer
+//! calls** – the retired "Strategy A" construction, kept as **test-only oracle
+//! machinery**.
 //!
-//! This is the production home of the tree-building machinery that landed in
-//! Phase 1 as a test-only oracle ([`inline_recorder`]). It promotes that
-//! machinery into the parser proper so that – when tree building is enabled on
-//! the [`Parser`] – every [`Content`] carries a
-//! [`Vec<InlineNode>`](crate::inlines::InlineNode) alongside its rendered
-//! string.
+//! This module was the production tree source through Phase 2 and Phase 4's
+//! additive increments: when tree building was enabled on the [`Parser`],
+//! `SubstitutionGroup::apply` re-ran the pipeline through the
+//! [`RecordingRenderer`] and parsed the recorded markers into each
+//! [`Content`]'s tree. The Phase 4 single-pass builder
+//! ([`inline_builder`](crate::content::inline_builder)) has since replaced it
+//! as `Content`'s tree source (the first half of the design's step 6
+//! cutover), so this module is now compiled only for tests, where it remains
+//! the independent construction the differential harness
+//! ([`inline_recorder`]) and the structural cross-check
+//! (`tests::inline_builder_recorder_parity`) compare the builder against.
 //!
 //! # Strategy A, unchanged
 //!
@@ -25,25 +32,18 @@
 //! Because the decorator wraps whatever renderer the [`Parser`] carries, the
 //! fold reproduces *that* renderer's bytes, not a hard-coded HTML backend.
 //!
-//! # Why a second pass (for now)
+//! # Why a second pass
 //!
 //! Making the tree the recognition sink directly – so there is no second pass
-//! and no markers – is "Strategy B", the Phase 4 single-pass builder. Until
-//! then the tree is built by a **second, counter-safe substitution pass**: the
-//! caller clones the [`Parser`] *before* the authoritative pass advances any
-//! document counter, so the recording pass numbers footnotes, callouts, and
-//! counters exactly as the authoritative pass did, then discards the clone. The
-//! authoritative rendered string is never produced by the recorder, so this is
-//! purely additive and cannot regress output.
-//!
-//! # Status
-//!
-//! This is the "promote the tree into [`Content`]" step of Phase 2. The tree is
-//! a real, live artifact, but it is built behind an **opt-in** flag
-//! ([`Parser::with_inline_tree`]) so the default parse path is byte- and
-//! performance-identical to before. Making the tree *canonical* (with
-//! `rendered_html()` folding it, and the three production sentinel systems
-//! retired) is the remainder of Phase 2 and Phase 4.
+//! and no markers – is "Strategy B", the Phase 4 single-pass builder that has
+//! now replaced this module in production. Here the tree is built by a
+//! **second, counter-safe substitution pass**: the caller clones the
+//! [`Parser`] *before* the authoritative pass advances any document counter,
+//! so the recording pass numbers footnotes, callouts, and counters exactly as
+//! the authoritative pass did, then discards the clone. The authoritative
+//! rendered string is never produced by the recorder, so the pass is purely
+//! additive and cannot regress output – which is also what makes it a clean
+//! *independent* construction for the cross-check to compare against.
 //!
 //! [`inline_recorder`]: ../../tests/inline_recorder.rs
 //! [`Content`]: crate::content::Content

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -13,6 +13,13 @@ pub(crate) use content::{
 
 pub(crate) mod inline_builder;
 
+// The Strategy-A recorder, retired from the production parse path when the
+// single-pass builder (`inline_builder`) replaced it as `Content`'s tree
+// source. It survives as test-only oracle machinery: the differential harness
+// (`tests::inline_recorder`) still drives it directly, and the structural
+// cross-check (`tests::inline_builder_recorder_parity`) compares its tree
+// against the builder's.
+#[cfg(test)]
 pub(crate) mod inline_tree;
 
 mod macros;

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -1,11 +1,7 @@
-use std::rc::Rc;
-
 use crate::{
     HasSpan, Parser,
     attributes::Attrlist,
-    content::{
-        Content, Passthroughs, SubstitutionStep, inline_tree, inline_tree::RecordingRenderer,
-    },
+    content::{Content, Passthroughs, SubstitutionStep},
     warnings::WarningType,
 };
 
@@ -224,33 +220,44 @@ impl SubstitutionGroup {
         (Self::Custom(deduped), invalid)
     }
 
-    pub(crate) fn apply(
+    pub(crate) fn apply<'src>(
         &self,
-        content: &mut Content<'_>,
+        content: &mut Content<'src>,
         parser: &Parser,
-        attrlist: Option<&Attrlist>,
+        attrlist: Option<&Attrlist<'src>>,
     ) {
-        // Snapshot the content and parser *before* the authoritative pass runs,
-        // when inline-tree building is enabled. The clone captures every
-        // document counter (footnote/callout numbers, `{counter:…}` values) at
-        // its pre-substitution value, so the recording pass below numbers
-        // constructs exactly as the authoritative pass does; the clone's
-        // mutations are then discarded, leaving the real parser advanced once.
-        let recording_seed = if parser.build_inline_tree {
-            Some((content.clone(), parser.clone()))
+        // Snapshot the pre-substitution value and the parser *before* the
+        // authoritative pass runs, when inline-tree building is enabled. The
+        // parser clone captures every document counter (footnote/callout
+        // numbers, `{counter:…}` values) at its pre-substitution value, so the
+        // single-pass builder below numbers constructs exactly as the
+        // authoritative pass does; the clone's mutations are then discarded,
+        // leaving the real parser advanced once.
+        let tree_seed = if parser.build_inline_tree {
+            Some((content.rendered.clone(), parser.clone()))
         } else {
             None
         };
 
         self.run_pipeline(content, parser, attrlist);
 
-        if let Some((mut recording_content, mut recording_parser)) = recording_seed {
-            self.build_inline_tree(
-                content,
-                &mut recording_content,
-                &mut recording_parser,
+        if let Some((value, mut tree_parser)) = tree_seed {
+            // The builder must not recurse into tree building itself: a
+            // passthrough with its own substitution list re-enters
+            // `SubstitutionGroup::apply` for its body (via
+            // `passthrough_text`), and that nested content needs no tree of
+            // its own.
+            tree_parser.build_inline_tree = false;
+
+            let tree = crate::content::inline_builder::build_for_group(
+                self,
+                value,
+                content.original(),
+                &tree_parser,
                 attrlist,
             );
+
+            content.set_inlines(tree);
         }
     }
 
@@ -289,73 +296,6 @@ impl SubstitutionGroup {
         // references are resolved. This is a no-op when no cross-references were
         // found.
         content.finalize_deferred(&*parser.renderer);
-    }
-
-    /// Builds the inline AST for `content` by re-running the pipeline over the
-    /// pre-substitution snapshot with a [`RecordingRenderer`] wrapped around
-    /// the parser's own renderer, then parsing the recorded markers into a
-    /// tree and storing it on `content`, then populating each footnote node's
-    /// subtree from the footnote texts that pass registered.
-    ///
-    /// This is Strategy A (design §4.1): a transparent recording pass whose
-    /// fold reproduces the authoritative `rendered_html()` byte-for-byte. It is
-    /// a second pass for now; the Phase 4 single-pass builder retires it.
-    fn build_inline_tree(
-        &self,
-        content: &mut Content<'_>,
-        recording_content: &mut Content<'_>,
-        recording_parser: &mut Parser,
-        attrlist: Option<&Attrlist>,
-    ) {
-        let (recorder, events) = RecordingRenderer::new(recording_parser.renderer.clone());
-        recording_parser.renderer = Rc::new(recorder);
-
-        // The recording pass must not recurse into tree building itself (nested
-        // content would clone the parser again and again); it only needs to
-        // record this content's own constructs.
-        recording_parser.build_inline_tree = false;
-
-        // A footnote's text is extracted out of the block, so it never reaches
-        // the marked string below; it is recovered from the footnotes this pass
-        // registers. Snapshot the registry length first so only *this* content's
-        // footnotes are picked up (the clone carries the ones defined earlier in
-        // the document).
-        let footnote_start = recording_parser.footnote_count();
-
-        self.run_pipeline(recording_content, recording_parser, attrlist);
-
-        let footnote_texts = recording_parser.footnote_texts_from(footnote_start);
-
-        let marked = recording_content.rendered_owned();
-        let events = events.borrow();
-        let mut tree = inline_tree::build_inline_tree(&marked, &events, content.original());
-
-        inline_tree::attach_footnote_subtrees(
-            &mut tree,
-            &footnote_texts,
-            &events,
-            content.original(),
-        );
-
-        // The recording pass re-runs the pipeline through a *clone* of the
-        // parser, but the clone shares the same `Rc`-held inline renderer and
-        // asset handlers as the authoritative pass. That is correct for the
-        // built-in (stateless) renderer and the default handlers, but a
-        // *stateful* custom renderer – or a one-shot asset handler – could
-        // observe different state the second time and make the recorded tree
-        // fold to something other than the authoritative `rendered_html()`. Assert
-        // parity so such a renderer fails loudly in debug/test builds rather
-        // than silently storing a divergent tree. (Retired with the second pass
-        // itself by the Phase 4 single-pass builder.)
-        debug_assert_eq!(
-            inline_tree::fold_marked(&marked, &events),
-            content.rendered_str(),
-            "inline tree fold diverged from rendered_html(); the configured inline \
-             renderer or an asset handler is stateful and unsafe for inline-tree \
-             building",
-        );
-
-        content.set_inlines(tree);
     }
 
     /// Applies any block style masquerade and `subs` attribute override from

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -478,14 +478,14 @@ pub struct Parser {
     datetime_context: RefCell<Option<DatetimeContext>>,
 
     /// When `true`, each [`Content`](crate::content::Content) also builds its
-    /// inline AST (an additional, counter-safe recording substitution pass; see
-    /// [`content::inline_tree`](crate::content::inline_tree)) and stores it for
+    /// inline AST (an additional, counter-safe single-pass recognition over
+    /// the same source; see `content::inline_builder`) and stores it for
     /// [`Content::inlines`](crate::content::Content::inlines).
     ///
     /// `false` by default, in which case the parse path is byte- and
     /// performance-identical to before the inline AST existed. Enable it with
     /// [`with_inline_tree`](Self::with_inline_tree). This is an opt-in switch
-    /// while the inline AST is being brought up (design Phase 2); it will
+    /// while the inline AST is being brought up (design Phase 4); it will
     /// eventually become the canonical representation and the flag will retire.
     pub(crate) build_inline_tree: bool,
 }
@@ -1720,37 +1720,6 @@ impl Parser {
         index
     }
 
-    /// The number of footnotes registered so far in the current document's
-    /// registry.
-    ///
-    /// Read by the inline-tree recording pass, which snapshots this count
-    /// before re-running the substitution pipeline so it can pick out exactly
-    /// the footnotes that pass defined; see
-    /// [`footnote_texts_from`](Self::footnote_texts_from).
-    pub(crate) fn footnote_count(&self) -> usize {
-        self.catalog.borrow().footnotes.len()
-    }
-
-    /// The already-substituted text of each footnote registered at or after
-    /// `start`, in registration (document) order.
-    ///
-    /// A footnote's text is extracted out of the flow of the block it was
-    /// written in, so it never reaches the block's rendered string; this is how
-    /// the inline-tree recording pass recovers it. During that pass the text
-    /// carries the recorder's markers, so it parses into the footnote's own
-    /// inline subtree (see
-    /// [`attach_footnote_subtrees`](crate::content::inline_tree::attach_footnote_subtrees)).
-    pub(crate) fn footnote_texts_from(&self, start: usize) -> Vec<String> {
-        self.catalog
-            .borrow()
-            .footnotes
-            .get(start..)
-            .unwrap_or_default()
-            .iter()
-            .map(|footnote| footnote.text.clone())
-            .collect()
-    }
-
     /// Removes and returns the current document's footnote list, leaving an
     /// empty list behind. Used to give a nested document (an AsciiDoc table
     /// cell) its own footnote registry; see [`restore_footnotes`].
@@ -2174,32 +2143,25 @@ impl Parser {
     /// its [`Content`](crate::content::Content) via
     /// [`Content::inlines`](crate::content::Content::inlines) (or, at the block
     /// level, [`IsBlock::inlines`](crate::blocks::IsBlock::inlines)). The tree
-    /// is a projection of the rendered output: folding it reproduces
-    /// [`Content::rendered_html`](crate::content::Content::rendered_html)
-    /// byte-for-byte.
+    /// is built by the single-pass builder
+    /// (`content::inline_builder`) directly from the pre-substitution source,
+    /// so its nodes carry precise source spans and their own parsed attribute
+    /// lists; see
+    /// [`Content::inlines`](crate::content::Content::inlines) for the tree's
+    /// guarantees (including the small set of documented deferred forms).
     ///
-    /// This is **off by default**. Building the tree currently costs a second,
-    /// counter-safe substitution pass per block (design Phase 2, "promote the
-    /// tree into `Content`"), so the default parse path is unchanged in both
-    /// output and performance. The switch is expected to retire once the inline
-    /// AST becomes the canonical representation.
+    /// This is **off by default**. Building the tree costs an additional,
+    /// counter-safe recognition pass per block over the same source, so the
+    /// default parse path is unchanged in both output and performance. The
+    /// switch is expected to retire once the inline AST becomes the canonical
+    /// representation (with `rendered_html()` a fold of it – the remaining
+    /// half of the design's step 6 cutover).
     ///
-    /// # Requires a side-effect-free renderer
-    ///
-    /// That second pass re-invokes the configured
-    /// [`InlineSubstitutionRenderer`]
-    /// and the registered asset handlers (for example the
-    /// [`ImageFileHandler`]), so it assumes
-    /// they are **idempotent**: rendering the same content twice must produce
-    /// the same bytes. The built-in HTML renderer and the default handlers
-    /// satisfy this. A *stateful* custom renderer (one whose output depends on
-    /// mutable internal state) or a *one-shot* asset handler may therefore be
-    /// invoked twice while this is enabled, and could make the tree diverge
-    /// from [`rendered_html`](crate::content::Content::rendered_html) – a
-    /// divergence caught by a debug assertion. Externally-visible reads
-    /// (such as loading an image for a `data-uri`) likewise occur an extra
-    /// time. The Phase 4 single-pass builder removes the second pass and
-    /// this caveat with it.
+    /// A custom [`InlineSubstitutionRenderer`] is consulted while the tree is
+    /// built only where a node's *value* is defined as already-substituted
+    /// text (a delimited passthrough's or STEM expression's body, whose
+    /// special characters it escapes); it is not otherwise re-run over the
+    /// content, and the registered asset handlers are not re-invoked.
     #[must_use]
     pub fn with_inline_tree(mut self, enabled: bool) -> Self {
         self.build_inline_tree = enabled;

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -1,6 +1,7 @@
 //! Structural cross-check: the Phase 4 single-pass builder's tree
-//! ([`inline_builder::build`]) against the Strategy-A recorder's tree
-//! (`Content::inlines()`, populated via [`Parser::with_inline_tree`]).
+//! ([`inline_builder::build`]) against the Strategy-A recorder's tree (built
+//! directly by the now test-only `inline_tree` machinery, reproducing the
+//! retired production recording path).
 //!
 //! Design §4.1 calls for exactly this during bring-up ("the node stream is
 //! cross-checked against Strategy A's recorder to catch structural
@@ -17,12 +18,15 @@
 //! With Phase 4 step 5 landed, the builder now covers essentially the whole
 //! vocabulary the recorder does, so a real structural mismatch here — not
 //! merely a difference in one of the fields below — would be a genuine
-//! regression, not an expected divergence. This is the last piece of
-//! due-diligence design §5.2's own "next steps" list calls for before the
-//! Phase 4 "cutover" (step 6) can safely replace the recorder with the
-//! builder as `Content`'s tree source: it gives confidence that swap changes
-//! only *how* the tree is built, not *what* tree callers of
-//! [`Content::inlines`] see.
+//! regression, not an expected divergence. This was the last piece of
+//! due-diligence design §5.2's own "next steps" list called for before the
+//! Phase 4 "cutover" (step 6) could safely replace the recorder with the
+//! builder as `Content`'s tree source — a swap that has since landed, which
+//! is why the recorder side here is built by driving the (now test-only)
+//! recorder machinery directly rather than by reading `Content::inlines()`:
+//! the production accessor now returns the builder's own tree, and comparing
+//! that to itself would prove nothing. The cross-check stays on as the
+//! regression guard that the two independent constructions keep agreeing.
 //!
 //! A handful of fields are **intentionally** excluded from the comparison,
 //! each already documented elsewhere in this crate as a known difference
@@ -137,17 +141,20 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::{borrow::Cow, collections::VecDeque};
+use std::{borrow::Cow, collections::VecDeque, rc::Rc};
 
 use crate::{
     Parser, Span,
     content::{
         Content, SubstitutionGroup,
         inline_builder::build,
-        inline_tree::{CharRefKind, classify_entity},
+        inline_tree::{
+            CharRefKind, RecordingRenderer, attach_footnote_subtrees, build_inline_tree,
+            classify_entity,
+        },
     },
     inlines::{CharRef, InlineNode, RefVariant},
-    parser::ModificationContext,
+    parser::{HtmlSubstitutionRenderer, ModificationContext},
     strings::CowStr,
 };
 
@@ -158,16 +165,51 @@ use crate::{
 /// corpora use, for the same reason: both sides advance real document
 /// counters, such as footnote numbers, so sharing a parser would double
 /// them), then asserts they are the same shape.
+///
+/// The recorder side reproduces the *retired* Strategy-A production path
+/// directly – a [`RecordingRenderer`] wrapped around the built-in HTML
+/// renderer, the real pipeline run over it, the recorded markers parsed into
+/// a tree, and each defining footnote's subtree attached from the footnote
+/// texts that pass registered – exactly what `SubstitutionGroup::apply` did
+/// before the single-pass builder replaced the recorder as `Content`'s tree
+/// source (the swap this module's cross-check cleared the way for). The
+/// builder side is the production path's own [`build`].
 fn assert_shapes_with(source: &str, configure: impl Fn() -> Parser) {
-    let recorder_parser = configure().with_inline_tree(true);
+    let (recorder, events) = RecordingRenderer::new(Rc::new(HtmlSubstitutionRenderer {}));
+    let recorder_parser = configure().with_inline_substitution_renderer(recorder);
+
+    // A footnote's text never reaches the marked block string (it is extracted
+    // out of the flow), so it is recovered from the footnotes the recording
+    // pass registers; snapshot the registry length first so only this
+    // content's own footnotes are picked up.
+    let footnote_start = recorder_parser.catalog().footnotes.len();
+
     let mut content = Content::from(Span::new(source));
     SubstitutionGroup::Normal.apply(&mut content, &recorder_parser, None);
-    let recorder_tree = content.inlines();
+
+    let footnote_texts: Vec<String> = recorder_parser
+        .catalog()
+        .footnotes
+        .get(footnote_start..)
+        .unwrap_or_default()
+        .iter()
+        .map(|footnote| footnote.text.clone())
+        .collect();
+
+    let marked = content.rendered_owned();
+    let events = events.borrow();
+    let mut recorder_tree = build_inline_tree(&marked, &events, Span::new(source));
+    attach_footnote_subtrees(
+        &mut recorder_tree,
+        &footnote_texts,
+        &events,
+        Span::new(source),
+    );
 
     let builder_parser = configure();
     let builder_tree = build(Span::new(source), &builder_parser, None);
 
-    assert_trees_equivalent(recorder_tree, &builder_tree, source);
+    assert_trees_equivalent(&recorder_tree, &builder_tree, source);
 }
 
 fn assert_shapes(source: &str) {

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -17,8 +17,8 @@
 //!    cross-check) – so the recorder stays honest as the independent
 //!    construction the structural cross-check
 //!    (`tests::inline_builder_recorder_parity`) compares the builder against.
-//! 2. The `with_inline_tree` wiring tests drive the **production** tree path
-//!    – now the single-pass builder – asserting what
+//! 2. The `with_inline_tree` wiring tests drive the **production** tree path –
+//!    now the single-pass builder – asserting what
 //!    [`Content::inlines`](crate::content::Content) stores for real parsed
 //!    documents, and that enabling the flag never changes rendered output.
 //!

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1,22 +1,26 @@
-//! Differential oracle for the inline AST, over the production
-//! [`inline_tree`](crate::content::inline_tree) module.
+//! Differential oracle for the inline AST, over the
+//! [`inline_tree`](crate::content::inline_tree) recorder and the flag-gated
+//! production tree path.
 //!
 //! This began as the Phase 1 bring-up oracle (a test-only recorder). In Phase 2
-//! the recorder machinery moved into the parser proper
-//! ([`inline_tree`](crate::content::inline_tree)); this module is now the
-//! **harness** that drives it, keeping the same corpus and the two invariants
-//! it proves:
+//! the recorder machinery moved into the parser proper and became the
+//! production tree source; in Phase 4 the single-pass builder
+//! ([`inline_builder`](crate::content::inline_builder)) replaced it there (the
+//! step 6 tree-source swap) and the recorder returned to test-only status.
+//! This module remains the **harness** for both:
 //!
-//! 1. Stripping/folding the recorder's marked string reproduces the built-in
-//!    renderer's `rendered_html()` output **byte-for-byte** (the
-//!    *no-perturbation* invariant).
-//! 2. The recovered [`InlineNode`] tree is structurally faithful (node kinds,
-//!    nesting, and the `constructs <= markers <= events` cross-check).
-//!
-//! Because the machinery is now the production code path, this corpus doubles
-//! as the differential test for what
-//! [`Content::inlines`](crate::content::Content) stores when inline-tree
-//! building is enabled on the [`Parser`].
+//! 1. The recorder-driven corpus keeps proving Strategy A's own invariants –
+//!    stripping/folding the marked string reproduces the built-in renderer's
+//!    `rendered_html()` output **byte-for-byte** (the *no-perturbation*
+//!    invariant), and the recovered [`InlineNode`] tree is structurally
+//!    faithful (node kinds, nesting, and the `constructs <= markers <= events`
+//!    cross-check) – so the recorder stays honest as the independent
+//!    construction the structural cross-check
+//!    (`tests::inline_builder_recorder_parity`) compares the builder against.
+//! 2. The `with_inline_tree` wiring tests drive the **production** tree path
+//!    – now the single-pass builder – asserting what
+//!    [`Content::inlines`](crate::content::Content) stores for real parsed
+//!    documents, and that enabling the flag never changes rendered output.
 //!
 //! [inline AST architecture]: ../../../docs/design/inline-ast-architecture.md
 
@@ -1086,6 +1090,179 @@ fn has_styled(nodes: &[InlineNode<'_>], variant: StyleVariant) -> bool {
 }
 
 #[test]
+fn inline_tree_honors_a_blocks_custom_subs_list() {
+    // A `subs="quotes"` paragraph runs only the quotes step, so the
+    // group-aware tree builder must mirror the string pipeline's own step
+    // selection: the tree carries a `Styled` node for `*bold*`, while `<`
+    // stays inside a plain `Text` run (no `CharRef` – the special-characters
+    // step never ran) exactly as the rendered string leaves it unescaped.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("[subs=quotes]\nkeep *bold* and a < b\n");
+
+    let tree = first_simple_inlines(&doc);
+
+    assert!(
+        has_styled(tree, StyleVariant::Strong),
+        "the quotes step did not run for the custom subs list: {tree:?}"
+    );
+
+    assert!(
+        !tree
+            .iter()
+            .any(|node| matches!(node, InlineNode::CharRef { .. })),
+        "the special-characters step ran despite being absent from the subs list: {tree:?}"
+    );
+}
+
+#[test]
+fn inline_tree_for_none_group_content_is_the_untouched_seed() {
+    // A `[pass]`-style paragraph applies no substitutions at all, so its tree
+    // is the untouched seed: one `Text` run holding the content exactly as
+    // written, mirroring the string pipeline leaving the text unchanged.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("[pass]\n<b>raw</b> and *not bold*\n");
+
+    let tree = first_simple_inlines(&doc);
+
+    assert_eq!(tree.len(), 1, "expected the untouched seed: {tree:?}");
+    assert!(
+        matches!(
+            &tree[0],
+            InlineNode::Text { value, .. } if value.as_ref() == "<b>raw</b> and *not bold*"
+        ),
+        "expected the untouched text run: {tree:?}"
+    );
+}
+
+#[test]
+fn inline_tree_for_a_listing_block_carries_callout_nodes() {
+    use crate::blocks::{Block, FindBlocks, IsBlock};
+
+    // A listing block applies the verbatim group (special characters, then
+    // callouts), so its tree must carry a `Callout` node for the trailing
+    // `<1>` – driving the group-aware builder's `Callouts` dispatch through a
+    // real parse.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("----\ncode line <1>\n----\n");
+
+    let listing = doc
+        .descendant_blocks()
+        .find(|block| matches!(block, Block::RawDelimited(_)))
+        .expect("a listing block");
+
+    let tree = listing.inlines().expect("a content-bearing block");
+
+    assert!(
+        tree.iter()
+            .any(|node| matches!(node, InlineNode::Callout(_))),
+        "expected a callout node in the listing tree: {tree:?}"
+    );
+}
+
+#[test]
+fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
+    // `xref:sec[with *bold* reftext]` is a documented builder divergence (a
+    // display text crossing a rendered span is left unrecognized), so the
+    // tree holds *fewer* cross-reference nodes than the string pipeline
+    // deferred. The positional resolution mirror must detect the count
+    // mismatch and skip – leaving the tree in its honest unresolved state –
+    // rather than assign destinations to the wrong nodes (or panic).
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[with *bold* reftext].");
+
+    // The rendered output is unaffected (the string pipeline is
+    // authoritative), …
+    let rendered = collect_rendered(&doc);
+    assert!(
+        rendered
+            .iter()
+            .any(|s| s.contains("href=\"#sec\"") && s.contains("<strong>bold</strong>")),
+        "the rendered xref regressed: {rendered:?}"
+    );
+
+    // … and the tree simply carries no node for the deferred form.
+    let refs = collect_refs(&doc);
+    assert!(
+        refs.iter().all(|r| r.variant != RefVariant::Xref),
+        "expected the deferred xref form to stay unrecognized in the tree: {refs:?}"
+    );
+}
+
+#[test]
+fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
+    // The footnote-side counterpart: one of the footnote's two embedded
+    // cross-references is a documented builder divergence, so the footnote
+    // subtree's slot count (1) differs from the re-homed segment count (2)
+    // and the footnote mirror must skip rather than misassign. The block-side
+    // mirror is unaffected and still resolves the block-level reference.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser
+        .parse("[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a,*b*>> and <<c>>]");
+
+    let refs = collect_refs(&doc);
+
+    // The block-level `<<c>>` still mirrors its resolved destination …
+    assert!(
+        refs.iter().any(|r| r.variant == RefVariant::Xref
+            && r.resolved.as_ref().is_some_and(|res| res.href == "#c")),
+        "the block-level xref should still resolve: {refs:?}"
+    );
+
+    // … while the footnote's recognized `<<c>>` is left unresolved (its
+    // sibling's deferred form broke the positional correlation for the
+    // subtree's list).
+    let footnote_refs = collect_footnote_refs(&doc);
+    assert!(
+        !footnote_refs.is_empty(),
+        "expected the footnote's recognized xref node: {footnote_refs:?}"
+    );
+    assert!(
+        footnote_refs.iter().all(|r| r.resolved.is_none()),
+        "the footnote mirror must skip on a count mismatch: {footnote_refs:?}"
+    );
+}
+
+/// Collects every cross-reference/link node found inside footnote subtrees of
+/// simple blocks in `doc`.
+fn collect_footnote_refs<'a>(doc: &'a crate::Document<'a>) -> Vec<crate::inlines::Ref<'a>> {
+    use crate::blocks::Block;
+
+    fn walk<'a>(
+        nodes: &[InlineNode<'a>],
+        in_footnote: bool,
+        out: &mut Vec<crate::inlines::Ref<'a>>,
+    ) {
+        for node in nodes {
+            match node {
+                InlineNode::Footnote(footnote) => walk(&footnote.children, true, out),
+
+                InlineNode::Ref(reference) => {
+                    if in_footnote {
+                        out.push(reference.clone());
+                    }
+
+                    walk(&reference.children, in_footnote, out);
+                }
+
+                InlineNode::Styled(styled) => walk(&styled.children, in_footnote, out),
+
+                _ => {}
+            }
+        }
+    }
+
+    let mut out = vec![];
+
+    for block in doc.child_blocks() {
+        if let Block::Simple(simple) = block {
+            walk(simple.content().inlines(), false, &mut out);
+        }
+    }
+
+    out
+}
+
+#[test]
 fn inline_tree_numbers_footnotes_in_document_order() {
     // The recording pass clones the parser *before* the authoritative pass
     // advances the footnote counter, so a footnote in the second paragraph is
@@ -1355,17 +1532,17 @@ fn inline_tree_xref_resolution_matches_the_rendered_string() {
 
 // The guard lives in `SubstitutionGroup::build_inline_tree` as a
 // `debug_assert!`, so both the test and the stateful renderer it needs are
-// gated on `debug_assertions` – otherwise the renderer is unused in release
-// (and `#![deny(warnings)]` rejects the dead code).
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "diverged from rendered_html()")]
-fn inline_tree_build_rejects_a_stateful_renderer() {
+fn inline_tree_build_tolerates_a_stateful_renderer() {
     /// A renderer whose output depends on mutable internal state: it emits
-    /// different bytes on its second invocation. Because the recording pass
-    /// shares the same renderer instance as the authoritative pass, such a
-    /// renderer makes the recorded tree fold to something other than
-    /// `rendered_html()`.
+    /// different bytes on each invocation. Under the retired Strategy-A
+    /// recorder, tree building re-ran the whole pipeline through the shared
+    /// renderer instance, so such a renderer poisoned the recorded tree (and a
+    /// debug assertion rejected it). The single-pass builder derives the tree
+    /// from source instead – a `CharRef` node carries the *logical* character,
+    /// not renderer output – so a stateful renderer is now safe: the
+    /// authoritative rendered string sees the renderer's stateful bytes, and
+    /// the tree stays logical.
     #[derive(Debug, Default)]
     struct FlipRenderer {
         flipped: std::cell::Cell<bool>,
@@ -1385,14 +1562,38 @@ fn inline_tree_build_rejects_a_stateful_renderer() {
         }
     }
 
-    // A stateful renderer is invoked a second time by the recording pass and
-    // diverges, which the debug assertion catches rather than silently storing a
-    // wrong tree.
     let mut parser = Parser::default()
         .with_inline_substitution_renderer(FlipRenderer::default())
         .with_inline_tree(true);
 
-    let _doc = parser.parse("a < b");
+    let doc = parser.parse("a < b");
+
+    let block = doc.child_blocks().next().unwrap();
+    let content = match block {
+        crate::blocks::Block::Simple(simple) => simple.content(),
+        _ => panic!("expected a simple block"),
+    };
+
+    // The authoritative rendered string reflects the stateful renderer's
+    // (first-invocation) output …
+    assert_eq!(content.rendered_html(), "a [first] b");
+
+    // … while the tree carries the logical special character, unpolluted by
+    // the renderer's state.
+    let has_logical_charref = content.inlines().iter().any(|node| {
+        matches!(
+            node,
+            InlineNode::CharRef {
+                value: CharRef::Special('<'),
+                ..
+            }
+        )
+    });
+    assert!(
+        has_logical_charref,
+        "expected a logical CharRef('<') in the tree: {:?}",
+        content.inlines()
+    );
 }
 
 // ─── Wiring: title cross-reference resolution reaches the tree ───────────────


### PR DESCRIPTION
## Summary

This lands the **tree-source swap** — the piece of the Phase 4 "Cut over" step (design doc §5.2, step 6) that every prep increment named as "this step's own job": `SubstitutionGroup::apply` now builds each content's inline tree with the **single-pass builder** in place of the Strategy-A recording pass, so `Content::inlines()` (and `IsBlock::inlines()`) now hands consumers the builder's tree — honest per-node spans (issue #944's precision stage) and self-describing macro nodes (`attrs`, `derived`, `xrefstyle`) — instead of the recorder's whole-content-span, `attrs: None` tree.

- **`build_for_group`** is the new group-aware entry point: it mirrors `run_pipeline`'s own step selection exactly — passthrough/STEM extraction first, iff the group's steps include `Macros` or the group is `Header` (the same gate `run_pipeline` places on `Passthroughs::extract_from`), then each of the group's `steps()` in the group's own order, each recast as its node transducer (`Macros` runs `apply_macros` then `apply_footnotes`, the builder's own required split). A `subs=` custom list, the verbatim group's `Callouts`, the header/attribute-entry-value two-step lists, and the empty `Pass`/`None` lists (untouched-seed tree) all follow the string pipeline's own selection. `build_from_value` is now the `Normal`-group special case.
- **The counter-safe discipline is retained**: `apply` snapshots the pre-substitution value and a clone of the parser before the authoritative pass runs, so footnote numbers and `{counter:…}` values come out identical to the authoritative output, and the clone's mutations are discarded.
- **The recorder is retired to test-only oracle machinery** (`#[cfg(test)]` on `content::inline_tree`), the §4.1 bring-up-oracle role. The structural cross-check (`inline_builder_recorder_parity`) now drives that machinery directly for its recorder side — the production accessor returns the builder's tree, so reading `Content::inlines()` for both sides would compare the builder to itself.
- **The positional xref-resolution mirror is now count-checked.** A documented builder-deferred form (e.g. a display text crossing a rendered span) means the tree can legitimately hold *fewer* cross-reference nodes than the string pipeline deferred, so the positional pairing is unknowable for that content. `mirror_tree_xref_resolution` counts each list's slots first and skips a diverged list — leaving those nodes honestly unresolved rather than positionally misassigned — replacing the count-parity debug assertions the recorder's one-to-one guarantee justified.
- **The stateful-renderer hazard retires with the second rendering pass.** The builder consults the configured renderer only where a node's value is defined as already-substituted text (a delimited passthrough's or STEM expression's body), so a stateful custom renderer now gets a logical, unpolluted tree; the old should-panic guard test is repurposed to pin the new behavior.

The authoritative rendered string is **unchanged** — the string pipeline still produces it, and all ~277 golden assertions plus the corpus-wide flag-parity sweep pass untouched. The remaining half of step 6 (tracked in the design doc): `rendered_html()` as an authoritative fold of this tree, calling `apply_macro_side_effects` for real (which must wait for the fold — until then the string pipeline still performs every registration), deleting the three production sentinel systems, and retiring the `with_inline_tree` flag.

## Testing

- `cargo fmt --check`
- `cargo clippy -p asciidoc-parser --all-targets` (clean)
- `cargo test --workspace` (all 5006 green — including the whole recorder-driven differential corpus, the flag-parity sweep over every corpus, and the builder↔recorder structural cross-check, all now exercising the swapped wiring)
- `cargo llvm-cov -p asciidoc-parser --lib` — `content/inline_builder/mod.rs` and `content/substitution_group.rs` at 100% line/region coverage; the touched lines in `content/content.rs` fully covered (its few uncovered lines are pre-existing defensive fallbacks elsewhere in the file)
- New per-group tests pin `build_for_group`'s step selection and extraction gate (`Header` extracts passthroughs, `AttributeEntryValue` does not, `Stem`/`Pass`/`None`, `subs=quotes`, `subs=macros`), plus production-path wiring tests for a `subs=` paragraph, a `[pass]` paragraph, and a listing block's `Callout` nodes.
- New tests pin both mirror skip paths (block-level and footnote-embedded) on documented divergence fixtures, asserting rendered output is unaffected and the tree stays honestly unresolved.

## Design doc

Updated `docs/design/inline-ast-architecture.md`: a "Step 6, first half, landed as (the tree-source swap …)" narrative paragraph and a ✅ **first half** checklist entry under Phase 4 step 6, with the remaining half itemized.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7rybCcuTCiVmgxc7rhmJQ)_