### PR TITLE
feat: Recognize the bibliography anchor in the single-pass inline builder (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2194,6 +2194,77 @@ Each phase is a reviewable unit with a clear exit gate.
   menu registers nothing), so there is none to stage. As with every prep piece before it, nothing
   further is wired in.
 
+  *Step 6 prep landed as (`Macros` → the bibliography anchor, the fourth of that map's
+  divergences):* the builder now recognizes the **bibliography anchor** (`[[[label]]]`,
+  `[[[label,xreftext]]]`) that prefixes a bibliography list item's principal text, as an
+  [`Anchor`](../../parser/src/inlines/anchor.rs) node carrying a new `is_bibliography` flag –
+  the same "one node kind, two forms told apart by a flag rather than by re-reading the source"
+  shape an [`Image`](../../parser/src/inlines/image.rs)'s own `is_icon` already has. It reuses the
+  string pipeline's *exact* recognition – [`INLINE_BIBLIO_ANCHOR`](../../parser/src/content/macros.rs)
+  is now shared `pub(crate)` – and its gate: the pass fires only when the parser flags that it is
+  substituting a bibliography list item's principal text
+  ([`in_bibliography_list_item`](../../parser/src/parser/parser.rs), set in
+  [`list_item`](../../parser/src/blocks/list_item.rs)), which the tree build sees because
+  [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) clones the parser –
+  flag included – before the authoritative pass runs. This is the divergence the audit's own map
+  reached *through the parse context* rather than through a construct's spelling: with the
+  tree-source swap landed, a real bibliography entry's tree was folding to
+  `[<a id="gof"></a>]` where the string pipeline emits `<a id="gof"></a>[gof]`.
+
+  Two things make it unlike the other macro families. First, it is **not a level pass**: its
+  pattern is `^`-anchored to the whole content (a `[[[…]]]` later in the entry is left to the
+  ordinary inline-anchor pass, which renders it but never catalogs its id – the `is_bibliography_inner`
+  suppression already mirrored in [`anchors`](../../parser/src/content/inline_builder/macros/anchors.rs)),
+  so it runs once, outside `apply_macros`'s own recursion, ahead of every other family exactly as the
+  string step runs it first. Second, the bracketed label the replacer renders (`[label]`, or
+  `[xreftext]`) is **left in the flow** – emitted as the sibling nodes following the anchor, sliced
+  from the match's own outer brackets and its label range – rather than becoming the node's children:
+  that is what lets every family after it see the label exactly as the string pipeline's own later
+  passes see the text the replacer pushed (an auto-link or a `link:` macro written in an xreftext is
+  linked in both), with no new container for any walk – recognition, side effects, or the eventual
+  fold – to descend into. The node's own `reftext` instead carries that bracketed label as the
+  **registered** reference text – what a cross-reference to the entry displays – taken from the level's
+  match string, i.e. in the *already-substituted* form the replacer itself registers (the contract an
+  [`IndexTerm`](../../parser/src/inlines/index_term.rs)'s `terms` already uses), so `[[[gof,A & B]]]`
+  catalogs `[A &amp; B]` byte-for-byte as the string path does. [`fold_anchor`](../../parser/src/content/inline_builder/fold.rs)
+  passes `render_anchor` a `None` reftext for such a node, mirroring the replacer's own
+  `render_anchor(id, None, …)` – the label reaches the output from the flow, not from the node.
+
+  One shape is deferred, documented and pinned by its own divergence test: a label crossing an
+  **opaque piece** – a rendered span, a passthrough or STEM expression (not restored yet), or a
+  character replacement (`(C)`, a smart apostrophe) – which
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) stands in as a single
+  placeholder rather than the markup or entity the string haystack holds there, so the
+  already-substituted label cannot be reconstructed. That is exactly the boundary the index-term
+  family's own visible term documents, and – for the character replacements – the one every macro
+  family already has at this point (the shared match string serves the quotes step too, where the
+  replacements have not yet run). An escaped special is *not* affected (a `CharRef::Special`
+  contributes its canonical entity), and a bibliography anchor reached through a synthesized run (an
+  attribute expansion, or a filtered block's joined seed) is recognized, the run contributing its
+  expanded value to the match string just as it does to the string pipeline's haystack.
+
+  The family's deferred recognition side effect is staged alongside it:
+  [`apply_biblio_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs) registers
+  the entry under `RefType::Bibliography` with the node's bracketed reftext and raises the same
+  duplicate-id warning, and
+  [`apply_macro_side_effects`](../../parser/src/content/inline_builder/macros/mod.rs) calls it
+  **first**, before the image, link, and anchor/ref functions – the string pipeline's own pass order,
+  which matters because a bibliography anchor's duplicate-id warning and an image's
+  dangerous-link-scheme warning land in the one shared warnings list (the same ordering concern that
+  entry point already records for image-before-anchor, one step earlier). `apply_ref_side_effects`
+  correspondingly skips a bibliography anchor, so composing the two neither double-registers the entry
+  nor warns against itself. A differential corpus pins both spellings, the label character classes and
+  the non-recognized leading-digit label, a `[[[…]]]` that is not at the entry's start, the
+  non-escape of a leading backslash, labels carrying an auto-link / a `link:` macro / an escaped
+  special, and constructs after the anchor; structural tests pin the node and the flow nodes that
+  follow it; registration parity is asserted against an independent golden parser (id, reference text,
+  and `RefType` alike), as is the cross-family warning order; and fixtures are added to the
+  whole-pipeline combined-constructs corpus and to the structural recorder cross-check – where the two
+  constructions reach the same anchor-then-label shape from opposite directions, the recorder
+  recovering it from the rendered output. A whole-document test drives the real parse path end to end,
+  folding a real bibliography list's trees to their own rendered strings. As with every prep piece
+  before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2362,6 +2433,21 @@ Each phase is a reviewable unit with a clear exit gate.
        still defer, each with its own divergence test. The family's escape check is hoisted ahead of
        the gate (the `footnoteref:` increment's own fix, for the identical reason), so an escaped
        macro the gate rejects still drops its backslash.
+     - ✅ **prep (bibliography anchor).** The fourth of that audit's divergences is closed – and the
+       first it reached through the *parse context* rather than a construct's spelling:
+       `[[[label]]]` prefixing a bibliography list item's principal text is recognized as an `Anchor`
+       node carrying a new `is_bibliography` flag (as an `Image`'s `is_icon` tells its two forms
+       apart), gated on the same `Parser::in_bibliography_list_item` flag the string step reads and
+       the tree build already inherits through `SubstitutionGroup::apply`'s parser clone. It runs
+       once, `^`-anchored, ahead of every other family and outside `apply_macros`'s recursion, and
+       leaves the bracketed label **in the flow** as sibling nodes (so every later family sees it
+       exactly as the string pipeline's later passes do) while the node's `reftext` carries that same
+       label as the entry's *registered* reference text, in already-substituted form.
+       [`apply_biblio_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs)
+       stages the `register_ref` and is called first by `apply_macro_side_effects`, matching the
+       string pipeline's own pass order for the shared warnings list; see the step's own "landed as"
+       note above. A label crossing an opaque piece (a rendered span, a passthrough, or a character
+       replacement) still defers, with its own divergence test.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -426,17 +426,30 @@ fn fold_xref(
 /// the same verbatim boundary the node documents; a custom backend that needs
 /// the full reference text unconditionally will get it once a re-flow consumer
 /// pins richer `reftext` population.
+///
+/// A **bibliography** anchor (`[[[label]]]`) passes `None` regardless of what
+/// its node carries, mirroring its own replacer exactly: that pass calls
+/// `render_anchor(id, None, …)` and pushes the bracketed label into the flow
+/// itself. The label is in the flow here too – as the sibling nodes following
+/// this one (see `biblio_anchor_level`) – so folding the node's `reftext`,
+/// which holds that same bracketed label as the entry's *registered* reference
+/// text, into `render_anchor` would hand a custom backend a reference text the
+/// string pipeline never passes it.
 fn fold_anchor(
     anchor: &Anchor<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
     out: &mut String,
 ) {
-    let reftext = anchor.reftext.as_ref().map(|children| {
-        let mut s = String::new();
-        fold_into_html(children, renderer, parser, &mut s);
-        s
-    });
+    let reftext = if anchor.is_bibliography {
+        None
+    } else {
+        anchor.reftext.as_ref().map(|children| {
+            let mut s = String::new();
+            fold_into_html(children, renderer, parser, &mut s);
+            s
+        })
+    };
 
     renderer.render_anchor(&anchor.id, reftext, out);
 }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1,4 +1,6 @@
-//! Inline anchor recognition (`[[id]]`, `[[id,reftext]]`, `anchor:id[…]`).
+//! Inline anchor recognition (`[[id]]`, `[[id,reftext]]`, `anchor:id[…]`), and
+//! the bibliography anchor (`[[[label]]]`) that prefixes a bibliography list
+//! item.
 
 use super::{
     MacroMatch, MacroMatchKind, image::range_is_verbatim_or_synthesized, rebuild_macro_level,
@@ -6,9 +8,10 @@ use super::{
 use crate::{
     Parser, Span,
     content::{
-        INLINE_ANCHOR,
+        INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR,
         inline_builder::quotes::{
-            Piece, build_match_string, range_overlaps_synthesized, source_slice, text_slice,
+            Piece, SPAN_PLACEHOLDER, build_match_string, emit_range, range_overlaps_synthesized,
+            source_slice, text_slice,
         },
     },
     document::RefType,
@@ -16,6 +19,166 @@ use crate::{
     strings::CowStr,
     warnings::WarningType,
 };
+
+/// Matches `INLINE_BIBLIO_ANCHOR` at the **content's own top level**, replacing
+/// a bibliography anchor (`[[[label]]]` / `[[[label,xreftext]]]`) with the
+/// [`Anchor`](InlineNode::Anchor) node it produces – `is_bibliography` set –
+/// followed by the bracketed label the string replacer emits into the flow.
+///
+/// # Where this runs, and why only here
+///
+/// The string pipeline runs this pass **first**, ahead of every other macro
+/// family, and only when the parser flags that it is substituting the principal
+/// text of a bibliography list item
+/// ([`in_bibliography_list_item`](Parser::in_bibliography_list_item), set in
+/// `blocks::list_item`); this mirrors both. The pattern is `^`-anchored – a
+/// `[[[…]]]` appearing later in the entry is left to the ordinary inline-anchor
+/// pass, which renders it but never catalogs its id (see
+/// [`is_bibliography_inner`]) – so this level pass runs once, at the top level
+/// [`apply_macros`](super::apply_macros) is called with, and never descends
+/// into a span's children: `^` matches only the very start of the *whole*
+/// content, exactly as it does for the string pipeline's own haystack.
+///
+/// # The bracketed label stays in the flow
+///
+/// The replacer renders the anchor from its id alone (`render_anchor(id,
+/// None)`) and then pushes the bracketed label (`[label]`, or `[xreftext]` when
+/// one was supplied) into the output as ordinary text – text every *later*
+/// string pass then scans. So the label is emitted here as the sibling nodes
+/// that follow the anchor node (sliced from the match's own outer brackets and
+/// its label range with [`emit_range`], so each keeps its exact `'src`
+/// provenance), rather than as the anchor's own children: that is what lets
+/// every family after this one see the label exactly as the string pipeline's
+/// later passes see it (an auto-link written in an xreftext is linked in both),
+/// with no container to descend into.
+///
+/// The node's own `reftext` instead carries the bracketed label as the
+/// **registered** reference text – what a cross-reference to the entry
+/// displays, and what [`apply_biblio_side_effects`] hands
+/// [`register_ref`](Parser::register_ref), mirroring the replacer's own single
+/// `format!("[{label}]")` serving both purposes.
+///
+/// # The registered label is already-substituted text
+///
+/// The string replacer captures its label out of the *escaped,
+/// already-rendered* haystack and registers **that** (`[[[gof,A & B]]]`
+/// catalogs `[A &amp; B]`), so the node's `reftext` holds the label in the same
+/// already-substituted form – the contract an
+/// [`IndexTerm`](InlineNode::IndexTerm)'s own `terms` already uses – taken
+/// straight from this level's match string, which reconstructs exactly that
+/// haystack (a [`CharRef`](InlineNode::CharRef) contributes its
+/// canonical entity, so an escaped special and a character replacement alike
+/// come out byte-identical to the replacer's own capture). Nothing re-escapes
+/// it: the fold hands `render_anchor` `None` for a bibliography anchor (see
+/// `fold_anchor`), exactly as the replacer does.
+///
+/// # Deferred: a label crossing an opaque piece
+///
+/// What the match string cannot reconstruct is an opaque piece – a rendered
+/// [`Styled`](crate::inlines::Styled) span (`[[[gof,*G*]]]`), a passthrough or
+/// STEM expression (not even restored yet), or a character replacement
+/// (`[[[gof,(C) 1995]]]`, `[[[oreilly,O'Reilly]]]`) – which stands in as a
+/// single [`SPAN_PLACEHOLDER`] here rather than as the markup or entity the
+/// string pipeline's haystack holds there. Such an anchor is left unrecognized,
+/// exactly the boundary the index-term family's own visible term documents
+/// (and, for the character replacements, the same one every macro family
+/// already has at this point: `build_match_string` serves the quotes step too,
+/// where the replacements have not run yet, so it can only treat them as
+/// opaque). A label reached through a synthesized run (an attribute expansion,
+/// or a filtered block's joined seed) *is* recognized – the run contributes its
+/// expanded value to the match string, just as it does to the string pipeline's
+/// own haystack.
+///
+/// As in the additive builder generally, this performs *no* recognition side
+/// effect; [`apply_biblio_side_effects`] stages the `register_ref` for the
+/// cutover.
+pub(super) fn biblio_anchor_level<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    if !parser.in_bibliography_list_item.get() {
+        return nodes;
+    }
+
+    let (s, pieces) = build_match_string(&nodes);
+
+    // Cheap pre-filter, mirroring the string step's own `text.contains("[[[")`
+    // guard: the pattern is `^`-anchored, so only content *starting* with the
+    // triple bracket can match at all.
+    if !s.starts_with("[[[") {
+        return nodes;
+    }
+
+    let Some(caps) = INLINE_BIBLIO_ANCHOR.captures(&s) else {
+        return nodes;
+    };
+
+    // `unwrap` on groups 0 and 1 is safe: a capture always has an overall
+    // match, and the label is not optional in the pattern.
+    #[allow(clippy::unwrap_used)]
+    let full = {
+        let whole = caps.get(0).unwrap();
+        whole.start()..whole.end()
+    };
+
+    #[allow(clippy::unwrap_used)]
+    let id_match = caps.get(1).unwrap();
+
+    // The displayed (and registered) label is the xreftext when one was
+    // supplied, else the id itself – exactly the string replacer's own
+    // `caps.get(2)…unwrap_or(id)`.
+    let label_match = caps.get(2).unwrap_or(id_match);
+
+    let id_range = id_match.start()..id_match.end();
+    let label_range = label_match.start()..label_match.end();
+
+    // The label is registered (and shown) as already-substituted text, which
+    // this level's match string reproduces for every piece except an opaque one
+    // – a rendered span, a passthrough, or a STEM expression – which stands in
+    // as a single placeholder.
+    let label = match s.get(label_range.clone()) {
+        Some(label) if !label.contains(SPAN_PLACEHOLDER) => label,
+        _ => return nodes,
+    };
+
+    let reftext = CowStr::from(format!("[{label}]"));
+
+    // The id, by contrast, rides on the node as logical text, so it is sliced
+    // back to `'src` (borrowing where it can) exactly as an ordinary anchor's
+    // own id is. Its character class admits neither a special nor a placeholder,
+    // so the two readings coincide – and, for the same reason, the `None` arm
+    // (the id crossing an atomic piece) is not actually reachable, kept only
+    // for symmetry with [`build_anchor_node`]'s own gate.
+    let Some(id) = text_slice(&nodes, &pieces, id_range) else {
+        return nodes;
+    };
+
+    let location = source_slice(&pieces, full.clone(), root);
+
+    let mut out = vec![InlineNode::Anchor(Anchor {
+        id,
+        reftext: Some(vec![InlineNode::Text {
+            value: reftext,
+            location,
+        }]),
+        is_bibliography: true,
+        location,
+    })];
+
+    // The bracketed label the replacer pushes into the flow. Its brackets are
+    // the match's own outer `[` and `]` (the very characters the triple bracket
+    // opens and closes with), so each emitted piece keeps an honest `'src`
+    // slice instead of a synthesized value.
+    emit_range(&nodes, &pieces, full.start..full.start + 1, &mut out);
+    emit_range(&nodes, &pieces, label_range, &mut out);
+    emit_range(&nodes, &pieces, full.end - 1..full.end, &mut out);
+
+    // Everything after the anchor is untouched.
+    emit_range(&nodes, &pieces, full.end..s.len(), &mut out);
+
+    out
+}
 
 /// Matches `INLINE_ANCHOR` at this level's escaped text, replacing each
 /// recognized inline anchor – the `[[id]]` / `[[id,reftext]]` shorthand and the
@@ -196,6 +359,7 @@ fn build_anchor_node<'src>(
     Some(InlineNode::Anchor(Anchor {
         id,
         reftext,
+        is_bibliography: false,
         location,
     }))
 }
@@ -218,8 +382,7 @@ fn build_anchor_node<'src>(
 /// coarse `location` regardless of trimming or unescaping (design §4.4) –
 /// sub-slicing a location has no honest meaning for bytes with no `'src`
 /// counterpart of their own, the same policy
-/// [`emit_range`](super::super::quotes::emit_range) already applies to every
-/// fragment of an expanded value.
+/// [`emit_range`] already applies to every fragment of an expanded value.
 fn build_anchor_reftext<'src>(
     range: std::ops::Range<usize>,
     pieces: &[Piece],
@@ -329,7 +492,10 @@ pub(crate) fn apply_ref_side_effects(
     for node in nodes {
         match node {
             InlineNode::Anchor(anchor) => {
-                if !is_bibliography_inner(anchor, source) {
+                // A bibliography anchor registers under its own [`RefType`],
+                // from its own earlier pass (see
+                // [`apply_biblio_side_effects`]), so it is skipped here.
+                if !anchor.is_bibliography && !is_bibliography_inner(anchor, source) {
                     let reftext = anchor_reftext_str(anchor);
 
                     if parser
@@ -377,6 +543,56 @@ pub(crate) fn apply_ref_side_effects(
     }
 }
 
+/// Performs the recognition side effect the string pipeline's
+/// `InlineBiblioAnchorReplacer` attaches to a **bibliography** anchor: it
+/// registers the entry's id under [`RefType::Bibliography`], with the bracketed
+/// label the node carries as its `reftext` (so a cross-reference to the entry
+/// renders identically to the label shown in the flow), and raises the same
+/// duplicate-id warning against the whole content's `source` span when the id
+/// is already taken.
+///
+/// Kept separate from [`apply_ref_side_effects`] – rather than folded into its
+/// walk – because the string pipeline runs the bibliography-anchor pass
+/// **first**, ahead of every other macro family, and
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects) must reproduce
+/// that order: a duplicate-id warning from a bibliography anchor precedes an
+/// image's dangerous-link-scheme warning in the one shared warnings list, the
+/// same ordering concern that function's own doc comment already records for
+/// image-before-anchor.
+///
+/// The pattern is `^`-anchored, so a bibliography anchor is always the
+/// content's *first* node and is never nested inside a container – hence no
+/// recursion here (and none needed for the bracketed label either: it stays in
+/// the flow as ordinary sibling nodes, see [`biblio_anchor_level`]).
+///
+/// As with every staged side effect in this module, **nothing here is wired
+/// into a real parse path yet** – it is exercised only by this module's own
+/// tests, against their own [`Parser`].
+pub(crate) fn apply_biblio_side_effects(
+    nodes: &[InlineNode<'_>],
+    parser: &Parser,
+    source: Span<'_>,
+) {
+    let Some(InlineNode::Anchor(anchor)) = nodes.first() else {
+        return;
+    };
+
+    if !anchor.is_bibliography {
+        return;
+    }
+
+    if parser
+        .register_ref(
+            &anchor.id,
+            anchor_reftext_str(anchor),
+            RefType::Bibliography,
+        )
+        .is_err()
+    {
+        parser.record_substitution_warning(source, WarningType::DuplicateId(anchor.id.to_string()));
+    }
+}
+
 /// The reference text `str` a built [`Anchor`] node's `reftext` carries, when
 /// it is populated (a single verbatim [`Text`](InlineNode::Text) child – see
 /// [`build_anchor_reftext`]), mirroring the `Option<&str>`
@@ -391,10 +607,10 @@ fn anchor_reftext_str<'a>(anchor: &'a Anchor<'_>) -> Option<&'a str> {
 /// Mirrors `InlineAnchorReplacer`'s own `is_bibliography_inner` check: a
 /// shorthand `[[id]]` anchor immediately preceded by a `[` in the source is
 /// the inner anchor of a bibliography-style `[[[id]]]` sequence appearing
-/// *outside* a bibliography list item (a genuine bibliography anchor there is
-/// consumed whole by a separate, list-item-gated pass this builder does not
-/// yet recognize as its own node – `INLINE_BIBLIO_ANCHOR`, see
-/// [`content::macros`](crate::content::macros)). Asciidoctor's own
+/// *outside* a bibliography list item (inside one, a genuine bibliography
+/// anchor at the entry's start is consumed whole by the separate,
+/// list-item-gated [`biblio_anchor_level`] pass, so it never reaches this
+/// function). Asciidoctor's own
 /// inline-anchor *scan* excludes a `[[id]]` preceded by a `[`, so it renders
 /// the anchor (already handled by [`build_anchor_node`], which does not
 /// exclude this case – see its own doc) but never catalogs the id; this
@@ -447,6 +663,7 @@ mod tests {
 
     use super::super::super::test_support::{
         assert_styled, assert_text, build_src, fold_html, golden_macros, golden_macros_with,
+        golden_passthroughs_with,
     };
     use crate::{
         Parser, Span,
@@ -1127,5 +1344,397 @@ mod tests {
                 "registered ids diverged for {fixture:?}"
             );
         }
+    }
+
+    // ---- the bibliography anchor (`[[[label]]]`) ------------------------
+
+    use super::{apply_biblio_side_effects, biblio_anchor_level};
+
+    /// A [`Parser`] flagged as substituting the principal text of a
+    /// bibliography list item – the context `blocks::list_item` puts the parser
+    /// in, and the only one in which either pipeline recognizes a bibliography
+    /// anchor.
+    fn biblio_parser() -> Parser {
+        let parser = Parser::default();
+        parser.in_bibliography_list_item.set(true);
+        parser
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_bibliography_anchor() {
+        // The differential corpus (design §5.3) pinning the bibliography-anchor
+        // increment: for each fixture, folding the single-pass tree reproduces
+        // the string pipeline's output byte-for-byte, with both sides run
+        // against a parser flagged as being inside a bibliography list item.
+        let fixtures = [
+            // Both spellings, alone and prefixing a real entry.
+            "[[[gof]]]",
+            "[[[gof]]] Gamma, Erich et al. _Design Patterns_.",
+            "[[[gof,GoF]]] Gamma, Erich et al. _Design Patterns_.",
+            "[[[gof, GoF]]] leading space after the comma is dropped",
+            // Label character classes (the pattern admits digits, but never a
+            // leading one).
+            "[[[_gof]]] leading underscore",
+            "[[[:gof]]] leading colon",
+            "[[[gof-2.a:b]]] punctuation in the label",
+            "[[[gof1995]]] digits after the first character",
+            // A label that must *not* be recognized: it starts with a digit,
+            // so the entry keeps its literal brackets (and the inner `[[…]]`
+            // falls through to the ordinary anchor pass, which renders it
+            // without cataloging its id).
+            "[[[1984]]] Orwell, George.",
+            // Not at the start of the entry: the `^`-anchored pass declines it,
+            // exactly as the string step does.
+            "See [[[mid]]] inline.",
+            // A backslash is not an escape here – `\\[[[x]]]` does not begin
+            // with `[[[`, so it is not a bibliography anchor at all.
+            "\\[[[gof]]] Gamma.",
+            // An xreftext carrying flow constructs of its own: the label stays
+            // in the flow, so every later family sees it exactly as the string
+            // pipeline's later passes do.
+            "[[[gof,see https://example.org]]] auto-linked inside the label",
+            "[[[gof,see link:x.html[X]]]] a link macro inside the label",
+            // A label carrying an escaped special: a `CharRef::Special` piece
+            // contributes its canonical entity to this level's match string, so
+            // the label is reconstructed – and registered – exactly as the
+            // string replacer captures it.
+            "[[[gof,A & B]]] an escaped special inside the label",
+            // Constructs after the entry's anchor.
+            "[[[gof]]] *bold* and _em_ and https://example.org",
+            "[[[gof]]] an inline [[mid]] anchor later in the entry",
+        ];
+
+        let parser = biblio_parser();
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = crate::content::inline_builder::fold_html(
+                &build_with(Span::new(fixture), &parser),
+                &renderer,
+                &parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_macros_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bibliography_anchor_becomes_a_node_followed_by_its_bracketed_label() {
+        let parser = biblio_parser();
+        let source = "[[[gof,GoF]]] Gamma.";
+        let nodes = build_with(Span::new(source), &parser);
+
+        let anchor = assert_anchor(&nodes[0]);
+        assert!(anchor.is_bibliography);
+
+        // The id borrows from source (no allocation).
+        assert!(matches!(anchor.id, CowStr::Borrowed(_)));
+        assert_eq!(anchor.id.as_ref(), "gof");
+
+        // Its location covers the whole anchor, the triple brackets included.
+        assert_eq!(anchor.location.data(), "[[[gof,GoF]]]");
+        assert_eq!(anchor.location.line(), 1);
+        assert_eq!(anchor.location.col(), 1);
+
+        // The node's own reference text is the *bracketed* label – what the
+        // entry is registered with, and what a cross-reference to it displays.
+        let reftext = anchor.reftext.as_ref().unwrap();
+        assert_eq!(reftext.len(), 1);
+        match &reftext[0] {
+            InlineNode::Text { value, .. } => assert_eq!(value.as_ref(), "[GoF]"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+
+        // The same bracketed label is *also* in the flow, as the sibling nodes
+        // that follow – each sliced from the match's own source characters (the
+        // outer `[` at column 1, the label, and the outer `]` at column 13).
+        assert_text(&nodes[1], "[", 1, 1);
+        assert_text(&nodes[2], "GoF", 1, 8);
+        assert_text(&nodes[3], "]", 1, 13);
+        assert_text(&nodes[4], " Gamma.", 1, 14);
+        assert_eq!(nodes.len(), 5);
+    }
+
+    #[test]
+    fn a_bibliography_anchor_with_no_xreftext_shows_its_label() {
+        let parser = biblio_parser();
+        let source = "[[[gof]]]";
+        let nodes = build_with(Span::new(source), &parser);
+
+        let anchor = assert_anchor(&nodes[0]);
+        assert!(anchor.is_bibliography);
+
+        match &anchor.reftext.as_ref().unwrap()[0] {
+            InlineNode::Text { value, .. } => assert_eq!(value.as_ref(), "[gof]"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+
+        assert_text(&nodes[1], "[", 1, 1);
+        assert_text(&nodes[2], "gof", 1, 4);
+        assert_text(&nodes[3], "]", 1, 9);
+        assert_eq!(nodes.len(), 4);
+    }
+
+    #[test]
+    fn a_bibliography_anchor_is_recognized_only_inside_a_bibliography_list_item() {
+        // The same source, built against a parser that is *not* flagged: the
+        // triple bracket falls through to the ordinary inline-anchor pass, whose
+        // node carries no bibliography flag (and whose id the side-effect pass
+        // deliberately does not catalog – see
+        // `does_not_register_the_inner_anchor_of_a_bibliography_style_triple_bracket`).
+        let nodes = build_src(Span::new("[[[gof]]]"));
+
+        let anchor = nodes
+            .iter()
+            .find_map(|n| match n {
+                InlineNode::Anchor(anchor) => Some(anchor),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected an Anchor node: {nodes:?}"));
+
+        assert!(!anchor.is_bibliography);
+    }
+
+    #[test]
+    fn a_bibliography_anchor_inside_a_synthesized_run_is_recognized() {
+        // A whole bibliography anchor supplied by an attribute reference: its
+        // id and label have no `'src` slice of their own, but – as with the
+        // ordinary anchor family's id – `text_slice` recovers their exact text,
+        // so the anchor is recognized (its `location` taking design §4.4's
+        // coarse fallback), and the fold matches the string pipeline.
+        use crate::parser::ModificationContext;
+
+        let parser = biblio_parser().with_intrinsic_attribute(
+            "entry",
+            "[[[gof,GoF]]]",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "{entry} Gamma.";
+        let nodes = build_with(Span::new(source), &parser);
+
+        let anchor = assert_anchor(&nodes[0]);
+        assert!(anchor.is_bibliography);
+        assert_eq!(anchor.id.as_ref(), "gof");
+        assert!(matches!(anchor.id, CowStr::Boxed(_)), "id is synthesized");
+
+        let folded = crate::content::inline_builder::fold_html(
+            &nodes,
+            &HtmlSubstitutionRenderer {},
+            &parser,
+        );
+
+        assert_eq!(folded, golden_attributes_with(source, &parser));
+    }
+
+    #[test]
+    fn a_bibliography_label_over_an_opaque_piece_is_a_documented_divergence() {
+        // A label crossing an opaque piece – a rendered span, a passthrough, or
+        // a character replacement, each a single placeholder in this level's
+        // match string rather than the markup/entity the string pipeline's
+        // haystack holds there – cannot be reconstructed as the
+        // already-substituted text the string replacer registers and shows, so
+        // the anchor is left unrecognized. The entry then keeps the shape it had
+        // before this increment (the inner `[[…]]` as an ordinary anchor), which
+        // is what diverges. This is exactly the boundary the index-term family's
+        // own visible term documents, and – for the character replacements –
+        // the same one every macro family already has at this point in the
+        // pipeline (a `(C)` or a smart apostrophe is atomic by macro time).
+        let parser = biblio_parser();
+
+        for source in [
+            "[[[gof,*GoF*]]] Gamma.",
+            "[[[gof,+++<b>GoF</b>+++]]] Gamma.",
+            "[[[gof,(C) 1995]]] Gamma.",
+            "[[[oreilly,O'Reilly]]] Hunt.",
+        ] {
+            let nodes = build_with(Span::new(source), &parser);
+
+            assert!(
+                !nodes
+                    .iter()
+                    .any(|n| matches!(n, InlineNode::Anchor(a) if a.is_bibliography)),
+                "expected no bibliography anchor node for {source:?}: {nodes:?}"
+            );
+
+            let folded = crate::content::inline_builder::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser,
+            );
+
+            assert_ne!(folded, golden_passthroughs_with(source, &parser));
+        }
+    }
+
+    #[test]
+    fn the_bibliography_pass_declines_a_level_it_can_never_match() {
+        // The pass is `^`-anchored to the whole content, so it is a no-op for a
+        // level whose text merely *contains* a triple bracket, and for one that
+        // starts with it but under a parser that is not inside a bibliography
+        // list item. Driven directly, since `apply_macros` only ever calls it at
+        // the content's top level.
+        let root = Span::new("x [[[gof]]]");
+        let nodes = vec![InlineNode::Text {
+            value: CowStr::from(root.data()),
+            location: root,
+        }];
+
+        let out = biblio_anchor_level(nodes, root, &biblio_parser());
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], InlineNode::Text { .. }));
+    }
+
+    #[test]
+    fn registers_a_bibliography_entry() {
+        let source = "[[[gof,GoF]]] Gamma.";
+        let parser = biblio_parser();
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_biblio_side_effects(&nodes, &parser, Span::new(source));
+
+        let catalog = parser.catalog();
+        let entry = catalog.get_ref("gof").unwrap();
+
+        // The bracketed label is the registered reference text, so a
+        // cross-reference to the entry renders exactly as the label does.
+        assert_eq!(entry.reftext.as_deref(), Some("[GoF]"));
+        assert_eq!(entry.ref_type, RefType::Bibliography);
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_bibliography_registrations() {
+        // Each side registers against its own *independent* parser (design
+        // §5.3's two-independent-parsers discipline), so the staged side effect
+        // is compared with the real pipeline's own registrations – id, reference
+        // text, and `RefType` alike.
+        let fixtures = [
+            "[[[gof]]] Gamma.",
+            "[[[gof,GoF]]] Gamma.",
+            "[[[gof, GoF ]]] Gamma.",
+            "[[[gof,A & B]]] Gamma.",
+            "[[[1984]]] Orwell.",
+            "See [[[mid]]] inline.",
+            "[[[gof]]] and an inline [[extra]] anchor",
+            // An ordinary anchor at the very start of the content: the
+            // bibliography pass leaves it to `apply_ref_side_effects`, which
+            // catalogs it under `RefType::Anchor`.
+            "[[plain]] leads an entry that has no bibliography anchor",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = biblio_parser();
+            let nodes = build_with(Span::new(fixture), &builder_parser);
+            apply_biblio_side_effects(&nodes, &builder_parser, Span::new(fixture));
+            apply_ref_side_effects(&nodes, &builder_parser, Span::new(fixture), false);
+
+            let golden_parser = biblio_parser();
+            golden_macros_with(fixture, &golden_parser);
+
+            let entries = |parser: &Parser| {
+                let catalog = parser.catalog();
+
+                catalog
+                    .ids()
+                    .map(|id| {
+                        let entry = catalog.get_ref(id).unwrap();
+                        (
+                            id.to_string(),
+                            entry.reftext.clone(),
+                            entry.ref_type.clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            assert_eq!(
+                entries(&builder_parser),
+                entries(&golden_parser),
+                "registered references diverged for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn records_a_duplicate_id_warning_for_a_repeated_bibliography_entry() {
+        let source = "[[[gof]]] Gamma.";
+        let parser = biblio_parser();
+        parser
+            .register_ref("gof", None, RefType::Bibliography)
+            .unwrap();
+
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_biblio_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::DuplicateId("gof".to_string())
+        );
+    }
+
+    #[test]
+    fn a_bibliography_anchor_is_registered_once_not_twice() {
+        // `apply_ref_side_effects` skips a bibliography anchor (its own earlier
+        // pass owns it), so composing the two – as
+        // `apply_macro_side_effects` does – neither double-registers the entry
+        // nor raises a spurious duplicate-id warning against itself.
+        let source = "[[[gof]]] Gamma.";
+        let parser = biblio_parser();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_biblio_side_effects(&nodes, &parser, Span::new(source));
+        apply_ref_side_effects(&nodes, &parser, Span::new(source), false);
+
+        assert_eq!(parser.substitution_warnings_len(), before);
+        assert_eq!(
+            parser.catalog().get_ref("gof").unwrap().ref_type,
+            RefType::Bibliography
+        );
+    }
+
+    #[test]
+    fn a_real_bibliography_list_items_tree_folds_to_its_rendered_string() {
+        // End-to-end, through the real parse path: the flag this pass reads is
+        // set by `blocks::list_item` while the entry's principal text is
+        // substituted, and `SubstitutionGroup::apply` clones the parser (flag
+        // included) to build the tree – so a real bibliography entry's tree
+        // folds to exactly the rendered string the string pipeline produced.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(
+            "[bibliography]\n* [[[gof,GoF]]] Gamma, Erich et al.\n* [[[pp]]] Hunt, Andrew.\n",
+        );
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default(),
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected both entries to be checked");
     }
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -7,7 +7,7 @@ pub(super) mod links;
 mod ui;
 mod xref;
 
-use anchors::anchor_macros_level;
+use anchors::{anchor_macros_level, biblio_anchor_level};
 use image::image_macros_level;
 use indexterm::indexterm_macros_level;
 use links::{email_level, inline_link_level, link_macro_level};
@@ -39,6 +39,12 @@ use crate::{Parser, Span, inlines::InlineNode};
 /// families (cross-references, footnotes, index terms, anchors, STEM) are later
 /// increments (see [`link_macro_level`], [`inline_link_level`], and
 /// [`email_level`] for the link forms this increment defers).
+///
+/// It also recognizes the **bibliography anchor** (`[[[label]]]`) that prefixes
+/// a bibliography list item, as an [`Anchor`](InlineNode::Anchor) node whose
+/// `is_bibliography` is set – the one family that is not a level pass, since
+/// its pattern is `^`-anchored to the whole content (see
+/// [`biblio_anchor_level`]).
 ///
 /// Each family is applied at each level in the **same order the string step
 /// applies them** – keyboard/button, then menu, then image/icon, then
@@ -82,18 +88,39 @@ pub(super) fn apply_macros<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // The bibliography anchor (`[[[label]]]`) runs before every other family,
+    // exactly as the string step runs its own `INLINE_BIBLIO_ANCHOR` pass
+    // first. It runs *only here*, at the content's own top level – its pattern
+    // is `^`-anchored, so it can only ever match the very start of the whole
+    // content, never the start of a span's children (see
+    // [`biblio_anchor_level`]) – which is why it sits outside
+    // [`apply_macro_families`]'s own recursion.
+    let nodes = biblio_anchor_level(nodes, root, parser);
+
+    apply_macro_families(nodes, root, parser)
+}
+
+/// Applies each macro family at this level – and, first, at every level nested
+/// inside it – in the string step's own family order. See
+/// [`apply_macros`], which wraps this with the once-per-content
+/// bibliography-anchor pass.
+fn apply_macro_families<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
     // Recurse into spans/refs first, matching the string pipeline's
     // whole-string pass.
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
         .map(|node| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_macros(styled.children, root, parser);
+                styled.children = apply_macro_families(styled.children, root, parser);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_macros(reference.children, root, parser);
+                reference.children = apply_macro_families(reference.children, root, parser);
                 InlineNode::Ref(reference)
             }
 
@@ -134,11 +161,10 @@ pub(super) fn apply_macros<'src>(
     let nodes = email_level(nodes, root);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
-    // before cross-references, mirroring the string step's order. The
-    // bibliography-anchor pass the string step runs *first* (a `^`-anchored
-    // `[[[id]]]`) fires only inside a bibliography list item – a context the
-    // additive builder is not wired into – so it is a cutover concern, not this
-    // pass's.
+    // before cross-references, mirroring the string step's order. (The
+    // bibliography-anchor pass the string step runs *first* – a `^`-anchored
+    // `[[[id]]]`, recognized only inside a bibliography list item – runs in
+    // [`apply_macros`], outside this recursion.)
     let nodes = anchor_macros_level(nodes, root);
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
@@ -158,16 +184,18 @@ pub(super) fn apply_macros<'src>(
 
 /// The eventual cutover's single entry point (design §5.2, Phase 4 step 6) for
 /// **every** recognition side effect the macro families above defer –
-/// composing [`image::apply_image_side_effects`],
-/// [`links::apply_link_side_effects`], and [`anchors::apply_ref_side_effects`],
-/// each staged and tested as its own standalone building block, into the one
-/// call the cutover makes exactly once per parse.
+/// composing [`anchors::apply_biblio_side_effects`],
+/// [`image::apply_image_side_effects`], [`links::apply_link_side_effects`], and
+/// [`anchors::apply_ref_side_effects`], each staged and tested as its own
+/// standalone building block, into the one call the cutover makes exactly once
+/// per parse.
 ///
 /// # Ordering
 ///
-/// The three are called in the same relative order the string pipeline's own
-/// macro passes run in (image/icon, …, links, …, anchors, …– see
-/// [`apply_macros`]'s own doc comment): image, then link, then anchor/ref.
+/// The four are called in the same relative order the string pipeline's own
+/// macro passes run in (the bibliography anchor, then image/icon, …, links, …,
+/// anchors, …– see [`apply_macros`]'s own doc comment): bibliography anchor,
+/// then image, then link, then anchor/ref.
 /// This is not cosmetic – it is what keeps this function's output identical to
 /// the golden pipeline's whenever more than one family's side effect touches
 /// the *same* shared list. Concretely, [`Parser::record_substitution_warning`]
@@ -176,10 +204,12 @@ pub(super) fn apply_macros<'src>(
 /// [`anchors::apply_ref_side_effects`]'s duplicate-id warning write to it – a
 /// content whose image triggers the first and whose anchor triggers the
 /// second must see the image warning recorded first, exactly as it would from
-/// the string pipeline's own image-then-anchor pass order. (The asset/ref
-/// catalogs the three write to are otherwise disjoint from one another –
-/// images, links, and refs are three separate lists – so this ordering does
-/// not, by itself, need to hold *within* a single catalog; see
+/// the string pipeline's own image-then-anchor pass order. The same holds one
+/// step earlier for [`anchors::apply_biblio_side_effects`]'s own duplicate-id
+/// warning, which the string pipeline's first pass records ahead of both. (The
+/// asset/ref catalogs the three write to are otherwise disjoint from one
+/// another – images, links, and refs are three separate lists – so this
+/// ordering does not, by itself, need to hold *within* a single catalog; see
 /// [`links::apply_link_side_effects`]'s own doc comment for the finer-grained
 /// ordering *within* the link family that the golden pipeline also requires.)
 ///
@@ -202,6 +232,7 @@ pub(crate) fn apply_macro_side_effects(
     source: Span<'_>,
     leading_anchor_registered: bool,
 ) {
+    anchors::apply_biblio_side_effects(nodes, parser, source);
     image::apply_image_side_effects(nodes, parser, source);
     links::apply_link_side_effects(nodes, parser);
     anchors::apply_ref_side_effects(nodes, parser, source, leading_anchor_registered);
@@ -425,6 +456,53 @@ mod tests {
             [
                 WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
                 WarningType::DuplicateId("dup".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_bibliography_entry_registers_before_every_other_family() {
+        // The string pipeline runs its bibliography-anchor pass *first*, ahead
+        // of every other macro family, so a duplicate bibliography id must be
+        // warned about before an image's dangerous-link-scheme warning in the
+        // one shared warnings list – the same ordering this function's own doc
+        // comment records for image-before-anchor, one step earlier. Each side
+        // uses its own independent parser.
+        let source = "[[[dup]]] image:x.png[alt,link=javascript:alert(1)] entry";
+
+        let builder_parser = Parser::default().with_catalog_assets(true);
+        builder_parser.in_bibliography_list_item.set(true);
+        builder_parser
+            .register_ref("dup", None, crate::document::RefType::Bibliography)
+            .unwrap();
+
+        let nodes = build(Span::new(source), &builder_parser, None);
+        apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
+
+        let golden_parser = Parser::default().with_catalog_assets(true);
+        golden_parser.in_bibliography_list_item.set(true);
+        golden_parser
+            .register_ref("dup", None, crate::document::RefType::Bibliography)
+            .unwrap();
+
+        golden_macros_with(source, &golden_parser);
+
+        let warnings = |parser: &Parser| {
+            parser
+                .drain_substitution_warnings_since(0)
+                .into_iter()
+                .map(|w| w.warning)
+                .collect::<Vec<_>>()
+        };
+
+        let builder_warnings = warnings(&builder_parser);
+
+        assert_eq!(builder_warnings, warnings(&golden_parser));
+        assert_eq!(
+            builder_warnings,
+            [
+                WarningType::DuplicateId("dup".to_string()),
+                WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
             ]
         );
     }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -814,6 +814,31 @@ mod tests {
                     )
             },
         );
+
+        // A bibliography entry: the `^`-anchored bibliography-anchor pass runs
+        // ahead of every other macro family, and the bracketed label it leaves
+        // in the flow is then seen by those families exactly as the string
+        // pipeline's later passes see it.
+        let in_bibliography_list_item = || {
+            let parser = Parser::default().with_intrinsic_attribute(
+                "product",
+                "Widget",
+                ModificationContext::Anywhere,
+            );
+
+            parser.in_bibliography_list_item.set(true);
+            parser
+        };
+
+        assert_parity_with(
+            "[[[gof,GoF]]] Gamma, Erich et al. _Design Patterns_. https://example.org",
+            in_bibliography_list_item,
+        );
+
+        assert_parity_with(
+            "[[[widget]]] The {product} handbook, with a footnote:[note] and an [[extra]] anchor.",
+            in_bibliography_list_item,
+        );
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -643,6 +643,7 @@ mod tests {
             InlineNode::Anchor(Anchor {
                 id: CowStr::from("id"),
                 reftext: Some(child()),
+                is_bibliography: false,
                 location: loc,
             }),
             InlineNode::Footnote(Footnote {

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -935,6 +935,7 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
         LeafNode::Anchor { id } => InlineNode::Anchor(Anchor {
             id: CowStr::from(id.clone()),
             reftext: None,
+            is_bibliography: false,
             location: span,
         }),
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1569,11 +1569,19 @@ impl Replacer for InlineEmailReplacer<'_> {
 /// Asciidoctor). The documented escape `[\[[id]]]` likewise does not start with
 /// `[[[` and is handled there.
 ///
+/// Shared `pub(crate)` so the single-pass
+/// [`inline_builder`](crate::content::inline_builder) recognizes a
+/// bibliography anchor with the *exact* same pattern this string step matches
+/// with, changing only the recognition *sink* (an
+/// [`Anchor`](crate::inlines::Anchor) node whose `is_bibliography` is set,
+/// instead of rendered markup). Group 1 is the label and group 2 its optional
+/// xreftext.
+///
 /// ## Examples
 ///
 /// * `[[[label]]]`
 /// * `[[[label,xreftext]]]`
-static INLINE_BIBLIO_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
+pub(crate) static INLINE_BIBLIO_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?x)

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -24,9 +24,9 @@ pub(crate) mod inline_tree;
 
 mod macros;
 pub(crate) use macros::{
-    INLINE_ANCHOR, INLINE_EMAIL, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO, INLINE_INDEXTERM,
-    INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO, INLINE_XREF,
-    NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
+    INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR, INLINE_EMAIL, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
+    INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
+    INLINE_XREF, NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
     document_xrefstyle, encode_uri_component, extract_attributes_from_text,
     normalize_footnote_text, normalize_index_text, normalize_text_lf_escaped_bracket,
     split_kbd_keys, strip_see_and_seealso,

--- a/parser/src/inlines/anchor.rs
+++ b/parser/src/inlines/anchor.rs
@@ -1,6 +1,8 @@
 use crate::{HasSpan, Span, inlines::InlineNode, strings::CowStr};
 
-/// An inline anchor (`[[id]]`, `[[id,reftext]]`, or `anchor:id[reftext]`).
+/// An inline anchor (`[[id]]`, `[[id,reftext]]`, or `anchor:id[reftext]`), or
+/// the bibliography anchor (`[[[label]]]`, `[[[label,xreftext]]]`) that
+/// prefixes a bibliography list item.
 ///
 /// Field set is provisional (Phase 0) and will be refined against the first
 /// consumer.
@@ -11,7 +13,30 @@ pub struct Anchor<'src> {
 
     /// The optional reference text, as child inline nodes. `None` when the
     /// anchor supplied no reftext.
+    ///
+    /// A **bibliography** anchor always carries one: the bracketed label
+    /// (`[label]`, or `[xreftext]` when one was supplied) that a
+    /// cross-reference to the entry displays. That same bracketed text is also
+    /// rendered into the flow — as the sibling nodes that follow this one, not
+    /// from this field (see [`is_bibliography`](Self::is_bibliography)).
     pub reftext: Option<Vec<InlineNode<'src>>>,
+
+    /// True when this is a **bibliography** anchor (`[[[label]]]`) prefixing a
+    /// bibliography list item, rather than an ordinary inline anchor.
+    ///
+    /// The two render differently — a bibliography anchor emits its empty `<a
+    /// id="…"></a>` *followed by* the bracketed label, and registers the entry
+    /// under [`RefType::Bibliography`](crate::document::RefType::Bibliography)
+    /// rather than [`RefType::Anchor`](crate::document::RefType::Anchor) — so
+    /// the two forms are told apart by this flag rather than by re-reading the
+    /// node's source, exactly as an [`Image`](crate::inlines::Image) node's own
+    /// `is_icon` tells its two forms apart.
+    ///
+    /// The bracketed label a bibliography anchor renders into the flow is
+    /// **not** this node's own children: it is emitted as the sibling text
+    /// nodes that follow, exactly as the string pipeline leaves that text in
+    /// the flow for its own later passes to see.
+    pub is_bibliography: bool,
 
     /// The source location of the whole anchor.
     pub location: Span<'src>,

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -187,6 +187,7 @@ mod tests {
             InlineNode::Anchor(Anchor {
                 id: CowStr::from("intro"),
                 reftext: None,
+                is_bibliography: false,
                 location,
             }),
             InlineNode::Ui(Ui {

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -896,4 +896,26 @@ fn shapes_match_across_combined_constructs() {
                 )
         },
     );
+
+    // A bibliography entry. The two constructions arrive at the same shape from
+    // opposite directions: the builder emits the anchor node and then leaves the
+    // bracketed label in the flow, while the recorder recovers that same
+    // anchor-then-text sequence out of the rendered output (the string
+    // replacer's `render_anchor` call is bracketed by markers, and the label it
+    // pushes after it is not).
+    let in_bibliography_list_item = || {
+        let parser = Parser::default();
+        parser.in_bibliography_list_item.set(true);
+        parser
+    };
+
+    assert_shapes_with(
+        "[[[gof,GoF]]] Gamma, Erich et al. _Design Patterns_.",
+        in_bibliography_list_item,
+    );
+
+    assert_shapes_with(
+        "[[[gof]]] An entry with an https://example.org link.",
+        in_bibliography_list_item,
+    );
 }


### PR DESCRIPTION
Closes the **fourth** of the corpus-wide fold-parity audit's itemized divergences (design §5.2, Phase 4 step 6 prep), after the bare e-mail auto-link (#1181), the angle-bracketed URL (#1182), and the `&gt;`-submenu menu form (#1183).

It is the first of that map's items reached through the **parse context** rather than a construct's spelling. With the tree-source swap landed (#1179), a real bibliography entry's tree folds to `[<a id="gof"></a>]` where the string pipeline emits `<a id="gof"></a>[gof]` — a wrong answer for content golden tests already exercise, not merely an unclaimed form.

## What lands

The builder now recognizes the **bibliography anchor** (`[[[label]]]`, `[[[label,xreftext]]]`) that prefixes a bibliography list item's principal text, as an `Anchor` node carrying a new `is_bibliography` flag — the same "one node kind, two forms told apart by a flag rather than by re-reading the source" shape an `Image`'s own `is_icon` already has. It reuses the string pipeline's *exact* recognition (`INLINE_BIBLIO_ANCHOR` is now shared `pub(crate)`) and its gate: the pass fires only when `Parser::in_bibliography_list_item` is set, which the tree build sees because `SubstitutionGroup::apply` clones the parser — flag included — before the authoritative pass runs.

Two things make it unlike the other macro families:

- **It is not a level pass.** Its pattern is `^`-anchored to the whole content (a `[[[…]]]` later in the entry is left to the ordinary inline-anchor pass, which renders it but never catalogs its id), so it runs once, outside `apply_macros`'s own recursion, ahead of every other family — exactly as the string step runs it first. `apply_macros` is split into that once-per-content wrapper plus the recursive `apply_macro_families`.
- **The bracketed label stays in the flow.** The replacer renders the anchor from its id alone and then pushes `[label]` into the output as ordinary text that every *later* string pass scans. So the label is emitted here as the sibling nodes following the anchor (sliced from the match's own outer brackets and its label range), rather than as the anchor's children: that is what lets every family after it see the label exactly as the string pipeline's later passes do — an auto-link or a `link:` macro written in an xreftext is linked in both — with no new container for any walk (recognition, side effects, or the eventual fold) to descend into.

The node's own `reftext` instead carries that bracketed label as the entry's **registered** reference text, taken from the level's match string, i.e. in the *already-substituted* form the replacer itself registers (the contract an `IndexTerm`'s `terms` already uses), so `[[[gof,A & B]]]` catalogs `[A &amp; B]` byte-for-byte as the string path does. `fold_anchor` passes `render_anchor` a `None` reftext for such a node, mirroring the replacer's own `render_anchor(id, None, …)` — the label reaches the output from the flow, not from the node.

## Staged side effect, and its ordering

`apply_biblio_side_effects` registers the entry under `RefType::Bibliography` with the node's bracketed reftext and raises the same duplicate-id warning; `apply_macro_side_effects` calls it **first**, ahead of the image, link, and anchor/ref functions — the string pipeline's own pass order, which matters because a bibliography anchor's duplicate-id warning and an image's dangerous-link-scheme warning land in the one shared warnings list (the same ordering concern that entry point already records for image-before-anchor, one step earlier). `apply_ref_side_effects` correspondingly skips a bibliography anchor, so composing the two neither double-registers the entry nor warns against itself.

## Deferred (documented, with its own divergence test)

A label crossing an **opaque piece** — a rendered span, a passthrough or STEM expression (not restored yet), or a character replacement (`(C)`, a smart apostrophe) — which `build_match_string` stands in as a single placeholder rather than the markup or entity the string haystack holds there, so the already-substituted label cannot be reconstructed. That is exactly the boundary the index-term family's own visible term documents, and — for the character replacements — the one every macro family already has at this point (the shared match string serves the quotes step too, where the replacements have not yet run). An escaped special is *not* affected (a `CharRef::Special` contributes its canonical entity), and a bibliography anchor reached through a synthesized run (an attribute expansion, or a filtered block's joined seed) *is* recognized.

## Tests

- A differential corpus pinning both spellings, the label character classes and the non-recognized leading-digit label, a `[[[…]]]` that is not at the entry's start, the non-escape of a leading backslash, labels carrying an auto-link / a `link:` macro / an escaped special, and constructs after the anchor.
- Structural tests for the node and the flow nodes that follow it.
- Registration parity against an independent golden parser (id, reference text, and `RefType` alike), plus the cross-family warning-order test.
- Fixtures added to the whole-pipeline combined-constructs corpus and to the structural recorder cross-check — where the two constructions reach the same anchor-then-label shape from opposite directions, the recorder recovering it from the rendered output.
- A whole-document test driving the real parse path end to end, folding a real bibliography list's trees to their own rendered strings.

As with every prep piece before it, **nothing further is wired in**: `rendered_html()` remains the string pipeline's own string.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5046 passed), and `cargo +nightly doc --no-deps --document-private-items` are all clean. Coverage of the new code was reviewed with `cargo-llvm-cov`: the only uncovered line in the new pass is the defensive `None` arm on the id slice, unreachable given the id's own character class and kept for symmetry with `build_anchor_node`'s existing gate (whose equivalent line is likewise uncovered today).

The design doc gains its "*Step 6 prep landed as (…)*" narrative paragraph and checklist entry, matching every prior increment on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7G9jsALitsRmjNFeQCw2q)_