### PR TITLE
fix: Pin take_line's newline scan to memchr

### DIFF
--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -13,8 +13,25 @@ impl<'src> Span<'src> {
     /// A line is terminated by end-of-input or a single `\n` character
     /// or a single `\r\n` sequence. The end of line sequence is consumed
     /// but not included in the returned line.
+    ///
+    /// # Why `memchr` rather than `str::find`
+    ///
+    /// This is the hottest scan in the parser — every block, every line, every
+    /// pass over the source runs through it — so which code the compiler picks
+    /// for the newline search dominates the whole parse. `self.find('\n')`
+    /// leaves that to inlining luck: `str::find` with a `char` pattern goes
+    /// through `CharSearcher`, whose SIMD fast path reaches the same `memchr`
+    /// underneath *only when the searcher is inlined away*. Whether it is
+    /// varies with unrelated codegen changes elsewhere in the crate, which has
+    /// repeatedly moved the `repeated example delimiters` benchmark by ±10-14%
+    /// in either direction on pull requests that never touched this file.
+    ///
+    /// Calling [`memchr::memchr`] directly pins the fast path. The two are
+    /// exactly equivalent on UTF-8: byte `0x0A` can only ever be a standalone
+    /// ASCII newline, since every continuation byte is `>= 0x80`, so the byte
+    /// index this finds is the same one `str::find` returns.
     pub(crate) fn take_line(self) -> MatchedItem<'src, Self> {
-        let line = match self.find('\n') {
+        let line = match memchr::memchr(b'\n', self.data().as_bytes()) {
             Some(index) => self.into_parse_result(index),
             None => self.into_parse_result(self.len()),
         };


### PR DESCRIPTION
`Span::take_line` is the hottest scan in the parser — every block, every line, every pass over the source runs through it — so which code the compiler picks for its newline search dominates the whole parse.

`self.find('\n')` left that to inlining luck. `str::find` with a `char` pattern goes through `CharSearcher`, whose SIMD fast path reaches the same `memchr` underneath **only when the searcher is inlined away**, and whether it is varies with unrelated codegen changes elsewhere in the crate.

## Why this is worth pinning

That inlining lottery has repeatedly moved the `repeated example delimiters` benchmark by ±10–14% **in either direction**, on pull requests that never touched this file — with `take_line`'s own source byte-identical across the comparison every time:

| PR | CodSpeed verdict on `repeated example delimiters` | diff scope |
| --- | --- | --- |
| #1183 | ⚡ improve 12.1% (16.2 ms → 14.5 ms) | `content/inline_builder/` only |
| #1189 | ⚡ improve 14% (16.2 ms → 14.2 ms) | `content/inline_builder/` only |
| #1200 | ❌ degrade 10.5% (16.1 ms → 18 ms) | `content/inline_builder/` only |

It is the only benchmark of the five that has moved at all in the last 25 PRs. CodSpeed's own bot investigated #1183 when asked why it was faster, traced the entire delta to `take_line`, found memory-access counts identical to four decimals, and concluded the gain was incidental to `CharSearcher` inlining — recommending exactly this change to stop the flapping.

## The change

One line, plus a doc comment recording why it must not drift back:

```rust
let line = match memchr::memchr(b'\n', self.data().as_bytes()) {
```

`memchr` is already a direct dependency of `parser`. No new dependency, no `unsafe`.

**The two are exactly equivalent on UTF-8.** Byte `0x0A` can only ever be a standalone ASCII newline, since every UTF-8 continuation byte is `>= 0x80`, so the byte index found here is precisely the one `str::find('\n')` returned. No behavior change, and no test needed to change.

## Measurements

Instructions retired under cachegrind (deterministic, same methodology CodSpeed's simulation mode uses), `main` at 09783d5 with and without the patch:

| workload | before | after | Δ |
| --- | --- | --- | --- |
| 4000 `====` delimiter lines (the benchmark's shape) | 143,881,662 | 124,436,247 | **−13.5%** |
| 759 KB of real AsciiDoc (all of `ref/asciidoc-lang/docs`) | 1,944,822,238 | 1,900,537,867 | **−2.2%** |

Branch mispredicts on the delimiter shape drop from 458,584 to 376,648.

The realistic-document figure is the honest one for general use; the larger number is the pathological line-scanning shape the benchmark deliberately targets. Both improve, neither regresses.

## Scope

This is independent of any in-flight branch work: `parser/src/span/line.rs` and `parser/benches/` are byte-identical between `main` and the `inline-ast` feature branch, and `take_line` is block-scanning code with no relationship to the inline AST.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (4714 passed), and `cargo +nightly doc --no-deps --document-private-items` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrziJukkqbj75KJSY289ky

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrziJukkqbj75KJSY289ky)_