### PR TITLE
fix: Emit an unescaped special as a Raw leaf when specialcharacters never runs (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1943,6 +1943,74 @@ Each phase is a reviewable unit with a clear exit gate.
   then the string pipeline still performs every registration), deleting the three production
   sentinel systems, and retiring the `with_inline_tree` flag.
 
+  *Step 6 prep landed as (the §3.4.1 classification for an order that never escapes, closing a
+  second real cutover blocker):* with the tree-source swap done, the next thing the remaining half
+  of step 6 needs – making `rendered_html()` an **authoritative** fold – is to know where the fold
+  still diverges from the string pipeline over the *whole* corpus, not over the hand-picked
+  fixtures each family's own differential corpus uses. A corpus-wide audit (tree building forced on
+  for every parse in the test suite, each content's tree folded and compared against that same
+  content's own rendered string) – the same due-diligence sweep that surfaced the `hardbreaks`
+  blocker above – found a second one of exactly that kind: not an unclaimed form the tree merely
+  leaves literal, but a **wrong answer** for content golden tests already exercise.
+
+  The cause is design §3.4's own definition read one step too narrowly. A
+  [`Text`](../../parser/src/inlines/inline_node.rs) node is *logical* text that **the fold
+  escapes**, which is exactly right when the `SpecialCharacters` step acted on the content – and
+  exactly wrong when that step never runs, because there the string pipeline emits the author's
+  `<`/`>`/`&` untouched. Every group whose effective order omits `specialcharacters` took that
+  path and folded escaped entities where the string pipeline emits raw ones: a passthrough block
+  ([`Pass`](../../parser/src/content/substitution_group.rs)), a comment block
+  ([`None`](../../parser/src/content/substitution_group.rs)), and every `subs=` custom list that
+  omits it (`subs=quotes`, `subs=attributes`, `subs=macros`, `subs=callouts` on a listing block,
+  the empty `subs=","` list, …). This is §3.4.1's own policy – "the kind a fragment becomes is
+  **not** a fixed property of where it came from; it is decided by which substitution steps still
+  act on it under the group's effective order" – applied to the *seed* rather than, as step 5b
+  first applied it, to a spliced attribute value: a literal special no `SpecialCharacters` step
+  ever acts on is a [`Raw`](../../parser/src/inlines/inline_node.rs) leaf.
+
+  [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs) is that
+  classification. It shares its whole split with
+  [`apply_special_characters`](../../parser/src/content/inline_builder/special_chars.rs) – one
+  `SpecialLeaf` discriminant now selects `CharRef::Special` or `Raw`, so the two cannot drift on
+  where a boundary falls – and therefore keeps the same span discipline: a verbatim run's leaves
+  are sliced from `'src` with honest `line`/`col`/`offset` (#944) while a synthesized run's fall
+  back to the whole enclosing span (§4.4). [`build_for_group`](../../parser/src/content/inline_builder/mod.rs)
+  runs it **last**, after the group's own steps, gated on
+  `!steps.contains(&SubstitutionStep::SpecialCharacters)` – and running it last, rather than in
+  place of the step that is absent, is what keeps it faithful: under such an order the string
+  pipeline's own steps also match over text in which the specials are still literal, so every
+  transducer must go on seeing them as ordinary `Text` characters, not as the opaque leaf a `Raw`
+  node is to [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs). Only the
+  finished tree's *classification* differs; nothing about recognition changes. It recurses into
+  every container a text run can be nested inside – a `Styled` span, a `Ref`'s display children,
+  an `Anchor`'s reference text, and a `Footnote`'s own children – mirroring the containers
+  [`fold_html`](../../parser/src/content/inline_builder/fold.rs) itself descends into, since a
+  `subs=` list omitting `specialcharacters` can still name `quotes` and `macros`.
+
+  A new differential corpus crosses a set of specials-bearing fixtures (bare specials in every
+  position; specials that would look like a construct *once escaped*, so the classification is
+  pinned not to perturb – or depend on – recognition; specials beside and inside each construct
+  these orders can build; multi-line runs) with every real group that takes this path, each
+  fixture driven through the real, public `SubstitutionGroup::apply` as the golden. Two existing
+  tests that pinned the *old* shape – "`Pass`/`None` yield one untouched `Text` run" and
+  `subs=quotes`'s own "`<` stays literal text" – are rewritten to assert the classification
+  instead; neither had called the module's own `assert_group_parity` helper, which is precisely
+  why the divergence went unnoticed, so both now do. As with every prep piece before it, nothing
+  further is wired in: `rendered_html()` remains the string pipeline's own string, and this changes
+  only what a tree consumer reads back (and what the eventual authoritative fold will emit).
+
+  The audit also leaves the rest of step 6 a map. Every remaining whole-corpus divergence under the
+  *normal* order is a form this file already documents as deferred – a display or reference text
+  crossing a rendered span, an angle-bracketed `<url>` link, a bare e-mail auto-link, `<<id,>>`'s
+  present-but-empty text, the `menu:View[Zoom > Reset]` submenu form, a macro inside an expanded
+  attribute value, a missing attribute under `AttributeMissing::Drop`/`::DropLine`, and the
+  bibliography anchor (`[[[label]]]`) – plus one category not previously named: an effective order
+  that runs `SpecialCharacters` **after** a step that already produced markup (`subs=quotes,
+  specialcharacters`), where the string pipeline escapes the very tags the earlier step emitted.
+  That last one is structurally different from the rest, and harder: a tree whose markup exists
+  only at fold time has no rendered tags for a later escaping step to act on, so it needs its own
+  policy rather than another recognition increment.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2067,6 +2135,15 @@ Each phase is a reviewable unit with a clear exit gate.
        "landed as" note above. The remaining half – `rendered_html()` as an authoritative fold,
        `apply_macro_side_effects` called for real, the sentinel deletions, and the flag's
        retirement – is still outstanding.
+     - ✅ **prep (unescaped specials).** A corpus-wide fold-parity audit – the same sweep that
+       identified `hardbreaks` – surfaced a second real blocker: under an effective order whose
+       steps omit `specialcharacters` (a `Pass` or `None` block, or a `subs=` list without it),
+       a literal `<`/`>`/`&` must be a `Raw` leaf the fold emits verbatim, not the `Text` run the
+       fold escapes (§3.4.1 applied to the seed).
+       [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs)
+       runs last in `build_for_group` for exactly those orders; see the step's own "landed as"
+       note above, which also records what the audit leaves outstanding for the authoritative
+       fold.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -283,7 +283,7 @@ use macros::apply_macros;
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
-use special_chars::apply_special_characters;
+use special_chars::{apply_special_characters, classify_unescaped_specials};
 use stem_step::apply_stem;
 
 use crate::{
@@ -455,6 +455,16 @@ pub(crate) fn build_for_group<'src>(
 
             SubstitutionStep::Callouts => apply_callouts(nodes, location, parser, attrlist),
         };
+    }
+
+    // Design §3.4.1: a literal `<`/`>`/`&` that no `SpecialCharacters` step
+    // ever acted on is emitted verbatim by the string pipeline, so it is a
+    // `Raw` leaf here rather than the `Text` run the fold would escape. This
+    // runs last, after the group's own steps, so every transducer still sees
+    // the specials as ordinary text — exactly as the string pipeline's steps
+    // do under such an order.
+    if !steps.contains(&SubstitutionStep::SpecialCharacters) {
+        nodes = classify_unescaped_specials(nodes);
     }
 
     nodes
@@ -819,6 +829,7 @@ mod tests {
     /// selection and the passthrough-extraction gate (`Macros` in the steps,
     /// or the `Header` group), which mirror `run_pipeline`'s own.
     mod build_for_group {
+        #![allow(clippy::panic)]
         #![allow(clippy::unwrap_used)]
 
         use super::super::{build_for_group, fold_html};
@@ -918,6 +929,14 @@ mod tests {
 
         #[test]
         fn pass_and_none_groups_yield_the_untouched_seed() {
+            // Neither group runs a single step, so the seed reaches the fold
+            // untouched *as text* – but "untouched" is a claim about the bytes
+            // the fold emits, not about the node kinds: because no
+            // `SpecialCharacters` step ever acted on it, a literal `<`/`>`/`&`
+            // is a `Raw` leaf the fold emits verbatim, not a `Text` run the
+            // fold would escape (design §3.4.1). Everything between the
+            // specials is one borrowed `Text` run, and nothing else is
+            // recognized.
             let source = "<b>raw</b> *not bold* {product}";
             let parser = parser_with_product();
 
@@ -925,12 +944,28 @@ mod tests {
                 let nodes = build_group(&group, source, &parser);
 
                 assert!(
-                    matches!(
-                        nodes.as_slice(),
-                        [InlineNode::Text { value, .. }] if value.as_ref() == source
-                    ),
-                    "expected the untouched single text run under {group:?}: {nodes:?}"
+                    nodes
+                        .iter()
+                        .all(|n| matches!(n, InlineNode::Text { .. } | InlineNode::Raw { .. })),
+                    "expected only text and raw-special leaves under {group:?}: {nodes:?}"
                 );
+
+                let rejoined: String = nodes
+                    .iter()
+                    .map(|n| match n {
+                        InlineNode::Text { value, .. } | InlineNode::Raw { value, .. } => {
+                            value.as_ref()
+                        }
+                        other => panic!("unexpected node kind: {other:?}"),
+                    })
+                    .collect();
+
+                assert_eq!(
+                    rejoined, source,
+                    "the leaves must rejoin to the untouched seed under {group:?}"
+                );
+
+                assert_group_parity(&group, source);
             }
         }
 
@@ -957,8 +992,10 @@ mod tests {
 
         #[test]
         fn a_custom_list_runs_exactly_the_named_steps_in_order() {
-            // `subs=quotes` alone: `*bold*` is recognized, `<` stays literal
-            // text (never escaped), and `{product}` stays unexpanded.
+            // `subs=quotes` alone: `*bold*` is recognized, `<` is emitted
+            // unescaped (a `Raw` leaf, not a `CharRef` – design §3.4.1, since
+            // no `SpecialCharacters` step acts on it), and `{product}` stays
+            // unexpanded.
             let (group, invalid) = SubstitutionGroup::from_custom_string(None, "quotes");
             assert!(invalid.is_empty());
 
@@ -979,9 +1016,17 @@ mod tests {
             assert!(
                 nodes
                     .iter()
+                    .any(|n| matches!(n, InlineNode::Raw { value, .. } if value.as_ref() == "<")),
+                "the unescaped `<` must be a Raw leaf for subs=quotes: {nodes:?}"
+            );
+            assert!(
+                nodes
+                    .iter()
                     .any(|n| matches!(n, InlineNode::Text { value, .. } if value.as_ref().contains("{product}"))),
                 "the attribute reference must stay literal for subs=quotes: {nodes:?}"
             );
+
+            assert_group_parity(&group, source);
         }
 
         #[test]
@@ -1009,6 +1054,83 @@ mod tests {
             );
 
             assert_group_parity(&group, source);
+        }
+
+        /// A differential corpus for the §3.4.1 classification the group-aware
+        /// entry point applies last: under an effective order whose steps
+        /// **never include** `SpecialCharacters`, a literal `<`/`>`/`&` is
+        /// emitted verbatim by the string pipeline, so it must fold verbatim
+        /// here too.
+        ///
+        /// This is the case a `Text` node cannot express on its own — `Text`
+        /// is logical text the fold *escapes* (design §3.4) — so every fixture
+        /// below folded to escaped entities before the classification landed,
+        /// diverging from the real pipeline. The corpus crosses a set of
+        /// specials-bearing fixtures with every real group that takes this
+        /// path: the two step-less groups (`Pass` for a passthrough block,
+        /// `None` for a comment block) and the `subs=` custom lists that omit
+        /// `specialcharacters`.
+        #[test]
+        fn a_group_that_never_escapes_folds_its_specials_verbatim() {
+            let custom = |subs: &str| {
+                let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs);
+                assert!(invalid.is_empty(), "unexpected invalid subs in {subs:?}");
+                group
+            };
+
+            let groups = [
+                SubstitutionGroup::Pass,
+                SubstitutionGroup::None,
+                // `subs=","` resolves to an empty step list (Ruby's
+                // `split(',')` drops the trailing empties), the third way to
+                // reach a group that runs nothing at all.
+                custom(","),
+                custom("quotes"),
+                custom("attributes"),
+                custom("replacements"),
+                custom("macros"),
+                custom("post_replacements"),
+                custom("callouts"),
+                custom("quotes,attributes"),
+                custom("quotes,attributes,replacements,macros,post_replacements"),
+            ];
+
+            let fixtures = [
+                // Bare specials, in every position a run can put them.
+                "<b>raw</b>",
+                "a < b & c > d",
+                "<",
+                "&",
+                "leading < text",
+                "text trailing >",
+                "<>&",
+                "a<b>c",
+                // Specials that would look like a construct once escaped —
+                // the escaped `&lt;&lt;` is what an `<<id>>` shorthand keys
+                // off, and an escaped `&` is what a restored entity keys off,
+                // so these pin that the classification does not perturb (or
+                // depend on) recognition.
+                "<<tigers>> stays literal",
+                "&#169; stays literal",
+                "-> and <- stay literal",
+                // Specials beside each construct these orders *can*
+                // recognize, so the classification is exercised inside and
+                // around a built node's own children.
+                "keep *bold < text* and a < b",
+                "a < b {product} > c",
+                "an <b>image</b> image:pic.png[Alt] here",
+                "a footnote:[note < text] and a < b",
+                "line one < +\nline two > end",
+                // Multi-line, so a run spanning a newline is split the same
+                // way as a single-line one.
+                "first < line\nsecond & line\nthird > line",
+            ];
+
+            for group in &groups {
+                for source in fixtures {
+                    assert_group_parity(group, source);
+                }
+            }
         }
     }
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -857,13 +857,19 @@ mod tests {
             build_for_group(group, CowStr::from(source), Span::new(source), parser, None)
         }
 
-        /// Runs `source` through the real pipeline under `group` and asserts
-        /// the group-aware tree folds to the same bytes.
-        fn assert_group_parity(group: &SubstitutionGroup, source: &str) {
+        /// The real pipeline's own output for `source` under `group` — the
+        /// golden every parity assertion in this module compares against.
+        fn golden_for_group(group: &SubstitutionGroup, source: &str) -> String {
             let golden_parser = parser_with_product();
             let mut content = Content::from(Span::new(source));
             group.apply(&mut content, &golden_parser, None);
-            let golden = content.rendered_str().to_string();
+            content.rendered_str().to_string()
+        }
+
+        /// Runs `source` through the real pipeline under `group` and asserts
+        /// the group-aware tree folds to the same bytes.
+        fn assert_group_parity(group: &SubstitutionGroup, source: &str) {
+            let golden = golden_for_group(group, source);
 
             let built_parser = parser_with_product();
             let nodes = build_group(group, source, &built_parser);
@@ -950,19 +956,21 @@ mod tests {
                     "expected only text and raw-special leaves under {group:?}: {nodes:?}"
                 );
 
-                let rejoined: String = nodes
-                    .iter()
-                    .map(|n| match n {
-                        InlineNode::Text { value, .. } | InlineNode::Raw { value, .. } => {
-                            value.as_ref()
-                        }
-                        other => panic!("unexpected node kind: {other:?}"),
-                    })
-                    .collect();
+                assert!(
+                    nodes.iter().any(
+                        |n| matches!(n, InlineNode::Raw { value, .. } if value.as_ref() == "<")
+                    ),
+                    "expected the unescaped `<` to be a Raw leaf under {group:?}: {nodes:?}"
+                );
 
+                // That the leaves rejoin to the *untouched* seed is what the
+                // parity assertion itself pins: neither group runs a step, so
+                // the string pipeline's own output for this content is the
+                // source verbatim, and the fold must reproduce it.
                 assert_eq!(
-                    rejoined, source,
-                    "the leaves must rejoin to the untouched seed under {group:?}"
+                    golden_for_group(&group, source),
+                    source,
+                    "the string pipeline must leave this content untouched under {group:?}"
                 );
 
                 assert_group_parity(&group, source);

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -1,4 +1,5 @@
-//! The special-characters substitution step.
+//! The special-characters substitution step, and its §3.4.1 counterpart for an
+//! effective order that never runs it.
 
 use super::passthrough_step::is_special;
 use crate::{
@@ -6,6 +7,23 @@ use crate::{
     inlines::{CharRef, InlineNode},
     strings::CowStr,
 };
+
+/// Which leaf kind a literal `<`/`>`/`&` becomes when a text run is split.
+///
+/// Design §3.4.1: the kind a fragment becomes is **not** a fixed property of
+/// where it came from; it is decided by which substitution steps still act on
+/// it under the group's effective order.
+#[derive(Clone, Copy)]
+enum SpecialLeaf {
+    /// A [`CharRef::Special`] the fold escapes – what the `SpecialCharacters`
+    /// step itself produces when it acts on a run.
+    CharRef,
+
+    /// A [`Raw`](InlineNode::Raw) leaf the fold emits verbatim – what a
+    /// literal special is under an effective order that never runs
+    /// `SpecialCharacters`, since the string pipeline leaves it untouched.
+    Raw,
+}
 
 /// The special-characters substitution, as a node transducer: every
 /// [`Text`](InlineNode::Text) run is split on `<`/`>`/`&` into
@@ -26,7 +44,7 @@ pub(super) fn apply_special_characters<'src>(
     for node in nodes {
         match node {
             InlineNode::Text { value, location } => {
-                split_text(value, location, &mut out);
+                split_text(value, location, SpecialLeaf::CharRef, &mut out);
             }
 
             InlineNode::Styled(mut styled) => {
@@ -46,8 +64,75 @@ pub(super) fn apply_special_characters<'src>(
     out
 }
 
+/// Classifies every literal `<`/`>`/`&` left in the finished tree as a
+/// [`Raw`](InlineNode::Raw) leaf – the §3.4.1 policy for an effective
+/// substitution order whose steps **never include**
+/// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters).
+///
+/// A [`Text`](InlineNode::Text) node is *logical* text the fold escapes (§3.4),
+/// which is exactly right when the `SpecialCharacters` step acted on the
+/// content — and exactly wrong when it never ran, because there the string
+/// pipeline emits the author's `<` unescaped. `subs=quotes` on a paragraph, a
+/// passthrough block ([`Pass`](crate::content::SubstitutionGroup::Pass)), a
+/// comment block ([`None`](crate::content::SubstitutionGroup::None)), and
+/// `subs=callouts` on a listing block all take that path, so the classification
+/// has to follow the *order*, not the node's origin.
+///
+/// This runs **after** every one of the group's own steps rather than in place
+/// of `apply_special_characters`, and that ordering is what keeps it faithful:
+/// under such an order the string pipeline's own steps also match over text in
+/// which the specials are still literal, so every transducer must see them as
+/// ordinary [`Text`](InlineNode::Text) characters – not as the opaque leaf a
+/// `Raw` node is to [`build_match_string`](super::quotes::build_match_string).
+/// Only the finished tree's *classification* differs, so nothing about
+/// recognition changes.
+///
+/// It recurses into every container a text run can be nested inside – a
+/// [`Styled`](crate::inlines::Styled) span, a [`Ref`](crate::inlines::Ref)'s
+/// own display children, an [`Anchor`](crate::inlines::Anchor)'s reference
+/// text, and a [`Footnote`](crate::inlines::Footnote)'s own children –
+/// mirroring the containers [`fold_html`](super::fold_html) itself descends
+/// into.
+pub(super) fn classify_unescaped_specials<'src>(
+    nodes: Vec<InlineNode<'src>>,
+) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::with_capacity(nodes.len());
+
+    for node in nodes {
+        match node {
+            InlineNode::Text { value, location } => {
+                split_text(value, location, SpecialLeaf::Raw, &mut out);
+            }
+
+            InlineNode::Styled(mut styled) => {
+                styled.children = classify_unescaped_specials(styled.children);
+                out.push(InlineNode::Styled(styled));
+            }
+
+            InlineNode::Ref(mut reference) => {
+                reference.children = classify_unescaped_specials(reference.children);
+                out.push(InlineNode::Ref(reference));
+            }
+
+            InlineNode::Anchor(mut anchor) => {
+                anchor.reftext = anchor.reftext.map(classify_unescaped_specials);
+                out.push(InlineNode::Anchor(anchor));
+            }
+
+            InlineNode::Footnote(mut footnote) => {
+                footnote.children = classify_unescaped_specials(footnote.children);
+                out.push(InlineNode::Footnote(footnote));
+            }
+
+            other => out.push(other),
+        }
+    }
+
+    out
+}
+
 /// Splits a [`Text`](InlineNode::Text) node's logical `value` into alternating
-/// text runs and `<`/`>`/`&` [`CharRef`](InlineNode::CharRef) specials.
+/// text runs and `<`/`>`/`&` leaves of the kind `leaf` names.
 ///
 /// When `value` is exactly the source its `location` covers – the common
 /// verbatim run – each sub-node is sliced from `location`, so its
@@ -55,11 +140,16 @@ pub(super) fn apply_special_characters<'src>(
 /// `'src`. When `value` is *synthesized* – it has no source of its own – the
 /// runs are owned slices of the value and every sub-node falls back to the
 /// whole `location` span, the documented coarse fallback (design §4.4).
-fn split_text<'src>(value: CowStr<'src>, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+fn split_text<'src>(
+    value: CowStr<'src>,
+    location: Span<'src>,
+    leaf: SpecialLeaf,
+    out: &mut Vec<InlineNode<'src>>,
+) {
     if value.as_ref() == location.data() {
-        split_verbatim(location, out);
+        split_verbatim(location, leaf, out);
     } else {
-        split_synthesized(value.as_ref(), location, out);
+        split_synthesized(value.as_ref(), location, leaf, out);
     }
 }
 
@@ -67,7 +157,7 @@ fn split_text<'src>(value: CowStr<'src>, location: Span<'src>, out: &mut Vec<Inl
 /// covers – slicing each sub-span from `location` with the crate's span
 /// primitives so `line`/`col`/`offset` stay honest; a run is never emitted
 /// empty.
-fn split_verbatim<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<InlineNode<'src>>) {
     let mut rest = location;
 
     while let Some(pos) = rest.position(is_special) {
@@ -84,11 +174,16 @@ fn split_verbatim<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
         // The three specials are ASCII, so the match is exactly one byte wide.
         let ch_span = rest.slice(pos..pos + 1);
 
-        let ch = ch_span.data().chars().next().unwrap_or('\u{FFFD}');
+        out.push(match leaf {
+            SpecialLeaf::CharRef => InlineNode::CharRef {
+                value: CharRef::Special(ch_span.data().chars().next().unwrap_or('\u{FFFD}')),
+                location: ch_span,
+            },
 
-        out.push(InlineNode::CharRef {
-            value: CharRef::Special(ch),
-            location: ch_span,
+            SpecialLeaf::Raw => InlineNode::Raw {
+                value: CowStr::from(ch_span.data()),
+                location: ch_span,
+            },
         });
 
         rest = rest.slice_from(pos + 1..);
@@ -103,10 +198,15 @@ fn split_verbatim<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
 }
 
 /// Splits a synthesized `value` – text with no source span of its own – into
-/// owned [`Text`](InlineNode::Text) runs and [`CharRef`](InlineNode::CharRef)
-/// specials, each carrying the whole `location` as its coarse fallback span; a
-/// run is never emitted empty.
-fn split_synthesized<'src>(value: &str, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+/// owned [`Text`](InlineNode::Text) runs and specials of the kind `leaf` names,
+/// each carrying the whole `location` as its coarse fallback span; a run is
+/// never emitted empty.
+fn split_synthesized<'src>(
+    value: &str,
+    location: Span<'src>,
+    leaf: SpecialLeaf,
+    out: &mut Vec<InlineNode<'src>>,
+) {
     let mut rest = value;
 
     while let Some(pos) = rest.find(is_special) {
@@ -121,9 +221,16 @@ fn split_synthesized<'src>(value: &str, location: Span<'src>, out: &mut Vec<Inli
         // The three specials are ASCII, so the match is exactly one byte wide.
         let ch = rest[pos..].chars().next().unwrap_or('\u{FFFD}');
 
-        out.push(InlineNode::CharRef {
-            value: CharRef::Special(ch),
-            location,
+        out.push(match leaf {
+            SpecialLeaf::CharRef => InlineNode::CharRef {
+                value: CharRef::Special(ch),
+                location,
+            },
+
+            SpecialLeaf::Raw => InlineNode::Raw {
+                value: CowStr::from(ch.to_string()),
+                location,
+            },
         });
 
         rest = &rest[pos + 1..];
@@ -145,12 +252,14 @@ mod tests {
 
     use super::{
         super::test_support::{assert_text, build_src, build_through_special, fold_html},
-        apply_special_characters,
+        apply_special_characters, classify_unescaped_specials,
     };
     use crate::{
         Span,
         content::{Content, SubstitutionStep},
-        inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled},
+        inlines::{
+            Anchor, CharRef, Footnote, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled,
+        },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
@@ -389,6 +498,207 @@ mod tests {
         let mut content = Content::from(Span::new(source));
         SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
         content.rendered_str().to_string()
+    }
+
+    /// Asserts that `node` is a [`Raw`](InlineNode::Raw) leaf holding `ch`,
+    /// located at `col` on line 1 with `offset`.
+    fn assert_raw_special(node: &InlineNode<'_>, ch: char, col: usize, offset: usize) {
+        match node {
+            InlineNode::Raw { value, location } => {
+                assert_eq!(value.as_ref(), ch.to_string());
+                assert_eq!(location.data(), ch.to_string());
+                assert_eq!(location.col(), col, "col for {ch:?}");
+                assert_eq!(location.byte_offset(), offset, "offset for {ch:?}");
+            }
+
+            other => panic!("expected Raw({ch:?}), got {other:?}"),
+        }
+    }
+
+    /// A single borrowed [`Text`](InlineNode::Text) node over the whole of
+    /// `source`, the seed shape `build_for_group` starts every group from.
+    fn seed(source: &str) -> Vec<InlineNode<'_>> {
+        let location = Span::new(source);
+
+        vec![InlineNode::Text {
+            value: CowStr::from(location.data()),
+            location,
+        }]
+    }
+
+    #[test]
+    fn classification_splits_specials_into_raw_with_precise_spans() {
+        // The `Raw` counterpart of `splits_text_and_specials_with_precise_spans`
+        // above: the same split, keeping the same honest per-node spans, but
+        // classifying each special as the verbatim leaf an order that never
+        // runs `SpecialCharacters` calls for (design §3.4.1).
+        let nodes = classify_unescaped_specials(seed("a<b>c&d"));
+
+        assert_eq!(nodes.len(), 7);
+        assert_text(&nodes[0], "a", 1, 1);
+        assert_raw_special(&nodes[1], '<', 2, 1);
+        assert_text(&nodes[2], "b", 1, 3);
+        assert_raw_special(&nodes[3], '>', 4, 3);
+        assert_text(&nodes[4], "c", 1, 5);
+        assert_raw_special(&nodes[5], '&', 6, 5);
+        assert_text(&nodes[6], "d", 1, 7);
+    }
+
+    #[test]
+    fn classification_leaves_specials_free_text_untouched() {
+        // Nothing to classify: the seed passes through as the single borrowed
+        // run it already was, so the common case allocates nothing new.
+        let nodes = classify_unescaped_specials(seed("plain text"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], "plain text", 1, 1);
+    }
+
+    #[test]
+    fn classification_preserves_a_synthesized_text_value() {
+        // The synthesized (attribute-expansion) counterpart of
+        // `special_characters_preserves_a_synthesized_text_value`: the split
+        // follows the *logical value*, and every fragment keeps the whole
+        // `location` as its coarse fallback span (design §4.4).
+        let location = Span::new("{x}");
+
+        let out = classify_unescaped_specials(vec![InlineNode::Text {
+            value: CowStr::from("a<b".to_string()),
+            location,
+        }]);
+
+        assert_eq!(out.len(), 3);
+
+        match (&out[0], &out[1], &out[2]) {
+            (
+                InlineNode::Text {
+                    value: leading,
+                    location: leading_loc,
+                },
+                InlineNode::Raw {
+                    value: special,
+                    location: special_loc,
+                },
+                InlineNode::Text {
+                    value: trailing,
+                    location: trailing_loc,
+                },
+            ) => {
+                assert_eq!(leading.as_ref(), "a");
+                assert_eq!(special.as_ref(), "<");
+                assert_eq!(trailing.as_ref(), "b");
+
+                for loc in [leading_loc, special_loc, trailing_loc] {
+                    assert_eq!(loc.data(), "{x}");
+                }
+            }
+
+            other => panic!("expected Text/Raw/Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classification_recurses_into_every_container_the_fold_descends_into() {
+        // A `subs=` order that omits `specialcharacters` can still build a
+        // `Styled` span (`quotes`), a `Ref` and a `Footnote` (`macros`), and an
+        // `Anchor` with a reference text, so the classification must reach the
+        // text nested inside each of them — the same containers `fold_html`
+        // itself descends into.
+        let loc = Span::new("a<b");
+
+        let child = || {
+            vec![InlineNode::Text {
+                value: CowStr::from(loc.data()),
+                location: loc,
+            }]
+        };
+
+        let out = classify_unescaped_specials(vec![
+            InlineNode::Styled(Styled {
+                variant: StyleVariant::Strong,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: vec![],
+                attrs: None,
+                children: child(),
+                location: loc,
+            }),
+            InlineNode::Ref(Ref {
+                variant: RefVariant::Link,
+                target: CowStr::from("https://example.com"),
+                children: child(),
+                roles: vec![],
+                window: None,
+                resolved: None,
+                derived: None,
+                xrefstyle: None,
+                attrs: None,
+                location: loc,
+            }),
+            InlineNode::Anchor(Anchor {
+                id: CowStr::from("id"),
+                reftext: Some(child()),
+                location: loc,
+            }),
+            InlineNode::Footnote(Footnote {
+                id: None,
+                number: Some(CowStr::from("1")),
+                is_reference: false,
+                children: child(),
+                location: loc,
+            }),
+        ]);
+
+        assert_eq!(out.len(), 4);
+
+        let assert_classified = |children: &[InlineNode<'_>], what: &str| {
+            assert_eq!(children.len(), 3, "children of {what}: {children:?}");
+            assert_text(&children[0], "a", 1, 1);
+            assert_raw_special(&children[1], '<', 2, 1);
+            assert_text(&children[2], "b", 1, 3);
+        };
+
+        match (&out[0], &out[1], &out[2], &out[3]) {
+            (
+                InlineNode::Styled(styled),
+                InlineNode::Ref(reference),
+                InlineNode::Anchor(anchor),
+                InlineNode::Footnote(footnote),
+            ) => {
+                assert_classified(&styled.children, "Styled");
+                assert_classified(&reference.children, "Ref");
+                match anchor.reftext.as_deref() {
+                    Some(reftext) => assert_classified(reftext, "Anchor"),
+                    None => panic!("the anchor's reftext went missing: {out:?}"),
+                }
+                assert_classified(&footnote.children, "Footnote");
+            }
+
+            other => panic!("expected Styled/Ref/Anchor/Footnote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classification_passes_other_nodes_through() {
+        // A node kind carrying no text of its own (here a line break) is
+        // forwarded unchanged, and an already-`Raw` passthrough leaf is never
+        // re-split.
+        let location = Span::new("<raw>");
+
+        let out = classify_unescaped_specials(vec![
+            InlineNode::LineBreak { location },
+            InlineNode::Raw {
+                value: CowStr::from(location.data()),
+                location,
+            },
+        ]);
+
+        assert_eq!(out.len(), 2);
+        assert!(matches!(out[0], InlineNode::LineBreak { .. }));
+        assert!(
+            matches!(&out[1], InlineNode::Raw { value, .. } if value.as_ref() == "<raw>"),
+            "an existing Raw leaf must pass through whole: {out:?}"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -160,7 +160,11 @@ fn split_text<'src>(
 fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<InlineNode<'src>>) {
     let mut rest = location;
 
-    while let Some(pos) = rest.position(is_special) {
+    // Finding the character alongside its offset keeps the special's own
+    // `char` in hand, so neither arm below has to re-derive it from the sliced
+    // span through a fallible `chars().next()` whose failure branch could
+    // never be reached (and so could never be tested).
+    while let Some((pos, ch)) = rest.data().char_indices().find(|(_, ch)| is_special(*ch)) {
         // Emit the borrowed text run preceding the special, when non-empty.
         if pos > 0 {
             let text = rest.slice_to(..pos);
@@ -172,11 +176,12 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
         }
 
         // The three specials are ASCII, so the match is exactly one byte wide.
-        let ch_span = rest.slice(pos..pos + 1);
+        let end = pos + ch.len_utf8();
+        let ch_span = rest.slice(pos..end);
 
         out.push(match leaf {
             SpecialLeaf::CharRef => InlineNode::CharRef {
-                value: CharRef::Special(ch_span.data().chars().next().unwrap_or('\u{FFFD}')),
+                value: CharRef::Special(ch),
                 location: ch_span,
             },
 
@@ -186,7 +191,7 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
             },
         });
 
-        rest = rest.slice_from(pos + 1..);
+        rest = rest.slice_from(end..);
     }
 
     if !rest.data().is_empty() {
@@ -209,7 +214,9 @@ fn split_synthesized<'src>(
 ) {
     let mut rest = value;
 
-    while let Some(pos) = rest.find(is_special) {
+    // As in [`split_verbatim`], the character comes back with its offset, so
+    // there is no unreachable fallback to re-derive it through.
+    while let Some((pos, ch)) = rest.char_indices().find(|(_, ch)| is_special(*ch)) {
         // Emit the owned text run preceding the special, when non-empty.
         if pos > 0 {
             out.push(InlineNode::Text {
@@ -217,9 +224,6 @@ fn split_synthesized<'src>(
                 location,
             });
         }
-
-        // The three specials are ASCII, so the match is exactly one byte wide.
-        let ch = rest[pos..].chars().next().unwrap_or('\u{FFFD}');
 
         out.push(match leaf {
             SpecialLeaf::CharRef => InlineNode::CharRef {
@@ -233,7 +237,8 @@ fn split_synthesized<'src>(
             },
         });
 
-        rest = &rest[pos + 1..];
+        // The three specials are ASCII, so each is exactly one byte wide.
+        rest = &rest[pos + ch.len_utf8()..];
     }
 
     if !rest.is_empty() {
@@ -667,10 +672,10 @@ mod tests {
             ) => {
                 assert_classified(&styled.children, "Styled");
                 assert_classified(&reference.children, "Ref");
-                match anchor.reftext.as_deref() {
-                    Some(reftext) => assert_classified(reftext, "Anchor"),
-                    None => panic!("the anchor's reftext went missing: {out:?}"),
-                }
+                // An absent reftext yields an empty slice, which
+                // `assert_classified` rejects on its own length check — so the
+                // missing case still fails loudly, with no unreachable arm.
+                assert_classified(anchor.reftext.as_deref().unwrap_or(&[]), "Anchor");
                 assert_classified(&footnote.children, "Footnote");
             }
 

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -847,6 +847,21 @@ fn first_simple_inlines<'a>(doc: &'a crate::Document<'a>) -> &'a [InlineNode<'a>
     panic!("no simple block found");
 }
 
+/// The rendered (string-pipeline) content of the first simple block in `doc` –
+/// the counterpart of [`first_simple_inlines`], for a test that pins both
+/// views of the same content.
+fn first_simple_rendered<'a>(doc: &'a crate::Document<'a>) -> &'a str {
+    use crate::blocks::Block;
+
+    for block in doc.child_blocks() {
+        if let Block::Simple(simple) = block {
+            return simple.content().rendered_html();
+        }
+    }
+
+    panic!("no simple block found");
+}
+
 #[test]
 fn inline_tree_is_empty_by_default() {
     let mut parser = Parser::default();
@@ -1117,21 +1132,38 @@ fn inline_tree_honors_a_blocks_custom_subs_list() {
 #[test]
 fn inline_tree_for_none_group_content_is_the_untouched_seed() {
     // A `[pass]`-style paragraph applies no substitutions at all, so its tree
-    // is the untouched seed: one `Text` run holding the content exactly as
-    // written, mirroring the string pipeline leaving the text unchanged.
+    // is the untouched seed: the content exactly as written, mirroring the
+    // string pipeline leaving the text unchanged. It is not a *single* `Text`
+    // run, though: because no `SpecialCharacters` step ever acted on it, each
+    // literal `<`/`>`/`&` is a `Raw` leaf the fold emits verbatim rather than
+    // a `Text` character the fold would escape (design §3.4.1).
     let mut parser = Parser::default().with_inline_tree(true);
     let doc = parser.parse("[pass]\n<b>raw</b> and *not bold*\n");
 
     let tree = first_simple_inlines(&doc);
 
-    assert_eq!(tree.len(), 1, "expected the untouched seed: {tree:?}");
-    assert!(
-        matches!(
-            &tree[0],
-            InlineNode::Text { value, .. } if value.as_ref() == "<b>raw</b> and *not bold*"
-        ),
-        "expected the untouched text run: {tree:?}"
+    let rejoined: String = tree
+        .iter()
+        .map(|node| match node {
+            InlineNode::Text { value, .. } | InlineNode::Raw { value, .. } => value.as_ref(),
+            other => panic!("expected only text and raw-special leaves, got {other:?}"),
+        })
+        .collect();
+
+    assert_eq!(
+        rejoined, "<b>raw</b> and *not bold*",
+        "expected the untouched seed: {tree:?}"
     );
+
+    assert!(
+        tree.iter()
+            .any(|node| matches!(node, InlineNode::Raw { value, .. } if value.as_ref() == "<")),
+        "expected the unescaped `<` to be a Raw leaf: {tree:?}"
+    );
+
+    // The rendered string is the string pipeline's own, unescaped output — the
+    // invariant the classification above exists to let the fold reproduce.
+    assert_eq!(first_simple_rendered(&doc), "<b>raw</b> and *not bold*");
 }
 
 #[test]


### PR DESCRIPTION
## What this is

Phase 4, step 6 prep (design §5.2). With the tree-source swap landed (#1179), the remaining half of step 6 — making `rendered_html()` an **authoritative** fold — needs to know where the fold still diverges from the string pipeline across the *whole* corpus, not just the hand-picked fixtures each family's own differential corpus uses.

A corpus-wide fold-parity audit (tree building forced on for every parse in the test suite, each content's tree folded and compared against that same content's own rendered string) — the same due-diligence sweep that surfaced the `hardbreaks` blocker — found a second one of exactly that kind: **not an unclaimed form the tree merely leaves literal, but a wrong answer** for content golden tests already exercise.

> **Note on this description:** GitHub's comment sanitizer strips angle-bracketed sequences even inside code fences, so the AsciiDoc constructs below are named in prose (e.g. "a doubled-angle-bracket shorthand") rather than written literally. The source and tests spell them out exactly.

## The bug

A `Text` node is *logical* text that **the fold escapes** (§3.4). That is right when the `SpecialCharacters` step acted on the content — and wrong when that step never runs, because there the string pipeline emits the author's specials untouched.

Every group whose effective order omits `specialcharacters` took that path and folded escaped entities where the string pipeline emits raw ones:

| group | reached by |
| --- | --- |
| `Pass` | a passthrough block |
| `None` | a comment block |
| `Custom([])` | `subs=","` (an empty resolved list) |
| `Custom([Quotes])`, `Custom([Macros])`, `Custom([Callouts])`, … | any `subs=` list omitting `specialcharacters` |

For a `[pass]` paragraph whose body is a bold-tag-wrapped word followed by `and *not bold*`:

- **string pipeline** emits the tags raw, exactly as written
- **fold, before this PR** emitted them entity-escaped (`&amp;lt;b&amp;gt;…`)

That is §3.4.1's own policy — *"the kind a fragment becomes is **not** a fixed property of where it came from; it is decided by which substitution steps still act on it under the group's effective order"* — applied to the **seed** rather than, as step 5b first applied it, to a spliced attribute value: a literal special that no `SpecialCharacters` step ever acts on is a `Raw` leaf.

## The fix

`classify_unescaped_specials` (`content/inline_builder/special_chars.rs`) shares its whole split with `apply_special_characters` — one `SpecialLeaf` discriminant selects `CharRef::Special` or `Raw` — so the two cannot drift on where a boundary falls, and the span discipline is preserved either way: a verbatim run's leaves are sliced from `'src` with honest `line`/`col`/`offset` (#944), a synthesized run's fall back to the whole enclosing span (§4.4).

`build_for_group` runs it **last**, after the group's own steps, gated on `!steps.contains(&SubstitutionStep::SpecialCharacters)`. Running it last rather than in place of the absent step is what keeps it faithful: under such an order the string pipeline's own steps also match over text in which the specials are still literal, so every transducer must go on seeing them as ordinary `Text` characters — not as the opaque leaf a `Raw` node is to `build_match_string`. **Only the finished tree's classification differs; nothing about recognition changes.**

It recurses into every container a text run can be nested inside — a `Styled` span, a `Ref`'s display children, an `Anchor`'s reference text, and a `Footnote`'s own children — mirroring the containers `fold_html` itself descends into, since a `subs=` list omitting `specialcharacters` can still name `quotes` and `macros`.

## Tests

**New differential corpus** (`a_group_that_never_escapes_folds_its_specials_verbatim`), crossing specials-bearing fixtures with every real group that takes this path, each driven through the real, public `SubstitutionGroup::apply` as the golden. Verified to fail without the fix. The fixture set covers:

- bare specials in every position a run can put them;
- specials that would look like a construct *once escaped* — a doubled-angle-bracket xref shorthand, a numeric character entity, and both arrow replacements — so the classification is pinned not to perturb, or depend on, recognition;
- specials beside and inside each construct these orders can build (a quoted span, an image macro, a footnote, a hard line break);
- multi-line runs.

**Structural unit tests** for the new pass: precise-span splitting, the synthesized coarse-fallback split, recursion into all four containers, and pass-through of nodes carrying no text of their own (including an already-`Raw` passthrough leaf, which is never re-split).

**Two existing tests rewritten.** `pass_and_none_groups_yield_the_untouched_seed` and `a_custom_list_runs_exactly_the_named_steps_in_order` pinned the old shape ("one untouched `Text` run", "the less-than sign stays literal text"). Neither called the module's own `assert_group_parity` helper — which is precisely why the divergence went unnoticed — so both now do, alongside asserting the classification.

## Second commit: coverage cleanup

A follow-up commit closes the coverage gaps the first one left. No behavior change:

- **Two unreachable defensive branches removed.** `split_verbatim` and `split_synthesized` located a special by byte offset and then re-derived the character through a fallible `chars().next().unwrap_or('\u{FFFD}')` — a fallback that can never be taken, since the offset comes from a predicate that just matched that very character. Both loops now find the character alongside its offset, so it is already in hand; `len_utf8()` replaces the hard-coded 1-byte step, making the ASCII-width assumption explicit. This is `CLAUDE.md`'s stated preference (remove a genuinely unreachable branch rather than leave it untested).
- **A redundant assertion dropped.** The hand-rolled rejoin loop in `pass_and_none_groups_yield_the_untouched_seed` restated what `assert_group_parity` already pins and needed an unreachable arm to do it. The test now asserts node kinds directly, with a new `golden_for_group` helper stating the "string pipeline leaves this content untouched" premise that made the rejoin meaningful.
- **The anchor reftext assertion made total** via `unwrap_or(&[])`; `assert_classified`'s own length check still fails loudly on a missing reftext.

## Scope

Purely a tree-classification fix. `rendered_html()` still returns the string pipeline's own string; nothing further is wired in. This changes only what a tree consumer reads back — and what the eventual authoritative fold will emit.

## What the audit leaves for the rest of step 6

Every remaining whole-corpus divergence under the *normal* order is a form the design doc already documents as deferred:

| form | what it is |
| --- | --- |
| `link:x[*bold*]`, `xref:id[*bold*]` | a display or reference text crossing a rendered span |
| a URL wrapped in angle brackets | the angle-bracketed link form |
| `hello@example.com` | the bare e-mail auto-link |
| a shorthand xref with a trailing comma and nothing after it | a present-but-empty reference text |
| `menu:View[Zoom` + greater-than + `Reset]` | the submenu form |
| an attribute whose value holds a macro | a macro inside an expanded attribute value |
| a missing attribute reference | under `AttributeMissing::Drop` / `::DropLine` |
| `[[[label]]]` | the bibliography anchor |

Plus one category not previously named: an effective order that runs `SpecialCharacters` **after** a step that already produced markup (`subs=quotes,specialcharacters`), where the string pipeline escapes the very tags the earlier step emitted. That one is structurally different and harder — a tree whose markup exists only at fold time has no rendered tags for a later escaping step to act on, so it needs its own policy rather than another recognition increment.

## Preflight

- `cargo fmt --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5012 passed, +6 new)
- **Coverage: 100% patch.** Verified against the exact artifact CI uploads — the `uncover-tests` action's `filter_lcov.py` applied to a locally generated lcov, which strips `#[cfg(test)]` modules and `#[test]` functions so only production lines count: `inline_builder/mod.rs` 3/3, `inline_builder/special_chars.rs` 68/68.