### PR TITLE
feat: Recognize an image macro crossing an escaped special (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2848,6 +2848,71 @@ Each phase is a reviewable unit with a clear exit gate.
   bracket is the one value in this module a match string genuinely cannot supply. As with every
   prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the image family crossing an escaped special — the fifth and last
+  family, closing the boundary as a **family** boundary altogether):* the increment above named
+  the **image** family as the one still holding the escaped-special boundary, "whose
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` bracket is the one value in this
+  module a match string genuinely cannot supply". That is true of the *bracket* — and of nothing
+  else the family holds. The expanded-value increment had already moved the family's boundary onto
+  that one capture for a synthesized run (an image's macro name and target read from the match
+  string and [`text_slice`](../../parser/src/content/inline_builder/quotes.rs), an empty bracket
+  parsed from a zero-length span); this makes the same one-gate swap for an escaped special, so
+  [`find_image_matches`](../../parser/src/content/inline_builder/macros/image.rs) takes
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) and
+  `image:a&b.png[]` is recognized as the same
+  [`Image`](../../parser/src/inlines/image.rs) node its verbatim spelling builds. The target
+  comes off the match string (`a&amp;b.png` — the very bytes `InlineImageMacroReplacer` reads as
+  `caps[1]`, renders as the `src`, derives its `default_alt` from, and
+  [`apply_image_side_effects`](../../parser/src/content/inline_builder/macros/image.rs)
+  registers), reached as `text_slice`'s fallback so a verbatim or synthesized target still
+  borrows `'src` (§4.5) rather than allocating.
+
+  This family needs no display-text recovery at all — an image has no shown text, only an `alt`
+  the attribute list or the target's own basename supplies — so
+  [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs), the shared helper
+  its four predecessors each needed, has no part here. Nor can a boundary split an entity: the
+  pattern's match begins at `i` (or a backslash) and ends at `]`, and each capture is delimited by
+  `image:`/`icon:`, `[`, and `]` — none of which occurs in `&lt;`, `&gt;`, or `&amp;` — so every
+  atomic overlap an image range can have is a **wholly contained** entity, the same structural
+  argument the bare-e-mail family makes for its own classes. What survives is therefore exactly the
+  bracket: a **non-empty attribute list** crossing a special keeps
+  [`range_is_verbatim`](../../parser/src/content/inline_builder/macros/image.rs), since
+  `Attrlist::parse` reads its `source: Span<'src>`'s bytes *as content* and the source holds one
+  character where the match string holds an entity. The escaped-special boundary is no longer a
+  *family* boundary anywhere in the macros step — only a **capture** boundary, and only for the
+  three attribute lists (a link's and a cross-reference's attribute-list-bearing display text, and
+  an image's bracket) that must ride on their node as a real `Attrlist<'src>`.
+
+  The family's escape check is hoisted ahead of the gate — the same fix the `footnoteref:`, menu,
+  cross-reference, and link increments each made, closing the same latent gap: before it, an
+  escaped `\image:x.png[*bold*]` whose match the gate rejected was left unrecognized *with its
+  backslash*, where the string replacer's own leading `caps[0].starts_with('\\')` check drops it.
+  That is a fold-parity fix in its own right, pinned by its own test.
+
+  Differential corpora extend the family's fixtures with a target crossing each of the three
+  specials, doubled, carrying a verbatim attribute list (positional alt, positional width/height,
+  named attributes, and both `link=` forms `apply_image_side_effects` reads), in flow, beside a
+  sibling family that took the same lift, inside a rendered span, escaped, and beside — rather than
+  crossing — a special; plus a target crossing *both* a synthesized run and an escaped special,
+  which only the level's own match string carries the bytes of. The
+  `a_macro_over_a_special_character_is_a_documented_divergence` test becomes a **parity** test with
+  a structural companion asserting the entity-bearing target, the derived default alt, and the
+  node's still-precise `location`, per the "if lifted, fold this into a parity corpus" convention;
+  the two boundaries that remain get divergence tests of their own — a non-empty bracket crossing a
+  special, and a *restored entity* in the target (`image:a&amp;b.png[]`, where
+  `CharacterReplacements` un-escapes what `SpecialCharacters` escaped, leaving an opaque leaf
+  rather than entity bytes) — as does the rendered span the old test's fixture is repointed at.
+  Registration parity is asserted for the escaped-special forms against an independent golden
+  parser, and fixtures are added to the whole-pipeline combined-constructs corpus, the broad
+  general-purpose sweep, and the structural recorder cross-check. Re-running the corpus-wide
+  fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence
+  set strictly **shrank**: one previously-surviving source is gone
+  (`image:data:image/svg+xml,<svg onload='alert(1)'></svg>[alt,link=self]`, a real golden fixture
+  in `parser/src/tests/security.rs`) and no new one appeared. The only escaped-special divergence
+  left anywhere in the macros step is an attribute list; a display or reference text crossing a
+  **rendered span** still defers everywhere. As with every prep piece before it, nothing further is
+  wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3154,6 +3219,21 @@ Each phase is a reviewable unit with a clear exit gate.
        too. See the step's own "landed as" note above. Only the **image** family still keeps the
        escaped-special boundary, and a display text crossing a rendered span still defers
        everywhere.
+     - ✅ **prep (the image family crossing an escaped special).** The fifth and last family to
+       lift that boundary, which closes it as a *family* boundary altogether: `image:a&b.png[]`
+       is recognized as the same `Image` node its verbatim spelling builds, its target read off
+       the match string (`a&amp;b.png`, the `caps[1]` the string replacer renders as the `src`,
+       derives `default_alt` from, and registers) through `text_slice`'s own fallback, so a
+       verbatim or synthesized target still borrows `'src`. An image has no shown text, so the
+       shared `macro_text_children` has no part here; and no capture boundary can split an entity,
+       since each is delimited by `image:`/`icon:`, `[`, or `]`. What remains is exactly the
+       **non-empty attribute list**, which keeps `range_is_verbatim` because `Attrlist::parse`
+       reads its own source span's bytes as content — so the escaped special is now only a
+       *capture* boundary, for the three attribute lists that must ride on a node as a real
+       `Attrlist<'src>`. The family's escape check is hoisted ahead of the gate, closing the same
+       latent gap its four predecessors did. A restored entity in the target, and a rendered span
+       anywhere in the match, still defer, each with its own divergence test. See the step's own
+       "landed as" note above.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -41,7 +41,7 @@ pub(super) fn image_macros_level<'src>(
 }
 
 /// Finds every image/icon macro at this level, skipping any whose match crosses
-/// an [`atomic`](Piece::atomic) piece (see
+/// an [`opaque`](range_has_no_opaque_piece) piece (see
 /// [`apply_macros`](super::apply_macros)) or whose attribute list
 /// [`build_image_node`] cannot slice from `'src`.
 fn find_image_matches<'src>(
@@ -60,14 +60,18 @@ fn find_image_matches<'src>(
 
         let full = whole.start()..whole.end();
 
-        // A match crossing an escaped special or a rendered span is left for a
-        // later increment; one crossing a `synthesized` run (an expanded
-        // attribute value) is admitted here and gated more narrowly — on its
-        // attribute list alone — inside `build_image_node`.
-        if !range_is_verbatim_or_synthesized(pieces, &full) {
-            continue;
-        }
-
+        // An escape (`\image:`) is honored by dropping the backslash and
+        // keeping the rest literal, mirroring `InlineImageMacroReplacer`'s own
+        // leading `caps[0].starts_with('\\')` check — which it makes *before*
+        // looking at anything else, so the escape needs no gate of its own
+        // here either: dropping the backslash keeps the rest of the match as
+        // its **own original nodes** (a rendered span or an escaped special
+        // among them), which fold back to exactly the bytes the replacer's
+        // `caps[0][1..]` emits. (This is the same check-order fix the
+        // `footnoteref:`, menu, cross-reference, and link increments made for
+        // their own families; before it, an escaped `\image:x.png[*bold*]`
+        // whose match the gate rejected was left unrecognized, backslash and
+        // all.)
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -79,13 +83,23 @@ fn find_image_matches<'src>(
             continue;
         }
 
+        // A match crossing a rendered span is left for a later increment; one
+        // crossing an expanded attribute value or an escaped special is
+        // admitted here and gated more narrowly — on its attribute list alone —
+        // inside `build_image_node`, since the macro name and target are read
+        // from the match string, whose bytes are, for both, exactly the ones
+        // the string replacer's own haystack carries there.
+        if !range_has_no_opaque_piece(nodes, pieces, &full) {
+            continue;
+        }
+
         let Some(node) =
             build_image_node(&caps, whole.as_str(), &full, pieces, root, parser, nodes)
         else {
-            // A non-empty attribute list crossing a synthesized run: an
-            // `Attrlist<'src>` reads its own source span's bytes as content, so
-            // there is nothing honest to parse it from. Left as literal source
-            // for a later increment.
+            // A non-empty attribute list crossing a synthesized run or an
+            // escaped special: an `Attrlist<'src>` reads its own source span's
+            // bytes as content, so there is nothing honest to parse it from.
+            // Left as literal source for a later increment.
             continue;
         };
 
@@ -238,17 +252,21 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
 /// string** (`whole`, and [`text_slice`] for the target) rather than from a
 /// source slice, so both are exact even when they come from a
 /// [`synthesized`](Piece::synthesized) run — an expanded attribute value
-/// (`image:{logo}[Logo]`), or a filtered multi-line block's own joined seed.
-/// Only the node's `location` then takes design §4.4's coarse fallback.
+/// (`image:{logo}[Logo]`) or a filtered multi-line block's own joined seed —
+/// or cross an **escaped special** (`image:a&b.png[]`, whose target the string
+/// replacer reads as `a&amp;b.png` out of its own escaped haystack: the very
+/// bytes this match string carries, and the ones
+/// [`apply_image_side_effects`] registers). Only the node's `location` then
+/// takes design §4.4's coarse fallback.
 ///
 /// The **attribute list** is the one part that cannot follow: an
 /// [`Attrlist`]`<'src>` reads its own `Span<'src>`'s bytes *as content*, not
 /// merely as a location tag, so it needs a real source slice. A non-empty
-/// bracket crossing a synthesized run therefore returns `None` — the macro is
-/// left literal for a later increment, exactly as the other boundaries in this
-/// module are. An **empty** bracket (`image:{logo}[]`) needs no bytes at all
-/// and parses from the same zero-length span an absent group already uses, so
-/// it is recognized.
+/// bracket crossing a synthesized run or an escaped special therefore returns
+/// `None` — the macro is left literal for a later increment, exactly as the
+/// other boundaries in this module are. An **empty** bracket
+/// (`image:{logo}[]`) needs no bytes at all and parses from the same
+/// zero-length span an absent group already uses, so it is recognized.
 fn build_image_node<'src>(
     caps: &regex::Captures<'_>,
     whole: &str,
@@ -270,10 +288,14 @@ fn build_image_node<'src>(
     let target = match caps.get(1) {
         None => CowStr::from(""),
 
-        // The caller admitted no atomic piece in the match, so `text_slice`
-        // always yields a value here — borrowed from `'src` for a verbatim
-        // target, the expansion's own exact bytes for a synthesized one.
-        Some(m) => text_slice(nodes, pieces, m.start()..m.end())?,
+        // Borrowed from `'src` for a verbatim target (§4.5), the expansion's
+        // own exact bytes for a synthesized one. A target crossing an escaped
+        // special has no `'src` slice at all — the source holds one character
+        // where the match string holds an entity — so it falls back to the
+        // match string's own bytes, which is what `text_slice` declines to
+        // recover and precisely what the string replacer reads as `caps[1]`.
+        Some(m) => text_slice(nodes, pieces, m.start()..m.end())
+            .unwrap_or_else(|| CowStr::from(m.as_str().to_string())),
     };
 
     // Group 2 always participates — its own pattern carries an empty
@@ -291,8 +313,9 @@ fn build_image_node<'src>(
         // a zero-length span wherever the macro sits.
         location.slice(0..0)
     } else {
-        // A non-empty attribute list crossing a synthesized run: deferred (see
-        // this function's own "what must be verbatim" note).
+        // A non-empty attribute list crossing a synthesized run or an escaped
+        // special: deferred (see this function's own "what must be verbatim"
+        // note).
         return None;
     };
 
@@ -660,27 +683,223 @@ mod tests {
     }
 
     #[test]
-    fn a_macro_over_a_special_character_is_a_documented_divergence() {
+    fn an_escaped_macro_over_a_rendered_span_still_drops_its_backslash() {
+        // The escape check runs *ahead* of the gate (the same check-order fix
+        // the `footnoteref:`, menu, cross-reference, and link families made),
+        // so a macro the gate would reject still honors its own escape:
+        // dropping the backslash leaves the rest as its own nodes, which fold
+        // back to exactly the bytes `caps[0][1..]` emits.
+        let source = "\\image:x.png[*bold*]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+            "an escaped macro must not produce an image node: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_target_crossing_an_escaped_special() {
         // The string pipeline matches macros over *escaped* text, so a target
-        // containing `&` is matched as `a&amp;b.png`. A self-describing node
-        // cannot carry that escaped text as an `'src` slice, so the single-pass
-        // builder leaves such a macro *unrecognized* for a later increment (the
-        // attribute-references step and the cutover). This is the documented
-        // boundary of the additive image increment; the differential corpus
-        // above deliberately excludes it.
+        // containing `&` is matched as `a&amp;b.png`. Those entity bytes are
+        // exactly what this level's match string carries, so the node's target
+        // is read off it and the fold reproduces the same `src`/default alt —
+        // the escaped special being the one atomic piece
+        // `range_has_no_opaque_piece` admits.
+        let fixtures = [
+            // A target crossing each of the three specials, alone and doubled.
+            "image:a&b.png[]",
+            "image:a<b.png[]",
+            "image:a>b.png[]",
+            "image:a&b&c.png[]",
+            "icon:a&b[]",
+            // A verbatim attribute list beside such a target: positional alt,
+            // positional width/height, and named attributes (including the
+            // `link=` forms `apply_image_side_effects` reads).
+            "image:a&b.png[Alt]",
+            "image:a&b.png[Alt,200,100]",
+            "image:a&b.png[alt=Alt Text,role=thumb]",
+            "image:a&b.png[link=self]",
+            "image:a&b.png[alt=X,link=javascript:alert(1)]",
+            // In surrounding flow, doubled, inside a rendered span, and beside
+            // a sibling family that takes the same lift.
+            "before image:a&b.png[A] after",
+            "image:a&b.png[] image:c&d.png[]",
+            "*image:a&b.png[A]*",
+            "image:a&b.png[Alt] and link:x&y.html[]",
+            // A special the target's own character classes reject (a newline
+            // is impossible, but a space ends the target), so neither pipeline
+            // builds a macro.
+            "image:a & b.png[]",
+            // The escape still keeps the macro literal, backslash dropped.
+            "\\image:a&b.png[A]",
+            // A special *beside* the macro rather than inside it.
+            "image:sunset.jpg[]&amp;",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_target_crossing_an_escaped_special_carries_the_entity_bytes() {
+        // The node's `target` is the string replacer's own `caps[1]` — the
+        // escaped haystack's bytes, not the source's single `&` — which is
+        // also what `apply_image_side_effects` registers. The default alt
+        // derives from that same string, exactly as `default_alt` does.
+        let source = "image:a&b.png[]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.target.as_ref(), "a&amp;b.png");
+        assert_eq!(image.alt.as_deref(), Some("a&amp;b"));
+
+        // The whole macro's span is still precise: neither the match's start
+        // (`i`, or a backslash) nor its end (`]`) can fall inside an entity,
+        // so no boundary lands in an atomic piece.
+        assert_eq!(image.location.data(), source);
+        assert_eq!(image.location.line(), 1);
+        assert_eq!(image.location.col(), 1);
+    }
+
+    #[test]
+    fn an_attribute_list_crossing_an_escaped_special_is_a_documented_divergence() {
+        // The attribute list is the one capture that still needs an honest
+        // `'src` slice: `Attrlist::parse` reads its own source span's bytes
+        // *as content*, and the source holds one character where the match
+        // string holds an entity. A non-empty bracket crossing one is
+        // therefore left literal rather than parsed from the wrong bytes —
+        // the same boundary the expanded-value divergence test below pins for
+        // a synthesized run.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        for source in [
+            "image:x.png[a < b]",
+            "image:x.png[alt=a & b]",
+            "image:a&b.png[a < b]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+                "an image whose bracket crosses an escaped special must stay literal: {nodes:?}"
+            );
+
+            assert!(
+                golden_macros(source).contains("<img"),
+                "the golden fixture stopped recognizing the image for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_target_crossing_a_restored_entity_is_a_documented_divergence() {
+        // An author-written entity (`&amp;`, `&lt;`) is escaped by
+        // `SpecialCharacters` and then *restored* by
+        // `CharacterReplacements`, which the builder represents as an opaque
+        // [`CharRef::Replacement`] leaf rather than the entity bytes the
+        // string pipeline's haystack carries. `range_has_no_opaque_piece`
+        // rejects it, so the macro stays literal — the same class every other
+        // family already defers (a rendered span, a passthrough, a character
+        // replacement).
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        for source in ["image:a&amp;b.png[]", "image:&lt;.png[]"] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+                "an image whose target crosses a restored entity must stay literal: {nodes:?}"
+            );
+
+            assert!(
+                golden_macros(source).contains("<img"),
+                "the golden fixture stopped recognizing the image for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_macro_over_a_rendered_span_is_a_documented_divergence() {
+        // A rendered span inside the match is the boundary this family keeps:
+        // `build_match_string` stands it in as one `SPAN_PLACEHOLDER`, so
+        // neither the target nor the bracket has bytes to read there.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        let source = "image:x.png[*bold*]";
+
         let nodes = apply_macros(
-            build_through_special_and_replacements(Span::new("image:a&b.png[]")),
-            Span::new("image:a&b.png[]"),
+            build_through_special_and_replacements(Span::new(source)),
+            Span::new(source),
             &Parser::default(),
         );
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-            "a macro crossing an escaped special must be left unrecognized: {nodes:?}"
+            "a macro crossing a rendered span must be left unrecognized: {nodes:?}"
         );
 
         // The string pipeline, by contrast, *does* build an image here.
-        assert!(golden_macros("image:a&b.png[]").contains("<img"));
+        assert!(golden_macros(source).contains("<img"));
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_a_target_crossing_an_escaped_special() {
+        // The staged `register_image` reads the node's own stored `target`,
+        // which is now the escaped one — so it must be byte-identical to the
+        // `caps[1]` the string replacer registers. Two independent parsers, as
+        // elsewhere in this module.
+        let fixtures = [
+            "image:a&b.png[]",
+            "image:a<b.png[Alt]",
+            "image:a&b.png[] image:c&d.png[]",
+            "icon:a&b[]",
+            "\\image:a&b.png[A]",
+        ];
+
+        for fixture in fixtures {
+            let builder_parser = Parser::default().with_catalog_assets(true);
+            let nodes = build_with(Span::new(fixture), &builder_parser);
+            apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
+
+            let golden_parser = Parser::default().with_catalog_assets(true);
+            golden_macros_with(fixture, &golden_parser);
+
+            let got: Vec<_> = builder_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+
+            let want: Vec<_> = golden_parser
+                .catalog()
+                .images()
+                .iter()
+                .map(|i| i.target.clone())
+                .collect();
+
+            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+        }
     }
 
     /// Builds the tree **through character replacements** (special characters,
@@ -1015,6 +1234,11 @@ mod tests {
             // A partially-expanded target: the expansion is one piece of it.
             "image:{dir}/sunset.jpg[Sunset]",
             "image:{dir}/{logo}[]",
+            // A target crossing *both* a synthesized run and an escaped
+            // special, so neither the source nor the expansion alone carries
+            // its bytes — only the level's own match string does.
+            "image:{dir}/a&b.png[]",
+            "image:{dir}/a&b.png[Alt]",
             // A verbatim attribute list beside an expanded target, including
             // the positional width/height and a named attribute.
             "image:{logo}[Alt Text,200,100]",

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -80,23 +80,27 @@ use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 /// the escaped piece is a delimiter *it consumes and never slices* — the
 /// angle-bracketed URL's own `&lt;`/`&gt;` (see
 /// `links::build_inline_link_node`) and a menu's `&gt;` submenu caret (see
-/// `ui::menu_match_is_sliceable`) — or, for the **cross-reference**, the
-/// **`link:`/`mailto:` macro**, and the **auto-link / formal-URL** families,
-/// wherever the escaped text need not
-/// ride on the node as an `'src` slice at all: no such family's target is
-/// `Span`-typed, so each reads its values out of the match string (whose entity
-/// bytes *are* the string pipeline's own) and rebuilds its display text as
-/// structured children through [`macro_text_children`], keeping each special as
-/// its own `CharRef` (see `xref::find_xref_matches`,
-/// `links::find_link_macro_matches`, `links::build_inline_link_node`, and
-/// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)). The one
-/// capture that keeps the stricter gate in any of the three is a display text
-/// carrying an attribute list, which is parsed as a real
-/// [`Attrlist`](crate::attributes::Attrlist)`<'src>` from the source's own
-/// bytes; the auto-link family additionally keeps a narrow deferral of its own
-/// for a bare URL whose trailing-punctuation strip would cut inside an escaped
-/// special. A rendered span stays deferred for every family. The differential
-/// corpus pins the cases each increment claims.
+/// `ui::menu_match_is_sliceable`) — or, for **every** family that can carry a
+/// target or a display text (the **cross-reference**, the **`link:`/`mailto:`
+/// macro**, the **auto-link / formal-URL**, the **bare e-mail**, and the
+/// **image/icon** families), wherever the escaped text need not
+/// ride on the node as an `'src` slice at all: none of those families' targets
+/// is `Span`-typed, so each reads its values out of the match string (whose
+/// entity bytes *are* the string pipeline's own) and rebuilds its display text
+/// as structured children through [`macro_text_children`], keeping each special
+/// as its own `CharRef` (see `xref::find_xref_matches`,
+/// `links::find_link_macro_matches`, `links::build_inline_link_node`,
+/// `links::email_level`, `image::build_image_node`, and
+/// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)). What keeps
+/// the stricter gate is never a *family* now, only the one **capture** that
+/// must ride on the node as a real
+/// [`Attrlist`](crate::attributes::Attrlist)`<'src>`, parsed from the source's
+/// own bytes: a link's or cross-reference's attribute-list-bearing display
+/// text, and an image's non-empty bracket. The auto-link family additionally
+/// keeps a narrow deferral of its own for a bare URL whose trailing-punctuation
+/// strip would cut inside an escaped special, and the e-mail family one for an
+/// address *abutting* an opaque piece. A rendered span stays deferred for every
+/// family. The differential corpus pins the cases each increment claims.
 pub(super) fn apply_macros<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -716,6 +716,7 @@ mod tests {
             "an user@ex&ample.com non-address",
             "image:a.png[An image with spaces,role=thumb]",
             "before image:b.svg[Vector] after",
+            "an image:a&b.png[Query] target",
             "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
             "a ((flow term)) and (((c1, c2, c3))) end",
             "indexterm:[primary, secondary]",
@@ -863,6 +864,23 @@ mod tests {
             "Write to a&b@example.com or plain@example.org about *{product}*.",
             with_product,
         );
+
+        // The last family to take the escaped-special lift, and the only one
+        // that keeps it for a *capture* rather than for the whole match: two
+        // images whose targets cross a special (their entity bytes read off
+        // the match string), beside a quoted span and a live attribute
+        // reference. The bracket that still defers is a divergence, so it is
+        // pinned in `image.rs`'s own test rather than here.
+        assert_parity_with(
+            "See image:a&b.png[Chart] and image:c<d.png[Diagram] \
+             about *{product}*.",
+            with_product,
+        );
+
+        // The same lift reached through an expansion: a target crossing *both*
+        // a synthesized run and an escaped special, which only the level's own
+        // match string carries the bytes of.
+        assert_parity_with("See image:{product}/a&b.png[Chart] here.", with_product);
 
         // A bare e-mail address spliced in by an attribute reference — a
         // *synthesized* run, which the e-mail family recognizes exactly the

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -740,6 +740,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "write to a&b@example.com today",
         "an image:photo.png[Alt Text] inline",
         "image:pic.png[Scaled,200,100]",
+        "an image:a&b.png[Query] inline",
         "see <<target>> for more",
         "see <<target,the target>> now",
         "see <<target,Tom & Jerry>> now",
@@ -883,6 +884,12 @@ fn shapes_match_across_combined_constructs() {
     // `CharRef`), which is the shape the recorder reaches from the opposite
     // direction — recovering it from the rendered anchor text.
     assert_shapes("Write to a&b@example.com or plain@example.org today.");
+
+    // The last family to lift the escaped-special boundary: an image whose
+    // target carries one, beside a plain image whose bracket does *not* — the
+    // capture that still defers — so both the recognized and the literal shape
+    // meet the recorder's own reconstruction.
+    assert_shapes("See image:a&b.png[Chart] and image:plain.png[Alt Text] today.");
 
     assert_shapes_with(
         "{counter:step}. Step one uses *{product}* and stem:[x+1].",


### PR DESCRIPTION
The previous increment (#1198) named the **image** family as the one still holding the escaped-special boundary, "whose `Attrlist<'src>` bracket is the one value in this module a match string genuinely cannot supply." That is true of the *bracket* — and of nothing else the family holds. This lifts the boundary for everything else, which closes it as a **family** boundary anywhere in the macros step.

## What changed

`find_image_matches` makes the same one-gate swap its four predecessors made — `range_is_verbatim_or_synthesized` → `range_has_no_opaque_piece` — so `image:a&b.png[]` is recognized as the same `Image` node its verbatim spelling builds, folding through the identical `render_image`.

- **The target** comes off the level's match string (`a&amp;b.png` — the very bytes `InlineImageMacroReplacer` reads as `caps[1]`, renders as the `src`, derives its `default_alt` from, and `apply_image_side_effects` registers), reached as `text_slice`'s fallback so a verbatim or synthesized target still borrows `'src` (§4.5) rather than allocating.
- **No display-text recovery is needed.** An image has no shown text — only an `alt` the attribute list or the target's basename supplies — so `macro_text_children`, the shared helper its four predecessors each needed, has no part here.
- **No boundary can split an entity.** The match begins at `i` (or a backslash) and ends at `]`, and each capture is delimited by `image:`/`icon:`, `[`, and `]` — none of which occurs in `&lt;`, `&gt;`, or `&amp;` — so every atomic overlap an image range can have is a *wholly contained* entity. Same structural argument the bare-e-mail family makes for its own classes.
- **What survives is exactly the bracket.** A non-empty attribute list crossing a special keeps `range_is_verbatim`, since `Attrlist::parse` reads its `source: Span<'src>`'s bytes *as content*. The escaped special is now only a **capture** boundary, for the three attribute lists (a link's and a cross-reference's attribute-list-bearing display text, and an image's bracket) that must ride on their node as a real `Attrlist<'src>`.

## A fold-parity fix along the way

The family's escape check is hoisted ahead of the gate — the same fix the `footnoteref:`, menu, cross-reference, and link increments each made, closing the same latent gap. Before it, an escaped `\image:x.png[*bold*]` whose match the gate rejected was left unrecognized *with its backslash*, where the string replacer's own leading `caps[0].starts_with('\\')` check drops it. Pinned by its own test.

## Testing

- The family's fixtures gain a target crossing each of the three specials, doubled, carrying a verbatim attribute list (positional alt, positional width/height, named attributes, and both `link=` forms `apply_image_side_effects` reads), in flow, beside a sibling family that took the same lift, inside a rendered span, escaped, and beside — rather than crossing — a special; plus a target crossing *both* a synthesized run and an escaped special, which only the match string carries the bytes of.
- `a_macro_over_a_special_character_is_a_documented_divergence` becomes a **parity** test with a structural companion asserting the entity-bearing target, the derived default alt, and the node's still-precise `location`, per the "if lifted, fold this into a parity corpus" convention.
- New divergence tests pin the two boundaries that remain — a non-empty bracket crossing a special, and a *restored entity* in the target (`image:a&amp;b.png[]`, where `CharacterReplacements` un-escapes what `SpecialCharacters` escaped, leaving an opaque leaf) — and the old test's fixture is repointed at the rendered span it now names.
- Registration parity is asserted for the escaped-special forms against an independent golden parser, and fixtures are added to the whole-pipeline combined-constructs corpus, the broad general-purpose sweep, and the structural recorder cross-check.
- **Corpus-wide fold-parity audit** (tree building forced on for every parse in the suite): the divergence set strictly **shrank** — one previously-surviving source is gone (`image:data:image/svg+xml,<svg onload='alert(1)'></svg>[alt,link=self]`, a real golden fixture in `parser/src/tests/security.rs`) and no new one appeared.

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5216 passed), and `cargo +nightly doc --no-deps --document-private-items` are all clean. Coverage on the touched file is 99.87% lines / 99.68% regions; the only uncovered spots are a test-assertion `panic!` arm and a pre-existing unreachable `?` in `rejected_link_target`.

Design doc updated with the "landed as" narrative and the §5.2 checklist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5MR6f1P1n4nN9qEaWMVKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5MR6f1P1n4nN9qEaWMVKJ)_