### PR TITLE
feat: Recognize a bare e-mail address crossing an escaped special (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2788,6 +2788,66 @@ Each phase is a reviewable unit with a clear exit gate.
   address baked as its own display text, an `Attrlist<'src>`) that a later increment must take up on
   its own terms. As with every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the bare e-mail auto-link crossing an escaped special — the fourth
+  family, and the first to need no gate at all):* the increment above named the **bare-e-mail**
+  and **image** families as the two still holding the escaped-special boundary, the first of
+  them because it holds "an address baked as its own display text". Auditing that shows the
+  address is not baked but *sliced*, exactly like a bare `link:` macro's own target-derived
+  text — the shape that family already solved — so the lift needs no new mechanism: the target
+  is a computed string read off the level's **match string**
+  (`mailto:a&amp;b@example.com` — the very bytes `InlineEmailReplacer` computes from its own
+  escaped haystack, and what [`register_link`](../../parser/src/content/inline_builder/macros/links.rs)
+  records), and the display text goes through
+  [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs), the shared
+  helper, so each special stays the [`CharRef`](../../parser/src/inlines/char_ref.rs) it
+  already is — with its own precise `'src` span (#944) — instead of being baked, already
+  escaped, into one [`Text`](../../parser/src/inlines/inline_node.rs) the fold would escape a
+  second time. `a&b@example.com` is therefore recognized as the same
+  [`Ref`](../../parser/src/inlines/ref_node.rs)`{Link}` node its verbatim spelling builds,
+  folding through the identical `render_link`.
+
+  What *is* new in kind is that this family takes the lift with **no gate**. Its three
+  predecessors each swapped [`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs)
+  (or its synthesized-admitting sibling) for
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs); here
+  that swap would add a branch no input can reach. An address **cannot cross an opaque piece**:
+  every such piece is exactly one [`SPAN_PLACEHOLDER`](../../parser/src/content/inline_builder/quotes.rs)
+  (U+E0F0, Unicode category `Co`), which none of [`INLINE_EMAIL`](../../parser/src/content/macros.rs)'s
+  character classes admit — not the local part's `[\w_]` / `[\w\-.%+]`, not the domain's
+  `[\p{L}\p{Nd}_\-.]`, not the TLD's `[a-zA-Z]` — and a match can neither *begin* nor *end*
+  strictly inside an escaped special's entity, since an entity's leading `&` is in no class the
+  domain or TLD accepts and its trailing `;` is neither a local-part character nor the `@` a
+  local part must be followed by. So the only atomic piece an address range can overlap is a
+  **wholly contained** `&amp;` — precisely the one this lift admits. That is the same structural
+  argument the sibling auto-link family already makes for its own *required* boundary-prefix
+  group ("a placeholder simply fails its match"), reached here through the match's interior
+  rather than its boundary. The family's `Option`-returning "this increment defers" machinery is
+  removed rather than left unreachable — as the `<<id,>>` increment removed the cross-reference
+  family's — so [`build_email_node`](../../parser/src/content/inline_builder/macros/links.rs) is
+  now **total**, and the one deferral the family keeps is the *abutting* boundary class it
+  already documented, which the placeholder-**prefix** check expresses (a range gate never
+  could).
+
+  Differential corpora extend the family's fixtures with a crossing address alone, in flow,
+  doubled, and carrying two specials; with a literal `&` the pattern's classes do *not* admit (in
+  the domain, and opening the local part), where neither pipeline matches; with an address beside
+  but not crossing a special; with the escape (`\a&b@example.com`); and with a construct *inside*
+  what would otherwise be an address — a rendered span, a character replacement, a smart em dash —
+  which pins the no-gate invariant above as fixtures rather than only as prose. The family's own
+  divergence test becomes a **parity** test asserting the three recovered children and the `&`'s
+  own precise span, per its "if lifted, fold this into a parity corpus" convention, and the
+  abutting-divergence test gains a character-replacement fixture (`a(C)b@example.com`) — the same
+  class reached with no macro at all, since `&#169;`'s trailing `;` is no mismatch character.
+  Registration parity is asserted for the escaped-special forms against an independent golden
+  parser, and fixtures are added to the whole-pipeline combined-constructs corpus, the broad
+  general-purpose sweep, and the structural recorder cross-check. Re-running the corpus-wide
+  fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence
+  set strictly **shrank**: one previously-surviving source is gone (`bert&ernie@sesamestreet.com`,
+  a real golden fixture) and no new one appeared. The escaped-special boundary now remains only
+  for the **image** family, whose [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>`
+  bracket is the one value in this module a match string genuinely cannot supply. As with every
+  prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3077,6 +3137,23 @@ Each phase is a reviewable unit with a clear exit gate.
        use the helper. See the step's own "landed as" note above. The bare-e-mail and image families
        still keep the escaped-special boundary, and a display text crossing a rendered span still
        defers everywhere.
+     - ✅ **prep (the bare e-mail auto-link crossing an escaped special).** The fourth family to
+       lift that boundary, and the first to need **no gate** for it: `a&b@example.com` is
+       recognized as the same `Ref{Link}` node its verbatim spelling builds, its target read off
+       the match string (`mailto:a&amp;b@example.com`, the bytes `InlineEmailReplacer` computes
+       and registers) and its shown text — the address itself, a *slice* rather than a baked
+       string — recovered through the shared `macro_text_children`. An address cannot cross an
+       opaque piece at all: `INLINE_EMAIL`'s character classes admit no `SPAN_PLACEHOLDER`
+       (category `Co`), and a match can neither begin nor end inside an entity (its `&` fits no
+       domain/TLD class; its `;` is neither a local-part character nor the `@` a local part needs),
+       so the only atomic overlap possible is a wholly-contained `&amp;` — exactly what the lift
+       admits, making `range_has_no_opaque_piece` here a branch no input reaches.
+       `build_email_node` is correspondingly **total**, its `Option` machinery removed rather than
+       left unreachable, and the family's one remaining deferral is the *abutting* boundary class
+       (a placeholder-**prefix** check, not a range gate), now pinned for a character replacement
+       too. See the step's own "landed as" note above. Only the **image** family still keeps the
+       escaped-special boundary, and a display text crossing a rendered span still defers
+       everywhere.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -11,9 +11,7 @@ use crate::{
     content::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
-        inline_builder::quotes::{
-            Piece, SPAN_PLACEHOLDER, build_match_string, source_slice, text_slice,
-        },
+        inline_builder::quotes::{Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
     },
     inlines::{InlineNode, Ref, RefVariant},
     parser::has_dangerous_scheme,
@@ -1093,13 +1091,9 @@ pub(super) fn build_link_node<'src>(
 /// nodes here (they are already-rendered `<a …>` markup there), so an address
 /// *inside* one is never re-recognized.
 ///
-/// Two forms are left **unrecognized** for a later increment, each documented
-/// and pinned by its own divergence test:
+/// One form is left **unrecognized** for a later increment, documented and
+/// pinned by its own divergence test:
 ///
-/// - An address carrying a literal `&` (`a&b@example.org`), which reaches this
-///   pass as an atomic [`CharRef`](InlineNode::CharRef) (`&amp;`, admitted by
-///   the pattern's own local-part class) that a node cannot carry as text — the
-///   same escaped-special boundary every other macro family documents.
 /// - An address **abutting an already-recognized construct**
 ///   (`**bold**doc@example.org`, `link:x[y]doc@example.org`,
 ///   `image:x.png[]doc@example.org`). The mismatch-prefix group reads the
@@ -1127,6 +1121,36 @@ pub(super) fn build_link_node<'src>(
 /// like an anchor's id, and unlike a URL link's own target, an e-mail node
 /// needs no `Span`-typed field, so [`build_email_node`] recovers the exact
 /// address text there too rather than deferring.
+///
+/// An **escaped special** ([`CharRef`](InlineNode::CharRef)`::Special`) is
+/// admitted too (`a&b@example.org`, whose literal `&` the pattern's own
+/// local-part class matches as `&amp;`) — the fourth family to lift that
+/// boundary, after the cross-reference, `link:`/`mailto:` macro, and
+/// auto-link/formal-URL families, and the last of the link family's own
+/// spellings to lift it. The match string carries such a leaf's canonical
+/// entity — the very bytes the string replacer's own escaped haystack holds
+/// there — so the target this pass computes off that string
+/// (`mailto:a&amp;b@example.org`) *is* the one the replacer computed and
+/// registered, and no value on the node needs the source's own `&`. The
+/// display text, which is the address itself, then becomes **structured
+/// children** rather than one baked `Text` (see [`macro_text_children`]), so
+/// the special folds back to its own entity instead of being escaped twice.
+///
+/// Unlike its three predecessors, this family needs no
+/// [`range_has_no_opaque_piece`] gate to express that lift: an address
+/// **cannot** cross an opaque piece in the first place. Every such piece is
+/// exactly one [`SPAN_PLACEHOLDER`] (U+E0F0, Unicode category `Co`), which
+/// none of the pattern's character classes admit — not the local part's
+/// `[\w_]` / `[\w\-.%+]`, not the domain's `[\p{L}\p{Nd}_\-.]`, not the TLD's
+/// `[a-zA-Z]` — so a match can never contain one. Nor can a match *begin* or
+/// *end* strictly inside an escaped special's entity: an entity's leading `&`
+/// is in no class the domain or TLD accepts, and its trailing `;` is neither
+/// a local-part character nor the `@` a local part must be followed by. So
+/// the only atomic piece an address range can overlap is a **wholly
+/// contained** `&amp;`, which is precisely the one this lift admits — the
+/// same structural argument the sibling auto-link family already makes for
+/// its own required boundary-prefix group ("a placeholder simply fails its
+/// match"). A gate here would be a branch no input can reach.
 pub(super) fn email_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -1149,8 +1173,9 @@ pub(super) fn email_level<'src>(
 }
 
 /// Finds every recognized bare e-mail address at this level, honoring the
-/// pattern's own mismatch-prefix group and skipping any address
-/// [`build_email_node`] defers (see [`email_level`]).
+/// pattern's own mismatch-prefix group and skipping an address that **abuts**
+/// an opaque piece (one it *crosses* being structurally impossible — see
+/// [`email_level`]).
 fn find_email_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -1209,20 +1234,15 @@ fn find_email_matches<'src>(
             continue;
         }
 
-        match build_email_node(&caps, pieces, root, nodes) {
-            Some(node) => matches.push(MacroMatch {
-                kind: MacroMatchKind::Node {
-                    consumed: full.clone(),
-                    node: Box::new(node),
-                },
-                full,
-            }),
+        let node = build_email_node(&caps, pieces, root, nodes);
 
-            // An address crossing an atomic piece (an escaped `&`); left as
-            // literal source, exactly as every other macro family defers a
-            // match it cannot recover the text of.
-            None => continue,
-        }
+        matches.push(MacroMatch {
+            kind: MacroMatchKind::Node {
+                consumed: full.clone(),
+                node: Box::new(node),
+            },
+            full,
+        });
     }
 
     matches
@@ -1236,14 +1256,26 @@ fn find_email_matches<'src>(
 /// part — the string replacer passes `extra_roles: vec![]` and the raw address
 /// as its `link_text`.
 ///
-/// The address is recovered with [`text_slice`] rather than
-/// [`source_slice`]`.data()`, so it is exact even when its bytes come from a
-/// [`synthesized`](Piece::synthesized) run — the same treatment an anchor's id
-/// receives, and available for the same reason: an e-mail node carries no
+/// The target is read straight off the level's **match string**, exactly as
+/// `InlineEmailReplacer` reads `caps[2]` off its own escaped haystack — the
+/// same bytes, whether the address is verbatim `'src`, comes from a
+/// [`synthesized`](Piece::synthesized) run (an attribute expansion), or
+/// carries an escaped special (`a&amp;b@example.org`). An e-mail node holds no
 /// `Span`-typed field (no [`Attrlist`] parsed out of `'src`), only plain text,
-/// so only the node's `location` needs design §4.4's coarse fallback. Returns
-/// `None` when the address crosses an [`atomic`](Piece::atomic) piece — an
-/// escaped `&`, the one form [`email_level`] defers.
+/// so only the node's `location` needs design §4.4's coarse fallback.
+///
+/// The display text is that same address, so it is a *slice* of the match's own
+/// range rather than a value this builder computes: [`macro_text_children`]
+/// recovers it, borrowing from `'src` in the common case (§4.5) and rebuilding
+/// it as structured children — each escaped special staying the
+/// [`CharRef`](InlineNode::CharRef) it already is — when it crosses one, rather
+/// than baking the already-escaped address into one `Text` node the fold would
+/// escape a second time (design §3.4). There is no `\]` bracket unescape: this
+/// text comes from the address, which the pattern's own character classes never
+/// let a bracket into.
+///
+/// This is **total**: what the family defers is decided entirely by the gate
+/// [`find_email_matches`] applies before calling it.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect: it does **not** `register_link` the target, which
@@ -1254,31 +1286,21 @@ fn build_email_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     nodes: &[InlineNode<'src>],
-) -> Option<InlineNode<'src>> {
+) -> InlineNode<'src> {
     // Group 2 is the address itself. The `unwrap` is safe: the group is the
     // pattern's one mandatory capture, so it participates in every match (the
     // same reason the overall-match `unwrap` above is safe).
     #[allow(clippy::unwrap_used)]
     let address_m = caps.get(2).unwrap();
 
+    let address = address_m.as_str();
     let range = address_m.start()..address_m.end();
+    let location = source_slice(pieces, range.clone(), root);
 
-    if !range_is_verbatim_or_synthesized(pieces, &range) {
-        return None;
-    }
-
-    let address = text_slice(nodes, pieces, range.clone())?;
-    let location = source_slice(pieces, range, root);
-
-    Some(InlineNode::Ref(Ref {
+    InlineNode::Ref(Ref {
         variant: RefVariant::Link,
         target: CowStr::from(format!("mailto:{address}")),
-
-        children: vec![InlineNode::Text {
-            value: address,
-            location,
-        }],
-
+        children: macro_text_children(address, range, false, nodes, pieces, root),
         roles: vec![],
         window: None,
         attrs: None,
@@ -1286,7 +1308,7 @@ fn build_email_node<'src>(
         derived: None,
         xrefstyle: None,
         location,
-    }))
+    })
 }
 
 /// Performs the recognition side effect the string pipeline's five link
@@ -2882,9 +2904,37 @@ mod tests {
             "mailto:hello@example.org[]",
             "https://example.org/x@y.com",
             "see https://user@example.org/path here",
+            // An address crossing an escaped special: the pattern's local-part
+            // class admits `&amp;`, so the `&` is part of the address in both
+            // pipelines.
+            "a&b@example.com",
+            "write to a&b@example.com today",
+            "a&b&c@example.com",
+            "a&b@example.com and d&e@example.org",
+            // A literal `&` the pattern's classes do *not* admit — in the
+            // domain, or opening the local part — so neither pipeline matches
+            // the whole address there.
+            "user@ex&ample.com",
+            "&doc@example.com",
+            // An address beside, but not crossing, an escaped special.
+            "a < b then doc@example.com",
+            "doc@example.com & more",
+            // A construct *inside* what would otherwise be an address. Every
+            // opaque piece is one `SPAN_PLACEHOLDER`, which none of the
+            // pattern's character classes admit, so neither pipeline matches
+            // across one — the invariant that lets this family lift the
+            // escaped-special boundary with no gate of its own (see
+            // `email_level`).
+            "a*b*c@example.com",
+            "a`b`c@example.com",
+            "doc@ex*a*ample.com",
+            "doc@ex(C)ample.com",
+            "doc@exa--mple.com",
+            "doc@example.co(C)m",
             // Escapes: the address stays literal, minus the backslash.
             "\\doc.writer@example.com",
             "a \\doc@example.com b",
+            "\\a&b@example.com",
             // An address beside and inside other constructs.
             "*bold* then doc@example.com and _em_",
             "*write to doc@example.com*",
@@ -3099,6 +3149,18 @@ mod tests {
         // them defer — see `email_level`'s own scope note.
         use super::super::super::test_support::golden_passthroughs;
 
+        // A character replacement is the same class, reached without a macro
+        // at all: `(C)` renders to `&#169;`, whose trailing `;` is no mismatch
+        // character, so the string pipeline links the address that follows it.
+        let replacement = "a(C)b@example.com";
+        let nodes = build_src(Span::new(replacement));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "an address abutting an opaque construct must stay literal: {nodes:?}"
+        );
+        assert!(golden_macros(replacement).contains(r#"href="mailto:b@example.com""#));
+
         let concealed_term = "indexterm:[a]doc@example.com";
         let nodes = build_src(Span::new(concealed_term));
 
@@ -3151,23 +3213,38 @@ mod tests {
     }
 
     #[test]
-    fn an_email_over_a_special_character_is_a_documented_divergence() {
+    fn an_email_crossing_an_escaped_special_shows_structured_children() {
         // The pattern's local-part class admits `&amp;`, so the string
         // pipeline matches an address carrying a literal `&` over its own
-        // *escaped* text. That `&amp;` is an atomic `CharRef` by the time
-        // macros run, so the builder cannot recover the address as text and
-        // leaves it unrecognized for a later increment — the same boundary the
-        // auto-link and image families document.
+        // *escaped* text. The match string carries the same entity there, so
+        // the target this pass computes off it is the very one the replacer
+        // computed (and registers), and the shown text — which for this form
+        // *is* the address — is recovered from the match's own range as
+        // structured children, so the `&` stays the `CharRef` it already is
+        // rather than being escaped a second time.
         let source = "a&b@example.com";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an address crossing an escaped special must be left unrecognized: {nodes:?}"
-        );
+        assert_eq!(nodes.len(), 1);
+        let reference = assert_link(&nodes[0]);
 
-        // The string pipeline, by contrast, *does* build a link here.
-        assert!(golden_macros(source).contains("<a href"));
+        assert_eq!(reference.target.as_ref(), "mailto:a&amp;b@example.com");
+        assert!(reference.roles.is_empty());
+        assert_eq!(reference.location.data(), source);
+
+        assert_eq!(reference.children.len(), 3);
+        assert_text(&reference.children[0], "a", 1, 1);
+
+        let location = assert_special_char(&reference.children[1], '&');
+        assert_eq!(location.data(), "&");
+        assert_eq!(location.byte_offset(), 1);
+
+        assert_text(&reference.children[2], "b@example.com", 1, 3);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
     }
 
     // ---- `apply_link_side_effects` (staged for the eventual cutover) ------
@@ -3387,6 +3464,11 @@ mod tests {
             "https://example.org/a&b[Example]",
             "<https://example.org/a&b>",
             "https://a.example/?x=1&y=2 then link:b&c.html[B]",
+            // And for the bare-e-mail family, whose registration pass runs
+            // last: the `mailto:` target it records carries the address's own
+            // `&amp;`.
+            "a&b@example.com",
+            "a&b@example.com then link:c.html[C] then https://d.example",
         ];
 
         for fixture in fixtures {

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -712,6 +712,8 @@ mod tests {
             "https://example.org[Example^]",
             "a https://example.org[] bare-macro link",
             "visit https://example.org/path?q=1 now",
+            "write to a&b@example.com about it",
+            "an user@ex&ample.com non-address",
             "image:a.png[An image with spaces,role=thumb]",
             "before image:b.svg[Vector] after",
             "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
@@ -849,6 +851,16 @@ mod tests {
         assert_parity_with(
             "See https://example.org/?a=1&b=2 and <https://other.example/x&y>, \
              or https://docs.example[Tom & Jerry] about *{product}*.",
+            with_product,
+        );
+
+        // The last of the link family's spellings to take the same lift: a
+        // bare address whose local part carries an *escaped special* (the
+        // pattern's own `&amp;` alternative), beside a plain address, a quoted
+        // span, and a live attribute reference — its shown text becoming
+        // structured children while the other families run around it.
+        assert_parity_with(
+            "Write to a&b@example.com or plain@example.org about *{product}*.",
             with_product,
         );
 

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -737,6 +737,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "A link:https://example.org[example] link.",
         "mailto:a@b.com[email me]",
         "write to doc.writer@example.com today",
+        "write to a&b@example.com today",
         "an image:photo.png[Alt Text] inline",
         "image:pic.png[Scaled,200,100]",
         "see <<target>> for more",
@@ -876,6 +877,12 @@ fn shapes_match_across_combined_constructs() {
         "Visit https://example.org or link:docs.html[the docs], \
          or just write to doc@example.org.",
     );
+
+    // A bare address whose local part carries an escaped special: the builder
+    // recovers its shown text as structured children (the `&` staying its own
+    // `CharRef`), which is the shape the recorder reaches from the opposite
+    // direction — recovering it from the rendered anchor text.
+    assert_shapes("Write to a&b@example.com or plain@example.org today.");
 
     assert_shapes_with(
         "{counter:step}. Step one uses *{product}* and stem:[x+1].",


### PR DESCRIPTION
The auto-link / formal-URL increment (#1197) named the **bare-e-mail** and **image** families as the two still holding the escaped-special boundary, the first of them because it holds "an address baked as its own display text". Auditing that shows the address is not baked but *sliced*, exactly like a bare `link:` macro's own target-derived text — the shape that family already solved — so the lift needs no new mechanism.

The target is a computed string read off the level's **match string** (`mailto:a&amp;b@example.com`, the very bytes `InlineEmailReplacer` computes from its own escaped haystack and `register_link` records), and the display text goes through the shared `macro_text_children`, so each special stays the `CharRef` it already is — with its own precise `'src` span (#944) — instead of being baked, already escaped, into one `Text` the fold would escape a second time. `a&b@example.com` is therefore recognized as the same `Ref{Link}` node its verbatim spelling builds, folding through the identical `render_link`.

### The new part: this family takes the lift with no gate

Its three predecessors each swapped `range_is_verbatim*` for `range_has_no_opaque_piece`. Here that swap would add a branch **no input can reach**, because an address cannot cross an opaque piece at all:

- every opaque piece is exactly one `SPAN_PLACEHOLDER` (U+E0F0, Unicode category `Co`), which none of `INLINE_EMAIL`'s character classes admit — not the local part's `[\w_]` / `[\w\-.%+]`, not the domain's `[\p{L}\p{Nd}_\-.]`, not the TLD's `[a-zA-Z]`;
- and a match can neither *begin* nor *end* strictly inside an escaped special's entity: an entity's leading `&` is in no class the domain or TLD accepts, and its trailing `;` is neither a local-part character nor the `@` a local part must be followed by.

So the only atomic piece an address range can overlap is a **wholly contained** `&amp;` — precisely what this lift admits. That is the same structural argument the sibling auto-link family already makes for its own *required* boundary-prefix group ("a placeholder simply fails its match"), reached here through the match's interior rather than its boundary. Per the repo's own guidance on unreachable defensive branches, the gate is left out rather than added and untested.

`build_email_node` is correspondingly **total**, its `Option`-returning "this increment defers" machinery removed rather than left unreachable (as the `<<id,>>` increment did for the cross-reference family). The one deferral the family keeps is the *abutting* boundary class it already documented, which the placeholder-**prefix** check expresses — a range gate never could.

### Tests

- Differential corpora gain the crossing address alone, in flow, doubled, and with two specials; a literal `&` the pattern's classes do *not* admit (in the domain, opening the local part), where neither pipeline matches; an address beside but not crossing a special; the escape (`\a&b@example.com`); and a construct **inside** what would otherwise be an address (a rendered span, a character replacement, a smart em dash), which pins the no-gate invariant as fixtures rather than only as prose.
- The family's own divergence test becomes a **parity** test asserting the three recovered children and the `&`'s own precise span, per its "if lifted, fold this into a parity corpus" convention.
- The abutting-divergence test gains a character-replacement fixture (`a(C)b@example.com`) — the same class reached with no macro at all, since `&#169;`'s trailing `;` is no mismatch character.
- Registration parity is asserted for the escaped-special forms against an independent golden parser (the two-independent-parsers discipline), and fixtures are added to the whole-pipeline combined-constructs corpus, the broad general-purpose sweep, and the structural recorder cross-check.

### Corpus-wide audit

Re-running the fold-parity audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) confirms the divergence set strictly **shrank**: one previously-surviving source is gone — `bert&ernie@sesamestreet.com`, a real golden fixture — and no new one appeared (78 → 77 unique sources).

The escaped-special boundary now remains only for the **image** family, whose `Attrlist<'src>` bracket is the one value in this module a match string genuinely cannot supply. As with every prep piece before it, nothing further is wired in.

### Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5210 passed), and `cargo +nightly doc --no-deps --document-private-items` are all clean. Diff coverage is 100% — the only missed lines/regions in the touched files are pre-existing `panic!` arms in test assertions.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Tyj3Q6XzB9ZSntAtyQnuY)_