### PR TITLE
feat: Recognize UI macros and index terms inside an expanded attribute value (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2405,6 +2405,54 @@ Each phase is a reviewable unit with a clear exit gate.
   field docs record the distinction for a tree consumer. As with every prep piece before it,
   nothing further is wired in.
 
+  *Step 6 prep landed as (the UI and index-term families inside an expanded attribute value, the
+  seventh of that map's divergences):* the audit's map names "a macro inside an expanded attribute
+  value" as one of its remaining items, and the two macro families whose nodes carry **no
+  `Span`-typed field at all** – [`Ui`](../../parser/src/inlines/ui.rs) (`kbd:`/`btn:`/`menu:`) and
+  [`IndexTerm`](../../parser/src/inlines/index_term.rs) – now close their half of it. This is the
+  *same* lift the anchor family made for its id (the "prep (anchor synthesized boundary lifted)"
+  note above) and the bare-e-mail family made for its address, applied to the two families that
+  were left: a family that never needs a real `'src` slice has no reason to defer inside a
+  [`synthesized`](../../parser/src/content/inline_builder/quotes.rs) run, and each of these
+  computes every value it holds either straight out of the level's **match string** – which carries
+  a synthesized run's bytes exactly – or, for the one exception, through
+  [`text_slice`](../../parser/src/content/inline_builder/quotes.rs).
+
+  The change is correspondingly small, which is the point: the boundary was drawn by *one gate per
+  family*, not by anything structural. `kbd:`/`btn:` swaps
+  [`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs) for
+  [`range_is_verbatim_or_synthesized`](../../parser/src/content/inline_builder/macros/image.rs)
+  (its keys and label already came from the match string via `split_kbd_keys` /
+  `normalize_index_text`); `menu:` drops the `piece.synthesized` rejection from
+  [`menu_match_is_sliceable`](../../parser/src/content/inline_builder/macros/ui.rs) and reads its
+  one `'src`-sliced value – the menu *name* – through `text_slice` instead of
+  [`source_slice`](../../parser/src/content/inline_builder/quotes.rs), which would have offered
+  only that run's coarse span (§4.4) rather than the name's exact bytes; and both index-term
+  spellings drop their `range_overlaps_synthesized` check, keeping only the
+  `SPAN_PLACEHOLDER` one, since a term's shown text is reconstructed from the match string and
+  nowhere else. Every other boundary each family draws is untouched: an escaped special or a
+  rendered span in a `kbd:`/`btn:` bracket, in a menu *name* or item text (the admitted `&gt;`
+  submenu caret aside), or in a visible term still defers, as does an `indexterm2:` term carrying
+  an attribute list. As throughout, only the node's **`location`** takes the coarse enclosing-span
+  fallback (§4.4); the values themselves are exact.
+
+  Differential corpora drive each family's expanded-value forms – an expanded menu name, item
+  list, and submenu path; expanded keyboard keys and button labels; a whole macro arriving from an
+  expanded value; both index-term spellings, visible and concealed, whole and partial, and a kept
+  literal parenthesis beside an expanded term – through the real, public
+  `SubstitutionGroup::Normal::apply` as the golden, since these need the `AttributeReferences`
+  step the family-scoped `golden_macros` helper deliberately omits. Structural tests pin the
+  exact-value/coarse-location split; the wholly-synthesized **seed** path
+  ([`build_from_value`](../../parser/src/content/inline_builder/mod.rs), a filtered multi-line
+  block) is covered for both families; a whole-document test drives the real parse path end to end;
+  and fixtures are added to the whole-pipeline combined-constructs corpus and to the structural
+  recorder cross-check – where the recorder side, which has always recovered these from the string
+  pipeline's own render params, can now be compared *structurally* against a builder that
+  recognizes them too. Re-running the corpus-wide fold-parity audit (tree building forced on for
+  every parse in the suite) confirms the divergence set strictly **shrank**: the three sources the
+  divergence tests pinned are gone and no new one appeared. As with every prep piece before it,
+  nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2615,6 +2663,21 @@ Each phase is a reviewable unit with a clear exit gate.
        preserve an empty `Text` node instead of splitting it away to nothing, and
        [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) stop seeding one for
        empty content. See the step's own "landed as" note above.
+     - ✅ **prep (UI + index terms inside an expanded value).** The seventh of that audit's
+       divergences – "a macro inside an expanded attribute value" – is closed for the two macro
+       families whose nodes carry no `Span`-typed field, which is the same reason the anchor and
+       bare-e-mail families already lifted it: `kbd:`/`btn:`/`menu:`
+       ([`ui`](../../parser/src/content/inline_builder/macros/ui.rs)) and index terms
+       ([`indexterm`](../../parser/src/content/inline_builder/macros/indexterm.rs)) now recognize a
+       macro sitting inside a [`synthesized`](../../parser/src/content/inline_builder/quotes.rs)
+       run, computing every value from the level's match string (or, for the menu *name*, through
+       [`text_slice`](../../parser/src/content/inline_builder/quotes.rs)) with only the node's
+       `location` taking §4.4's coarse fallback; see the step's own "landed as" note above. Every
+       other boundary the two families draw – an escaped special or a rendered span in a bracket,
+       a menu name, or a visible term, and an `indexterm2:` attribute-list term – is unchanged.
+       The families that carry an [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` or
+       another `Span`-typed field (image, link, cross-reference) still defer here, so that half of
+       the map item remains open.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -6,9 +6,7 @@ use crate::{
     Span,
     content::{
         INLINE_INDEXTERM,
-        inline_builder::quotes::{
-            Piece, SPAN_PLACEHOLDER, build_match_string, range_overlaps_synthesized, source_slice,
-        },
+        inline_builder::quotes::{Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
         normalize_index_text, strip_see_and_seealso,
     },
     inlines::{IndexTerm, InlineNode},
@@ -144,6 +142,15 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// term), is **deferred** – the match is left as literal source for a later
 /// increment, each pinned by a divergence test.
 ///
+/// A term crossing a [`synthesized`](Piece::synthesized) run (an attribute
+/// expansion, or – reached at a tree's root – a filtered multi-line block's
+/// own joined seed) is **not** deferred. The match string carries such a run's
+/// bytes exactly, and this family reads its term from nowhere else – it never
+/// slices `'src`, and an [`IndexTerm`] node carries no `Span`-typed field – so
+/// the shown text is recovered precisely; only the node's `location` takes
+/// design §4.4's coarse fallback. This is the same lift the anchor and
+/// bare-e-mail families already made, for the same reason.
+///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect; the string replacer records nothing in a catalog either (the HTML
 /// backend generates no index), so there is none to skip here.
@@ -242,10 +249,11 @@ fn build_indexterm_macro_match<'src>(
     let (node, rendered_nonempty) = if is_visible {
         // A visible flow term crossing an opaque span cannot be reconstructed
         // from this level's escaped string (a span is a placeholder here, not
-        // its markup), so it is deferred; one crossing a synthesized run (an
-        // attribute expansion) is deferred too – design §3.4.1 leaves a macro
-        // *inside* such a run for a later increment.
-        if arg.contains(SPAN_PLACEHOLDER) || range_overlaps_synthesized(pieces, &full) {
+        // its markup), so it is deferred. A term crossing a
+        // [`synthesized`](Piece::synthesized) run is *not*: the match string
+        // carries such a run's bytes exactly, which is the only thing this
+        // family ever reads a term from (see [`find_indexterm_matches`]).
+        if arg.contains(SPAN_PLACEHOLDER) {
             return None;
         }
 
@@ -375,10 +383,10 @@ fn build_indexterm_shorthand_match<'src>(
 
     let (node, rendered_nonempty) = if visible {
         // A visible term crossing an opaque span cannot be reconstructed from
-        // the escaped string; defer it (see [`find_indexterm_matches`]), and
-        // likewise for one crossing a synthesized run (see the macro form's
-        // own check above).
-        if term_src.contains(SPAN_PLACEHOLDER) || range_overlaps_synthesized(pieces, &full) {
+        // the escaped string; defer it (see [`find_indexterm_matches`]). One
+        // crossing a synthesized run is recognized, exactly as in the macro
+        // form's own check above.
+        if term_src.contains(SPAN_PLACEHOLDER) {
             return None;
         }
 
@@ -750,21 +758,68 @@ mod tests {
     }
 
     #[test]
-    fn a_visible_term_inside_an_expanded_value_is_a_documented_divergence() {
-        // A visible term whose shown text crosses a *synthesized* run (an
-        // attribute expansion) cannot be reconstructed from this level's
-        // escaped match string any more honestly than one crossing a rendered
-        // span can – its bytes have no source counterpart of their own – so
-        // `range_overlaps_synthesized` defers it too, the same boundary every
-        // other macro family draws around a synthesized run (see
-        // `attribute_refs::apply_attribute_references`'s own doc comment).
-        // Unlike a *character replacement* inside such a run – recognized as
-        // of this increment, since its leaf needs no `'src` slice of its own –
-        // an index term's macro-family recognition is still deferred.
+    fn fold_matches_the_string_pipeline_for_index_terms_inside_expanded_values() {
+        // A term whose shown text crosses a *synthesized* run (an attribute
+        // expansion) is now recognized: this family reads a term from the
+        // match string alone – which carries such a run's bytes exactly – and
+        // an [`IndexTerm`] node carries no `Span`-typed field, so nothing on
+        // it needs an `'src` slice. The same lift the anchor and bare-e-mail
+        // families already made; it closes the two divergences
+        // `a_visible_term_inside_an_expanded_value_is_a_documented_divergence`
+        // and its `indexterm2:` twin used to pin.
         use crate::{
             Parser,
             content::{Content, SubstitutionGroup, inline_builder::build},
             parser::{HtmlSubstitutionRenderer, ModificationContext},
+        };
+
+        let parser = Parser::default()
+            .with_intrinsic_attribute("term", "coffee", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("second", "brewing", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("shorthand", "((tea))", ModificationContext::Anywhere);
+
+        let fixtures = [
+            // The visible shorthand and macro spellings, whole and partial.
+            "x (({term})) y",
+            "x ((hot {term})) y",
+            "x indexterm2:[{term}] y",
+            "x indexterm2:[hot {term}] y",
+            // The concealed spellings (always recognized, but now over an
+            // expanded value too).
+            "x ((({term}, {second}))) y",
+            "x indexterm:[{term}, {second}] y",
+            // The whole construct arriving from an expanded value.
+            "x {shorthand} y",
+            // A kept literal parenthesis beside an expanded term.
+            "x (((({term}))) y",
+        ];
+
+        for source in fixtures {
+            let nodes = build(Span::new(source), &parser, None);
+
+            let mut golden = Content::from(Span::new(source));
+            SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &parser
+                ),
+                golden.rendered_str(),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_term_inside_an_expanded_value_keeps_a_coarse_location() {
+        // The shown term is exact – and necessarily owned, since an expanded
+        // value's bytes have no `'src` counterpart – while the node's
+        // `location` falls back to the whole match's source span (design
+        // §4.4), exactly as an anchor's does.
+        use crate::{
+            Parser, content::inline_builder::build, parser::ModificationContext, strings::CowStr,
         };
 
         let parser = Parser::default().with_intrinsic_attribute(
@@ -776,68 +831,22 @@ mod tests {
         let source = "x (({term})) y";
         let nodes = build(Span::new(source), &parser, None);
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
-            "a term crossing a synthesized run must be left unrecognized: {nodes:?}"
-        );
+        let term = nodes
+            .iter()
+            .find_map(|n| match n {
+                InlineNode::IndexTerm(term) => Some(term),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected an IndexTerm node: {nodes:?}"));
 
-        // The string pipeline, by contrast, recognizes it (the attribute
-        // expands before the index-term shorthand is matched), showing the
-        // term text in place of the whole shorthand.
-        let mut golden = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+        assert!(term.visible);
+        assert_eq!(term.terms.len(), 1);
+        assert_eq!(term.terms[0].as_ref(), "coffee");
+        assert!(matches!(term.terms[0], CowStr::Boxed(_)), "{term:?}");
 
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        assert_eq!(folded, "x ((coffee)) y", "builder output for {source:?}");
-        assert_eq!(
-            golden.rendered_str(),
-            "x coffee y",
-            "golden output for {source:?}"
-        );
-        assert_ne!(folded, golden.rendered_str());
-    }
-
-    #[test]
-    fn a_visible_macro_term_inside_an_expanded_value_is_a_documented_divergence() {
-        // The same boundary as
-        // `a_visible_term_inside_an_expanded_value_is_a_documented_divergence`,
-        // for the `indexterm2:[…]` *macro* spelling – its own, separate
-        // `range_overlaps_synthesized` call site in
-        // `build_indexterm_macro_match`.
-        use crate::{
-            Parser,
-            content::{Content, SubstitutionGroup, inline_builder::build},
-            parser::{HtmlSubstitutionRenderer, ModificationContext},
-        };
-
-        let parser = Parser::default().with_intrinsic_attribute(
-            "term",
-            "coffee",
-            ModificationContext::Anywhere,
-        );
-
-        let source = "x indexterm2:[{term}] y";
-        let nodes = build(Span::new(source), &parser, None);
-
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
-            "a macro term crossing a synthesized run must be left unrecognized: {nodes:?}"
-        );
-
-        let mut golden = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
-
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        assert_eq!(
-            folded, "x indexterm2:[coffee] y",
-            "builder output for {source:?}"
-        );
-        assert_eq!(
-            golden.rendered_str(),
-            "x coffee y",
-            "golden output for {source:?}"
-        );
-        assert_ne!(folded, golden.rendered_str());
+        assert_eq!(term.location.data(), "(({term}))");
+        assert_eq!(term.location.line(), 1);
+        assert_eq!(term.location.col(), 3);
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -1,11 +1,13 @@
 //! UI macro recognition (`kbd:[…]`, `btn:[…]`, `menu:…[…]`).
 
-use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
+use super::{
+    MacroMatch, MacroMatchKind, image::range_is_verbatim_or_synthesized, rebuild_macro_level,
+};
 use crate::{
     Span,
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
-        inline_builder::quotes::{Piece, build_match_string, source_slice},
+        inline_builder::quotes::{Piece, build_match_string, source_slice, text_slice},
         normalize_index_text, split_kbd_keys,
     },
     inlines::{InlineNode, Ui, UiKind},
@@ -46,8 +48,8 @@ pub(super) fn kbd_btn_macros_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
-/// Finds every keyboard/button macro at this level, skipping any whose match is
-/// not wholly verbatim source (see [`apply_macros`](super::apply_macros)).
+/// Finds every keyboard/button macro at this level, skipping any whose match
+/// crosses an atomic piece (see [`apply_macros`](super::apply_macros)).
 fn find_kbd_btn_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -62,10 +64,19 @@ fn find_kbd_btn_matches<'src>(
 
         let full = whole.start()..whole.end();
 
-        // Only a wholly-verbatim match maps its bracket content 1:1 onto source;
-        // a match crossing an escaped special or a rendered span is left for a
-        // later increment.
-        if !range_is_verbatim(pieces, &full) {
+        // A match crossing an escaped special or a rendered span is left for a
+        // later increment: its bracket content would have to carry that
+        // escaped/rendered text, which the node cannot hold.
+        //
+        // A [`synthesized`](Piece::synthesized) run (an attribute expansion,
+        // or – reached at a tree's root – a filtered multi-line block's own
+        // joined seed) *is* admitted: this family never slices `'src` for a
+        // value at all – its keys and label come straight from the match
+        // string, which carries a synthesized run's bytes exactly – so only
+        // the node's `location` takes design §4.4's coarse fallback. The same
+        // lift the anchor and bare-e-mail families already made, for the same
+        // reason (see [`build_kbd_btn_node`]).
+        if !range_is_verbatim_or_synthesized(pieces, &full) {
             continue;
         }
 
@@ -95,12 +106,18 @@ fn find_kbd_btn_matches<'src>(
     matches
 }
 
-/// Builds one [`Ui`](InlineNode::Ui) node from a verbatim keyboard/button
-/// match, splitting the keys / normalizing the label exactly as the string
-/// replacer does so the fold reproduces the same bytes. On a verbatim match the
-/// bracket content is source text, so this splits/normalizes precisely what the
-/// string step splits/normalizes from the (identical, un-escaped) rendered
-/// text.
+/// Builds one [`Ui`](InlineNode::Ui) node from a keyboard/button match,
+/// splitting the keys / normalizing the label exactly as the string replacer
+/// does so the fold reproduces the same bytes.
+///
+/// Every value it computes comes from the **match string**, never from an
+/// `'src` slice: on a verbatim match those bytes *are* the source text, and on
+/// a [`synthesized`](Piece::synthesized) one they are the expanded value the
+/// string pipeline itself matched over – which is precisely what lets this
+/// family recognize a macro inside an expanded attribute value where a family
+/// carrying an [`Attrlist`](crate::attributes::Attrlist)`<'src>` cannot. Only
+/// the node's `location` falls back to the enclosing run's coarse span
+/// (design §4.4) in the synthesized case.
 fn build_kbd_btn_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
@@ -142,7 +159,9 @@ fn build_kbd_btn_node<'src>(
 /// relaxed gate [`menu_match_is_sliceable`] applies (see its own doc comment).
 /// A name or item text crossing any *other* escaped special, or a rendered
 /// [`Styled`](crate::inlines::Styled) span, is still deferred – the verbatim
-/// boundary every macro family documents.
+/// boundary every macro family documents. A
+/// [`synthesized`](Piece::synthesized) run is **not** deferred: see
+/// [`menu_match_is_sliceable`].
 pub(super) fn menu_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -153,7 +172,7 @@ pub(super) fn menu_macros_level<'src>(
         return nodes;
     }
 
-    let matches = find_menu_matches(&s, &pieces, root);
+    let matches = find_menu_matches(&nodes, &s, &pieces, root);
 
     if matches.is_empty() {
         return nodes;
@@ -163,10 +182,15 @@ pub(super) fn menu_macros_level<'src>(
 }
 
 /// Finds every menu macro at this level, skipping any whose name or item text
-/// cannot be sliced from `'src` (see [`menu_match_is_sliceable`], which
+/// cannot be recovered (see [`menu_match_is_sliceable`], which
 /// [`build_menu_node`] applies once the match's own capture groups are
 /// resolved).
-fn find_menu_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<MacroMatch<'src>> {
+fn find_menu_matches<'src>(
+    nodes: &[InlineNode<'src>],
+    s: &str,
+    pieces: &[Piece],
+    root: Span<'src>,
+) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
     for caps in INLINE_MENU_MACRO.captures_iter(s) {
@@ -194,7 +218,7 @@ fn find_menu_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
             continue;
         }
 
-        let Some(node) = build_menu_node(&caps, &full, s, pieces, root) else {
+        let Some(node) = build_menu_node(&caps, &full, s, pieces, root, nodes) else {
             // A name or item text this increment cannot slice from `'src`:
             // left unrecognized, so the surrounding gap reproduces the source
             // unchanged (see [`menu_macros_level`]).
@@ -213,8 +237,9 @@ fn find_menu_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
     matches
 }
 
-/// Reports whether a menu match's own text maps back onto `'src`, the menu
-/// family's counterpart of [`range_is_verbatim`].
+/// Reports whether a menu match's own text can be recovered, the menu
+/// family's counterpart of
+/// [`range_is_verbatim_or_synthesized`].
 ///
 /// It differs from that check in exactly one admitted case: a
 /// [`SUBMENU_DELIMITER`] (`&gt;`) *inside the item list*. Every other macro
@@ -232,9 +257,16 @@ fn find_menu_matches<'src>(s: &str, pieces: &[Piece], root: Span<'src>) -> Vec<M
 /// Everything else is unchanged: an atomic piece that is *not* an item-list
 /// caret – another escaped special (`menu:File[A & B]`, and a `&`/`>` in the
 /// menu *name*, which the pattern admits) or a rendered
-/// [`Styled`](crate::inlines::Styled) span – still fails, as does a
-/// [`synthesized`](Piece::synthesized) run, whose bytes have no `'src` slice
-/// for the name to borrow.
+/// [`Styled`](crate::inlines::Styled) span – still fails.
+///
+/// A [`synthesized`](Piece::synthesized) run (an attribute expansion, or –
+/// reached at a tree's root – a filtered multi-line block's own joined seed)
+/// is admitted: the item list is split straight out of the match string, and
+/// the menu *name*, the one value that used to need an `'src` slice, is now
+/// recovered exactly by [`text_slice`] – the same lift the anchor family made
+/// for its id, and for the same reason (a [`Ui`] node carries no `Span`-typed
+/// field, so nothing on it needs real source bytes). Only the node's
+/// `location` keeps design §4.4's coarse fallback.
 fn menu_match_is_sliceable(
     s: &str,
     pieces: &[Piece],
@@ -248,10 +280,6 @@ fn menu_match_is_sliceable(
         // Skip pieces that do not overlap the match.
         if p_end <= full.start || p_start >= full.end {
             continue;
-        }
-
-        if piece.synthesized {
-            return false;
         }
 
         if !piece.atomic {
@@ -283,15 +311,17 @@ fn menu_match_is_sliceable(
 /// know which sub-range may carry a submenu caret. Returns `None` for a match
 /// it rejects, which the caller leaves unrecognized.
 ///
-/// The menu name borrows from `'src`; the submenu path and trailing item are
-/// split exactly as the string replacer splits them (owned, because a split
-/// part is trimmed).
+/// The menu name borrows from `'src` in the verbatim case (and is recovered as
+/// an owned value from a [`synthesized`](Piece::synthesized) run, via
+/// [`text_slice`]); the submenu path and trailing item are split exactly as the
+/// string replacer splits them (owned, because a split part is trimmed).
 fn build_menu_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
     s: &str,
     pieces: &[Piece],
     root: Span<'src>,
+    nodes: &[InlineNode<'src>],
 ) -> Option<InlineNode<'src>> {
     // Group 1 (the menu name) is mandatory in the pattern; group 2 (the items)
     // is optional. `unwrap` is safe: the pattern cannot match without group 1.
@@ -306,7 +336,10 @@ fn build_menu_node<'src>(
 
     let location = source_slice(pieces, full.clone(), root);
 
-    let menu = CowStr::from(source_slice(pieces, name.start()..name.end(), root).data());
+    // The gate above admits no atomic piece in the name, so `text_slice`
+    // always yields its exact text – borrowed from `'src` when the name is
+    // verbatim, owned when it comes from a synthesized run.
+    let menu = text_slice(nodes, pieces, name.start()..name.end())?;
 
     let (submenus, item) = split_menu_items(caps.get(2).map(|m| m.as_str()));
 
@@ -741,44 +774,186 @@ mod tests {
         assert!(golden_macros_with("kbd:[a<b]", &experimental_parser()).contains("<kbd>"));
     }
 
+    /// A parser with `experimental` plus the attributes the
+    /// expanded-value fixtures below reference.
+    fn expanding_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        experimental_parser()
+            .with_intrinsic_attribute("zoom", "Zoom", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("view", "View", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("key", "Ctrl+T", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("label", "Save", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("macro-src", "kbd:[Esc]", ModificationContext::Anywhere)
+    }
+
+    /// The real, public pipeline's output for `source` – the golden for the
+    /// expanded-value fixtures, which need the `AttributeReferences` step the
+    /// module's own [`golden_macros`] helper deliberately omits.
+    fn golden_normal(source: &str, parser: &Parser) -> String {
+        use crate::content::{Content, SubstitutionGroup};
+
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        content.rendered_str().to_string()
+    }
+
     #[test]
-    fn a_menu_inside_an_expanded_value_is_a_documented_divergence() {
-        // Admitting the submenu caret relaxes the gate for an *atomic* piece
-        // only. A menu whose item list crosses a *synthesized* run (an
-        // attribute expansion) is still deferred, exactly as
-        // `range_is_verbatim` defers one for every other macro family that
-        // slices its own text from `'src` – the menu name and item texts have
-        // no source counterpart there (see
-        // `attribute_refs::apply_attribute_references`'s own doc comment).
-        use crate::{
-            content::{Content, SubstitutionGroup},
-            parser::ModificationContext,
-        };
+    fn fold_matches_the_string_pipeline_for_ui_macros_inside_expanded_values() {
+        // A UI macro whose name, keys, label, or item list crosses a
+        // *synthesized* run (an attribute expansion) is now recognized: a
+        // [`Ui`] node carries no `Span`-typed field, so every value it holds
+        // comes straight from the match string – which carries a synthesized
+        // run's bytes exactly – or, for the menu name, from `text_slice`. This
+        // is the same lift the anchor family made for its id, and it closes
+        // the divergence `a_menu_inside_an_expanded_value_is_a_documented_
+        // divergence` used to pin.
+        let parser = expanding_parser();
 
-        let parser = experimental_parser().with_intrinsic_attribute(
-            "zoom",
-            "Zoom",
-            ModificationContext::Anywhere,
-        );
+        let fixtures = [
+            // The item list, the submenu path, and the menu name.
+            "menu:View[{zoom} > Reset]",
+            "menu:View[{zoom}, Reset]",
+            "menu:{view}[Zoom > Reset]",
+            "menu:{view}[{zoom} > Reset]",
+            "menu:{view}[]",
+            // Keyboard keys and a button label.
+            "kbd:[{key}]",
+            "kbd:[{key}+Shift]",
+            "btn:[{label}]",
+            "press kbd:[{key}] then btn:[{label}]",
+            // The whole macro arriving from an expanded value.
+            "{macro-src}",
+            "before {macro-src} after",
+        ];
 
-        let source = "menu:View[{zoom} > Reset]";
+        for source in fixtures {
+            let nodes = build(Span::new(source), &parser, None);
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &parser
+                ),
+                golden_normal(source, &parser),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_menu_inside_an_expanded_value_keeps_a_coarse_location() {
+        // The values are exact; only the node's `location` falls back to the
+        // enclosing synthesized run's coarse span (design §4.4), since an
+        // expanded value's bytes have no `'src` counterpart of their own. The
+        // menu name recovered from such a run is necessarily owned.
+        let parser = expanding_parser();
+
+        let source = "menu:{view}[{zoom} > Reset]";
         let nodes = build(Span::new(source), &parser, None);
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ui(_))),
-            "a menu crossing a synthesized run must be left unrecognized: {nodes:?}"
+        assert_eq!(nodes.len(), 1, "{nodes:?}");
+
+        let InlineNode::Ui(ui) = &nodes[0] else {
+            panic!("expected a Ui node, got {:?}", nodes[0]);
+        };
+
+        match &ui.kind {
+            UiKind::Menu {
+                menu,
+                submenus,
+                item,
+            } => {
+                assert_eq!(menu.as_ref(), "View");
+                assert!(matches!(menu, CowStr::Boxed(_)), "{menu:?}");
+                assert_eq!(submenus.len(), 1);
+                assert_eq!(submenus[0].as_ref(), "Zoom");
+                assert_eq!(item.as_deref(), Some("Reset"));
+            }
+
+            other => panic!("expected a menu, got {other:?}"),
+        }
+
+        // The whole match is the node's location; its `{view}`/`{zoom}` bytes
+        // are the source's, not the expanded value's.
+        assert_eq!(ui.location.data(), source);
+        assert_eq!(ui.location.line(), 1);
+        assert_eq!(ui.location.col(), 1);
+    }
+
+    #[test]
+    fn ui_macros_are_recognized_when_the_whole_seed_is_synthesized() {
+        // The same lift reached at the tree's *root* rather than a nested
+        // splice: `build_from_value`'s synthesized-seed path (the shape
+        // `Content::from_filtered_lines` produces for a genuinely multi-line,
+        // filtered block), mirroring the anchor family's own
+        // `an_anchor_is_recognized_when_the_whole_seed_is_synthesized`.
+        use crate::content::inline_builder::build_from_value;
+
+        let filtered = "press kbd:[Ctrl+T]\nor menu:View[Zoom > Reset]";
+        let source = "  press kbd:[Ctrl+T]\n  or menu:View[Zoom > Reset]";
+
+        let parser = experimental_parser();
+        let nodes = build_from_value(
+            CowStr::from(filtered.to_string()),
+            Span::new(source),
+            &parser,
+            None,
         );
 
-        // The string pipeline, by contrast, recognizes it (the attribute
-        // expands before the menu macro is matched) – the divergence this test
-        // documents.
-        let mut golden = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+        let ui_nodes = nodes
+            .iter()
+            .filter(|n| matches!(n, InlineNode::Ui(_)))
+            .count();
+
+        assert_eq!(ui_nodes, 2, "expected both UI macros: {nodes:?}");
+
+        assert_eq!(
+            crate::content::inline_builder::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser
+            ),
+            golden_normal(filtered, &parser),
+            "fold diverged from the string pipeline for the synthesized seed"
+        );
+    }
+
+    #[test]
+    fn a_real_documents_expanded_ui_macro_reaches_its_tree() {
+        // End-to-end, through the real parse path: a document attribute whose
+        // value feeds a UI macro. The rendered string and the fold of the
+        // block's own tree agree, and the tree carries the recognized node
+        // rather than the literal text it used to.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default()
+            .with_inline_tree(true)
+            .parse(":experimental:\n:view: View\n\nChoose menu:{view}[Zoom > Reset].");
+
+        let blocks: Vec<_> = doc.descendant_blocks().collect();
+        let rendered = blocks[0].rendered_html_content().unwrap();
+        let inlines = blocks[0].inlines().unwrap();
 
         assert!(
-            golden.rendered_str().contains(r#"class="submenu""#),
-            "golden output for {source:?}: {}",
-            golden.rendered_str()
+            rendered.contains(r#"class="submenu""#),
+            "rendered: {rendered}"
+        );
+
+        assert!(
+            inlines.iter().any(|n| matches!(n, InlineNode::Ui(_))),
+            "expected a Ui node in the block's tree: {inlines:?}"
+        );
+
+        assert_eq!(
+            crate::content::inline_builder::fold_html(
+                inlines,
+                &HtmlSubstitutionRenderer {},
+                &Parser::default()
+            ),
+            rendered,
+            "fold diverged from the rendered string for {inlines:?}"
         );
     }
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -56,8 +56,10 @@
 //!   when that slice sits inside one, since a synthesized run's bytes have no
 //!   source counterpart to slice for a type that requires a real `Span` (see
 //!   [`range_is_verbatim`](macros::image::range_is_verbatim)) – but a macro
-//!   needing only its own *text* (no `Span`-typed field), like an anchor's id,
-//!   can now be recovered exactly via [`text_slice`](quotes::text_slice)
+//!   needing only its own *text* (no `Span`-typed field) – an anchor's id, a
+//!   bare e-mail address, a UI macro's keys/label/menu path, or an index term's
+//!   shown text – can now be recovered exactly via
+//!   [`text_slice`](quotes::text_slice) or straight out of the match string
 //!   instead (see
 //!   [`range_is_verbatim_or_synthesized`](macros::image::range_is_verbatim_or_synthesized)).
 //! - [`apply_character_replacements`] recognizes [character replacements] –
@@ -112,8 +114,9 @@
 //!   string step gates them. The cross-reference pass claims the same-document,
 //!   inter-document, and document-as-a-whole target forms in both spellings
 //!   (`xref:id[text]` and `<<id>>` / `<<id,text>>`), and the `xref:` macro's own
-//!   attribute-list text; only the shorthand's own `,>`-empty-text form remains
-//!   deferred. A display/reference text crossing a rendered span
+//!   attribute-list text, so what a cross-reference defers is decided entirely
+//!   by the verbatim gate that precedes both builders. A display/reference text
+//!   crossing a rendered span
 //!   (`link:x[*bold*]`, `xref:id[*bold*]`, `<<id,*bold*>>`) remains deferred for
 //!   every reference-bearing family, since a rendered span is an opaque piece
 //!   the node's single `Text` child cannot absorb without becoming structured
@@ -132,7 +135,11 @@
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
 //!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
 //!   `((term))`) is deferred only when its shown text crosses a rendered span or
-//!   carries an attribute list.
+//!   carries an attribute list. The **UI** and **index-term** families share the
+//!   anchor's synthesized-run lift, and for the same reason – neither node
+//!   carries a `Span`-typed field, so a `kbd:`/`btn:`/`menu:` macro or an index
+//!   term inside an expanded attribute value is recognized with its exact text
+//!   (only the node's `location` taking design §4.4's coarse fallback).
 //! - [`apply_footnotes`] recognizes **footnotes** (`footnote:[…]`,
 //!   `footnote:id[…]`, `footnote:id[]`), replacing each with a
 //!   [`Footnote`](InlineNode::Footnote) node, folding through the shared
@@ -885,6 +892,29 @@ mod tests {
             "A {nope} in *bold {product}* text.\n{nope}\nlink:docs.html[Docs] {nope} tail.",
             missing_mode("drop"),
         );
+
+        // UI macros and index terms spliced in by attribute references –
+        // *synthesized* runs, which those two families now recognize exactly
+        // the way the anchor and bare-e-mail families do (neither node carries
+        // a `Span`-typed field). The real `AttributeReferences` step runs
+        // here, unlike the family-scoped corpora.
+        let with_ui_attributes = || {
+            Parser::default()
+                .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
+                .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("view", "View", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("key", "Ctrl+T", ModificationContext::Anywhere)
+        };
+
+        assert_parity_with(
+            "Press kbd:[{key}] then choose menu:{view}[Zoom > Reset] in *{product}*.",
+            with_ui_attributes,
+        );
+
+        assert_parity_with(
+            "The (({product})) index term beside *bold* text and indexterm:[{product}, docs].",
+            with_product,
+        );
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -935,6 +965,16 @@ mod tests {
             (
                 "  write to doc@example.com\n  today",
                 "write to doc@example.com\ntoday",
+            ),
+            // An index term in a wholly-synthesized seed: like an anchor's id
+            // and a bare address, its shown text is recovered exactly (from
+            // the match string) rather than deferred. The UI macros need the
+            // `experimental` attribute, so they are exercised by `ui.rs`'s own
+            // `ui_macros_are_recognized_when_the_whole_seed_is_synthesized`
+            // instead.
+            (
+                "  a ((flow term)) here\n  and a (((c1, c2))) one",
+                "a ((flow term)) here\nand a (((c1, c2))) one",
             ),
         ];
 

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -918,4 +918,26 @@ fn shapes_match_across_combined_constructs() {
         "[[[gof]]] An entry with an https://example.org link.",
         in_bibliography_list_item,
     );
+
+    // A UI macro and an index term spliced in by attribute references. The
+    // recorder has always recovered these (it reads the string pipeline's own
+    // render params, and the pipeline expands the reference before matching);
+    // the builder now recognizes them too, so the two constructions'
+    // *structures* – not just the HTML they fold to – can finally be compared
+    // for this shape.
+    assert_shapes_with(
+        "Press kbd:[{key}] then choose menu:{view}[Zoom > Reset] in *{product}*.",
+        || {
+            Parser::default()
+                .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
+                .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("view", "View", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("key", "Ctrl+T", ModificationContext::Anywhere)
+        },
+    );
+
+    assert_shapes_with(
+        "The (({product})) index term beside *bold* text and indexterm:[{product}, docs].",
+        with_product,
+    );
 }


### PR DESCRIPTION
The corpus-wide fold-parity audit (design doc §5.2, Phase 4 step 6) leaves an itemized list of divergences to close before `rendered_html()` can become an authoritative fold of the tree. This closes the seventh of them — **"a macro inside an expanded attribute value"** — for the two macro families whose nodes carry **no `Span`-typed field at all**: `Ui` (`kbd:`/`btn:`/`menu:`) and `IndexTerm`.

This is the *same* lift the anchor family made for its id (#1178) and the bare-e-mail family made for its address (#1181), applied to the two families that were left: a family that never needs a real `'src` slice has no reason to defer inside a `synthesized` run, and each of these computes every value it holds either straight out of the level's **match string** — which carries a synthesized run's bytes exactly — or, for the one exception, through `text_slice`.

## What changed

The change is correspondingly small, which is the point: the boundary was drawn by *one gate per family*, not by anything structural.

- **`kbd:`/`btn:`** swaps `range_is_verbatim` for `range_is_verbatim_or_synthesized`. Its keys and label already came from the match string via `split_kbd_keys` / `normalize_index_text`, so nothing else moved.
- **`menu:`** drops the `piece.synthesized` rejection from `menu_match_is_sliceable` and reads its one `'src`-sliced value — the menu *name* — through `text_slice` instead of `source_slice`, which would have offered only that run's coarse span (§4.4) rather than the name's exact bytes.
- **Both index-term spellings** drop their `range_overlaps_synthesized` check, keeping only the `SPAN_PLACEHOLDER` one, since a term's shown text is reconstructed from the match string and nowhere else.

Every other boundary each family draws is untouched: an escaped special or a rendered span in a `kbd:`/`btn:` bracket, in a menu *name* or item text (the admitted `&gt;` submenu caret aside), or in a visible term still defers, as does an `indexterm2:` term carrying an attribute list. As throughout, only the node's **`location`** takes the coarse enclosing-span fallback (§4.4); the values themselves are exact.

The families that carry an `Attrlist<'src>` or another `Span`-typed field (image, link, cross-reference) still defer here, so that half of the map item remains open.

## Tests

- Differential corpora drive each family's expanded-value forms — an expanded menu name, item list, and submenu path; expanded keyboard keys and button labels; a whole macro arriving from an expanded value; both index-term spellings, visible and concealed, whole and partial; a kept literal parenthesis beside an expanded term — through the real, public `SubstitutionGroup::Normal::apply` as the golden, since these need the `AttributeReferences` step the family-scoped `golden_macros` helper deliberately omits.
- The three divergence tests this closes (`a_menu_inside_an_expanded_value_…`, `a_visible_term_inside_an_expanded_value_…`, and its `indexterm2:` twin) become parity tests.
- Structural tests pin the exact-value / coarse-location split.
- The wholly-synthesized **seed** path (`build_from_value`, a filtered multi-line block) is covered for both families.
- A whole-document test drives the real parse path end to end.
- Fixtures are added to the whole-pipeline combined-constructs corpus and to the structural recorder cross-check — where the recorder side, which has always recovered these from the string pipeline's own render params, can now be compared *structurally* against a builder that recognizes them too.

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) confirms the divergence set strictly **shrank**: the three sources the divergence tests pinned are gone and **no new one appeared** (92 → 89 unique diverging sources).

Purely additive: nothing further is wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PykCzLUkNRYHbqUK2akNF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PykCzLUkNRYHbqUK2akNF4)_