### PR TITLE
feat: Recognize a cross-reference shorthand's empty reference text in the single-pass inline builder (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2345,6 +2345,66 @@ Each phase is a reviewable unit with a clear exit gate.
   whole-pipeline combined-constructs corpus; and a whole-document test drives the real parse path
   end to end. As with every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (`<<id,>>`'s present-but-empty reference text, the sixth of that map's
+  divergences – and its fourth real blocker):* the builder now recognizes the one cross-reference
+  form it still deferred, closing out the `Ref{Xref}` family. A shorthand's reference text is made
+  *present* by its **comma**, not by what follows it: `InlineXrefReplacer`'s own
+  `inner.split_once(',')` records `<<id,>>` (and `<<id,   >>`) as `Some("")`, which renders an
+  empty `<a href="#id"></a>`, where a comma-less `<<id>>` records `None` and falls back to the
+  target's own reference text (or a bracketed `[id]` when it resolves to none). Like `hardbreaks`,
+  the unescaped-specials classification, and the `attribute-missing` drop modes before it, this is
+  a **blocker** rather than an unclaimed form: a golden test already exercises it
+  (`xref_should_use_title_of_target_as_link_text_when_explicit_link_text_is_empty` in
+  `tests/asciidoctor_rb/links_test.rs`, design §5.3's oracle), so an authoritative fold over a tree
+  that left the shorthand literal would silently regress it.
+
+  What had blocked it was the *representation*, not the recognition, and closing it needed no new
+  node field. The step-3b note reads "an empty child vector cannot distinguish a present-but-empty
+  text from no text provided" – true, but the distinction was never the *vector's* to carry:
+  [`build_xref_shorthand_node`](../../parser/src/content/inline_builder/macros/xref.rs) now builds
+  exactly one [`Text`](../../parser/src/inlines/inline_node.rs) child whenever the shorthand carries
+  a comma, empty value and all (a zero-length `'src` borrow where the trim left it, so even the
+  degenerate case keeps an honest span), and
+  [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) keys `XrefRenderParams::provided_text`
+  on the **presence of a child** rather than on the bytes the children fold to. Every text the
+  builder recognizes is baked into exactly one child, so the two cases cannot collide – the
+  `xref:` macro form's own empty text (`xref:id[]`, and an attribute list whose positional value is
+  absent or empty) records `None` in the string replacer too, and correspondingly builds no child.
+  With this the shorthand builder is **total**: what a cross-reference defers is now decided
+  entirely by the verbatim gate that precedes both builders, so the family's own
+  `Option`-returning "this increment defers" machinery is removed rather than left as an
+  unreachable branch.
+
+  That representation has one invariant to keep, and it is the one thing outside the family this
+  step touched: an empty `Text` node must survive the steps that walk one. Both splitters in
+  [`special_chars`](../../parser/src/content/inline_builder/special_chars.rs) deliberately never
+  emit an empty run (there is nothing in one to escape), so splitting an empty node *deletes* it –
+  which is exactly what happened to a shorthand recognized under an effective order that omits
+  `specialcharacters` and therefore ends in
+  [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs) (a
+  `subs=macros` block whose source spells the delimiters out as `&lt;&lt;install,&gt;&gt;`, which
+  the string pipeline matches as written). [`split_text`](../../parser/src/content/inline_builder/special_chars.rs)
+  now keeps an empty value as the node it already is. The one place an empty `Text` is *not*
+  wanted is the tree's root seed for empty content, where it would be a leaf carrying nothing for
+  every consumer to skip; [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) now
+  declines to seed one at all, which also makes the empty-content tree the same (`[]`) under every
+  group rather than only under those that ran a splitting step.
+
+  A differential corpus extends the existing xref fixtures with both spellings of the empty text
+  (bare and whitespace-only) and one over a *derived* destination – `render_xref`'s
+  `(None, Some(derived))` branch, which unlike the resolved branch renders `Some("")` as an empty
+  body rather than falling back – alongside structural tests pinning the empty child's own
+  zero-length span, its absence for a comma-less shorthand, and the classification fixture above;
+  fixtures are added to the whole-pipeline combined-constructs corpus, the broad general-purpose
+  sweep, and the structural recorder cross-check. A whole-document test drives the real parse path
+  end to end on the golden test's own shape, where the reference **resolves**: reaching resolution
+  is itself part of the fix, since the positional mirror
+  ([`mirror_tree_xref_resolution`](../../parser/src/content/content.rs)) skips a list whose node
+  count diverges from the string pipeline's deferred segments, so an unrecognized shorthand used to
+  cost its whole content the resolved destinations. The [`Ref::children`](../../parser/src/inlines/ref_node.rs)
+  field docs record the distinction for a tree consumer. As with every prep piece before it,
+  nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2542,6 +2602,19 @@ Each phase is a reviewable unit with a clear exit gate.
        straddling a line break disables the drop for the whole content (its interior newlines are
        hidden behind one placeholder), with its own divergence test; the `drop-line` diagnostic is
        deferred to the cutover like every other family's warning.
+     - ✅ **prep (`<<id,>>`'s present-but-empty text).** The sixth of that audit's divergences is
+       closed – a **blocker** like the three before it, since a golden test exercises it – and with
+       it the `Ref{Xref}` family: a shorthand's comma is what makes its reference text *present*,
+       so [`build_xref_shorthand_node`](../../parser/src/content/inline_builder/macros/xref.rs)
+       always builds one [`Text`](../../parser/src/inlines/inline_node.rs) child for a
+       comma-carrying shorthand (empty value and all) and
+       [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) keys `provided_text` on that
+       child's *presence* rather than on what it folds to – no new node field, and the family's
+       "this increment defers" machinery removed, its verbatim gate now the only deferral. Keeping
+       the marker alive made [`split_text`](../../parser/src/content/inline_builder/special_chars.rs)
+       preserve an empty `Text` node instead of splitting it away to nothing, and
+       [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) stop seeding one for
+       empty content. See the step's own "landed as" note above.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -387,7 +387,14 @@ fn fold_xref(
     let mut provided = String::new();
     fold_into_html(&reference.children, renderer, parser, &mut provided);
 
-    let provided_text = if provided.is_empty() {
+    // Whether a display text was *provided* is the presence of a child, not
+    // what that child folds to: the `<<id,>>` shorthand records a
+    // present-but-empty text (one empty `Text` child) that the string replacer
+    // carries as `Some("")` – an empty `<a>…</a>` – which an absent text
+    // (`None`, the bracketed `[id]` / reference-text fallback) renders quite
+    // differently. Every text the builder recognizes is baked into exactly one
+    // child, so the two cases never collide.
+    let provided_text = if reference.children.is_empty() {
         None
     } else {
         Some(provided.as_str())

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -103,8 +103,8 @@ pub(super) fn xref_macros_level<'src>(
 
 /// Finds every recognized cross-reference at this level – the `xref:` macro
 /// form and the `<<id>>` shorthand – skipping any match that is not verbatim
-/// enough to slice from `'src` or that this increment defers (see
-/// [`build_xref_node`] and [`build_xref_shorthand_node`]).
+/// enough to slice from `'src`. That gate is now the family's *only* deferral:
+/// both builders claim every target and text shape a verbatim match can carry.
 fn find_xref_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -156,25 +156,21 @@ fn find_xref_matches<'src>(
             continue;
         }
 
+        // Both builders claim every shape they are handed, so a verbatim match
+        // always yields a node: what a cross-reference *defers* is decided by
+        // the verbatim gate above, not by the builders.
         let node = match &shorthand_inner {
             Some(inner) => build_xref_shorthand_node(inner.clone(), &full, pieces, root, parser),
             None => build_xref_node(&caps, &full, pieces, root, parser),
         };
 
-        match node {
-            Some(node) => matches.push(MacroMatch {
-                kind: MacroMatchKind::Node {
-                    consumed: full.clone(),
-                    node: Box::new(node),
-                },
-                full,
-            }),
-
-            // A form this increment defers (an attribute-list-in-text macro or
-            // a degenerate shorthand – see the two builders) is left as
-            // literal source for a later increment.
-            None => continue,
-        }
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
     }
 
     matches
@@ -182,8 +178,7 @@ fn find_xref_matches<'src>(
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a verbatim `xref:`
 /// macro match, computing the target and display text exactly as the string
-/// replacer does so the fold reproduces the same bytes. Returns `None` for a
-/// form this increment defers.
+/// replacer does so the fold reproduces the same bytes.
 ///
 /// The scope this builder claims is every macro-form target, including a text
 /// carrying an attribute list; the `<<id>>` shorthand is built by
@@ -213,10 +208,13 @@ fn build_xref_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
-) -> Option<InlineNode<'src>> {
-    // Group 3 is the `xref:` macro target; when it is absent the match is the
-    // shorthand form, which this increment defers.
-    let raw_target = caps.get(3)?.as_str();
+) -> InlineNode<'src> {
+    // Group 3 is the `xref:` macro target. It always participates here: the
+    // pattern's two branches are mutually exclusive, and the caller routes a
+    // match whose group 2 (the shorthand's inner) participated to
+    // [`build_xref_shorthand_node`] instead.
+    #[allow(clippy::unwrap_used)]
+    let raw_target = caps.get(3).unwrap().as_str();
 
     let (target, derived) = xref_target_and_derived(raw_target, true, parser);
 
@@ -226,7 +224,7 @@ fn build_xref_node<'src>(
 
     let location = source_slice(pieces, full.clone(), root);
 
-    Some(InlineNode::Ref(Ref {
+    InlineNode::Ref(Ref {
         variant: RefVariant::Xref,
         target: CowStr::from(target),
         children,
@@ -237,7 +235,7 @@ fn build_xref_node<'src>(
         xrefstyle,
         attrs: None,
         location,
-    }))
+    })
 }
 
 /// Interprets the bracketed display text of an `xref:` macro, mirroring
@@ -368,32 +366,33 @@ fn plain_xref_text<'src>(
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a `<<id>>` shorthand
 /// cross-reference, computing the target and display text exactly as the string
 /// replacer's shorthand branch does so the fold reproduces the same bytes.
-/// Returns `None` for a form this increment defers.
 ///
 /// `inner` is the shorthand's inner text (`INLINE_XREF` group 2) in
 /// match-string coordinates; the caller guarantees it is verbatim, so its
 /// match-string bytes coincide with source. It is split on the first `,` into
 /// an id and an optional reference text, each trimmed – mirroring the string
 /// replacer's `inner.split_once(',')` with `id.trim()` / `text.trim()`. The
-/// reference text becomes the node's single [`Text`](InlineNode::Text) child
-/// (an empty text yields no children, which the fold reads as "no text
-/// provided" – the bracketed `[id]` fallback), and the whole `<<…>>` – its
-/// `CharRef` delimiters included – is the node's `location`.
+/// reference text becomes the node's single [`Text`](InlineNode::Text) child,
+/// and the whole `<<…>>` – its `CharRef` delimiters included – is the node's
+/// `location`.
 ///
-/// The scope this builder claims is every shorthand target *except* one whose
-/// reference text is present but empty. A same-document shorthand
-/// (`<<install>>`) resolves through the catalog later (`derived: None`); an
-/// inter-document shorthand (`<<other#frag>>`) and the document-as-a-whole
-/// shorthand (`<<>>`, an empty id) both carry a destination *derived* from the
-/// target itself, computed by [`xref_target_and_derived`] exactly as the macro
-/// form's – so this builder no longer defers any target shape. One form
-/// remains deferred, left as literal source for a later increment and pinned
-/// by a divergence test:
+/// **A comma is what makes a text *present*, not what it contains.** The
+/// string replacer's own split records `<<id,>>` (and `<<id,   >>`) as a
+/// *present-but-empty* text – `Some("")`, which renders an empty `<a>…</a>`
+/// rather than the bracketed `[id]` fallback `None` renders – so a shorthand
+/// carrying a comma always builds exactly one `Text` child, empty value and
+/// all (a zero-length `'src` borrow at the position the trim left). The fold
+/// keys "was a text provided?" on the *presence* of a child rather than on
+/// what it folds to, so the two cases stay distinct end to end; see
+/// [`fold_xref`](super::super::fold). A shorthand with no comma keeps an empty
+/// child vector, which the fold reads as "no text provided".
 ///
-/// - a **`<<id,>>` with an empty reference text**: the string replacer records
-///   this as a *present-but-empty* text (rendering an empty `<a>…</a>`), which
-///   an empty child vector cannot distinguish from "no text provided" – so the
-///   whole shorthand is deferred rather than rendered with the wrong fallback.
+/// The scope this builder claims is every shorthand target. A same-document
+/// shorthand (`<<install>>`) resolves through the catalog later (`derived:
+/// None`); an inter-document shorthand (`<<other#frag>>`) and the
+/// document-as-a-whole shorthand (`<<>>`, an empty id) both carry a
+/// destination *derived* from the target itself, computed by
+/// [`xref_target_and_derived`] exactly as the macro form's.
 ///
 /// A shorthand whose id already carries a rendered `<` (an earlier-substituted
 /// macro, e.g. `<<link:https://example.com[], Example>>`) – which the string
@@ -410,7 +409,7 @@ fn build_xref_shorthand_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
-) -> Option<InlineNode<'src>> {
+) -> InlineNode<'src> {
     // The inner is verbatim (the caller checked), so its source slice's bytes
     // coincide with the match string's – a byte offset within `inner_data` maps
     // to a match-string offset by adding `inner.start`.
@@ -436,15 +435,10 @@ fn build_xref_shorthand_node<'src>(
             let raw_text = &inner_data[index + 1..];
             let trimmed = raw_text.trim();
 
-            // A `<<id,>>` with an empty (or whitespace-only) reference text is a
-            // present-but-empty text the node cannot represent (see the doc
-            // comment); defer the whole shorthand.
-            if trimmed.is_empty() {
-                return None;
-            }
-
             // Locate the trimmed reference text at its source. It is verbatim, so
-            // the `Text` child borrows the very bytes its location covers.
+            // the `Text` child borrows the very bytes its location covers – a
+            // zero-length borrow when the text is empty (or whitespace-only),
+            // which is the present-but-empty text the doc comment describes.
             let lead = raw_text.len() - raw_text.trim_start().len();
 
             let text_start = inner.start + index + 1 + lead;
@@ -457,7 +451,7 @@ fn build_xref_shorthand_node<'src>(
         }
     };
 
-    Some(InlineNode::Ref(Ref {
+    InlineNode::Ref(Ref {
         variant: RefVariant::Xref,
         target: CowStr::from(target),
         children,
@@ -468,7 +462,7 @@ fn build_xref_shorthand_node<'src>(
         xrefstyle: None,
         attrs: None,
         location,
-    }))
+    })
 }
 
 #[cfg(test)]
@@ -586,6 +580,16 @@ mod tests {
             "<<a.b.c>>",
             // The id and reference text are each trimmed around the comma.
             "<< spaced , Trimmed Text >>",
+            // A *present-but-empty* reference text: the comma makes the text
+            // present, so this renders an empty `<a>…</a>` rather than the
+            // bracketed `[id]` fallback a comma-less shorthand renders. A
+            // whitespace-only text trims to the same thing.
+            "<<install,>>",
+            "<<install,   >>",
+            // The same, with a target carrying its own derived destination
+            // (the branch of `render_xref` an empty text reaches differently
+            // from the unresolved one).
+            "<<other#frag,>>",
             // An inter-document shorthand – with and without a fragment – and
             // the document-as-a-whole shorthand (an empty id).
             "<<other#frag,Elsewhere>>",
@@ -859,24 +863,104 @@ mod tests {
     }
 
     #[test]
-    fn an_xref_shorthand_with_empty_text_is_a_documented_divergence() {
+    fn an_xref_shorthand_with_an_empty_text_keeps_it_present() {
         // `<<id,>>` records a *present-but-empty* reference text: the string
-        // replacer renders an empty `<a href="#id"></a>`, whereas an empty child
-        // vector is indistinguishable from "no text provided" (the `[id]`
-        // fallback). The builder cannot represent the distinction, so it defers
-        // the whole shorthand (left literal).
+        // replacer renders an empty `<a href="#install"></a>`, not the
+        // bracketed `[install]` fallback a comma-less shorthand renders. The
+        // node keeps the distinction structurally – the text is present as one
+        // empty `Text` child – so the fold reproduces the same bytes.
         let source = "<<install,>>";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a shorthand with an empty text must be left unrecognized: {nodes:?}"
-        );
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert_eq!(reference.children.len(), 1);
+        assert_text(&reference.children[0], "", 1, 11);
 
-        // The string pipeline builds an anchor with an empty body, which the
-        // bracketed fallback the builder would produce does not match.
-        assert!(golden_xref(source).contains(r##"href="#install">"##));
-        assert!(!golden_xref(source).contains("[install]"));
+        let golden = golden_xref(source);
+        assert!(golden.contains(r##"href="#install">"##), "{golden}");
+        assert!(!golden.contains("[install]"), "{golden}");
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), golden);
+    }
+
+    #[test]
+    fn an_xref_shorthand_without_a_comma_provides_no_text() {
+        // The complement of the test above, and what makes the empty `Text`
+        // child load-bearing rather than noise: with no comma there is no text
+        // to provide, so the node carries *no* child and the fold renders the
+        // bracketed fallback. Both shorthands fold to an `<a>` element; only
+        // the presence of a child tells the two bodies apart.
+        let source = "<<install>>";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert!(reference.children.is_empty());
+
+        assert!(golden_xref(source).contains("[install]"));
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn a_real_documents_empty_shorthand_text_reaches_its_tree() {
+        // End-to-end, through the real parse path, and with the reference
+        // *resolved*: this is the shape that makes the form a blocker for the
+        // authoritative fold rather than an unclaimed one – a golden test
+        // already exercises it (`xref_should_use_title_of_target_as_link_text_
+        // when_explicit_link_text_is_empty` in `tests/asciidoctor_rb/
+        // links_test.rs`, design §5.3's oracle). Resolution reaches the node
+        // too: the positional mirror skips a list whose node count diverges
+        // from the string pipeline's deferred segments, so leaving the
+        // shorthand unrecognized used to cost the whole content its resolved
+        // destinations.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default()
+            .with_inline_tree(true)
+            .parse("<<tigers,>>\n\n[#tigers]\n== Tigers");
+
+        let blocks: Vec<_> = doc.descendant_blocks().collect();
+        let rendered = blocks[0].rendered_html_content().unwrap();
+        let inlines = blocks[0].inlines().unwrap();
+
+        // The empty explicit text falls back to the target's own reference
+        // text, exactly as Asciidoctor's resolved branch does.
+        assert_eq!(rendered, r##"<a href="#tigers">Tigers</a>"##);
+
+        let reference = assert_xref(&inlines[0]);
+        assert_eq!(reference.children.len(), 1);
+        assert!(reference.resolved.is_some(), "{reference:?}");
+
+        assert_eq!(
+            super::super::super::fold_html(
+                inlines,
+                &HtmlSubstitutionRenderer {},
+                &Parser::default()
+            ),
+            rendered,
+            "fold diverged from the rendered string for {inlines:?}"
+        );
+    }
+
+    #[test]
+    fn a_whitespace_only_xref_shorthand_text_trims_to_an_empty_present_text() {
+        // The reference text is trimmed exactly as the string replacer trims
+        // it, so a whitespace-only text is the same present-but-empty text –
+        // its zero-length span sitting where the trim left it, after the
+        // leading whitespace.
+        let source = "<<install,   >>";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.children.len(), 1);
+        assert_text(&reference.children[0], "", 1, 14);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -405,7 +405,13 @@ pub(crate) fn build_from_value<'src>(
 /// A group whose steps are empty ([`Pass`](SubstitutionGroup::Pass) /
 /// [`None`](SubstitutionGroup::None), or an empty custom list) yields the
 /// untouched seed: a single [`Text`](InlineNode::Text) node holding `value`,
-/// exactly as the string pipeline leaves such content's text unchanged.
+/// exactly as the string pipeline leaves such content's text unchanged. Empty
+/// content is seeded with **no** node at all rather than an empty one: a leaf
+/// carrying nothing is not something a consumer should have to skip, and the
+/// steps would have nothing to do with it anyway. (The distinction matters
+/// because an empty `Text` node *elsewhere* in the tree is meaningful – a
+/// `<<id,>>` cross-reference's present-but-empty reference text is exactly one
+/// – so the steps themselves preserve one where they find it.)
 pub(crate) fn build_for_group<'src>(
     group: &SubstitutionGroup,
     value: CowStr<'src>,
@@ -414,6 +420,10 @@ pub(crate) fn build_for_group<'src>(
     attrlist: Option<&Attrlist<'src>>,
 ) -> Vec<InlineNode<'src>> {
     let steps = group.steps();
+
+    if value.is_empty() {
+        return vec![];
+    }
 
     let mut nodes = vec![InlineNode::Text { value, location }];
 
@@ -656,7 +666,7 @@ mod tests {
             "visit https://example.org/path?q=1 now",
             "image:a.png[An image with spaces,role=thumb]",
             "before image:b.svg[Vector] after",
-            "<<a>> and <<b>> and <<c,C text>>",
+            "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
             "a ((flow term)) and (((c1, c2, c3))) end",
             "indexterm:[primary, secondary]",
             "indexterm2:[shown]",
@@ -735,6 +745,15 @@ mod tests {
         assert_parity(
             "Visit https://example.org[the site] or mailto:a@example.org[email us], \
              then see <<conclusion,the conclusion>>.",
+        );
+
+        // Both shorthand cross-reference bodies in one sentence – a
+        // present-but-empty reference text (`<<id,>>`, an empty `<a>…</a>`)
+        // beside one with no text at all (`<<id>>`, the bracketed fallback) –
+        // with the other families live around them.
+        assert_parity_with(
+            "See <<intro,>> and <<intro>> about *{product}*, or <<intro,the intro>>.",
+            with_product,
         );
 
         // All three link-recognizing passes in one sentence, the bare address
@@ -1237,6 +1256,15 @@ mod tests {
                 // so these pin that the classification does not perturb (or
                 // depend on) recognition.
                 "<<tigers>> stays literal",
+                // The converse: a source-written `&lt;&lt;…&gt;&gt;` *is* the
+                // shorthand's escaped spelling, so the group that runs
+                // `macros` recognizes it (the string pipeline matches the very
+                // bytes the author wrote). Its present-but-empty reference
+                // text is one empty `Text` child, which the classification
+                // must carry through rather than split away – splitting emits
+                // no empty run, and the fold reads an absent child as "no text
+                // provided" (a different rendering entirely).
+                "&lt;&lt;install,&gt;&gt;",
                 "&#169; stays literal",
                 "-> and <- stay literal",
                 // Specials beside each construct these orders *can*

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -140,13 +140,23 @@ pub(super) fn classify_unescaped_specials<'src>(
 /// `'src`. When `value` is *synthesized* – it has no source of its own – the
 /// runs are owned slices of the value and every sub-node falls back to the
 /// whole `location` span, the documented coarse fallback (design §4.4).
+///
+/// An **empty** value is kept as the node it already is rather than split.
+/// Neither splitter ever emits an empty run (there is nothing in one to
+/// escape), so splitting an empty node would silently delete it – and an empty
+/// `Text` can be load-bearing: a `<<id,>>` cross-reference's present-but-empty
+/// reference text is exactly one, and the fold tells it from an absent text by
+/// the child's *presence* (see `build_xref_shorthand_node` in
+/// [`macros`](super::macros)).
 fn split_text<'src>(
     value: CowStr<'src>,
     location: Span<'src>,
     leaf: SpecialLeaf,
     out: &mut Vec<InlineNode<'src>>,
 ) {
-    if value.as_ref() == location.data() {
+    if value.is_empty() {
+        out.push(InlineNode::Text { value, location });
+    } else if value.as_ref() == location.data() {
         split_verbatim(location, leaf, out);
     } else {
         split_synthesized(value.as_ref(), location, leaf, out);

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -36,6 +36,14 @@ pub struct Ref<'src> {
     pub target: CowStr<'src>,
 
     /// The display text, as child inline nodes. Empty when none was supplied.
+    ///
+    /// "None was supplied" is a distinct state from "an empty one was": a
+    /// `<<id,>>` cross-reference supplies a *present-but-empty* reference text
+    /// – one [`Text`](InlineNode::Text) child whose value is empty – and
+    /// renders an empty `<a>…</a>`, where a `<<id>>` with no text at all falls
+    /// back to the target's own reference text (or a bracketed `[id]` when it
+    /// resolves to none). A consumer that needs the distinction should test
+    /// whether a child is *present*, not whether the text it carries is empty.
     pub children: Vec<InlineNode<'src>>,
 
     /// The roles (CSS classes) assigned to the reference.

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -778,7 +778,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "visit https://example.org/path?q=1 now",
         "image:a.png[An image with spaces,role=thumb]",
         "before image:b.svg[Vector] after",
-        "<<a>> and <<b>> and <<c,C text>>",
+        "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
         "a ((flow term)) and (((c1, c2, c3))) end",
         "indexterm:[primary, secondary]",
         "indexterm2:[shown]",


### PR DESCRIPTION
Closes the sixth of the corpus-wide audit's itemized divergences (design §5.2, Phase 4 step 6's own map), and with it the `Ref{Xref}` family: `<<id,>>`'s **present-but-empty reference text**.

## The divergence

A shorthand's reference text is made *present* by its **comma**, not by what follows it. `InlineXrefReplacer`'s own `inner.split_once(',')` records `<<id,>>` (and `<<id,   >>`) as `Some("")`, which renders an empty `<a href="#id"></a>`; a comma-less `<<id>>` records `None` and falls back to the target's own reference text (or a bracketed `[id]` when it resolves to none).

Like `hardbreaks`, the unescaped-specials classification, and the `attribute-missing` drop modes before it, this is a **blocker** for the authoritative fold rather than an unclaimed form — a golden test already exercises it (`xref_should_use_title_of_target_as_link_text_when_explicit_link_text_is_empty`, `tests/asciidoctor_rb/links_test.rs`), so folding a tree that left the shorthand literal would silently regress it.

## The fix

What had blocked it was the *representation*, not the recognition, and closing it needed no new node field. Step 3b's note reads "an empty child vector cannot distinguish a present-but-empty text from no text provided" — true, but the distinction was never the vector's to carry:

- `build_xref_shorthand_node` now builds exactly one `Text` child whenever the shorthand carries a comma, empty value and all (a zero-length `'src` borrow where the trim left it, so even the degenerate case keeps an honest span).
- `fold_xref` keys `XrefRenderParams::provided_text` on the **presence of a child** rather than on the bytes the children fold to. Every text the builder recognizes is baked into exactly one child, so the two cases cannot collide — the `xref:` macro form's own empty text (`xref:id[]`, and an attribute list whose positional value is absent or empty) records `None` in the string replacer too, and correspondingly builds no child.

With this the shorthand builder is **total**, so what a cross-reference defers is decided entirely by the verbatim gate preceding both builders; the family's `Option`-returning "this increment defers" machinery is removed rather than left as an unreachable branch.

## The one invariant outside the family

An empty `Text` node must survive the steps that walk one. Both splitters in `special_chars` deliberately never emit an empty run (there is nothing in one to escape), so splitting an empty node *deletes* it — which is what happened to a shorthand recognized under an effective order that omits `specialcharacters` and therefore ends in `classify_unescaped_specials` (a `subs=macros` block whose source spells the delimiters out as `&lt;&lt;install,&gt;&gt;`, which the string pipeline matches as written). `split_text` now keeps an empty value as the node it already is.

The one place an empty `Text` is *not* wanted is the tree's root seed for empty content, where it would be a leaf carrying nothing for every consumer to skip; `build_for_group` now declines to seed one, which also makes the empty-content tree the same (`[]`) under every group rather than only under those that ran a splitting step.

## Tests

- The xref differential corpus gains both spellings of the empty text (bare and whitespace-only) and one over a *derived* destination — `render_xref`'s `(None, Some(derived))` branch, which unlike the resolved branch renders `Some("")` as an empty body rather than falling back.
- Structural tests pin the empty child's own zero-length span, its absence for a comma-less shorthand, and the `subs=`-order classification fixture (verified load-bearing: reverting the `split_text` guard fails it).
- Fixtures added to the whole-pipeline combined-constructs corpus, the broad general-purpose sweep, and the structural recorder cross-check.
- A whole-document test drives the real parse path end to end on the golden test's own shape, where the reference **resolves** — reaching resolution is part of the fix, since the positional mirror (`mirror_tree_xref_resolution`) skips a list whose node count diverges from the string pipeline's deferred segments, so an unrecognized shorthand used to cost its whole content the resolved destinations.
- `Ref::children`'s field docs record the distinction for a tree consumer.

The former `an_xref_shorthand_with_empty_text_is_a_documented_divergence` test is now a parity test, per its own note.

As with every prep piece before it, **nothing further is wired into the parse path**.

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅ (clean)
- `cargo test --workspace` ✅ (5055 passed, 0 failed)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- `cargo llvm-cov -p asciidoc-parser --lib` ✅ — every touched file's new lines/regions covered; the only remaining misses in the touched files are pre-existing test `panic!` arms and `fold_html`'s defensive `debug_assert!` fallback. The one line this change *would* have left dead (`find_xref_matches`' deferral arm) is deleted rather than left untested.

Design doc updated with the step's own "landed as" narrative and its checklist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juw9CkR3idxfr9Zsc9iNLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Juw9CkR3idxfr9Zsc9iNLd)_