### PR TITLE
feat: Recognize a construct crossing a restored entity (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2913,6 +2913,72 @@ Each phase is a reviewable unit with a clear exit gate.
   **rendered span** still defers everywhere. As with every prep piece before it, nothing further is
   wired in.
 
+  *Step 6 prep landed as (a **restored entity** as the second recoverable piece, closing that
+  divergence for every family at once):* the increment above left a restored entity
+  (`&amp;copy;` written in the source, which `SpecialCharacters` escapes to `&amp;amp;copy;` and
+  `CharacterReplacements` then un-escapes back to `&amp;copy;`) as the image family's own last
+  deferral, and the auto-link family's alongside it. Both are closed here, and not family by
+  family: recoverability is a property of the **piece**, not of the family reading across it, so
+  naming the new class once lifts the boundary everywhere a family's gate is already
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs).
+
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) gives a
+  [`CharRef`](../../parser/src/inlines/char_ref.rs)`::Entity` leaf its **own bytes**, exactly as it
+  already gives a `CharRef::Special` its canonical entity, and for the identical reason: those
+  bytes *are* what the string pipeline's haystack holds at that position from the replacements step
+  onward, and the fold emits them verbatim (`fold`'s `Entity` arm), so the two sides agree with **no
+  renderer involved** — the distinction that separates this class from a rendered span, whose markup
+  exists only at fold time. The leaf stays `atomic` (it is one indivisible node, never sliced) but
+  becomes *recoverable*, which is precisely the distinction the third gate draws. Nothing else in
+  any family changes: a target or computed value reads the entity's bytes off the match string, and
+  a display text keeps the leaf as its own child through `macro_text_children`'s `emit_range` path,
+  where one `Text` holding `&amp;copy;` would have had its `&amp;` escaped a second time.
+
+  One computed value had no range to rebuild from, and is the increment's only new code: a
+  cross-reference's **attribute-list positional text**, which comes back from an `Attrlist` parse of
+  a normalized *copy* of the match string rather than from a range of it. The single-`Text`
+  `unescape_specials` that branch used is replaced by
+  [`escaped_value_children`](../../parser/src/content/inline_builder/macros/xref.rs), which
+  re-derives §3.4's trichotomy from the value's own bytes: an escaped special becomes the character
+  a `Text` holds *logically* (re-escaped once at fold time), a restored entity becomes its own
+  `CharRef::Entity` child (emitted verbatim). The scan is left to right, one `&amp;` at a time,
+  because the two classes nest — `&amp;amp;copy;` is a literal `&amp;` followed by the letters
+  `copy;`, **not** a `&amp;copy;` entity — and only consuming the `&amp;amp;` first tells them
+  apart, the same one-level unwind the fold performs in reverse. The entity-name class itself is
+  hoisted into a shared `ENTITY_NAME` constant that both the restore-entities replacement rule and
+  the new [`restored_entity_pattern`](../../parser/src/content/substitution_step.rs) are built from,
+  so the two spellings of one class cannot drift.
+
+  What does **not** move is the boundary held by a gate other than the opaque-piece one: the UI
+  family (a `kbd:`/`btn:` key or label, a menu name or item) and a footnote's text each still need a
+  value they can slice from `'src`, for a restored entity exactly as for an escaped special, and a
+  test pins the two spellings side by side so they move together whenever that boundary is lifted.
+  The three attribute-list captures that must ride on a node as a real `Attrlist<'src>` (a link's
+  attribute-list-bearing display text, an image's non-empty bracket) likewise keep
+  `range_is_verbatim` — the source holds `&amp;amp;copy;` where the match string holds `&amp;copy;`
+  — while a cross-reference's own attribute list, parsed from a normalized copy, takes both lifts.
+
+  Differential corpora gain, per family, a target and a display text crossing a restored entity in
+  each of its spellings (`&amp;amp;`, a named entity, a numeric one), doubled, crossing *both* an
+  entity and an escaped special, in flow, inside a rendered span, beside a sibling family, escaped,
+  and beside — rather than crossing — an entity; plus structural companions asserting the recovered
+  child's own precise span, the entity-bearing target and derived default alt, and the one-level
+  unwind of a doubly-escaped entity. The two `…_over_a_restored_entity_is_a_documented_divergence`
+  tests become **parity** tests per the "if lifted, fold this into a parity corpus" convention, and
+  the boundaries that remain get divergence tests of their own. Fixtures are added to the
+  whole-pipeline broad sweep, the group-parity corpus (so an order that never reaches the
+  replacements step is exercised too), and the structural recorder cross-check.
+
+  Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the
+  suite) confirms the divergence set strictly **shrank**: five previously-surviving sources are
+  gone, all of them real golden fixtures rather than constructed ones —
+  `http://example.com[sam&#93;ple]bracket]`, `l&#8217;http://www.irit.fr[IRIT]`,
+  `link:My&#32;Documents/report.pdf[Get Report]`, and the two `menu:Tools[… &gt; …]` submenu forms,
+  whose caret is a restored entity — and no pre-existing one appeared. (The set's only additions are
+  this increment's own new divergence-pinning fixtures for the untouched UI/footnote boundary.) As
+  with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string
+  pipeline's own string.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3234,6 +3300,23 @@ Each phase is a reviewable unit with a clear exit gate.
        latent gap its four predecessors did. A restored entity in the target, and a rendered span
        anywhere in the match, still defer, each with its own divergence test. See the step's own
        "landed as" note above.
+     - ✅ **prep (a restored entity, the second recoverable piece).** The escaped-special lift's own
+       leftover — a *restored* entity (`&amp;copy;`, `&#8217;`), which the image and auto-link
+       families each pinned as their last deferral — is closed for **every** family at once, since
+       recoverability is a property of the piece rather than of the family reading across it:
+       [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) gives a
+       `CharRef::Entity` leaf its own bytes (what the string pipeline's haystack holds there, and
+       what the fold emits verbatim — no renderer involved, which is what separates it from a
+       rendered span) and
+       [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) admits
+       it. The one computed value with no range to rebuild from — a cross-reference's attribute-list
+       positional text — gets
+       [`escaped_value_children`](../../parser/src/content/inline_builder/macros/xref.rs), which
+       re-derives §3.4's trichotomy from the value's own bytes, scanning left to right so a
+       doubly-escaped `&amp;amp;copy;` unwinds exactly one level. The UI family and a footnote's
+       text keep their own stricter gates (pinned for both spellings side by side), as do the
+       attribute-list captures that need a real `Attrlist<'src>`. See the step's own "landed as"
+       note above. Only a **rendered span** now defers as a whole class.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -184,28 +184,31 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
 /// The most relaxed of the three gates: accepts a range whose overlapping
 /// pieces are all ones the tree can reproduce **exactly** — a
 /// [`Text`](InlineNode::Text) run (verbatim or
-/// [`synthesized`](Piece::synthesized)) or an *escaped special*, a
-/// [`CharRef`](InlineNode::CharRef)`::Special` leaf — rejecting only an
-/// **opaque** piece: a rendered [`Styled`](crate::inlines::Styled) span, an
-/// earlier-recognized macro node, a masked passthrough or STEM expression, or a
-/// character replacement, each of which
+/// [`synthesized`](Piece::synthesized)) or either
+/// [`CharRef`](InlineNode::CharRef) leaf, an *escaped special*
+/// ([`Special`](CharRef::Special)) or a *restored entity*
+/// ([`Entity`](CharRef::Entity)) — rejecting only an **opaque** piece: a
+/// rendered [`Styled`](crate::inlines::Styled) span, an earlier-recognized
+/// macro node, a masked passthrough or STEM expression, or a character
+/// replacement, each of which
 /// [`build_match_string`] stands in as one
 /// `SPAN_PLACEHOLDER` rather than the markup or entity the string pipeline's
 /// own haystack holds there.
 ///
-/// An escaped special is admissible because its match-string bytes are its
-/// canonical entity (`&lt;`, `&gt;`, `&amp;`) — the very byte sequence the
-/// string pipeline's own escaped haystack carries at that position — so a
-/// family that reads its values out of the match string sees exactly what the
-/// string replacer sees. What such a family cannot do is *slice* those bytes
-/// from `'src` (the source holds one character where the match string holds an
-/// entity), so a value that must ride on the node as an `'src` slice — an
-/// [`Attrlist`]`<'src>`, an [`Image`](InlineNode::Image)'s bracket — keeps
-/// [`range_is_verbatim`], and a *display text* recovered under this gate is
-/// rebuilt as structured children with
-/// [`emit_range`](super::super::quotes::emit_range) (the escaped special
-/// becoming its own `CharRef` child, which folds back to the same entity)
-/// rather than as one sliced `Text`.
+/// Both `CharRef` leaves are admissible for the same reason: their
+/// match-string bytes — a special's canonical entity (`&lt;`, `&gt;`,
+/// `&amp;`), a restored entity's own text (`&copy;`, `&#8217;`) — are the very
+/// byte sequence the string pipeline's own haystack carries at that position,
+/// so a family that reads its values out of the match string sees exactly what
+/// the string replacer sees. What such a family cannot do is *slice* those
+/// bytes from `'src` (the source holds one character where the match string
+/// holds an entity, and `&amp;copy;` where it holds `&copy;`), so a value that
+/// must ride on the node as an `'src` slice — an [`Attrlist`]`<'src>`, an
+/// [`Image`](InlineNode::Image)'s bracket — keeps [`range_is_verbatim`], and a
+/// *display text* recovered under this gate is rebuilt as structured children
+/// with [`emit_range`](super::super::quotes::emit_range) (the leaf staying its
+/// own `CharRef` child, which folds back to the same bytes) rather than as one
+/// sliced `Text`.
 pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
@@ -224,12 +227,13 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
             continue;
         }
 
-        // The only atomic piece `build_match_string` gives real bytes to is an
-        // escaped special; everything else it stands in as one placeholder.
+        // The atomic pieces `build_match_string` gives real bytes to are the
+        // two `CharRef` leaves — an escaped special and a restored entity;
+        // everything else it stands in as one placeholder.
         let recoverable = matches!(
             nodes.get(piece.node_index),
             Some(InlineNode::CharRef {
-                value: CharRef::Special(_),
+                value: CharRef::Special(_) | CharRef::Entity(_),
                 ..
             })
         );
@@ -810,24 +814,93 @@ mod tests {
     }
 
     #[test]
-    fn a_target_crossing_a_restored_entity_is_a_documented_divergence() {
-        // An author-written entity (`&amp;`, `&lt;`) is escaped by
-        // `SpecialCharacters` and then *restored* by
-        // `CharacterReplacements`, which the builder represents as an opaque
-        // [`CharRef::Replacement`] leaf rather than the entity bytes the
-        // string pipeline's haystack carries. `range_has_no_opaque_piece`
-        // rejects it, so the macro stays literal — the same class every other
-        // family already defers (a rendered span, a passthrough, a character
-        // replacement).
+    fn fold_matches_the_string_pipeline_for_a_target_crossing_a_restored_entity() {
+        // An author-written entity (`&amp;copy;`, `&amp;#8217;`) is escaped by
+        // `SpecialCharacters` and then *restored* by `CharacterReplacements`
+        // into a `CharRef::Entity` leaf whose value is the entity itself. Those
+        // bytes are what the string pipeline's own haystack carries from the
+        // replacements step onward, and what the fold emits verbatim, so
+        // `range_has_no_opaque_piece` admits the leaf exactly as it admits an
+        // escaped special.
+        let fixtures = [
+            // A target crossing a restored entity — the `&amp;` spelling of
+            // `&`, a named entity, and a numeric one.
+            "image:a&amp;b.png[]",
+            "image:&lt;.png[]",
+            "image:a&copy;b.png[]",
+            "image:a&#8217;b.png[]",
+            "icon:a&copy;b[]",
+            // Beside a verbatim attribute list, and doubled.
+            "image:a&copy;b.png[Alt]",
+            "image:a&copy;b.png[Alt,200,100]",
+            "image:a&copy;b&reg;c.png[]",
+            // A target crossing *both* a restored entity and an escaped
+            // special, which only the match string carries the bytes of.
+            "image:a&copy;b&c.png[]",
+            // In surrounding flow, inside a rendered span, and beside a
+            // sibling family that takes the same lift.
+            "before image:a&copy;b.png[A] after",
+            "*image:a&copy;b.png[A]*",
+            "image:a&copy;b.png[Alt] and link:x&reg;y.html[]",
+            // The escape still keeps the macro literal, backslash dropped.
+            "\\image:a&copy;b.png[A]",
+            // An entity *beside* the macro rather than inside it.
+            "&copy;image:sunset.jpg[]&reg;",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_target_crossing_a_restored_entity_carries_the_entity_bytes() {
+        // As for an escaped special, the node's `target` is the string
+        // replacer's own `caps[1]` — here the *restored* entity's bytes, which
+        // are also the source's own — and the default alt derives from that
+        // same string.
+        let source = "image:a&copy;b.png[]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.target.as_ref(), "a&copy;b.png");
+        assert_eq!(image.alt.as_deref(), Some("a&copy;b"));
+
+        // The whole macro's span is still precise: neither the match's start
+        // nor its end can fall inside an entity.
+        assert_eq!(image.location.data(), source);
+        assert_eq!(image.location.line(), 1);
+        assert_eq!(image.location.col(), 1);
+    }
+
+    #[test]
+    fn an_attribute_list_crossing_a_restored_entity_is_a_documented_divergence() {
+        // The bracket keeps `range_is_verbatim` for a restored entity too, and
+        // for the same reason it keeps it for an escaped special: the source
+        // holds `&amp;copy;` where the match string holds `&copy;`, so
+        // `Attrlist::parse` would read the wrong bytes as content.
         //
         // If this boundary is ever lifted, fold these fixtures into the parity
         // corpus above.
-        for source in ["image:a&amp;b.png[]", "image:&lt;.png[]"] {
+        for source in [
+            "image:x.png[Tom &amp; Jerry]",
+            "image:x.png[alt=a &copy; b]",
+        ] {
             let nodes = build_src(Span::new(source));
 
             assert!(
                 nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image whose target crosses a restored entity must stay literal: {nodes:?}"
+                "an image whose bracket crosses a restored entity must stay literal: {nodes:?}"
             );
 
             assert!(

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1447,8 +1447,8 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::super::test_support::{
-        assert_link, assert_special_char, assert_styled, assert_text, build_src, fold_html,
-        golden_macros, golden_macros_with, link_text_of,
+        assert_entity, assert_link, assert_special_char, assert_styled, assert_text, build_src,
+        fold_html, golden_macros, golden_macros_with, link_text_of,
     };
     use crate::{
         Parser, Span,
@@ -2761,23 +2761,108 @@ mod tests {
     }
 
     #[test]
-    fn an_auto_link_over_a_restored_entity_is_a_documented_divergence() {
-        // The relaxed gate admits an escaped special because the match string
-        // carries its canonical entity — the string pipeline's own haystack
-        // bytes. A *restored entity* (`&amp;` written in the source, which the
-        // character-replacements step turns back into a `CharRef::Entity`) is
-        // not that: `build_match_string` stands it in as one opaque
-        // placeholder, so it is rejected like a rendered span.
-        let source = "https://example.org[a &amp; b]";
+    fn fold_matches_the_string_pipeline_for_a_link_crossing_a_restored_entity() {
+        // A *restored entity* (`&amp;copy;` written in the source, which the
+        // character-replacements step turns back into a `CharRef::Entity`
+        // whose value is `&copy;`) is admitted for the same reason an escaped
+        // special is: its match-string bytes are the string pipeline's own
+        // haystack bytes there, and the fold emits them verbatim. It is
+        // recovered as its own `CharRef` child rather than baked into a `Text`
+        // the fold would escape a second time.
+        let fixtures = [
+            // A display text crossing one, in each of the four link spellings.
+            "https://example.org[a &amp; b]",
+            "https://example.org[a &copy; b]",
+            "link:index.html[a &copy; b]",
+            "mailto:a@b.com[Tom &copy; Jerry]",
+            "<https://example.org/a&copy;b>",
+            // A *target* crossing one, bare and bracketed.
+            "https://example.org/?a=&copy;b",
+            "link:a&copy;b.html[]",
+            "link:a&copy;b.html[Text]",
+            // A bare e-mail address, the family's fifth spelling.
+            "doc&copy;a@example.org",
+            // A target crossing both a restored entity and an escaped special.
+            "link:a&copy;b&c.html[]",
+            // In flow, doubled, inside a rendered span, and escaped.
+            "see link:a&copy;b.html[Docs] now",
+            "link:a&copy;b.html[] link:c&reg;d.html[]",
+            "*link:a&copy;b.html[Docs]*",
+            "\\link:a&copy;b.html[Docs]",
+            // An entity beside the macro rather than inside it.
+            "&copy;link:x.html[Docs]&reg;",
+            // The numeric spellings, as three real-world fixtures elsewhere in
+            // this crate's Asciidoctor port write them: a display text
+            // carrying an escaped `]`, a target carrying an escaped space, and
+            // a typographic apostrophe immediately before a bare auto-link.
+            "http://example.com[sam&#93;ple]bracket]",
+            "link:My&#32;Documents/report.pdf[Get Report]",
+            "l&#8217;http://www.irit.fr[IRIT]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_display_text_crossing_a_restored_entity_keeps_the_entity_as_its_own_child() {
+        // The structural companion: the text is rebuilt through
+        // `macro_text_children`'s `emit_range` path, so the entity stays the
+        // `CharRef::Entity` leaf it already is — folding back to its own bytes
+        // — with `Text` runs on either side borrowing `'src`.
+        let source = "https://example.org[a &copy; b]";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a display text crossing a restored entity must stay literal: {nodes:?}"
-        );
+        assert_eq!(nodes.len(), 1);
+        let reference = assert_link(&nodes[0]);
 
-        // The string pipeline, by contrast, *does* build a link here.
-        assert!(golden_macros(source).contains("<a href"));
+        assert_eq!(reference.target.as_ref(), "https://example.org");
+        assert_eq!(reference.children.len(), 3);
+        assert_text(&reference.children[0], "a ", 1, 21);
+
+        // The leaf's own span is precise — the entity as the author wrote it,
+        // which is also the value it carries (the `SpecialCharacters` escape
+        // the replacements step undid leaves no trace in either).
+        let entity = assert_entity(&reference.children[1], "&copy;");
+        assert_eq!(entity.data(), "&copy;");
+        assert_eq!(entity.col(), 23);
+
+        assert_text(&reference.children[2], " b", 1, 29);
+    }
+
+    #[test]
+    fn an_attribute_list_text_crossing_a_restored_entity_is_a_documented_divergence() {
+        // The one capture in this family that still needs a real `'src` slice
+        // keeps the boundary for a restored entity too: the source holds
+        // `&amp;copy;` where the match string holds `&copy;`, so
+        // `Attrlist::parse` would read the wrong bytes as content.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        for source in [
+            "https://example.org[a &copy; b,role=hl]",
+            "link:index.html[a &copy; b,role=hl]",
+            "mailto:a@b.com[Tom &copy; Jerry,Subject here]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "an attribute-list text crossing a restored entity must stay literal: {nodes:?}"
+            );
+
+            // The string pipeline, by contrast, *does* build a link here.
+            assert!(golden_macros(source).contains("<a href"));
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -91,15 +91,23 @@ use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 /// as its own `CharRef` (see `xref::find_xref_matches`,
 /// `links::find_link_macro_matches`, `links::build_inline_link_node`,
 /// `links::email_level`, `image::build_image_node`, and
-/// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)). What keeps
+/// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)). A
+/// **restored entity** (`&copy;`, `&#8217;` — an author-written entity the
+/// replacements step un-escaped) rides on that same gate, since
+/// [`build_match_string`](super::quotes::build_match_string) gives it its own
+/// bytes too; it needs no per-family work, so it is admitted for the
+/// index-term, anchor and STEM families as well. What keeps
 /// the stricter gate is never a *family* now, only the one **capture** that
 /// must ride on the node as a real
 /// [`Attrlist`](crate::attributes::Attrlist)`<'src>`, parsed from the source's
-/// own bytes: a link's or cross-reference's attribute-list-bearing display
-/// text, and an image's non-empty bracket. The auto-link family additionally
-/// keeps a narrow deferral of its own for a bare URL whose trailing-punctuation
-/// strip would cut inside an escaped special, and the e-mail family one for an
-/// address *abutting* an opaque piece. A rendered span stays deferred for every
+/// own bytes: a link's attribute-list-bearing display text and an image's
+/// non-empty bracket (a cross-reference's own attribute list is parsed from a
+/// normalized *copy*, so it takes both lifts). The auto-link family
+/// additionally keeps a narrow deferral of its own for a bare URL whose
+/// trailing-punctuation strip would cut inside an escaped special, and the
+/// e-mail family one for an address *abutting* an opaque piece; the UI family
+/// and a footnote's text keep their own stricter gates for either `CharRef`
+/// leaf. A rendered span stays deferred for every
 /// family. The differential corpus pins the cases each increment claims.
 pub(super) fn apply_macros<'src>(
     nodes: Vec<InlineNode<'src>>,
@@ -376,12 +384,14 @@ pub(super) fn rebuild_macro_level<'src>(
 /// longer carries. Slicing the pieces themselves, as [`emit_range`] already
 /// does for the structured path below, cannot reintroduce it.
 ///
-/// A text crossing an **escaped special** (`xref:sec[a<b]`, `link:x[a<b]`) —
-/// or, degenerately, one [`text_slice`] declines to recover — instead becomes
+/// A text crossing an **escaped special** (`xref:sec[a<b]`, `link:x[a<b]`) or a
+/// **restored entity** (`xref:sec[a &copy; b]`) — or, degenerately, one
+/// [`text_slice`] declines to recover — instead becomes
 /// **structured children**, recovered with [`emit_range`]: the
-/// special is its own [`CharRef`](crate::inlines::CharRef) child that folds
-/// back to the same entity the string replacer's text carries, where one `Text`
-/// child holding the match string's `&lt;` would be escaped a second time by
+/// leaf is its own [`CharRef`](crate::inlines::CharRef) child that folds
+/// back to the same bytes the string replacer's text carries, where one `Text`
+/// child holding the match string's `&lt;` (or `&copy;`) would be escaped a
+/// second time by
 /// the fold (design §3.4). A text crossing an *opaque* piece never reaches this
 /// function at all — each caller's own gate
 /// ([`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)) rejects
@@ -463,7 +473,7 @@ mod tests {
             inline_builder::{build, build_for_group, fold_html},
         },
         inlines::{InlineNode, Ref, RefVariant},
-        parser::HtmlSubstitutionRenderer,
+        parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
         warnings::WarningType,
     };
@@ -508,6 +518,102 @@ mod tests {
 
             assert_eq!(folded, content.rendered_html());
             assert!(!folded.contains('\\'));
+        }
+    }
+
+    #[test]
+    fn the_other_families_recognize_a_construct_crossing_a_restored_entity() {
+        // A restored entity is a property of the *piece*, not of any one
+        // family, so admitting it lifts the boundary wherever a family's own
+        // gate is the opaque-piece one — including the families with no
+        // escaped-special corpus of their own, which this pins. (The UI
+        // family and a footnote's text keep their own stricter gates, for a
+        // restored entity exactly as for an escaped special; see
+        // `the_ui_and_footnote_families_keep_their_own_boundary` below.)
+        let parser = Parser::default().with_intrinsic_attribute(
+            "experimental",
+            "",
+            ModificationContext::Anywhere,
+        );
+
+        for source in [
+            // Index terms: the flow form, the concealed form, and both macros.
+            "((term &copy; other))",
+            "(((a &copy; b, c)))",
+            "indexterm:[a &copy; b]",
+            "indexterm2:[a &copy; b]",
+            // Anchors: the macro form, the shorthand, and the bibliography
+            // anchor.
+            "anchor:id[Tom &copy; Jerry]",
+            "[[i&copy;d]]text",
+            "[[[b&copy;bref]]] entry",
+            // A footnote *id*, which is read off the match string (its text
+            // is a separate capture — see the companion test).
+            "footnote:i&copy;d[Tom]",
+            // A bare e-mail address, whose own local part admits an entity.
+            "doc&copy;a@example.org",
+            // Inline STEM, whose expression is a passthrough.
+            "stem:[a &copy; b]",
+        ] {
+            let mut content = Content::from(Span::new(source));
+            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+            let nodes = build_for_group(
+                &SubstitutionGroup::Normal,
+                CowStr::from(source),
+                Span::new(source),
+                &parser,
+                None,
+            );
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+                content.rendered_html(),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_ui_and_footnote_families_keep_their_own_boundary() {
+        // The two families whose gate is *not* the opaque-piece one keep the
+        // boundary they already keep for an escaped special: a `kbd:`/`btn:`
+        // key or label, a menu name or item, and a footnote's text each still
+        // need a value they can slice from `'src`. A restored entity is
+        // neither better nor worse for them than an escaped special — this
+        // pins the two spellings side by side so the pair moves together
+        // whenever that boundary is lifted.
+        let parser = Parser::default().with_intrinsic_attribute(
+            "experimental",
+            "",
+            ModificationContext::Anywhere,
+        );
+
+        for (special, entity) in [
+            ("kbd:[Ctrl&C]", "kbd:[Ctrl&copy;C]"),
+            ("btn:[Save & Close]", "btn:[Save &copy; Close]"),
+            ("menu:F&le[Save]", "menu:F&copy;le[Save]"),
+            ("menu:File[Save & Exit]", "menu:File[Save &copy; Exit]"),
+            ("footnote:[Tom & Jerry]", "footnote:[Tom &copy; Jerry]"),
+        ] {
+            for source in [special, entity] {
+                let mut content = Content::from(Span::new(source));
+                SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+                let nodes = build_for_group(
+                    &SubstitutionGroup::Normal,
+                    CowStr::from(source),
+                    Span::new(source),
+                    &parser,
+                    None,
+                );
+
+                assert_ne!(
+                    fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+                    content.rendered_html(),
+                    "{source:?} is now recognized; fold it into the parity corpus above"
+                );
+            }
         }
     }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -9,12 +9,13 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_XREF,
-        inline_builder::quotes::{Piece, build_match_string, source_slice},
+        inline_builder::quotes::{Piece, build_match_string, source_slice, special_entity},
+        restored_entity_pattern,
         xref_target::{
             XrefTarget, interpret_xref_target, other_document_reference, this_document_reference,
         },
     },
-    inlines::{InlineNode, Ref, RefVariant},
+    inlines::{CharRef, InlineNode, Ref, RefVariant},
     parser::{DerivedReference, XrefStyle},
     strings::CowStr,
 };
@@ -125,20 +126,24 @@ pub(super) fn xref_macros_level<'src>(
 /// already made, and for the same reason; the families that hold a real
 /// [`Attrlist`]`<'src>` (image, link) still cannot make it.
 ///
-/// An **escaped special** (`xref:sec[a<b]`, `<<sec,Tom & Jerry>>`) is admitted
-/// for the same reason: the level's match string carries the
-/// [`CharRef`](InlineNode::CharRef)`::Special`'s canonical entity — the very
-/// bytes the string replacer's own escaped haystack holds there — so every
+/// An **escaped special** (`xref:sec[a<b]`, `<<sec,Tom & Jerry>>`) and a
+/// **restored entity** (`xref:sec[Tom &copy; Jerry]`) are admitted for the same
+/// reason: the level's match string carries the
+/// [`CharRef`](InlineNode::CharRef) leaf's own bytes — a `Special`'s canonical
+/// entity, an `Entity`'s entity itself — the very bytes the string replacer's
+/// own escaped haystack holds there — so every
 /// value this family computes off that string (the target, the
 /// `raw_text.contains('=')` attribute-list probe, the attrlist parse itself,
 /// the shorthand's `split_once(',')`) sees exactly what the string replacer
 /// sees. The reference *text* is then rebuilt as structured children rather
 /// than one sliced [`Text`](InlineNode::Text) (see [`macro_text_children`]), so
-/// the escaped special folds back to its own entity instead of being escaped
-/// twice. A **rendered span** stays deferred: it is one opaque placeholder
-/// here where the string pipeline's haystack holds its markup inline, and that
-/// markup — which only exists at fold time — is what the string replacer's own
-/// `=` probe and the pattern's `]` boundary read.
+/// the leaf folds back to its own bytes instead of being escaped
+/// twice — and the attribute-list branch, whose value comes back from a parse
+/// rather than from a range, re-derives the same split with
+/// [`escaped_value_children`]. A **rendered span** stays deferred: it is one
+/// opaque placeholder here where the string pipeline's haystack holds its
+/// markup inline, and that markup — which only exists at fold time — is what
+/// the string replacer's own `=` probe and the pattern's `]` boundary read.
 fn find_xref_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -348,27 +353,16 @@ fn xref_macro_text<'src>(
                     #[allow(clippy::unwrap_used)]
                     let span = text_span.unwrap();
 
-                    vec![InlineNode::Text {
-                        // The positional value is *already-escaped* text (it
-                        // was parsed out of the level's match string, where an
-                        // escaped special is its entity), while a
-                        // `Text` node holds *logical* text the fold escapes
-                        // (design §3.4). `unescape_specials` puts the three
-                        // entities the match string can carry back to their
-                        // characters, so the round trip through the fold is
-                        // byte-exact; it is a no-op for a text carrying no
-                        // escaped special, which is every text this branch saw
-                        // before the gate admitted one.
-                        value: CowStr::from(unescape_specials(&text)),
-                        // The parsed positional attribute is a synthesized
-                        // value with no `'src` slice of its own (it comes
-                        // from the normalized, attrlist-parsed copy, not the
-                        // source directly); it falls back to the bracketed
-                        // text's own span (design §4.4), mirroring the
-                        // synthesized-value location policy
-                        // `apply_attribute_references` already establishes.
-                        location: source_slice(pieces, span.start()..span.end(), root),
-                    }]
+                    // The parsed positional attribute is a synthesized value
+                    // with no `'src` slice of its own (it comes from the
+                    // normalized, attrlist-parsed copy, not the source
+                    // directly); it falls back to the bracketed text's own
+                    // span (design §4.4), mirroring the synthesized-value
+                    // location policy `apply_attribute_references` already
+                    // establishes.
+                    let location = source_slice(pieces, span.start()..span.end(), root);
+
+                    escaped_value_children(&text, location)
                 }
             };
 
@@ -404,33 +398,109 @@ fn plain_xref_text<'src>(
     macro_text_children(raw_text, text_range, true, nodes, pieces, root)
 }
 
-/// Puts the three character entities a level's match string can carry back to
-/// the characters they stand for.
+/// Rebuilds an **already-escaped computed value** — a value a family read off
+/// the level's own match string rather than out of the tree, here this family's
+/// attribute list's positional value — as the nodes that fold back to exactly
+/// those bytes, all sharing `location` (the value has no `'src` slice of its
+/// own, so design §4.4's coarse fallback is the only honest span for any part
+/// of it).
 ///
-/// [`build_match_string`] gives a
-/// [`CharRef`](InlineNode::CharRef)`::Special` leaf its canonical entity, so
-/// a value a family *computes* off that string — this family's attribute list's
-/// positional value — is already-escaped text, while a
-/// [`Text`](InlineNode::Text) node holds logical text the fold escapes (design
-/// §3.4). Undoing the escape is exact rather than heuristic: inside a range
-/// that crosses an escaped special, an `&` can only ever be the first byte of
-/// one of these three entities — a verbatim run holds no special at all (the
-/// `SpecialCharacters` step split every one into its own leaf), a synthesized
-/// run's own specials are [`Raw`](InlineNode::Raw) leaves (opaque, and so
-/// rejected by every caller's gate), and an author-written entity is a
-/// `CharRef::Entity` (likewise opaque). A caller therefore applies this only
-/// where its value's own source range crosses such a special: under an
-/// effective order that never escapes (§3.4.1), a literal `&` *does* survive
-/// into a verbatim run, and there is no entity to undo.
+/// The rebuild is design §3.4's trichotomy applied to a string:
+/// [`build_match_string`] gives an escaped special its canonical entity and a
+/// *restored* entity its own bytes, while a [`Text`](InlineNode::Text) node
+/// holds **logical** text the fold escapes. So the two classes come apart here
+/// — the special becomes the character it stands for (inside a `Text` the fold
+/// escapes back), and the restored entity becomes its own
+/// [`CharRef`](InlineNode::CharRef)`::Entity` leaf (which the fold emits
+/// verbatim) — where one `Text` holding both would escape the entity's `&` a
+/// second time.
 ///
-/// `&amp;` is undone **last** so a doubly-escaped sequence unwinds one level,
-/// exactly as the fold re-escapes one level: `&amp;lt;` (a literal `&`
-/// followed by the text `lt;`) becomes `&lt;`, which the fold escapes back to
-/// `&amp;lt;`.
-fn unescape_specials(text: &str) -> String {
-    text.replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
+/// The scan is left to right, one `&` at a time, precisely because the two
+/// classes can nest: `&amp;copy;` is a literal `&` followed by the letters
+/// `copy;`, **not** a `&copy;` entity, and only consuming the `&amp;` first
+/// tells them apart. That is the same one-level unwind the fold performs in
+/// reverse.
+///
+/// Splitting on the three specials is exact rather than heuristic: inside such
+/// a value an `&` can only ever open one of these two classes or stand alone —
+/// a verbatim run holds no special at all (the `SpecialCharacters` step split
+/// every one into its own leaf) and a synthesized run's own specials are
+/// [`Raw`](InlineNode::Raw) leaves, which are opaque and so rejected by the
+/// caller's gate. Under an effective order that never escapes (§3.4.1) a
+/// literal `&` *does* survive into a verbatim run, and is left exactly as it
+/// is here, since neither class matches it.
+fn escaped_value_children<'src>(text: &str, location: Span<'src>) -> Vec<InlineNode<'src>> {
+    let mut children: Vec<InlineNode<'src>> = Vec::new();
+    let mut pending = String::new();
+    let mut rest = text;
+
+    while let Some(at) = rest.find('&') {
+        let (before, from_amp) = rest.split_at(at);
+
+        // Everything before this `&` is ordinary logical text.
+        pending.push_str(before);
+
+        let consumed = if let Some((ch, len)) = special_of(from_amp) {
+            // An escaped special: the character it stands for, which the fold
+            // escapes back to these very bytes.
+            pending.push(ch);
+            len
+        } else if let Some(entity) = restored_entity_pattern().find(from_amp) {
+            // A restored entity: its own leaf, emitted verbatim by the fold.
+            if !pending.is_empty() {
+                children.push(InlineNode::Text {
+                    value: CowStr::from(std::mem::take(&mut pending)),
+                    location,
+                });
+            }
+
+            children.push(InlineNode::CharRef {
+                value: CharRef::Entity(CowStr::from(entity.as_str().to_string())),
+                location,
+            });
+
+            // The pattern is `^`-anchored, so the match ends where the entity
+            // does.
+            entity.end()
+        } else {
+            // A bare `&` that opens neither class (an effective order that
+            // never escaped, §3.4.1): ordinary logical text like any other
+            // byte.
+            pending.push('&');
+            '&'.len_utf8()
+        };
+
+        rest = from_amp.get(consumed..).unwrap_or_default();
+    }
+
+    pending.push_str(rest);
+
+    if !pending.is_empty() {
+        children.push(InlineNode::Text {
+            value: CowStr::from(pending),
+            location,
+        });
+    }
+
+    children
+}
+
+/// The character an escaped special's canonical entity at the start of `rest`
+/// stands for, with the entity's own length, or `None` when `rest` does not
+/// open one.
+fn special_of(rest: &str) -> Option<(char, usize)> {
+    // The same three characters `SpecialCharacters` splits into their own
+    // leaves, read through `build_match_string`'s own mapping rather than a
+    // second copy of it.
+    for ch in ['<', '>', '&'] {
+        let entity = special_entity(ch);
+
+        if rest.starts_with(entity) {
+            return Some((ch, entity.len()));
+        }
+    }
+
+    None
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a `<<id>>` shorthand
@@ -566,10 +636,10 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::super::test_support::{
-        assert_styled, assert_text, build_src, fold_html, link_text_of,
+        assert_entity, assert_styled, assert_text, build_src, fold_html, link_text_of,
     };
     use crate::{
-        Parser, Span,
+        HasSpan, Parser, Span,
         content::{Content, SubstitutionStep},
         inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
         parser::{HtmlSubstitutionRenderer, XrefStyle},
@@ -1243,6 +1313,146 @@ mod tests {
         assert_eq!(link_text_of(reference), "Tom & Jerry");
         assert_eq!(reference.roles.len(), 1);
         assert_eq!(reference.roles[0].as_ref(), "hl");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_cross_reference_crossing_a_restored_entity() {
+        // A restored entity (`&copy;`, `&#8217;`) is admitted for the same
+        // reason an escaped special is: the level's match string carries its
+        // own bytes — the string pipeline's haystack bytes from the
+        // replacements step onward — and the fold emits them verbatim.
+        let fixtures = [
+            // A reference text crossing one, in both spellings.
+            "xref:sec[Tom &copy; Jerry]",
+            "<<sec,Tom &copy; Jerry>>",
+            "xref:sec[&copy;]",
+            "xref:sec[&#8217;t is]",
+            // A *target* crossing one, in both spellings.
+            "xref:s&copy;c[Text]",
+            "<<s&copy;c>>",
+            // An attribute-list text crossing one — the capture this family
+            // parses from a normalized copy rather than an `'src` slice, so
+            // (unlike the link and image families) it takes the lift too.
+            "xref:sec[Tom &copy; Jerry,role=hl]",
+            "xref:sec[&copy;&reg;,role=hl,window=_blank]",
+            // A text crossing both a restored entity and an escaped special.
+            "xref:sec[a &copy; b < c]",
+            "xref:sec[a &copy; b < c,role=hl]",
+            // A *doubly* escaped entity: `&amp;copy;` is a literal `&`
+            // followed by the letters `copy;`, not an entity, and the fold
+            // must unwind exactly one level.
+            "xref:sec[Tom &amp;copy; Jerry]",
+            "xref:sec[Tom &amp;copy; Jerry,role=hl]",
+            // In flow, inside a rendered span, doubled, and escaped.
+            "see xref:sec[Tom &copy; Jerry] now",
+            "*xref:sec[Tom &copy; Jerry]*",
+            "xref:a[&copy;] and xref:b[&reg;]",
+            "\\xref:sec[Tom &copy; Jerry]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_xref(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_reference_text_crossing_a_restored_entity_keeps_the_entity_as_its_own_child() {
+        // The plain-text path rebuilds the text through `emit_range`, so the
+        // entity stays the leaf it already is rather than being baked into a
+        // `Text` the fold would escape a second time.
+        let source = "xref:sec[Tom &copy; Jerry]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.children.len(), 3);
+        assert_text(&reference.children[0], "Tom ", 1, 10);
+
+        // The leaf's own span is precise — the entity as the author wrote it,
+        // which is also the value it carries (the `SpecialCharacters` escape
+        // the replacements step undid leaves no trace in either).
+        let entity = assert_entity(&reference.children[1], "&copy;");
+        assert_eq!(entity.data(), "&copy;");
+        assert_eq!(entity.col(), 14);
+
+        assert_text(&reference.children[2], " Jerry", 1, 20);
+    }
+
+    #[test]
+    fn an_attribute_list_text_crossing_a_restored_entity_splits_the_entity_out() {
+        // The attribute-list branch has no range to rebuild from — its value
+        // comes back from an `Attrlist` parse of a normalized *copy* — so
+        // `escaped_value_children` re-derives the same split from the value's
+        // own bytes: the escaped special becomes the character a `Text` holds
+        // logically, and the restored entity its own `CharRef` leaf. Both fold
+        // back to one escape level, as the string replacer's own text does.
+        let source = "xref:sec[Tom &copy; & Jerry,role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.roles.len(), 1);
+        assert_eq!(reference.children.len(), 3);
+
+        // Every part of a parsed positional value shares the bracketed text's
+        // own coarse span (design §4.4) — it has no `'src` slice of its own.
+        let text_span = reference.children[0].span();
+        assert_eq!(text_span.data(), "Tom &copy; & Jerry,role=hl");
+
+        match &reference.children[0] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "Tom ");
+                assert_eq!(*location, text_span);
+            }
+
+            other => panic!("expected a Text run, got {other:?}"),
+        }
+
+        assert_eq!(assert_entity(&reference.children[1], "&copy;"), text_span);
+
+        match &reference.children[2] {
+            InlineNode::Text { value, location } => {
+                // The escaped special comes back as the *character*, which the
+                // fold escapes once.
+                assert_eq!(value.as_ref(), " & Jerry");
+                assert_eq!(*location, text_span);
+            }
+
+            other => panic!("expected a Text run, got {other:?}"),
+        }
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
+    }
+
+    #[test]
+    fn a_doubly_escaped_entity_in_an_attribute_list_text_unwinds_one_level() {
+        // `&amp;copy;` in the source is a literal `&` followed by the letters
+        // `copy;`, which the match string carries as `&amp;copy;` too (the
+        // `SpecialCharacters` escape of the `&`, which the restore-entities
+        // rule declines because `amp;copy` is not an entity name). Scanning
+        // left to right consumes the `&amp;` first, so the value is one `Text`
+        // holding `&copy;` *logically* — which the fold escapes back to
+        // `&amp;copy;` — not an entity leaf that would emit `&copy;`.
+        let source = "xref:sec[Tom &amp;copy; Jerry,role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.children.len(), 1);
+        assert_eq!(link_text_of(reference), "Tom &copy; Jerry");
 
         assert_eq!(
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -717,6 +717,9 @@ mod tests {
             "image:a.png[An image with spaces,role=thumb]",
             "before image:b.svg[Vector] after",
             "an image:a&b.png[Query] target",
+            "an image:a&copy;b.png[Entity] target",
+            "link:a&copy;b.html[a &copy; b] and xref:s&copy;c[a &copy; b]",
+            "https://example.org/?a=&copy;b and doc&copy;a@example.org",
             "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
             "a ((flow term)) and (((c1, c2, c3))) end",
             "indexterm:[primary, secondary]",
@@ -1479,6 +1482,17 @@ mod tests {
                 "&lt;&lt;install,&gt;&gt;",
                 "&#169; stays literal",
                 "-> and <- stay literal",
+                // A restored entity beside — and inside — a construct these
+                // orders can recognize, so the piece's own match-string bytes
+                // are exercised under an order that reaches the replacements
+                // step and one that does not.
+                "a &copy; b and image:x&copy;y.png[]",
+                // A cross-reference attribute-list text carrying a bare `&`,
+                // which only an order *without* `specialcharacters` can
+                // present: the value's own bytes open neither recoverable
+                // class, so `escaped_value_children` keeps the `&` as
+                // ordinary logical text.
+                "xref:sec[a & b,role=hl]",
                 // Specials beside each construct these orders *can*
                 // recognize, so the classification is exercised inside and
                 // around a built node's own children.

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -128,9 +128,11 @@ fn match_level<'src>(
 /// to its nodes.
 ///
 /// A verbatim [`Text`](InlineNode::Text) run contributes its (special-free)
-/// value; a [`CharRef`](InlineNode::CharRef) contributes its canonical entity,
-/// so the boundary classes the quote patterns key off (`&`, `;`) see exactly
-/// what the string pipeline's escaped text presents; a *synthesized*
+/// value; a [`CharRef`](InlineNode::CharRef) contributes its canonical entity
+/// (a [`Special`](CharRef::Special)) or the entity itself (a *restored*
+/// [`Entity`](CharRef::Entity)), so the boundary classes the quote patterns key
+/// off (`&`, `;`) see exactly what the string pipeline's escaped text presents
+/// — and so does a later step reading a value across one; a *synthesized*
 /// `Text` run (design §3.4.1 — an attribute expansion, a `counter` directive)
 /// contributes its `value` too, so [`apply_character_replacements`]
 /// (design §3.4.1: `replacements` still runs over an expanded value) can
@@ -198,6 +200,35 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                 });
             }
 
+            InlineNode::CharRef {
+                value: CharRef::Entity(entity),
+                location,
+            } => {
+                // A *restored* entity (`&amp;copy;` un-escaped back to
+                // `&copy;` by the character-replacements step) contributes its
+                // own bytes for the same reason a `Special` contributes its
+                // canonical entity: those bytes *are* what the string
+                // pipeline's own haystack holds at that position from the
+                // replacements step onward, and the fold emits them verbatim
+                // (see `fold`'s `CharRef::Entity` arm), so the two agree with
+                // no renderer involved. It stays `atomic` — the leaf is one
+                // indivisible node, never sliced — but is *recoverable*, which
+                // is the distinction
+                // [`range_has_no_opaque_piece`](super::macros::image::range_has_no_opaque_piece)
+                // draws.
+                s.push_str(entity);
+
+                pieces.push(Piece {
+                    node_index,
+                    s_start,
+                    s_len: entity.len(),
+                    src_offset: location.byte_offset(),
+                    src_len: location.data().len(),
+                    atomic: true,
+                    synthesized: false,
+                });
+            }
+
             other => {
                 // A span from an earlier sub (or any other synthesized-value
                 // node, e.g. a `Raw` leaf) is opaque: a single placeholder
@@ -249,7 +280,11 @@ pub(in crate::content::inline_builder) fn range_overlaps_synthesized(
 /// The canonical special-character entity a [`CharRef::Special`] contributes to
 /// the match string. These are the AsciiDoc-standard escapes the quote patterns
 /// were written against, independent of the render-time backend.
-fn special_entity(ch: char) -> &'static str {
+///
+/// Shared with the macro families, which need the same mapping in reverse to
+/// take an already-escaped *computed* value apart (see
+/// `xref::escaped_value_children`), so the two directions cannot drift.
+pub(super) fn special_entity(ch: char) -> &'static str {
     match ch {
         '<' => "&lt;",
         '>' => "&gt;",
@@ -1442,6 +1477,46 @@ mod tests {
             style_variant(crate::parser::QuoteType::Unquoted, false),
             StyleVariant::Unquoted
         );
+    }
+
+    #[test]
+    fn a_restored_entity_contributes_its_own_bytes_to_the_match_string() {
+        // The two `CharRef` leaves are the atomic pieces `build_match_string`
+        // gives real bytes to: a `Special` its canonical entity, and an
+        // `Entity` the entity itself. Both are what the string pipeline's own
+        // haystack holds at that position, which is what lets a family read a
+        // value across one; both stay `atomic`, since a leaf is one
+        // indivisible node.
+        let nodes = vec![
+            InlineNode::Text {
+                value: CowStr::from("a"),
+                location: Span::new("a"),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Entity(CowStr::from("&copy;")),
+                location: Span::new("&copy;"),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Special('&'),
+                location: Span::new("&"),
+            },
+        ];
+
+        let (s, pieces) = super::build_match_string(&nodes);
+
+        assert_eq!(s, "a&copy;&amp;");
+        assert_eq!(pieces.len(), 3);
+
+        assert!(!pieces[0].atomic);
+
+        assert_eq!(pieces[1].s_start, 1);
+        assert_eq!(pieces[1].s_len, "&copy;".len());
+        assert!(pieces[1].atomic);
+        assert!(!pieces[1].synthesized);
+
+        assert_eq!(pieces[2].s_start, "a&copy;".len());
+        assert_eq!(pieces[2].s_len, "&amp;".len());
+        assert!(pieces[2].atomic);
     }
 
     #[test]

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -99,6 +99,26 @@ pub(super) fn assert_special_char<'src>(node: &InlineNode<'src>, ch: char) -> Sp
     location
 }
 
+/// Asserts that `node` is a [`CharRef`](InlineNode::CharRef)`::Entity` for
+/// `entity` — a *restored* entity a macro family recovers as its own child
+/// rather than baking into a `Text` the fold would escape a second time — and
+/// returns its `location` for further inspection.
+///
+/// Written as a whole-node [`assert_eq!`] for the same coverage reason
+/// [`assert_special_char`] is.
+pub(super) fn assert_entity<'src>(node: &InlineNode<'src>, entity: &str) -> Span<'src> {
+    let location = node.span();
+
+    let expected = InlineNode::CharRef {
+        value: CharRef::Entity(CowStr::from(entity.to_string())),
+        location,
+    };
+
+    assert_eq!(*node, expected);
+
+    location
+}
+
 /// Asserts that `node` is a [`Raw`](InlineNode::Raw) with the given
 /// `value`, returning its `location`.
 pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'src> {

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -48,5 +48,6 @@ pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
     ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, build_callout_regexes,
     character_replacements, hard_line_break_pattern, maybe_has_quotes, maybe_has_replacements,
-    quote_subs, substitute_attributes_in_macro_target, substitute_attributes_in_reftext,
+    quote_subs, restored_entity_pattern, substitute_attributes_in_macro_target,
+    substitute_attributes_in_reftext,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1220,9 +1220,40 @@ static REPLACEMENTS: LazyLock<Vec<CharacterReplacement>> = LazyLock::new(|| {
             // Restore entities
             type_: CharacterReplacementType::CharacterReference("".to_owned()),
             #[allow(clippy::unwrap_used)]
-            pattern: Regex::new(r#"\\?&amp;((?:[a-zA-Z][a-zA-Z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-fA-F][\da-fA-F][\da-fA-F]{0,3}));"#).unwrap(),
+            pattern: Regex::new(&format!(r#"\\?&amp;({ENTITY_NAME});"#)).unwrap(),
         },
     ]
+});
+
+/// The name an entity reference must carry for the **restore entities**
+/// replacement rule above to recognize it: a named entity (`copy`, `hellip`,
+/// `frac12`), a decimal numeric reference (`#8217`), or a hexadecimal one
+/// (`#x2014`).
+///
+/// Shared with [`restored_entity_pattern`] so the two spellings of the same
+/// class — the rule that *produces* a restored entity, and the pattern that
+/// recognizes one already produced — cannot drift.
+const ENTITY_NAME: &str =
+    r#"(?:[a-zA-Z][a-zA-Z]+\d{0,2}|#\d\d\d{0,4}|#x[\da-fA-F][\da-fA-F][\da-fA-F]{0,3})"#;
+
+/// A **restored** entity reference (`&copy;`, `&#8217;`) as it appears once the
+/// **restore entities** replacement rule above has un-escaped it — that is, the
+/// same class that rule matches, minus the `&amp;` escaping its `&` had before
+/// the rule ran.
+///
+/// Shared with the single-pass
+/// [`inline_builder`](crate::content::inline_builder), which needs to find such
+/// an entity inside a value a macro family *computed* off an already-escaped
+/// string, so the entity becomes its own
+/// [`CharRef`](crate::inlines::InlineNode::CharRef)`::Entity` child rather than
+/// text a fold would escape a second time.
+pub(crate) fn restored_entity_pattern() -> &'static Regex {
+    &RESTORED_ENTITY
+}
+
+static RESTORED_ENTITY: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(&format!(r#"^&{ENTITY_NAME};"#)).unwrap()
 });
 
 #[derive(Debug)]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -891,6 +891,12 @@ fn shapes_match_across_combined_constructs() {
     // meet the recorder's own reconstruction.
     assert_shapes("See image:a&b.png[Chart] and image:plain.png[Alt Text] today.");
 
+    // A *restored* entity, the second atomic piece the match string carries
+    // real bytes for: a target crossing one, and a display text crossing one
+    // (which the builder keeps as its own `CharRef::Entity` child, the shape
+    // the recorder reaches by re-reading the rendered anchor text).
+    assert_shapes("See image:a&copy;b.png[Chart] and link:x.html[a &copy; b] today.");
+
     assert_shapes_with(
         "{counter:step}. Step one uses *{product}* and stem:[x+1].",
         with_product,


### PR DESCRIPTION
The previous increment (#1199) closed the escaped-special boundary as a *family* boundary, and named what it left behind: "A restored entity in the target, and a rendered span anywhere in the match, still defer." The auto-link family pinned the same restored-entity deferral of its own. This closes it — and not family by family, because **recoverability is a property of the piece, not of the family reading across it**.

A restored entity is `&amp;copy;` written in the source, which `SpecialCharacters` escapes to `&amp;amp;copy;` and `CharacterReplacements` then un-escapes back to `&amp;copy;`, leaving a `CharRef::Entity` leaf.

## What changed

`build_match_string` gives a `CharRef::Entity` leaf **its own bytes**, exactly as it already gives a `CharRef::Special` its canonical entity, and for the identical reason: those bytes *are* what the string pipeline's haystack holds at that position from the replacements step onward, and the fold emits them verbatim (`fold`'s `Entity` arm), so the two sides agree **with no renderer involved** — the distinction that separates this class from a rendered span, whose markup exists only at fold time. The leaf stays `atomic` (one indivisible node, never sliced) but becomes *recoverable*, which is precisely what `range_has_no_opaque_piece` names.

Nothing else in any family needed to change: a target or computed value reads the entity's bytes off the match string, and a display text keeps the leaf as its own child through `macro_text_children`'s `emit_range` path (where one `Text` holding `&amp;copy;` would have had its `&amp;` escaped a second time).

### The one computed value that needed new code

A cross-reference's **attribute-list positional text** has no range to rebuild from — it comes back from an `Attrlist` parse of a normalized *copy* of the match string. The single-`Text` `unescape_specials` that branch used is replaced by `escaped_value_children`, which re-derives §3.4's trichotomy from the value's own bytes: an escaped special becomes the character a `Text` holds *logically* (re-escaped once at fold time), a restored entity becomes its own `CharRef::Entity` child (emitted verbatim).

The scan is left to right, one `&amp;` at a time, because the two classes nest — `&amp;amp;copy;` is a literal `&amp;` followed by the letters `copy;`, **not** a `&amp;copy;` entity — and only consuming the `&amp;amp;` first tells them apart, the same one-level unwind the fold performs in reverse.

### No drift between the two spellings of one class

- The entity-name class is hoisted into a shared `ENTITY_NAME` constant that both the restore-entities replacement rule and the new `restored_entity_pattern` are built from.
- `special_entity` is now shared with the macro families rather than copied, so the char→entity and entity→char directions cannot drift.

## What still defers

- **The UI family** (a `kbd:`/`btn:` key or label, a menu name or item) and **a footnote's text** hold their own stricter gates — they need a value they can slice from `'src`, for a restored entity exactly as for an escaped special. A new test pins the two spellings side by side so they move together whenever that boundary is lifted.
- **The attribute-list captures that need a real `Attrlist&lt;'src&gt;`** (a link's attribute-list-bearing display text, an image's non-empty bracket) keep `range_is_verbatim`: the source holds `&amp;amp;copy;` where the match string holds `&amp;copy;`. A cross-reference's own attribute list, parsed from a normalized copy, takes both lifts.
- **A rendered span**, now the only class that defers as a whole.

## Testing

- Per family, a target and a display text crossing a restored entity in each spelling (`&amp;amp;`, a named entity, a numeric one), doubled, crossing *both* an entity and an escaped special, in flow, inside a rendered span, beside a sibling family, escaped, and beside — rather than crossing — an entity.
- Structural companions asserting the recovered child's own precise span, the entity-bearing target and derived default alt, and the one-level unwind of a doubly-escaped entity.
- The two `…_over_a_restored_entity_is_a_documented_divergence` tests become **parity** tests per the "if lifted, fold this into a parity corpus" convention; the boundaries that remain get divergence tests of their own.
- Fixtures added to the whole-pipeline broad sweep, the group-parity corpus (so an order that never reaches the replacements step exercises the bare-`&amp;` path too), and the structural recorder cross-check.
- **Corpus-wide fold-parity audit** (tree building forced on for every parse in the suite): the divergence set strictly **shrank** — five previously-surviving sources are gone, all of them real golden fixtures rather than constructed ones:
  - `http://example.com[sam&amp;#93;ple]bracket]`
  - `l&amp;#8217;http://www.irit.fr[IRIT]`
  - `link:My&amp;#32;Documents/report.pdf[Get Report]`
  - `menu:Tools[Project &amp;gt; Build]` and `menu:Tools[More Tools &amp;gt; Extensions]`, whose submenu caret is a restored entity

  and no pre-existing one appeared. (The set's only additions are this increment's own new divergence-pinning fixtures for the untouched UI/footnote boundary.)

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5227 passed), and `cargo +nightly doc --no-deps --document-private-items` are all clean.

Design doc updated with the "landed as" narrative and the §5.2 checklist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrziJukkqbj75KJSY289ky

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrziJukkqbj75KJSY289ky)_