### PR TITLE
feat: Recognize cross-references inside an expanded attribute value (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2453,6 +2453,56 @@ Each phase is a reviewable unit with a clear exit gate.
   divergence tests pinned are gone and no new one appeared. As with every prep piece before it,
   nothing further is wired in.
 
+  *Step 6 prep landed as (cross-references inside an expanded attribute value, closing the third
+  family of that same divergence):* the increment directly above closed "a macro inside an expanded
+  attribute value" for the two families whose nodes carry no `Span`-typed field, and named the
+  families that hold an [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` "or another
+  `Span`-typed field (image, link, cross-reference)" as still deferring. Auditing that grouping
+  found the **cross-reference** family does not belong in it: a
+  [`Ref`](../../parser/src/inlines/ref_node.rs)`{Xref}` node is built with `attrs: None` in both
+  spellings, because the `xref:` macro's own attribute-list text is parsed from a *newline-normalized
+  copy* rather than a source slice
+  ([`xref_macro_text`](../../parser/src/content/inline_builder/macros/xref.rs), mirroring
+  `InlineXrefReplacer`, which parses that same copy) – and every other value the node holds is a
+  computed `String` or a display text. So the family needs no honest `'src` slice at all, and the
+  same lift the anchor, bare-e-mail, UI, and index-term families made applies to it unchanged.
+
+  As with those, the change is **one gate per family**:
+  [`find_xref_matches`](../../parser/src/content/inline_builder/macros/xref.rs) swaps
+  [`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs) for
+  [`range_is_verbatim_or_synthesized`](../../parser/src/content/inline_builder/macros/image.rs), and
+  the two builders read what used to come from an `'src` slice out of the level's **match string**
+  instead – which carries a [`synthesized`](../../parser/src/content/inline_builder/quotes.rs) run's
+  bytes exactly, and is the very text the string replacer's own `inner.split_once(',')` /
+  `raw_text.contains('=')` see. `build_xref_shorthand_node` splits the shorthand's inner on the match
+  string rather than on the inner's source slice, and both builders take a display text's value from
+  the match string when it crosses a synthesized run while still *borrowing* it from `'src`
+  (via the location `source_slice` gives) when it does not, so the common case allocates nothing
+  (§4.5). Only the node's `location` (and its children's) takes §4.4's coarse enclosing-span
+  fallback; every value is exact.
+  Every other boundary the family draws is untouched: an [`atomic`](../../parser/src/content/inline_builder/quotes.rs)
+  piece – an escaped special, a rendered span, or an expanded value's own unescaped `<` (a
+  [`Raw`](../../parser/src/inlines/inline_node.rs) leaf, §3.4.1) – still defers, each with its own
+  divergence test, and the string pipeline's own `id.contains('<')` guard leaves that last one
+  literal too, so the two agree.
+
+  Differential corpora drive both spellings' expanded-value forms – an expanded id, reference text,
+  attribute-list text, and inter-document target; an expanded shorthand id and trimmed reference
+  text; a present-but-empty text behind an expanded id; a cross-reference inside a rendered span –
+  through the real, public `SubstitutionGroup::Normal::apply` as the golden, since these need the
+  `AttributeReferences` step the family-scoped `golden_xref_with` helper deliberately omits.
+  Structural tests pin the exact-value/coarse-location split for both spellings; a whole-document
+  test drives the real parse path end to end; and fixtures are added to the whole-pipeline
+  combined-constructs corpus and to the structural recorder cross-check. The wholly-synthesized
+  **seed** path ([`build_from_value`](../../parser/src/content/inline_builder/mod.rs)) gains
+  cross-reference fixtures too, and the test that pinned that path's deferral – which used an
+  `<<target>>` fixture – now pins it with a `link:` macro, the family for which
+  [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs) genuinely does read its `source:
+  Span<'src>`'s bytes as content, so a real `'src` slice is not optional. Re-running the corpus-wide
+  fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence
+  set strictly **shrank**: four whole-corpus sources are gone and no new one appeared. As with every
+  prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2678,6 +2728,15 @@ Each phase is a reviewable unit with a clear exit gate.
        The families that carry an [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` or
        another `Span`-typed field (image, link, cross-reference) still defer here, so that half of
        the map item remains open.
+     - ✅ **prep (cross-references inside an expanded value).** The same map item, closed for a
+       third family: a `Ref{Xref}` node is built with `attrs: None` in both spellings – the `xref:`
+       macro's own attribute list is parsed from a newline-normalized *copy*, not a source slice –
+       so the cross-reference family never needed an honest `'src` slice either, and
+       [`find_xref_matches`](../../parser/src/content/inline_builder/macros/xref.rs) makes the same
+       one-gate swap to `range_is_verbatim_or_synthesized`, reading its target and reference text
+       out of the match string and through `text_slice`; see the step's own "landed as" note above.
+       The `Attrlist<'src>`-bearing families (image, link) still defer, so that last part of the map
+       item remains open.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1,6 +1,10 @@
 //! Cross-reference recognition (`xref:id[…]`, `<<id>>`).
 
-use super::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level};
+use super::{
+    MacroMatch, MacroMatchKind,
+    image::{range_is_verbatim, range_is_verbatim_or_synthesized},
+    rebuild_macro_level,
+};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
@@ -102,9 +106,24 @@ pub(super) fn xref_macros_level<'src>(
 }
 
 /// Finds every recognized cross-reference at this level – the `xref:` macro
-/// form and the `<<id>>` shorthand – skipping any match that is not verbatim
-/// enough to slice from `'src`. That gate is now the family's *only* deferral:
-/// both builders claim every target and text shape a verbatim match can carry.
+/// form and the `<<id>>` shorthand – skipping any match that crosses an
+/// [`atomic`](Piece::atomic) piece. That gate is the family's *only* deferral:
+/// both builders claim every target and text shape an admitted match can
+/// carry.
+///
+/// A [`synthesized`](Piece::synthesized) run (an attribute expansion, or –
+/// reached at a tree's root – a filtered multi-line block's own joined seed)
+/// **is** admitted, which is what lets a cross-reference be recognized inside
+/// an expanded attribute value (`xref:{id}[{text}]`, `<<{id},text>>`). Nothing
+/// on a cross-reference node is `Span`-typed: its target and reference text
+/// come straight out of the level's match string – which carries a synthesized
+/// run's bytes exactly – and its own attribute list is parsed from a normalized
+/// *copy* rather than a source slice (see
+/// [`xref_macro_text`]), so `attrs` is always `None` here. Only the node's
+/// `location` (and its children's) takes design §4.4's coarse fallback. This
+/// is the same lift the anchor, bare-e-mail, UI, and index-term families
+/// already made, and for the same reason; the families that hold a real
+/// [`Attrlist`]`<'src>` (image, link) still cannot make it.
 fn find_xref_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -121,16 +140,16 @@ fn find_xref_matches<'src>(
         let full = whole.start()..whole.end();
 
         // The `xref:` macro (group 3) and the `<<…>>` shorthand (group 2) differ
-        // in what must be verbatim to build a node. The macro's whole match is
-        // sliced from `'src`, so all of it must be verbatim. The shorthand's
+        // in how much of the match the gate covers. The macro's whole match is
+        // read as one construct, so all of it must be admitted. The shorthand's
         // `&lt;&lt;` / `&gt;&gt;` delimiters are always `CharRef`s that the node
-        // *consumes* rather than slices, so only its inner text (group 2) – the
-        // id and any reference text – need be verbatim.
+        // *consumes* rather than reads, so only its inner text (group 2) – the
+        // id and any reference text – is gated.
         let shorthand_inner = caps.get(2).map(|inner| inner.start()..inner.end());
 
         let verbatim = match &shorthand_inner {
-            Some(inner) => range_is_verbatim(pieces, inner),
-            None => range_is_verbatim(pieces, &full),
+            Some(inner) => range_is_verbatim_or_synthesized(pieces, inner),
+            None => range_is_verbatim_or_synthesized(pieces, &full),
         };
 
         // An escape (`\xref:` / `\<<`) is honored by dropping the backslash and
@@ -156,11 +175,11 @@ fn find_xref_matches<'src>(
             continue;
         }
 
-        // Both builders claim every shape they are handed, so a verbatim match
+        // Both builders claim every shape they are handed, so an admitted match
         // always yields a node: what a cross-reference *defers* is decided by
-        // the verbatim gate above, not by the builders.
+        // the gate above, not by the builders.
         let node = match &shorthand_inner {
-            Some(inner) => build_xref_shorthand_node(inner.clone(), &full, pieces, root, parser),
+            Some(inner) => build_xref_shorthand_node(inner.clone(), &full, s, pieces, root, parser),
             None => build_xref_node(&caps, &full, pieces, root, parser),
         };
 
@@ -344,17 +363,25 @@ fn plain_xref_text<'src>(
     #[allow(clippy::unwrap_used)]
     let span = text_span.unwrap();
 
-    let text_location = source_slice(pieces, span.start()..span.end(), root);
+    let text_range = span.start()..span.end();
+    let text_location = source_slice(pieces, text_range.clone(), root);
 
     // An escaped bracket (`\]`) makes the logical text a computed (owned)
     // value – a *synthesized* `Text` whose value need not coincide with its
-    // source, mirroring the string replacer's `raw_text.replace`. Without one
-    // the text is verbatim, so it borrows the very bytes its location covers
-    // (the builder's `'src`-borrowing goal).
+    // source, mirroring the string replacer's `raw_text.replace`. Without one,
+    // a verbatim text borrows the very bytes its location covers (the
+    // builder's `'src`-borrowing goal, §4.5), while a text crossing a
+    // [`synthesized`](Piece::synthesized) run has no `'src` slice of its own:
+    // it takes the match string's bytes – the expanded value exactly, and the
+    // very text the string replacer matched over – as an owned value, with only
+    // `text_location` falling back to the enclosing run's coarse span (design
+    // §4.4).
     let value = if raw_text.contains("\\]") {
         CowStr::from(raw_text.replace("\\]", "]"))
-    } else {
+    } else if range_is_verbatim(pieces, &text_range) {
         CowStr::from(text_location.data())
+    } else {
+        CowStr::from(raw_text.to_string())
     };
 
     vec![InlineNode::Text {
@@ -368,13 +395,18 @@ fn plain_xref_text<'src>(
 /// replacer's shorthand branch does so the fold reproduces the same bytes.
 ///
 /// `inner` is the shorthand's inner text (`INLINE_XREF` group 2) in
-/// match-string coordinates; the caller guarantees it is verbatim, so its
-/// match-string bytes coincide with source. It is split on the first `,` into
-/// an id and an optional reference text, each trimmed – mirroring the string
-/// replacer's `inner.split_once(',')` with `id.trim()` / `text.trim()`. The
-/// reference text becomes the node's single [`Text`](InlineNode::Text) child,
-/// and the whole `<<…>>` – its `CharRef` delimiters included – is the node's
-/// `location`.
+/// match-string coordinates; the caller guarantees it crosses no
+/// [`atomic`](Piece::atomic) piece, so the match string carries its bytes
+/// exactly – whether they are source bytes (a verbatim run) or an expanded
+/// attribute value's (a [`synthesized`](Piece::synthesized) run). It is split
+/// on the first `,` into an id and an optional reference text, each trimmed –
+/// mirroring the string replacer's `inner.split_once(',')` with `id.trim()` /
+/// `text.trim()`, which runs over the very same bytes. The reference text
+/// becomes the node's single [`Text`](InlineNode::Text) child – still borrowed
+/// from `'src` when the text is verbatim (§4.5), owned when it crosses a
+/// synthesized run – and the whole `<<…>>` – its `CharRef` delimiters included
+/// – is the node's `location` (a synthesized run's coarse enclosing span, per
+/// design §4.4).
 ///
 /// **A comma is what makes a text *present*, not what it contains.** The
 /// string replacer's own split records `<<id,>>` (and `<<id,   >>`) as a
@@ -406,15 +438,19 @@ fn plain_xref_text<'src>(
 fn build_xref_shorthand_node<'src>(
     inner: std::ops::Range<usize>,
     full: &std::ops::Range<usize>,
+    s: &str,
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
 ) -> InlineNode<'src> {
-    // The inner is verbatim (the caller checked), so its source slice's bytes
-    // coincide with the match string's – a byte offset within `inner_data` maps
-    // to a match-string offset by adding `inner.start`.
-    let inner_span = source_slice(pieces, inner.clone(), root);
-    let inner_data = inner_span.data();
+    // The inner crosses no atomic piece (the caller checked), so the match
+    // string carries its logical bytes exactly – which is what the string
+    // replacer's own `inner.split_once(',')` sees. Reading them here rather
+    // than through the inner's source slice is what lets a shorthand inside an
+    // expanded attribute value be recognized: a synthesized run has no `'src`
+    // slice of its own. A byte offset within `inner_data` maps to a
+    // match-string offset by adding `inner.start`.
+    let inner_data = s.get(inner.start..inner.end).unwrap_or_default();
 
     // Split an optional ", reference text" off the id at the first comma.
     let comma = inner_data.find(',');
@@ -435,17 +471,26 @@ fn build_xref_shorthand_node<'src>(
             let raw_text = &inner_data[index + 1..];
             let trimmed = raw_text.trim();
 
-            // Locate the trimmed reference text at its source. It is verbatim, so
-            // the `Text` child borrows the very bytes its location covers – a
-            // zero-length borrow when the text is empty (or whitespace-only),
-            // which is the present-but-empty text the doc comment describes.
+            // Locate the trimmed reference text at its source. A verbatim text
+            // borrows the very bytes its location covers – a zero-length borrow
+            // when the text is empty (or whitespace-only), which is the
+            // present-but-empty text the doc comment describes – while a
+            // synthesized one keeps its exact expanded bytes against the
+            // enclosing run's coarse location (design §4.4).
             let lead = raw_text.len() - raw_text.trim_start().len();
 
             let text_start = inner.start + index + 1 + lead;
-            let text_location = source_slice(pieces, text_start..text_start + trimmed.len(), root);
+            let text_range = text_start..text_start + trimmed.len();
+            let text_location = source_slice(pieces, text_range.clone(), root);
+
+            let value = if range_is_verbatim(pieces, &text_range) {
+                CowStr::from(text_location.data())
+            } else {
+                CowStr::from(trimmed.to_string())
+            };
 
             vec![InlineNode::Text {
-                value: CowStr::from(text_location.data()),
+                value,
                 location: text_location,
             }]
         }
@@ -1222,5 +1267,213 @@ mod tests {
 
         let folded = super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
         assert_eq!(folded, golden_xref_with(source, &parser));
+    }
+
+    /// A parser carrying the attributes the expanded-value fixtures below
+    /// reference.
+    fn expanding_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default()
+            .with_intrinsic_attribute("id", "install", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("label", "Install Now", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("doc", "other.adoc", ModificationContext::Anywhere)
+            .with_intrinsic_attribute(
+                "xref-src",
+                "<<install,Install>>",
+                ModificationContext::Anywhere,
+            )
+    }
+
+    /// The real, public pipeline's output for `source` – the golden for the
+    /// expanded-value fixtures, which need the `AttributeReferences` step
+    /// [`golden_xref_with`] deliberately omits (it also finalizes the deferred
+    /// cross-references, which this does through the group's own pipeline).
+    fn golden_normal(source: &str, parser: &Parser) -> String {
+        use crate::content::SubstitutionGroup;
+
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        content.finalize_deferred(&HtmlSubstitutionRenderer {});
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_xrefs_inside_expanded_values() {
+        // A cross-reference whose target or reference text crosses a
+        // *synthesized* run (an attribute expansion) is now recognized:
+        // nothing on a `Ref{Xref}` node is `Span`-typed – its target and text
+        // come from the match string, which carries a synthesized run's bytes
+        // exactly – so only the node's `location` takes
+        // design §4.4's coarse fallback. This is the same lift the anchor,
+        // bare-e-mail, UI, and index-term families already made.
+        let parser = expanding_parser();
+
+        let fixtures = [
+            // The macro form: an expanded target, an expanded text, both.
+            "xref:{id}[Install]",
+            "xref:install[{label}]",
+            "xref:{id}[{label}]",
+            "xref:{id}[]",
+            // An expanded inter-document target keeps its derived destination.
+            "xref:{doc}#frag[Elsewhere]",
+            // An expanded value inside a longer text, and beside literal text.
+            "see xref:{id}[the {label} page] now",
+            // The macro form's attribute-list text, expanded.
+            "xref:{id}[{label}, window=_blank]",
+            // The shorthand: an expanded id, an expanded reference text, both.
+            "<<{id}>>",
+            "<<install,{label}>>",
+            "<<{id},{label}>>",
+            // A present-but-empty reference text survives an expanded id.
+            "<<{id},>>",
+            // The whole cross-reference arriving from an expanded value. The
+            // shorthand's `<<` is *literal* in the expanded value (it never
+            // passes through `specialcharacters`), so neither pipeline
+            // recognizes it as a shorthand – the tree and the string agree
+            // that it stays literal.
+            "{xref-src}",
+            "before {xref-src} after",
+            // A cross-reference inside a rendered span, itself carrying an
+            // expansion.
+            "*xref:{id}[{label}]*",
+        ];
+
+        for source in fixtures {
+            let nodes = super::super::super::build(Span::new(source), &parser, None);
+
+            assert_eq!(
+                super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+                golden_normal(source, &parser),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_xref_inside_an_expanded_value_keeps_a_coarse_location() {
+        // The values are exact; only the node's `location` (and its children's)
+        // falls back to the enclosing synthesized run's coarse span (design
+        // §4.4), since an expanded value's bytes have no `'src` counterpart of
+        // their own. A reference text recovered from such a run is necessarily
+        // owned rather than borrowed.
+        use crate::strings::CowStr;
+
+        let parser = expanding_parser();
+
+        let source = "xref:{id}[{label}]";
+        let nodes = super::super::super::build(Span::new(source), &parser, None);
+
+        assert_eq!(nodes.len(), 1, "{nodes:?}");
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+        assert_eq!(reference.children.len(), 1);
+
+        match &reference.children[0] {
+            InlineNode::Text { value, .. } => {
+                assert_eq!(value.as_ref(), "Install Now");
+                assert!(matches!(value, CowStr::Boxed(_)), "{value:?}");
+            }
+
+            other => panic!("expected a Text child, got {other:?}"),
+        }
+
+        // The whole match is the node's location; its `{id}`/`{label}` bytes
+        // are the source's, not the expanded values'.
+        assert_eq!(reference.location.data(), source);
+        assert_eq!(reference.location.line(), 1);
+        assert_eq!(reference.location.col(), 1);
+    }
+
+    #[test]
+    fn an_xref_shorthand_inside_an_expanded_value_keeps_its_exact_text() {
+        // The shorthand's own version of the split above: the id and the
+        // trimmed reference text are read out of the match string, which
+        // carries the expanded bytes exactly, while the node's location keeps
+        // the coarse fallback.
+        let parser = expanding_parser();
+
+        let source = "<<{id}, {label} >>";
+        let nodes = super::super::super::build(Span::new(source), &parser, None);
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "install");
+
+        assert_eq!(reference.children.len(), 1);
+        match &reference.children[0] {
+            InlineNode::Text { value, .. } => assert_eq!(value.as_ref(), "Install Now"),
+            other => panic!("expected a Text child, got {other:?}"),
+        }
+
+        assert_eq!(
+            super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            golden_normal(source, &parser)
+        );
+    }
+
+    #[test]
+    fn an_xref_over_a_rendered_span_in_an_expanded_value_is_still_deferred() {
+        // Lifting the boundary admits a *synthesized* run, not an
+        // [`atomic`](Piece::atomic) one: an expanded value whose own `<` became
+        // a `Raw` leaf (design §3.4.1 – the attributes step runs after
+        // `specialcharacters`, so a literal special in a value is emitted
+        // unescaped) is opaque, so the shorthand around it still defers. The
+        // string pipeline leaves it literal too, for its own reason: its
+        // `id.contains('<')` guard.
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "markup",
+            "<b>x</b>",
+            ModificationContext::Anywhere,
+        );
+
+        let source = "<<{markup}>>";
+        let nodes = super::super::super::build(Span::new(source), &parser, None);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a shorthand crossing an opaque piece must be left unrecognized: {nodes:?}"
+        );
+
+        assert_eq!(
+            super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            golden_normal(source, &parser)
+        );
+    }
+
+    #[test]
+    fn a_real_documents_expanded_xref_reaches_its_tree() {
+        // End-to-end, through the real parse path: a document attribute whose
+        // value feeds a cross-reference. The rendered string and the fold of
+        // the block's own tree agree, and the tree carries the recognized node
+        // rather than the literal text it used to.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default()
+            .with_inline_tree(true)
+            .parse(":id: install\n\n[#install]\n== Install\n\nSee xref:{id}[the install steps].");
+
+        let block = doc
+            .descendant_blocks()
+            .find(|b| {
+                b.rendered_html_content()
+                    .is_some_and(|c| c.contains("install steps"))
+            })
+            .unwrap();
+
+        let rendered = block.rendered_html_content().unwrap();
+        let inlines = block.inlines().unwrap();
+
+        assert!(
+            rendered.contains(r##"href="#install""##),
+            "rendered: {rendered}"
+        );
+
+        assert!(
+            inlines.iter().any(|n| matches!(n, InlineNode::Ref(_))),
+            "expected a Ref node in the block's tree: {inlines:?}"
+        );
     }
 }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -52,15 +52,15 @@
 //!   [`build_match_string`](quotes::build_match_string) to look inside a
 //!   [`synthesized`](quotes::Piece::synthesized) run instead of treating it as
 //!   opaque; a **macro** needing an honest `'src` slice for its own
-//!   target/attribute list (a link, image, or cross-reference) still defers
-//!   when that slice sits inside one, since a synthesized run's bytes have no
-//!   source counterpart to slice for a type that requires a real `Span` (see
-//!   [`range_is_verbatim`](macros::image::range_is_verbatim)) – but a macro
-//!   needing only its own *text* (no `Span`-typed field) – an anchor's id, a
-//!   bare e-mail address, a UI macro's keys/label/menu path, or an index term's
-//!   shown text – can now be recovered exactly via
-//!   [`text_slice`](quotes::text_slice) or straight out of the match string
-//!   instead (see
+//!   target/attribute list (a link or an image, the two that are left) still
+//!   defers when that slice sits inside one, since a synthesized run's bytes
+//!   have no source counterpart to slice for a type that requires a real `Span`
+//!   (see [`range_is_verbatim`](macros::image::range_is_verbatim)) – but a
+//!   macro needing only its own *text* (no `Span`-typed field) – an anchor's
+//!   id, a bare e-mail address, a UI macro's keys/label/menu path, an index
+//!   term's shown text, or a cross-reference's target and reference text – can
+//!   now be recovered exactly via [`text_slice`](quotes::text_slice) or
+//!   straight out of the match string instead (see
 //!   [`range_is_verbatim_or_synthesized`](macros::image::range_is_verbatim_or_synthesized)).
 //! - [`apply_character_replacements`] recognizes [character replacements] –
 //!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities – replacing
@@ -115,8 +115,12 @@
 //!   inter-document, and document-as-a-whole target forms in both spellings
 //!   (`xref:id[text]` and `<<id>>` / `<<id,text>>`), and the `xref:` macro's own
 //!   attribute-list text, so what a cross-reference defers is decided entirely
-//!   by the verbatim gate that precedes both builders. A display/reference text
-//!   crossing a rendered span
+//!   by the gate that precedes both builders – and that gate now admits a
+//!   [`synthesized`](quotes::Piece::synthesized) run, since nothing on a
+//!   `Ref{Xref}` node is `Span`-typed (its own attribute list is parsed from a
+//!   normalized copy, never a source slice), so a cross-reference inside an
+//!   expanded attribute value is recognized with its exact target and text.
+//!   A display/reference text crossing a rendered span
 //!   (`link:x[*bold*]`, `xref:id[*bold*]`, `<<id,*bold*>>`) remains deferred for
 //!   every reference-bearing family, since a rendered span is an opaque piece
 //!   the node's single `Text` child cannot absorb without becoming structured
@@ -135,11 +139,12 @@
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
 //!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
 //!   `((term))`) is deferred only when its shown text crosses a rendered span or
-//!   carries an attribute list. The **UI** and **index-term** families share the
-//!   anchor's synthesized-run lift, and for the same reason – neither node
-//!   carries a `Span`-typed field, so a `kbd:`/`btn:`/`menu:` macro or an index
-//!   term inside an expanded attribute value is recognized with its exact text
-//!   (only the node's `location` taking design §4.4's coarse fallback).
+//!   carries an attribute list. The **UI**, **index-term**, and
+//!   **cross-reference** families share the anchor's synthesized-run lift, and
+//!   for the same reason – none of those nodes carries a `Span`-typed field, so
+//!   a `kbd:`/`btn:`/`menu:` macro, an index term, or a cross-reference inside
+//!   an expanded attribute value is recognized with its exact text (only the
+//!   node's `location` taking design §4.4's coarse fallback).
 //! - [`apply_footnotes`] recognizes **footnotes** (`footnote:[…]`,
 //!   `footnote:id[…]`, `footnote:id[]`), replacing each with a
 //!   [`Footnote`](InlineNode::Footnote) node, folding through the shared
@@ -915,6 +920,23 @@ mod tests {
             "The (({product})) index term beside *bold* text and indexterm:[{product}, docs].",
             with_product,
         );
+
+        // Cross-references spliced in by attribute references, in both
+        // spellings and in both halves (target and reference text) – the same
+        // synthesized-run lift, for the family whose attribute list is parsed
+        // from a normalized copy rather than a source slice, so nothing on its
+        // node is `Span`-typed.
+        let with_xref_attributes = || {
+            Parser::default()
+                .with_intrinsic_attribute("id", "install", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("label", "Install Now", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+        };
+
+        assert_parity_with(
+            "See *xref:{id}[{label}]* and <<{id},the {product} steps>> plus a (C) mark.",
+            with_xref_attributes,
+        );
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -975,6 +997,17 @@ mod tests {
             (
                 "  a ((flow term)) here\n  and a (((c1, c2))) one",
                 "a ((flow term)) here\nand a (((c1, c2))) one",
+            ),
+            // A cross-reference in a wholly-synthesized seed, in both
+            // spellings: nothing on a `Ref{Xref}` node is `Span`-typed, so its
+            // target and reference text come from the match string (or
+            // `text_slice`) rather than an `'src` slice. The link and image
+            // families, which hold a real `Attrlist<'src>`, still defer – see
+            // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
+            // below.
+            (
+                "  see <<target>> and\n  xref:other[the other one]",
+                "see <<target>> and\nxref:other[the other one]",
             ),
         ];
 
@@ -1328,33 +1361,37 @@ mod tests {
         }
     }
 
-    /// A documented divergence, not a bug: a macro family whose recognition
-    /// needs an honest `'src` slice for its own target/id (a link, image, or
-    /// cross-reference) is left unrecognized when the *whole* seed is
-    /// synthesized – the same
+    /// A documented divergence, not a bug: a macro family that holds a real
+    /// [`Attrlist`](crate::attributes::Attrlist)`<'src>` – a link or an image,
+    /// the two that are left – is still unrecognized when the *whole* seed is
+    /// synthesized, because
+    /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) reads its
+    /// `source: Span<'src>`'s bytes as content, not merely as a location tag,
+    /// so a real `'src` slice is not optional there. This is the same
     /// [`range_is_verbatim`](macros::image::range_is_verbatim) boundary that
-    /// already defers a macro *nested inside* an attribute expansion's
-    /// spliced value (see [`apply_attribute_references`]'s own doc comment),
-    /// now reached at the tree's root instead of a nested splice.
+    /// defers those families *nested inside* an attribute expansion's spliced
+    /// value (see [`apply_attribute_references`]'s own doc comment), now
+    /// reached at the tree's root instead of a nested splice.
+    ///
     /// [`build_from_value`] does not lift this boundary: it only unblocks a
-    /// synthesized (filtered/joined multi-line) seed for the steps that
-    /// never needed a verbatim slice in the first place (quotes,
+    /// synthesized (filtered/joined multi-line) seed for the steps and
+    /// families that never needed a verbatim slice in the first place (quotes,
     /// specialcharacters, attribute references, character replacements,
-    /// post-replacement, and a macro family – like a bare `footnote:[…]` –
-    /// whose own content is captured as children rather than a literal
-    /// value). Lifting it for link/image/xref/anchor/index-term targets, so a
-    /// real multi-line block carrying one of those still folds identically
-    /// through `build_from_value`, remains a later increment's job.
+    /// post-replacement, and the anchor / bare-e-mail / UI / index-term /
+    /// cross-reference families, each of which computes every value it holds
+    /// from the match string or [`text_slice`](quotes::text_slice) – all
+    /// exercised by the parity sweep above). Lifting it for a link's or an
+    /// image's own target remains a later increment's job.
     #[test]
     fn a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized() {
-        let filtered = "see <<target>> here";
-        let source = "  see <<target>> here";
+        let filtered = "see link:https://example.org[Example] here";
+        let source = "  see link:https://example.org[Example] here";
 
         let golden_parser = Parser::default();
         let golden = golden(filtered, &golden_parser);
         assert!(
-            golden.contains("href=\"#target\""),
-            "golden fixture stopped recognizing the xref: {golden:?}"
+            golden.contains(r#"href="https://example.org""#),
+            "golden fixture stopped recognizing the link: {golden:?}"
         );
 
         let built_parser = Parser::default();
@@ -1371,6 +1408,6 @@ mod tests {
             "expected the documented divergence to still reproduce; the boundary may have \
              been lifted – if so, fold this fixture back into the parity sweep above"
         );
-        assert_eq!(built, "see &lt;&lt;target&gt;&gt; here");
+        assert_eq!(built, "see link:https://example.org[Example] here");
     }
 }

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -940,4 +940,16 @@ fn shapes_match_across_combined_constructs() {
         "The (({product})) index term beside *bold* text and indexterm:[{product}, docs].",
         with_product,
     );
+
+    // Cross-references spliced in by attribute references, in both spellings –
+    // the same comparison, for the family that just made the same lift.
+    assert_shapes_with(
+        "See xref:{id}[{label}] and <<{id},the {product} steps>> here.",
+        || {
+            Parser::default()
+                .with_intrinsic_attribute("id", "install", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("label", "Install Now", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+        },
+    );
 }


### PR DESCRIPTION
The corpus-wide fold-parity audit (design doc §5.2, Phase 4 step 6) leaves an itemized list of divergences to close before `rendered_html()` can become an authoritative fold of the tree. #1188 closed "a macro inside an expanded attribute value" for the two macro families whose nodes carry no `Span`-typed field (`Ui` and `IndexTerm`), and named the families holding an `Attrlist<'src>` "or another `Span`-typed field (image, link, cross-reference)" as still deferring.

Auditing that grouping found the **cross-reference** family does not belong in it. A `Ref{Xref}` node is built with `attrs: None` in *both* spellings, because the `xref:` macro's own attribute-list text is parsed from a newline-normalized **copy** rather than a source slice (`xref_macro_text`, mirroring `InlineXrefReplacer`, which parses that same copy) — and every other value the node holds is a computed `String` or a display text. So the family needs no honest `'src` slice at all, and the same lift the anchor, bare-e-mail, UI, and index-term families made applies to it unchanged.

## The change

As with those, it is **one gate per family**:

- `find_xref_matches` swaps `range_is_verbatim` for `range_is_verbatim_or_synthesized`.
- `build_xref_shorthand_node` splits the shorthand's inner on the level's **match string** rather than on the inner's source slice — the match string carries a `synthesized` run's bytes exactly, and is the very text the string replacer's own `inner.split_once(',')` sees.
- Both builders take a display text's value from the match string when it crosses a synthesized run, while still **borrowing** it from `'src` when it does not, so the common case allocates nothing (§4.5).

Only the node's `location` (and its children's) takes design §4.4's coarse enclosing-span fallback; every value is exact.

Every other boundary the family draws is untouched: an `atomic` piece — an escaped special, a rendered span, or an expanded value's own unescaped `<` (a `Raw` leaf, §3.4.1) — still defers, each with its own divergence test. For that last one the string pipeline leaves the shorthand literal too, for its own reason (its `id.contains('<')` guard), so the two agree.

## Testing

- Differential corpora drive both spellings' expanded-value forms (expanded id / reference text / attribute-list text / inter-document target; an expanded shorthand id and trimmed reference text; a present-but-empty text behind an expanded id; a cross-reference inside a rendered span) through the real, public `SubstitutionGroup::Normal::apply` as the golden, since these need the `AttributeReferences` step the family-scoped `golden_xref_with` helper deliberately omits.
- Structural tests pin the exact-value/coarse-location split for both spellings; a whole-document test drives the real parse path end to end.
- Fixtures added to the whole-pipeline combined-constructs corpus and to the structural recorder cross-check.
- The wholly-synthesized **seed** path (`build_from_value`) gains cross-reference fixtures, and the test that pinned that path's deferral — which used an `<<target>>` fixture — now pins it with a `link:` macro, the family for which `Attrlist::parse` genuinely does read its `source: Span<'src>`'s bytes as content, so a real `'src` slice is not optional there.
- Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence set strictly **shrank**: four whole-corpus sources are gone and no new one appeared.

Purely additive: nothing further is wired in.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5063 passing), and `cargo +nightly doc --no-deps --document-private-items` are all clean. Coverage of `macros/xref.rs` went from 98.98% → 99.41% regions and 100% functions; the remaining uncovered regions are one pre-existing short-circuit and `other => panic!(…)` arms inside test assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorTPbwHrTRuwvxDopxCAM)_