### PR TITLE
feat: Recognize images and links inside an expanded attribute value (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2503,6 +2503,80 @@ Each phase is a reviewable unit with a clear exit gate.
   set strictly **shrank**: four whole-corpus sources are gone and no new one appeared. As with every
   prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the image and link families inside an expanded attribute value,
+  closing the last of that divergence):* the two increments above closed "a macro inside an
+  expanded attribute value" for every family whose node carries no `Span`-typed field; the two
+  that are left – [`Image`](../../parser/src/inlines/image.rs) and the
+  [`Ref`](../../parser/src/inlines/ref_node.rs)`{Link}` family, the two that hold a real
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` – now make the same lift for
+  everything *except* that attribute list, which is the one value in this whole module that a
+  match string genuinely cannot supply:
+  [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs) reads its `source: Span<'src>`'s
+  bytes **as content**, not merely as a location tag, so an expanded value – which has no `'src`
+  slice of its own – leaves it nothing to parse. The boundary therefore moves from *the family*
+  to *the one capture that needs a slice*, which is what makes the common real-world spellings
+  (`image:{logo}[Logo]`, `link:{url}[Docs]`, `https://{host}/path`) work while the genuinely
+  blocked ones stay documented divergences.
+
+  Concretely, the same one-gate-per-family swap
+  ([`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs) →
+  [`range_is_verbatim_or_synthesized`](../../parser/src/content/inline_builder/macros/image.rs))
+  the four prior families made, plus a narrower check where a slice is still required:
+
+  - **Image / icon.** [`build_image_node`](../../parser/src/content/inline_builder/macros/image.rs)
+    reads the macro *name* from the level's match string rather than from `location.data()` (which
+    is the coarse enclosing span for a wholly-expanded macro, so the `image:`-vs-`icon:`
+    discriminant would otherwise be read off the attribute *reference*), and its *target* through
+    [`text_slice`](../../parser/src/content/inline_builder/quotes.rs) – still borrowing from `'src`
+    when the target is verbatim (§4.5), exact when it is not. The **bracket** keeps the verbatim
+    check: a non-empty attribute list crossing a synthesized run leaves the macro literal, while an
+    **empty** one (`image:{logo}[]`) needs no bytes at all and parses from the same zero-length span
+    an absent group already used – so even a wholly-expanded `image:x.png[]` is recognized.
+  - **Links.** Every value the three URL-link passes hold – the scheme, the URL, the bracketed
+    display text – is already computed out of the match string, so
+    [`build_inline_link_node`](../../parser/src/content/inline_builder/macros/links.rs) and
+    [`find_link_macro_matches`](../../parser/src/content/inline_builder/macros/links.rs) needed only
+    the gate swap. The **attribute-list-bearing display text** (a `link:`/formal-URL `=`, a
+    `mailto:` `,` subject) keeps the verbatim check, for the same `Attrlist<'src>` reason and
+    alongside the multi-line form the family already defers there.
+  - **One extra rule, for the `link:`/`mailto:` macro pass only.** That pass additionally requires
+    its own `link:`/`mailto:` **marker** to be verbatim, so a *wholly* expanded macro (`{m}`, where
+    `:m: link:index.html[Docs]`) stays literal. The reason is not the node but the staged side
+    effect: [`link_form`](../../parser/src/content/inline_builder/macros/links.rs) tells this pass's
+    nodes from the other two link passes' by whether the node's `location` starts with that literal
+    marker – the "no new node field" signal the combined-entry-point increment introduced to replay
+    the string pipeline's family-pass registration order – and a coarse §4.4 location cannot carry
+    it. A marker written in the source (`link:{url}[Docs]`) keeps an honest location end to end and
+    is recognized. The URL-link and bare-e-mail passes need no such rule: their own targets never
+    carry the `link:`/`mailto:` scheme `link_form` keys on, so a wholly expanded `{site}`
+    auto-link *is* recognized.
+
+  Building the differential corpora surfaced a latent test-harness hazard worth recording, of
+  exactly the kind these lifts keep exposing: the family-scoped golden helper
+  ([`golden_macros_with`](../../parser/src/content/inline_builder/test_support.rs)) deliberately
+  omits the `AttributeReferences` step, so a fixture carrying a reference makes the two sides read
+  *different* text. The link family's own registration corpus used `{sp}` as an interleaving
+  separator, which was inert only while every link family deferred inside a synthesized run: with
+  the lift, the builder sees the expanded space and links a following bare URL where the golden –
+  still holding a literal `}` boundary character `INLINE_LINK` rejects – does not. Those separators
+  are now plain spaces, which is what the fixture always meant (and which makes its interleaved
+  registration-order assertion non-vacuous for the first time). Every expanded-value fixture in this
+  increment is driven through the real, public `SubstitutionGroup::Normal::apply` instead.
+
+  Differential corpora drive each family's expanded-value forms – an expanded image/icon target,
+  whole or partial, with a verbatim, an empty, and a positional/named attribute list; an expanded
+  `link:`/`mailto:` target and display text; expanded auto-link, formal-URL and angle-bracketed
+  hosts; a wholly expanded auto-link – through that real entry point as the golden, alongside
+  structural tests pinning the exact-value/coarse-location split and the match-string-read macro
+  name. Registration parity is asserted for both staged side effects against an independent golden
+  parser (the same two-independent-parsers discipline), including the interleaved link forms that
+  pin the marker rule above. Fixtures are added to the whole-pipeline combined-constructs corpus,
+  the synthesized-seed sweep (whose own deferral test keeps its `link:` macro fixture – now
+  deferred by the marker rule rather than by a whole-family gate), and the structural recorder
+  cross-check. Re-running the corpus-wide fold-parity audit (tree building forced on for every
+  parse in the suite) confirms the divergence set strictly **shrank**: one more whole-corpus source
+  is gone and no new one appeared. As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -2735,8 +2809,17 @@ Each phase is a reviewable unit with a clear exit gate.
        [`find_xref_matches`](../../parser/src/content/inline_builder/macros/xref.rs) makes the same
        one-gate swap to `range_is_verbatim_or_synthesized`, reading its target and reference text
        out of the match string and through `text_slice`; see the step's own "landed as" note above.
-       The `Attrlist<'src>`-bearing families (image, link) still defer, so that last part of the map
-       item remains open.
+     - ✅ **prep (images and links inside an expanded value).** The map item closed in full, for the
+       two families that hold a real `Attrlist<'src>`: the same one-gate swap, with the boundary
+       moved from *the family* to *the one capture that still needs an `'src` slice* – an image's
+       non-empty attribute list and a link's attribute-list-bearing display text, since
+       `Attrlist::parse` reads its own source span's bytes as content. An image's macro name and
+       target now come from the match string / `text_slice`, and an empty bracket parses from a
+       zero-length span, so even a wholly-expanded `image:x.png[]` is recognized. The
+       `link:`/`mailto:` macro pass additionally requires its own literal marker to be verbatim,
+       because that marker is how `link_form` tells its nodes from the other link passes' when
+       replaying the string pipeline's registration order; see the step's own "landed as" note
+       above.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -66,13 +66,21 @@ use crate::{
 /// so `apply_character_replacements`'s pattern sweep, still ahead in the
 /// effective order, can match inside it exactly as it would over any other
 /// run (a follow-up to this step, closing the gap this doc comment used to
-/// describe). A **macro** *inside* an expanded value remains deferred,
-/// though: a macro node bakes its target/attribute list straight from an
-/// honest `'src` slice, which a synthesized run – its bytes have no source
-/// counterpart of their own – cannot supply; see
-/// [`range_is_verbatim`](super::macros::image::range_is_verbatim), which
-/// every macro family gates recognition on, and which rejects a synthesized
-/// piece for exactly this reason.
+/// describe). Most **macro** families are recognized inside an expanded value
+/// too, for the same reason and by the same mechanism: a family that computes
+/// every value it holds from the match string gates recognition on
+/// [`range_is_verbatim_or_synthesized`](super::macros::image::range_is_verbatim_or_synthesized)
+/// rather than
+/// [`range_is_verbatim`](super::macros::image::range_is_verbatim), rejecting
+/// only an [`atomic`](super::quotes::Piece::atomic) piece. What still needs an
+/// honest `'src` slice, and so still defers, is an
+/// [`Attrlist`](crate::attributes::Attrlist)`<'src>`, which reads its own
+/// source span's bytes *as content* rather than merely as a location tag: an
+/// image macro's non-empty attribute list (`image:sunset.jpg[{caption}]`) and
+/// a link's attribute-list-bearing display text (`link:x[{text},role=hl]`).
+/// A *wholly* expanded `link:`/`mailto:` macro defers for a second reason of
+/// its own – see `link_macro_level`'s own scope note in
+/// [`macros::links`](super::macros).
 ///
 /// [`AttributeMissing::Drop`]: crate::content::AttributeMissing::Drop
 /// [`AttributeMissing::DropLine`]: crate::content::AttributeMissing::DropLine
@@ -1213,19 +1221,39 @@ mod tests {
     }
 
     #[test]
-    fn a_macro_inside_an_expanded_value_is_a_documented_divergence() {
-        // The same boundary as
-        // `a_replacement_inside_an_expanded_value_is_a_documented_divergence`,
-        // for the macros step.
-        let parser = parser_with_attribute("linktext", "link:https://example.org[Example]");
-        let nodes = build(Span::new("see {linktext} now"), &parser, None);
+    fn an_attrlist_bearing_macro_inside_an_expanded_value_is_a_documented_divergence() {
+        // Most macro families are now recognized inside a spliced value (see
+        // this module's own doc comment, and each family's own parity corpus).
+        // What still defers is a construct needing an `Attrlist<'src>`, which
+        // reads its own source span's bytes *as content*: an image macro's
+        // non-empty attribute list here, alongside a link's own
+        // attribute-list-bearing display text (pinned in `macros/links.rs`).
+        let parser = parser_with_attribute("imgtext", "image:sunset.jpg[Sunset]");
+        let nodes = build(Span::new("see {imgtext} now"), &parser, None);
 
         assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a macro inside a spliced value must not yet be recognized: {nodes:?}"
+            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+            "an attrlist-bearing macro inside a spliced value must not yet be recognized: \
+             {nodes:?}"
         );
 
-        assert!(golden_attributes_with("see {linktext} now", &parser).contains("<a href"));
+        assert!(golden_attributes_with("see {imgtext} now", &parser).contains("<img"));
+    }
+
+    #[test]
+    fn a_macro_inside_an_expanded_value_is_recognized() {
+        // The counterpart of the divergence above: a family that computes
+        // every value it holds from the level's match string – here the
+        // `link:` macro, whose own marker is written in the source – is
+        // recognized inside a spliced value, with only the node's `location`
+        // taking design §4.4's coarse fallback.
+        let parser = parser_with_attribute("target", "https://example.org");
+        let nodes = build(Span::new("see link:{target}[Example] now"), &parser, None);
+
+        assert!(
+            nodes.iter().any(|n| matches!(n, InlineNode::Ref(_))),
+            "a link macro over a spliced target should be recognized: {nodes:?}"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -215,21 +215,24 @@ fn build_image_node<'src>(
         Some(m) => text_slice(nodes, pieces, m.start()..m.end())?,
     };
 
-    let bracket = match caps.get(2) {
-        Some(m) if range_is_verbatim(pieces, &(m.start()..m.end())) => {
-            source_slice(pieces, m.start()..m.end(), root)
-        }
+    // Group 2 always participates – its own pattern carries an empty
+    // alternative – so the degenerate fallback range here is unreachable, and
+    // stands in for the same empty attribute list an absent group would mean
+    // rather than adding a branch of its own that no input can take.
+    let bracket_range = caps
+        .get(2)
+        .map_or(full.end..full.end, |m| m.start()..m.end());
 
+    let bracket = if range_is_verbatim(pieces, &bracket_range) {
+        source_slice(pieces, bracket_range, root)
+    } else if bracket_range.is_empty() {
         // An empty attribute list carries no bytes to slice, so it parses from
-        // a zero-length span wherever the macro sits (the same span an absent
-        // group takes).
-        Some(m) if m.is_empty() => location.slice(0..0),
-
+        // a zero-length span wherever the macro sits.
+        location.slice(0..0)
+    } else {
         // A non-empty attribute list crossing a synthesized run: deferred (see
         // this function's own "what must be verbatim" note).
-        Some(_) => return None,
-
-        None => location.slice(0..0),
+        return None;
     };
 
     let attrlist = Attrlist::parse(bracket, parser, AttrlistContext::Inline)
@@ -1105,5 +1108,31 @@ mod tests {
 
             assert_eq!(got, want, "registered images diverged for {fixture:?}");
         }
+    }
+
+    #[test]
+    fn a_targetless_macro_yields_an_empty_target() {
+        // `INLINE_IMAGE_MACRO`'s target group is optional, so `image:[…]`
+        // matches with it absent and the node's target is the empty string
+        // (its default alt deriving from that, exactly as `default_alt` does
+        // for any other target).
+        //
+        // This is a structural test rather than a differential one on purpose:
+        // the string pipeline's own `InlineImageMacroReplacer` reads that
+        // group as `&caps[1]`, which **panics** for this shape, so there is no
+        // golden to compare against. That panic is a pre-existing bug in the
+        // shared string pipeline (it reproduces on `main`, through an ordinary
+        // `Parser::parse`), independent of this module – so the builder's own
+        // handling of the shape is pinned here and the fix belongs in its own
+        // change against `main`.
+        let nodes = build_src(Span::new("image:[Alt Text]"));
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert!(!image.is_icon);
+        assert_eq!(image.target.as_ref(), "");
+        assert_eq!(image.alt.as_deref(), Some("Alt Text"));
+        assert_eq!(image.location.data(), "image:[Alt Text]");
     }
 }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -6,7 +6,7 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_IMAGE_MACRO, basename,
-        inline_builder::quotes::{Piece, build_match_string, source_slice},
+        inline_builder::quotes::{Piece, build_match_string, source_slice, text_slice},
         normalize_text_lf_escaped_bracket,
     },
     inlines::{Image, InlineNode},
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Matches `INLINE_IMAGE_MACRO` at this level's escaped text, replacing each
-/// verbatim match with the [`Image`](InlineNode::Image) node it produces and
+/// recognized match with the [`Image`](InlineNode::Image) node it produces and
 /// leaving everything else in place.
 pub(super) fn image_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
@@ -31,7 +31,7 @@ pub(super) fn image_macros_level<'src>(
         return nodes;
     }
 
-    let matches = find_image_matches(&s, &pieces, root, parser);
+    let matches = find_image_matches(&s, &pieces, root, parser, &nodes);
 
     if matches.is_empty() {
         return nodes;
@@ -40,13 +40,16 @@ pub(super) fn image_macros_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
-/// Finds every image/icon macro at this level, skipping any whose match is not
-/// wholly verbatim source (see [`apply_macros`](super::apply_macros)).
+/// Finds every image/icon macro at this level, skipping any whose match crosses
+/// an [`atomic`](Piece::atomic) piece (see
+/// [`apply_macros`](super::apply_macros)) or whose attribute list
+/// [`build_image_node`] cannot slice from `'src`.
 fn find_image_matches<'src>(
     s: &str,
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    nodes: &[InlineNode<'src>],
 ) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
@@ -57,10 +60,11 @@ fn find_image_matches<'src>(
 
         let full = whole.start()..whole.end();
 
-        // Only a wholly-verbatim match can slice its target/attrlist from
-        // `'src`; a match crossing an escaped special or a rendered span is left
-        // for a later increment.
-        if !range_is_verbatim(pieces, &full) {
+        // A match crossing an escaped special or a rendered span is left for a
+        // later increment; one crossing a `synthesized` run (an expanded
+        // attribute value) is admitted here and gated more narrowly – on its
+        // attribute list alone – inside `build_image_node`.
+        if !range_is_verbatim_or_synthesized(pieces, &full) {
             continue;
         }
 
@@ -75,7 +79,15 @@ fn find_image_matches<'src>(
             continue;
         }
 
-        let node = build_image_node(&caps, &full, pieces, root, parser);
+        let Some(node) =
+            build_image_node(&caps, whole.as_str(), &full, pieces, root, parser, nodes)
+        else {
+            // A non-empty attribute list crossing a synthesized run: an
+            // `Attrlist<'src>` reads its own source span's bytes as content, so
+            // there is nothing honest to parse it from. Left as literal source
+            // for a later increment.
+            continue;
+        };
 
         matches.push(MacroMatch {
             kind: MacroMatchKind::Node {
@@ -129,7 +141,7 @@ pub(in crate::content::inline_builder) fn range_is_verbatim(
 /// still enforces unchanged. A caller that accepts a range under this check
 /// still cannot slice `'src` directly for it (the same reason
 /// [`range_is_verbatim`] exists at all); it needs
-/// [`text_slice`](super::super::quotes::text_slice) rather than
+/// [`text_slice`] rather than
 /// [`source_slice`] to recover the
 /// range's own *text* precisely, since `source_slice` only ever offers a
 /// synthesized piece's coarse *location* fallback (design §4.4), never its
@@ -155,33 +167,70 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
     true
 }
 
-/// Builds one [`Image`](InlineNode::Image) node from a verbatim image/icon
-/// match: it slices the target and attribute list straight from `'src` and
-/// pre-extracts the alt/width/height the way the string replacer does, so the
-/// fold reproduces the same bytes.
+/// Builds one [`Image`](InlineNode::Image) node from a recognized image/icon
+/// match, pre-extracting the alt/width/height the way the string replacer does
+/// so the fold reproduces the same bytes.
+///
+/// # What must be verbatim, and what need not be
+///
+/// The macro name and the target are read from the level's own **match
+/// string** (`whole`, and [`text_slice`] for the target) rather than from a
+/// source slice, so both are exact even when they come from a
+/// [`synthesized`](Piece::synthesized) run – an expanded attribute value
+/// (`image:{logo}[Logo]`), or a filtered multi-line block's own joined seed.
+/// Only the node's `location` then takes design §4.4's coarse fallback.
+///
+/// The **attribute list** is the one part that cannot follow: an
+/// [`Attrlist`]`<'src>` reads its own `Span<'src>`'s bytes *as content*, not
+/// merely as a location tag, so it needs a real source slice. A non-empty
+/// bracket crossing a synthesized run therefore returns `None` – the macro is
+/// left literal for a later increment, exactly as the other boundaries in this
+/// module are. An **empty** bracket (`image:{logo}[]`) needs no bytes at all
+/// and parses from the same zero-length span an absent group already uses, so
+/// it is recognized.
 fn build_image_node<'src>(
     caps: &regex::Captures<'_>,
+    whole: &str,
     full: &std::ops::Range<usize>,
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
-) -> InlineNode<'src> {
+    nodes: &[InlineNode<'src>],
+) -> Option<InlineNode<'src>> {
     let location = source_slice(pieces, full.clone(), root);
 
     // The macro name (past any – here absent – escape) is `image:` or `icon:`.
-    let is_icon = !location.data().starts_with("image:");
+    // It is read from the match string rather than `location.data()`, which is
+    // the coarse enclosing span for a macro reached through a synthesized run.
+    let is_icon = !whole.starts_with("image:");
 
     // Group 1 is the (optional) target; group 2 is the bracket text, which
     // always participates (it may be empty).
-    let target = caps
-        .get(1)
-        .map(|m| source_slice(pieces, m.start()..m.end(), root))
-        .map_or_else(|| CowStr::from(""), |sp| CowStr::from(sp.data()));
+    let target = match caps.get(1) {
+        None => CowStr::from(""),
 
-    let bracket = caps.get(2).map_or_else(
-        || location.slice(0..0),
-        |m| source_slice(pieces, m.start()..m.end(), root),
-    );
+        // The caller admitted no atomic piece in the match, so `text_slice`
+        // always yields a value here – borrowed from `'src` for a verbatim
+        // target, the expansion's own exact bytes for a synthesized one.
+        Some(m) => text_slice(nodes, pieces, m.start()..m.end())?,
+    };
+
+    let bracket = match caps.get(2) {
+        Some(m) if range_is_verbatim(pieces, &(m.start()..m.end())) => {
+            source_slice(pieces, m.start()..m.end(), root)
+        }
+
+        // An empty attribute list carries no bytes to slice, so it parses from
+        // a zero-length span wherever the macro sits (the same span an absent
+        // group takes).
+        Some(m) if m.is_empty() => location.slice(0..0),
+
+        // A non-empty attribute list crossing a synthesized run: deferred (see
+        // this function's own "what must be verbatim" note).
+        Some(_) => return None,
+
+        None => location.slice(0..0),
+    };
 
     let attrlist = Attrlist::parse(bracket, parser, AttrlistContext::Inline)
         .item
@@ -219,7 +268,7 @@ fn build_image_node<'src>(
         (Some(CowStr::from(alt)), width, height)
     };
 
-    InlineNode::Image(Image {
+    Some(InlineNode::Image(Image {
         is_icon,
         target,
         alt,
@@ -227,7 +276,7 @@ fn build_image_node<'src>(
         height,
         attrs: Some(attrlist),
         location,
-    })
+    }))
 }
 
 /// Performs the recognition side effects the string pipeline's own
@@ -846,5 +895,215 @@ mod tests {
         apply_image_side_effects(&nodes, &parser, Span::new(source));
 
         assert_eq!(parser.substitution_warnings_len(), before);
+    }
+
+    /// A parser carrying the attributes the expanded-value fixtures below
+    /// reference.
+    fn expanding_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default()
+            .with_intrinsic_attribute("logo", "sunset.jpg", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("dir", "assets", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("iconname", "home", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("caption", "Sunset", ModificationContext::Anywhere)
+            .with_intrinsic_attribute(
+                "img-src",
+                "image:sunset.jpg[]",
+                ModificationContext::Anywhere,
+            )
+            .with_intrinsic_attribute(
+                "img-src-alt",
+                "image:sunset.jpg[Sunset]",
+                ModificationContext::Anywhere,
+            )
+    }
+
+    /// The real, public pipeline's output for `source` – the golden for the
+    /// expanded-value fixtures, which need the `AttributeReferences` step
+    /// [`golden_macros_with`] deliberately omits.
+    fn golden_normal(source: &str, parser: &Parser) -> String {
+        use crate::content::{Content, SubstitutionGroup};
+
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_images_inside_expanded_values() {
+        // An image or icon macro whose *target* (or whose whole macro name)
+        // crosses a synthesized run is now recognized: the name and target are
+        // read from the level's match string, which carries an expanded value's
+        // bytes exactly, so only the node's `location` takes design §4.4's
+        // coarse fallback. The macro's own attribute list is the one part that
+        // still needs an honest `'src` slice – see the divergence test below –
+        // so every fixture here either carries a verbatim bracket or an empty
+        // one.
+        let parser = expanding_parser();
+
+        let fixtures = [
+            // An expanded target, with and without an attribute list.
+            "image:{logo}[Logo]",
+            "image:{logo}[]",
+            "icon:{iconname}[]",
+            "icon:{iconname}[Home]",
+            // A partially-expanded target: the expansion is one piece of it.
+            "image:{dir}/sunset.jpg[Sunset]",
+            "image:{dir}/{logo}[]",
+            // A verbatim attribute list beside an expanded target, including
+            // the positional width/height and a named attribute.
+            "image:{logo}[Alt Text,200,100]",
+            "image:{logo}[alt=Alt Text,width=200]",
+            "image:{logo}[Logo,role=thumb]",
+            // The whole macro arriving from an expanded value – recognized
+            // only because its bracket is empty (see the divergence test for
+            // the non-empty case).
+            "see {img-src} here",
+            // Embedded in surrounding flow, beside another macro, and inside a
+            // rendered span.
+            "See image:{logo}[Logo] here.",
+            "image:{logo}[A] then image:other.png[B]",
+            "*image:{logo}[Logo]*",
+            // An escape still keeps the macro literal.
+            "\\image:{logo}[Logo]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = crate::content::inline_builder::fold_html(
+                &build(Span::new(fixture), &parser, None),
+                &renderer,
+                &parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_normal(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_inside_an_expanded_value_keeps_a_coarse_location() {
+        // The target is recovered *exactly* (through `text_slice`), while the
+        // node's `location` falls back to the enclosing synthesized run's own
+        // span – design §4.4's documented split, the same one the anchor, UI,
+        // index-term, and cross-reference families already take.
+        let parser = expanding_parser();
+        let source = "image:{logo}[Logo]";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert!(!image.is_icon);
+        assert_eq!(image.target.as_ref(), "sunset.jpg");
+        assert_eq!(image.alt.as_deref(), Some("Logo"));
+
+        // The whole macro's span: its own source bytes, not the expansion's.
+        assert_eq!(image.location.data(), source);
+    }
+
+    #[test]
+    fn an_icons_name_inside_an_expanded_value_is_read_from_the_match_string() {
+        // The `image:`/`icon:` discriminant is read from the match string, not
+        // from `location.data()` – which, for a wholly-expanded macro, is the
+        // attribute reference rather than the macro.
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute(
+            "icon-src",
+            "icon:home[]",
+            ModificationContext::Anywhere,
+        );
+
+        let nodes = build(Span::new("{icon-src}"), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert!(
+            image.is_icon,
+            "the macro name must come from the match string"
+        );
+        assert_eq!(image.target.as_ref(), "home");
+        assert_eq!(image.location.data(), "{icon-src}");
+    }
+
+    #[test]
+    fn an_attribute_list_inside_an_expanded_value_is_a_documented_divergence() {
+        // A non-empty attribute list crossing a synthesized run is the one
+        // part of an image macro that cannot follow the lift: an
+        // `Attrlist<'src>` reads its own `Span<'src>`'s bytes *as content*, and
+        // an expanded value has no source slice carrying them. The macro is
+        // left literal rather than built with a wrong attribute list.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        let parser = expanding_parser();
+
+        for source in [
+            "image:sunset.jpg[{caption}]",
+            "image:{logo}[{caption},200]",
+            // The whole macro arriving from an expanded value, this time with
+            // a non-empty bracket – the empty-bracket spelling of the same
+            // shape *is* recognized (see the parity corpus above).
+            "see {img-src-alt} here",
+        ] {
+            let nodes = build(Span::new(source), &parser, None);
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+                "an image whose attribute list crosses an expansion must stay literal: {nodes:?}"
+            );
+
+            assert!(
+                golden_normal(source, &parser).contains("<img"),
+                "the golden fixture stopped recognizing the image for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_images_inside_expanded_values() {
+        // The staged `register_image` side effect reads the node's own stored
+        // `target`, which is now the *expanded* one – so the catalog must match
+        // the golden pipeline's, which registers what its own expanded haystack
+        // matched. Two independent parsers, as elsewhere in this module.
+        let fixtures = [
+            "image:{logo}[Logo]",
+            "image:{logo}[]",
+            "image:{dir}/{logo}[]",
+            "see {img-src} here",
+            "image:{logo}[A] then image:other.png[B]",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = expanding_parser().with_catalog_assets(true);
+            let nodes = build(Span::new(fixture), &builder_parser, None);
+            apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
+
+            let golden_parser = expanding_parser().with_catalog_assets(true);
+            golden_normal(fixture, &golden_parser);
+
+            let got: Vec<_> = builder_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+
+            let want: Vec<_> = golden_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+
+            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+        }
     }
 }

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -44,15 +44,28 @@ use crate::{
 ///   the identical node; running that pass second mirrors the string step's
 ///   order.
 /// - A **formal text carrying an attribute list** (an `=` selecting roles / id
-///   / title / window) is deferred, exactly as [`link_macro_level`] defers it:
-///   the attribute list is parsed from a newline-normalized *copy* of the text,
-///   so it cannot ride on the node as an [`Attrlist`]`<'src>` yet.
-/// - A **non-verbatim match** – a URL crossing an escaped special
-///   ([`CharRef`](InlineNode::CharRef)) or a rendered
+///   / title / window) is deferred when the bracketed text is not verbatim
+///   `'src`, exactly as [`link_macro_level`] defers it: the attribute list is
+///   parsed from a newline-normalized *copy* of the text, and only a text with
+///   no embedded newline *and* no [`synthesized`](Piece::synthesized) run in it
+///   has an `'src` slice that copy coincides with – the one thing an
+///   [`Attrlist`]`<'src>` cannot do without.
+/// - A match crossing an [`atomic`](Piece::atomic) piece – a URL crossing an
+///   escaped special ([`CharRef`](InlineNode::CharRef)) or a rendered
 ///   [`Styled`](crate::inlines::Styled) span – is deferred exactly as the image
 ///   increment defers `image:a&b.png[]`. For the ANGLE branch this means the
 ///   URL *between* the delimiters: the delimiters themselves are escaped
 ///   specials by construction (see [`build_inline_link_node`]).
+///
+/// A [`synthesized`](Piece::synthesized) run (an attribute expansion, or –
+/// reached at a tree's root – a filtered multi-line block's own joined seed)
+/// **is** admitted: every value this pass's nodes hold – the scheme, the URL,
+/// and the bracketed display text – is computed out of the level's match
+/// string, which carries a synthesized run's bytes exactly, so
+/// `https://{host}/path` and `{url}[Docs]` are recognized with only the node's
+/// `location` taking design §4.4's coarse fallback. The one exception is the
+/// attribute-list text above, which is what `Attrlist<'src>` needs a real
+/// slice for.
 ///
 /// An invalid quoted bare URL (`"https://example.org`) and a bare scheme with no
 /// body (`http://;`) are left literal by the string step *and* the builder, so
@@ -141,20 +154,24 @@ fn find_inline_link_matches<'src>(
 /// by [`build_angle_link_node`], to which this delegates on the same condition
 /// the replacer branches on.
 ///
-/// # The verbatim gate lives here
+/// # The gate lives here
 ///
-/// Only a wholly-verbatim match can slice its target / attribute list from
-/// `'src`, so a match crossing an escaped special
+/// A match crossing an [`atomic`](Piece::atomic) piece – an escaped special
 /// ([`CharRef`](InlineNode::CharRef)) or a rendered
-/// [`Styled`](crate::inlines::Styled) span is deferred. *Which* sub-range must
-/// be verbatim depends on the branch, which is why the check sits here rather
+/// [`Styled`](crate::inlines::Styled) span – is deferred. *Which* sub-range the
+/// gate covers depends on the branch, which is why the check sits here rather
 /// than in [`find_inline_link_matches`]: the ANGLE branch's `&lt;` prefix and
 /// `&gt;` terminator are themselves escaped specials – atomic pieces – under
-/// every effective order that escapes them, so requiring the whole match to be
-/// verbatim would defer that branch outright. Those two delimiters carry no
-/// value a node slices (the replacer emits neither), so for the ANGLE branch
-/// the gate covers only the interior between them: the scheme, the URL, and any
-/// `[…]` attribute list.
+/// every effective order that escapes them, so gating the whole match would
+/// defer that branch outright. Those two delimiters carry no value a node
+/// slices (the replacer emits neither), so for the ANGLE branch the gate covers
+/// only the interior between them: the scheme, the URL, and any `[…]`
+/// attribute list.
+///
+/// A [`synthesized`](Piece::synthesized) run is admitted (see
+/// [`inline_link_level`]); only the attribute-list branch below, which parses a
+/// real [`Attrlist`]`<'src>` out of the bracketed text's own source slice,
+/// still requires that one sub-range to be verbatim.
 ///
 /// Like every macro family in this additive builder, it deliberately performs
 /// *no* recognition side effect: it does **not** `register_link` the target in
@@ -179,16 +196,16 @@ fn build_inline_link_node<'src>(
     let scheme_m = n.scheme_match()?;
     let scheme = scheme_m.as_str();
 
-    // The sub-range that must be verbatim source (see this function's own
-    // "verbatim gate" note): the whole match, except for the ANGLE branch,
-    // whose escaped-special delimiters sit outside the interior.
-    let verbatim_range = if n.is_angle() {
+    // The sub-range the gate covers (see this function's own "the gate lives
+    // here" note): the whole match, except for the ANGLE branch, whose
+    // escaped-special delimiters sit outside the interior.
+    let gated_range = if n.is_angle() {
         scheme_m.start()..n.angle_url().map_or(full.end, |m| m.end())
     } else {
         full.clone()
     };
 
-    if !range_is_verbatim(pieces, &verbatim_range) {
+    if !range_is_verbatim_or_synthesized(pieces, &gated_range) {
         return None;
     }
 
@@ -285,10 +302,18 @@ fn build_inline_link_node<'src>(
         // (`Ref::attrs`'s own field docs explain why `roles`/`window` alone
         // are not enough). A text that *does* embed a newline still needs a
         // synthesized (owned) copy the node cannot hold yet, so that one form
-        // remains deferred.
+        // remains deferred – as does one crossing a
+        // [`synthesized`](Piece::synthesized) run, whose match-string bytes
+        // have no `'src` slice at all (the one sub-range this family's
+        // expanded-value lift cannot cover).
         if link_text.contains('=') {
             #[allow(clippy::unwrap_used)]
             let range = text_location_range.clone().unwrap();
+
+            if !range_is_verbatim(pieces, &range) {
+                return None;
+            }
+
             let text_span = source_slice(pieces, range, root);
 
             if text_span.data().contains('\n') {
@@ -499,13 +524,30 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 ///   trailing-punctuation handling) and are a separate later increment.
 /// - **A link text that carries an attribute list** – a `,` in a `mailto:` text
 ///   (its `subject`/`body`) or an `=` in a `link:` text (roles / id / title /
-///   window) – is deferred, because that attribute list is parsed from a
-///   newline-normalized *copy* of the text (not from `'src`) and so cannot be
-///   carried as an [`Attrlist`]`<'src>` on the node yet.
-/// - **A non-verbatim match** – a macro whose target or text crosses an escaped
-///   special ([`CharRef`](InlineNode::CharRef)) or a rendered
+///   window) – is deferred unless the bracketed text is verbatim `'src`,
+///   because that attribute list is parsed from a newline-normalized *copy* of
+///   the text and only a text with no embedded newline and no
+///   [`synthesized`](Piece::synthesized) run in it has a source slice that copy
+///   coincides with – the one thing an [`Attrlist`]`<'src>` cannot do without.
+/// - **A match crossing an [`atomic`](Piece::atomic) piece** – a macro whose
+///   target or text crosses an escaped special
+///   ([`CharRef`](InlineNode::CharRef)) or a rendered
 ///   [`Styled`](crate::inlines::Styled) span (`link:a&b[]`, `link:x[*bold*]`) –
 ///   is deferred exactly as the image increment defers `image:a&b.png[]`.
+/// - **A macro whose own `link:`/`mailto:` marker is not verbatim** – a
+///   *wholly* expanded macro (`:m: link:index.html[Docs]`, then `{m}`) – is
+///   deferred. Its target and bracketed text could be read from the match
+///   string like every other value here, but the node's `location` would then
+///   fall back to the expansion's coarse span (design §4.4), and that location
+///   is the very signal [`link_form`] reads to tell this pass's nodes apart
+///   from the other two link passes' when [`apply_link_side_effects`] replays
+///   the string pipeline's own family-pass registration order. A macro whose
+///   marker *is* written in the source (`link:{url}[Docs]`,
+///   `mailto:{addr}[Team]`) keeps an honest location and is recognized.
+///
+/// Apart from that marker, a [`synthesized`](Piece::synthesized) run is
+/// admitted: the target and display text are read out of the level's match
+/// string, which carries an expanded value's bytes exactly.
 ///
 /// A `link:` (not `mailto:`) target whose scheme could execute script
 /// (`javascript:`, `data:`, `vbscript:`) is likewise left literal – matching
@@ -552,10 +594,25 @@ fn find_link_macro_matches<'src>(
 
         let full = whole.start()..whole.end();
 
-        // Only a wholly-verbatim match can slice its target/text from `'src`; a
-        // match crossing an escaped special or a rendered span is left for a
-        // later increment.
-        if !range_is_verbatim(pieces, &full) {
+        // A match crossing an escaped special or a rendered span is left for a
+        // later increment; one crossing an expanded attribute value is
+        // admitted, since the target and text are read from the match string.
+        if !range_is_verbatim_or_synthesized(pieces, &full) {
+            continue;
+        }
+
+        // The macro's own `link:`/`mailto:` marker must be verbatim source, so
+        // the node's `location` still starts with it – the signal
+        // [`link_form`] reads (see [`link_macro_level`]'s own scope note). The
+        // marker runs from the match's start to wherever the target group
+        // begins; one of groups 2 (empty target) and 3 always participates.
+        let marker = full.start
+            ..caps
+                .get(2)
+                .or_else(|| caps.get(3))
+                .map_or(full.end, |m| m.start());
+
+        if !range_is_verbatim(pieces, &marker) {
             continue;
         }
 
@@ -652,12 +709,20 @@ pub(super) fn build_link_node<'src>(
         // slice, so the node can carry the real `Attrlist<'src>` `render_link`
         // needs (`Ref::attrs`'s own field docs). A text that *does* embed a
         // newline still needs a synthesized copy the node cannot hold yet, so
-        // that one form remains deferred.
+        // that one form remains deferred – as does one crossing a
+        // [`synthesized`](Piece::synthesized) run, whose match-string bytes
+        // have no `'src` slice at all.
         if is_mailto {
             if link_text.contains(',') {
                 #[allow(clippy::unwrap_used)]
                 let m = raw_text_m.unwrap();
-                let text_span = source_slice(pieces, m.start()..m.end(), root);
+                let range = m.start()..m.end();
+
+                if !range_is_verbatim(pieces, &range) {
+                    return None;
+                }
+
+                let text_span = source_slice(pieces, range, root);
 
                 if text_span.data().contains('\n') {
                     return None;
@@ -685,7 +750,13 @@ pub(super) fn build_link_node<'src>(
         } else if link_text.contains('=') {
             #[allow(clippy::unwrap_used)]
             let m = raw_text_m.unwrap();
-            let text_span = source_slice(pieces, m.start()..m.end(), root);
+            let range = m.start()..m.end();
+
+            if !range_is_verbatim(pieces, &range) {
+                return None;
+            }
+
+            let text_span = source_slice(pieces, range, root);
 
             if text_span.data().contains('\n') {
                 return None;
@@ -2230,13 +2301,16 @@ mod tests {
     #[test]
     fn an_email_inside_an_expanded_attribute_value_is_recognized() {
         // An address whose bytes come from a *synthesized* run (an attribute
-        // reference's resolved value). Unlike a URL link – whose node bakes an
-        // `Attrlist`/target straight out of `'src` – an e-mail node carries
-        // only plain text, so `text_slice` recovers the address exactly here,
-        // the same lift the anchor family already has (design §3.4.1's "a
-        // macro inside an expanded value" boundary). Byte-parity for this
-        // shape is pinned by the whole-pipeline corpus in this module's
-        // `mod.rs`, which runs the real `AttributeReferences` step.
+        // reference's resolved value) – recovered exactly by `text_slice`,
+        // since an e-mail node carries only plain text (design §3.4.1's "a
+        // macro inside an expanded value" boundary). The two URL-link passes
+        // now make the same lift for their own targets and display texts; the
+        // one part of this family that still needs an honest `'src` slice is
+        // an attribute-list-bearing display text (see
+        // `a_link_attribute_list_text_inside_an_expanded_value_is_a_documented_divergence`).
+        // Byte-parity for this shape is pinned by the whole-pipeline corpus in
+        // this module's `mod.rs`, which runs the real `AttributeReferences`
+        // step.
         use crate::parser::ModificationContext;
 
         let parser = Parser::default().with_intrinsic_attribute(
@@ -2561,6 +2635,15 @@ mod tests {
         // that the real string pipeline (`golden_macros_with`) runs against
         // directly. Because neither path is wired into the other, comparing
         // their two catalogs after the fact is the whole test.
+        //
+        // The separators are plain spaces, not `{sp}` attribute references:
+        // `golden_macros_with` deliberately skips the `AttributeReferences`
+        // step (see its own doc comment), so a reference in a fixture makes the
+        // two sides read *different* text – latent while every link family
+        // deferred inside a synthesized run, but live now that they no longer
+        // do (a `{sp}` before a bare URL leaves the golden a `}` boundary
+        // character, which `INLINE_LINK` rejects, while the builder sees the
+        // expanded space and links it).
         let fixtures = [
             "link:index.html[Docs]",
             "link:[]",
@@ -2570,17 +2653,17 @@ mod tests {
             "https://example.org[Example]",
             "link:https://example.org[Example]",
             "\\link:index.html[Docs]",
-            "link:a.html[A]{sp}link:b.html[B]",
+            "link:a.html[A] link:b.html[B]",
             // Interleaved forms, out of source order relative to the family
             // passes that register them (see `apply_link_side_effects`'s own
             // "Registration order" doc note).
-            "link:b.html[B]{sp}then{sp}https://a.example",
+            "link:b.html[B] then https://a.example",
             // The bare e-mail form, alone and interleaved with both URL-link
             // forms – it registers last of the three, wherever it appears.
             "doc@example.com",
             "\\doc@example.com",
-            "doc@example.com{sp}then{sp}link:b.html[B]",
-            "a@example.org{sp}link:b.html[B]{sp}https://c.example{sp}d@example.org",
+            "doc@example.com then link:b.html[B]",
+            "a@example.org link:b.html[B] https://c.example d@example.org",
         ];
 
         for fixture in fixtures {
@@ -2590,6 +2673,206 @@ mod tests {
 
             let golden_parser = Parser::default().with_catalog_assets(true);
             golden_macros_with(fixture, &golden_parser);
+
+            assert_eq!(
+                builder_parser.catalog().links(),
+                golden_parser.catalog().links(),
+                "registered links diverged for {fixture:?}"
+            );
+        }
+    }
+
+    /// A parser carrying the attributes the expanded-value fixtures below
+    /// reference.
+    fn expanding_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default()
+            .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("host", "example.org", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("addr", "hello@example.org", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("label", "Docs", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("site", "https://example.org", ModificationContext::Anywhere)
+            .with_intrinsic_attribute(
+                "link-src",
+                "link:index.html[Docs]",
+                ModificationContext::Anywhere,
+            )
+    }
+
+    /// The real, public pipeline's output for `source` – the golden for the
+    /// expanded-value fixtures, which need the `AttributeReferences` step
+    /// [`golden_macros_with`] deliberately omits.
+    fn golden_normal(source: &str, parser: &Parser) -> String {
+        use crate::content::{Content, SubstitutionGroup};
+
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_links_inside_expanded_values() {
+        // A link whose target or display text crosses a synthesized run (an
+        // attribute expansion) is now recognized: every value these nodes hold
+        // is computed out of the level's match string, which carries an
+        // expanded value's bytes exactly, so only the node's `location` takes
+        // design §4.4's coarse fallback. The two shapes that still defer – an
+        // attribute-list-bearing display text, and a wholly expanded
+        // `link:`/`mailto:` macro – have their own divergence tests below.
+        let parser = expanding_parser();
+
+        let fixtures = [
+            // The `link:`/`mailto:` macro with an expanded target: labeled,
+            // bare, and with the `^` new-window suffix.
+            "link:{url}[Docs]",
+            "link:{url}[]",
+            "link:{url}[Open^]",
+            "mailto:{addr}[Team]",
+            "mailto:{addr}[]",
+            // An expanded *display text* beside a verbatim target.
+            "link:index.html[{label}]",
+            "link:{url}[{label}]",
+            // Auto-links and formal-URL links over an expanded host.
+            "https://{host}",
+            "https://{host}/path",
+            "https://{host}[Example]",
+            "https://{host}[{label}]",
+            // A wholly expanded auto-link (the URL-link passes need no
+            // literal marker of their own, unlike the `link:` macro).
+            "see {site} now",
+            "see {site}[Home] now",
+            // The angle-bracketed spellings.
+            "<https://{host}>",
+            "<https://{host}[Example]",
+            // Embedded in surrounding flow, beside another link, and inside a
+            // rendered span.
+            "See link:{url}[Docs] here.",
+            "link:{url}[A] and link:other.html[B]",
+            "*link:{url}[Docs]*",
+            // The escapes still keep the macro literal.
+            "\\link:{url}[Docs]",
+            "\\https://{host}",
+        ];
+
+        for fixture in fixtures {
+            let folded = crate::content::inline_builder::fold_html(
+                &build(Span::new(fixture), &parser, None),
+                &HtmlSubstitutionRenderer {},
+                &parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_normal(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_link_inside_an_expanded_value_keeps_a_coarse_location() {
+        // The target and display text are recovered *exactly* from the match
+        // string, while the node's `location` falls back to the enclosing
+        // synthesized run's own span – design §4.4's documented split.
+        let parser = expanding_parser();
+        let source = "link:{url}[{label}]";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+        let reference = assert_link(&nodes[0]);
+
+        assert_eq!(reference.target.as_ref(), "index.html");
+        assert_eq!(link_text_of(reference), "Docs");
+
+        // The macro's own source bytes: its `link:` marker is verbatim (which
+        // is what this pass requires), so the location is honest end to end
+        // here even though both captures came from expansions.
+        assert_eq!(reference.location.data(), source);
+    }
+
+    #[test]
+    fn a_wholly_expanded_link_macro_is_a_documented_divergence() {
+        // A `link:`/`mailto:` macro whose own marker comes from the expansion
+        // has no location starting with that marker, and that location is the
+        // signal `link_form` reads to replay the string pipeline's family-pass
+        // registration order. Rather than build a node the side-effect walk
+        // would then mis-attribute, the macro is left literal.
+        //
+        // If this boundary is ever lifted (with a signal that does not depend
+        // on the location), fold this fixture into the parity corpus above.
+        let parser = expanding_parser();
+        let source = "see {link-src} now";
+
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a wholly expanded link macro must stay literal: {nodes:?}"
+        );
+
+        assert!(
+            golden_normal(source, &parser).contains("<a href"),
+            "the golden fixture stopped recognizing the link"
+        );
+    }
+
+    #[test]
+    fn a_link_attribute_list_text_inside_an_expanded_value_is_a_documented_divergence() {
+        // A display text carrying an attribute list is parsed as a real
+        // `Attrlist<'src>`, which reads its own source span's bytes *as
+        // content* – so, unlike every other value these nodes hold, it cannot
+        // be taken from the match string. Both link-recognizing passes defer
+        // it, as does a `mailto:` text carrying a `,` subject.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        let parser = expanding_parser();
+
+        for source in [
+            "link:index.html[{label},role=hl]",
+            "https://example.org[{label},role=hl]",
+            "mailto:hello@example.org[{label},Hi there]",
+        ] {
+            let nodes = build(Span::new(source), &parser, None);
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a link whose attribute-list text crosses an expansion must stay literal: \
+                 {nodes:?}"
+            );
+
+            assert!(
+                golden_normal(source, &parser).contains("<a href"),
+                "the golden fixture stopped recognizing the link for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_links_inside_expanded_values() {
+        // The staged `register_link` side effect classifies each node by the
+        // pass that built it, from the node's own `location` – which is exactly
+        // why `link_macro_level` still requires its `link:`/`mailto:` marker to
+        // be verbatim. These fixtures interleave the two URL-link passes' forms
+        // over expanded values, in both relative orders, so a misclassification
+        // would show up as the wrong catalog order.
+        let fixtures = [
+            "link:{url}[Docs]",
+            "https://{host}",
+            "link:{url}[Docs] and https://{host}",
+            "https://{host} then link:{url}[Docs]",
+            "see {site} now",
+            "mailto:{addr}[Team] and https://{host}",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = expanding_parser().with_catalog_assets(true);
+            let nodes = build(Span::new(fixture), &builder_parser, None);
+            apply_link_side_effects(&nodes, &builder_parser);
+
+            let golden_parser = expanding_parser().with_catalog_assets(true);
+            golden_normal(fixture, &golden_parser);
 
             assert_eq!(
                 builder_parser.catalog().links(),

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -937,6 +937,32 @@ mod tests {
             "See *xref:{id}[{label}]* and <<{id},the {product} steps>> plus a (C) mark.",
             with_xref_attributes,
         );
+
+        // Links and images spliced in by attribute references – the last two
+        // families to make that lift, and the two that hold a real
+        // `Attrlist<'src>`. Their targets and display texts come from the
+        // match string like every other family's values; what still defers is
+        // an image's non-empty attribute list, a link's attribute-list-bearing
+        // display text, and a wholly expanded `link:` macro (each pinned by
+        // its own divergence test in `macros/image.rs` and `macros/links.rs`).
+        let with_link_attributes = || {
+            Parser::default()
+                .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("host", "example.org", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("label", "Docs", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("logo", "sunset.jpg", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+        };
+
+        assert_parity_with(
+            "Read *link:{url}[{label}]* or visit https://{host}/docs about {product}.",
+            with_link_attributes,
+        );
+
+        assert_parity_with(
+            "See image:{logo}[Logo] and image:{logo}[] beside <https://{host}> and a (C) mark.",
+            with_link_attributes,
+        );
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1008,6 +1034,21 @@ mod tests {
             (
                 "  see <<target>> and\n  xref:other[the other one]",
                 "see <<target>> and\nxref:other[the other one]",
+            ),
+            // The URL-link family in a wholly-synthesized seed, and an image
+            // macro with an *empty* bracket: neither needs an `'src` slice
+            // (the empty attribute list parses from a zero-length span). An
+            // image with a non-empty bracket, and the `link:`/`mailto:` macro
+            // in any spelling, still defer – see
+            // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
+            // below.
+            (
+                "  visit https://example.org[the site]\n  or https://plain.example",
+                "visit https://example.org[the site]\nor https://plain.example",
+            ),
+            (
+                "  see image:sunset.jpg[] and\n  icon:home[] here",
+                "see image:sunset.jpg[] and\nicon:home[] here",
             ),
         ];
 
@@ -1361,27 +1402,38 @@ mod tests {
         }
     }
 
-    /// A documented divergence, not a bug: a macro family that holds a real
-    /// [`Attrlist`](crate::attributes::Attrlist)`<'src>` – a link or an image,
-    /// the two that are left – is still unrecognized when the *whole* seed is
-    /// synthesized, because
+    /// A documented divergence, not a bug: two shapes stay unrecognized when
+    /// the *whole* seed is synthesized.
+    ///
+    /// The first is a construct needing a real
+    /// [`Attrlist`](crate::attributes::Attrlist)`<'src>` – an image macro's
+    /// non-empty attribute list, or a link's attribute-list-bearing display
+    /// text – because
     /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) reads its
     /// `source: Span<'src>`'s bytes as content, not merely as a location tag,
     /// so a real `'src` slice is not optional there. This is the same
     /// [`range_is_verbatim`](macros::image::range_is_verbatim) boundary that
-    /// defers those families *nested inside* an attribute expansion's spliced
+    /// defers those shapes *nested inside* an attribute expansion's spliced
     /// value (see [`apply_attribute_references`]'s own doc comment), now
     /// reached at the tree's root instead of a nested splice.
     ///
-    /// [`build_from_value`] does not lift this boundary: it only unblocks a
-    /// synthesized (filtered/joined multi-line) seed for the steps and
-    /// families that never needed a verbatim slice in the first place (quotes,
-    /// specialcharacters, attribute references, character replacements,
-    /// post-replacement, and the anchor / bare-e-mail / UI / index-term /
-    /// cross-reference families, each of which computes every value it holds
-    /// from the match string or [`text_slice`](quotes::text_slice) – all
-    /// exercised by the parity sweep above). Lifting it for a link's or an
-    /// image's own target remains a later increment's job.
+    /// The second – exercised by this test's own fixture – is a
+    /// `link:`/`mailto:` macro whose own marker is not verbatim, which a
+    /// wholly-synthesized seed guarantees: that marker is what keeps the
+    /// node's `location` telling this pass's nodes from the other link
+    /// passes' when
+    /// [`apply_link_side_effects`](macros::links::apply_link_side_effects)
+    /// replays the string pipeline's registration order (see
+    /// [`link_macro_level`](macros::links::link_macro_level)).
+    ///
+    /// Everything else is recognized here, including an image macro with an
+    /// *empty* bracket and every URL-link spelling – both exercised by the
+    /// parity sweep above, alongside the steps and families that never needed
+    /// a verbatim slice in the first place (quotes, specialcharacters,
+    /// attribute references, character replacements, post-replacement, and the
+    /// anchor / bare-e-mail / UI / index-term / cross-reference families, each
+    /// of which computes every value it holds from the match string or
+    /// [`text_slice`](quotes::text_slice)).
     #[test]
     fn a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized() {
         let filtered = "see link:https://example.org[Example] here";

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -952,4 +952,29 @@ fn shapes_match_across_combined_constructs() {
                 .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
         },
     );
+
+    // Links and images spliced in by attribute references – the last two
+    // families to make that lift. What each still defers (an image's non-empty
+    // attribute list, a link's attribute-list-bearing display text, and a
+    // wholly expanded `link:` macro) is deliberately absent here: the recorder
+    // recognizes those, so a fixture carrying one would compare a node against
+    // literal text rather than two constructions of the same node.
+    let with_link_attributes = || {
+        Parser::default()
+            .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("host", "example.org", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("label", "Docs", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("logo", "sunset.jpg", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+    };
+
+    assert_shapes_with(
+        "Read link:{url}[{label}] or visit https://{host}/docs about {product}.",
+        with_link_attributes,
+    );
+
+    assert_shapes_with(
+        "See image:{logo}[Logo] and image:{logo}[] beside a *bold* run.",
+        with_link_attributes,
+    );
 }


### PR DESCRIPTION
The corpus-wide fold-parity audit (design doc §5.2, Phase 4 step 6) leaves an itemized list of divergences to close before `rendered_html()` can become an authoritative fold of the tree. "A macro inside an expanded attribute value" was closed in #1188 and #1189 for the anchor, bare-e-mail, UI, index-term, and cross-reference families — every family whose node carries **no `Span`-typed field**. This closes it for the two that are left: [`Image`](https://github.com/asciidoc-rs/asciidoc-parser/blob/inline-ast/parser/src/inlines/image.rs) and the `Ref{Link}` family, the two that hold a real `Attrlist<'src>`.

## The boundary moves from *the family* to *the one capture that needs a slice*

`Attrlist::parse` reads its `source: Span<'src>`'s bytes **as content**, not merely as a location tag, so an expanded value — which has no `'src` slice of its own — leaves it nothing to parse. That is real, and it is why #1189 grouped image and link together as "still cannot make this lift."

But it applies to the *attribute list alone*. Everything else these two families hold is already computed out of the level's match string, which carries a synthesized run's bytes exactly. So the same one-gate swap the four prior families made (`range_is_verbatim` → `range_is_verbatim_or_synthesized`) applies here too, plus a narrower check where a slice is genuinely required — which is what makes the common real-world spellings (`image:{logo}[Logo]`, `link:{url}[Docs]`, `https://{host}/path`) work while the genuinely blocked ones stay documented divergences.

- **Image / icon.** `build_image_node` reads the macro *name* from the match string rather than from `location.data()` (which is the coarse enclosing span for a wholly-expanded macro, so the `image:`-vs-`icon:` discriminant would otherwise be read off the attribute *reference*), and its *target* through `text_slice` — still borrowing from `'src` when the target is verbatim (§4.5), exact when it is not. The **bracket** keeps the verbatim check: a non-empty attribute list crossing a synthesized run leaves the macro literal, while an **empty** one (`image:{logo}[]`) needs no bytes at all and parses from the same zero-length span an absent group already used — so even a wholly-expanded `image:x.png[]` is recognized.
- **Links.** The three URL-link passes already computed every value they hold (scheme, URL, bracketed display text) from the match string, so `build_inline_link_node` and `find_link_macro_matches` needed only the gate swap. The **attribute-list-bearing display text** (a `link:`/formal-URL `=`, a `mailto:` `,` subject) keeps the verbatim check, for the same `Attrlist<'src>` reason and alongside the multi-line form the family already defers there.
- **One extra rule, for the `link:`/`mailto:` macro pass only.** That pass additionally requires its own literal `link:`/`mailto:` **marker** to be verbatim, so a *wholly* expanded macro (`{m}`, where `:m: link:index.html[Docs]`) stays literal. The reason is the staged side effect, not the node: `link_form` tells this pass's nodes from the other two link passes' by whether the node's `location` starts with that marker — the "no new node field" signal #1168 introduced to replay the string pipeline's family-pass registration order — and a coarse §4.4 location cannot carry it. A marker written in the source (`link:{url}[Docs]`) keeps an honest location end to end and is recognized. The URL-link and bare-e-mail passes need no such rule (their targets never carry the scheme `link_form` keys on), so a wholly expanded `{site}` auto-link *is* recognized.

## A latent test-harness hazard this surfaced

The family-scoped golden helper `golden_macros_with` deliberately omits the `AttributeReferences` step, so a fixture carrying a reference makes the two sides read *different* text. The link family's own registration corpus used `{sp}` as an interleaving separator, which was inert only while every link family deferred inside a synthesized run: with the lift, the builder sees the expanded space and links a following bare URL where the golden — still holding a literal `}` boundary character `INLINE_LINK` rejects — does not.

Those separators are now plain spaces, which is what the fixture always meant, and which makes its interleaved registration-order assertion non-vacuous for the first time. Every expanded-value fixture in this PR is driven through the real, public `SubstitutionGroup::Normal::apply` instead.

## Tests

- Differential corpora for each family's expanded-value forms — an expanded image/icon target (whole or partial) with a verbatim, an empty, and a positional/named attribute list; an expanded `link:`/`mailto:` target and display text; expanded auto-link, formal-URL and angle-bracketed hosts; a wholly expanded auto-link — all against the real `SubstitutionGroup::Normal::apply` as the golden.
- Structural tests pinning the exact-value/coarse-location split (§4.4) and the match-string-read macro name.
- Divergence tests for each shape that still defers: an image's non-empty attribute list, a link's attribute-list-bearing display text (all three spellings), and a wholly expanded `link:` macro. Each asserts the golden pipeline *does* recognize it, so a future boundary-lifting increment has a fixture ready to move into the parity corpus.
- Registration parity for both staged side effects against an independent golden parser (the two-independent-parsers discipline), including the interleaved link forms that pin the marker rule.
- Fixtures added to the whole-pipeline combined-constructs corpus, the synthesized-seed sweep (whose own deferral test keeps its `link:` macro fixture — now deferred by the marker rule rather than by a whole-family gate), and the structural recorder cross-check.
- Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence set strictly **shrank**: one more whole-corpus source is gone and no new one appeared.

`cargo test --all-features`, `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo +nightly fmt --all -- --check`, and `cargo +nightly doc --no-deps --document-private-items` are all clean.

As with every prep piece before it, **nothing further is wired into a real parse path**.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VKMXLN9GbWzTFQhwXdydg)_