### PR TITLE
feat: Recognize a reference text crossing a rendered span (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -2979,6 +2979,85 @@ Each phase is a reviewable unit with a clear exit gate.
   with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string
   pipeline's own string.
 
+  *Step 6 prep landed as (a **reference text** crossing a rendered span — the cross-reference
+  family, first of the last remaining class):* with every recoverable piece now admitted, a
+  **rendered span** — a [`Styled`](../../parser/src/inlines/styled.rs) span, an already-recognized
+  macro node, a masked passthrough — was the one class still deferring as a whole, and the audit
+  map's own last *normal*-order item ("a display or reference text crossing a rendered span"). It
+  is closed here for the cross-reference family, in both spellings, the same family that went
+  first for the escaped-special lift and for the same reason: nothing on a `Ref{Xref}` node is
+  `Span`-typed.
+
+  The lift is not another gate relaxation but a change of *which bytes the gate covers*. A
+  rendered span is genuinely unrecoverable —
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) stands it in as one
+  placeholder where the string pipeline's haystack holds markup that exists only at fold time,
+  which is exactly what separates it from a `CharRef` leaf — so every value this family *computes*
+  off the match string (its target, an attribute list's parsed positional value) still needs
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs). A
+  **reference text** computes nothing: it becomes structured children through
+  [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs), whose
+  [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) path clones the opaque piece's
+  own **node** whole into them, so the text carries the construct itself rather than the markup it
+  will fold to — the "nesting is the point" recovery a footnote's own content has always used,
+  applied to a reference's display text.
+  [`find_xref_matches`](../../parser/src/content/inline_builder/macros/xref.rs) therefore gates
+  the macro form's *target* (group 3) rather than its whole match, and the shorthand's *id half*
+  (its inner up to the first `,`, factored out as `shorthand_id_range` so the gate and
+  [`build_xref_shorthand_node`](../../parser/src/content/inline_builder/macros/xref.rs) split on
+  the same byte) rather than its whole inner. That the shorthand's split cannot be moved unnoticed
+  by a comma inside the markup falls straight out of it: such a piece would have to sit in the id
+  half, which the gate then rejects. No builder changed at all — `macro_text_children` already
+  routed a range it could not slice through `emit_range`, which already cloned an atomic piece
+  whole.
+
+  What the structural recovery cannot do is make the *recognition* agree in every case, and this
+  is the first increment where that gap is real rather than avoidable: the string replacer matches
+  over the markup where the builder matches over one placeholder standing in for it, so the two
+  read the same extent only while that markup carries no character the pattern is sensitive to —
+  and the builder cannot know what it carries without folding, which building a tree must never do
+  (a fold is renderer-dependent; recognition must not be). Three shapes are therefore documented
+  divergences, each pinned by its own test, and in each the string pipeline's reading is the
+  markup-perturbed one while the tree's is the well-formed one — the same shape of intended
+  divergence the quotes step's own crossed delimiters have: a `]` inside the span (which ends the
+  macro form's lazy text capture early for the string replacer), a `&gt;&gt;` inside it (the
+  shorthand's own terminator), and markup carrying an `=` beside a comma elsewhere in the text
+  (which sends the string replacer down its attribute-list branch, where the parse then keeps only
+  what precedes that comma). The text shape that keeps the stricter gate outright is a text
+  carrying its own **attribute list**: its display text comes back from an `Attrlist` parse of the
+  match string rather than from a range of it, and a placeholder inside a *parsed* value has no
+  node to be mapped back to — the same reason the image and link families defer their own
+  `Attrlist`-bearing captures.
+
+  A differential corpus pins the reference text crossing every opaque shape the earlier steps can
+  produce — each quoted form (including an attributed span, whose markup carries the `=` the
+  string replacer's own probe reads and this one does not), an image, a link, an anchor, an index
+  term, a masked passthrough, a span beside an escaped special and beside a restored entity,
+  escaped, in flow, and inside a rendered span of its own — in both spellings, alongside a
+  structural test asserting the recovered children's own precise spans (three children where the
+  single-`Text` shape this replaced could express one). The passthrough fixtures live in the
+  whole-pipeline sweep rather than the family's own step-driven corpus, since only the real
+  `SubstitutionGroup::apply` brackets the steps with the extraction that makes a passthrough
+  opaque on *both* sides. Fixtures are added to that sweep, to the group-parity corpus (so an
+  order that never escapes exercises the recovered children too), and to the structural recorder
+  cross-check — where this form can finally be compared at all, since the tree the builder now
+  produces is the shape the recorder recovers from the rendered markup. Two tests that used this
+  very divergence as their *vehicle* — the resolution mirror's own count-mismatch skip, block-side
+  and footnote-side — move to forms that still defer.
+
+  Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**:
+  four previously-surviving sources are gone — the two spellings of
+  `xref:sec[with *bold* reftext]`, one nesting an image macro
+  (`See xref:sec[image:logo.png[Logo]] now.`), and the golden corpus's own tigers fixture, whose
+  reference text is a code span wrapping a passthrough — and the set's only addition is this
+  increment's own new divergence-pinning fixture. As with every prep piece before it, nothing
+  further is wired in. The remaining families — the `link:`/`mailto:` macro, the auto-link /
+  formal-URL family, and the image family's own attribute list — still defer a capture crossing a
+  rendered span, each a later increment; and the audit's one structurally different item (an
+  effective order that runs `SpecialCharacters` *after* a step that already produced markup,
+  `subs=quotes,specialcharacters`) is unchanged, still needing its own policy rather than another
+  recognition increment.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3317,6 +3396,23 @@ Each phase is a reviewable unit with a clear exit gate.
        text keep their own stricter gates (pinned for both spellings side by side), as do the
        attribute-list captures that need a real `Attrlist<'src>`. See the step's own "landed as"
        note above. Only a **rendered span** now defers as a whole class.
+     - ✅ **prep (a reference text crossing a rendered span — the cross-reference family).** The
+       first family of that last class, and the first lift that is not a gate relaxation but a
+       change of *which bytes the gate covers*: a rendered span stays unrecoverable (its markup
+       exists only at fold time), so every value a family **computes** keeps
+       [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs), while
+       a **reference text** — which computes nothing, becoming structured children whose
+       [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) path clones the piece's own
+       node whole — needs no gate at all.
+       [`find_xref_matches`](../../parser/src/content/inline_builder/macros/xref.rs) therefore gates
+       the macro form's target and the shorthand's id half (`shorthand_id_range`) rather than the
+       whole match; no builder changed. Three shapes stay divergent because the string replacer
+       matches over the markup where this matches over one placeholder — a `]` or a `&gt;&gt;`
+       inside the span, and markup carrying an `=` beside a comma — each the markup-perturbed
+       reading against the tree's well-formed one, as the quotes step's crossed delimiters are; a
+       text carrying its own attribute list keeps the stricter gate outright. See the step's own
+       "landed as" note above. The `link:`/`mailto:`, auto-link/formal-URL, and image families keep
+       the boundary, each a later increment.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -107,8 +107,17 @@ use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 /// trailing-punctuation strip would cut inside an escaped special, and the
 /// e-mail family one for an address *abutting* an opaque piece; the UI family
 /// and a footnote's text keep their own stricter gates for either `CharRef`
-/// leaf. A rendered span stays deferred for every
-/// family. The differential corpus pins the cases each increment claims.
+/// leaf. The differential corpus pins the cases each increment claims.
+///
+/// An **opaque** piece — a rendered span, an earlier-recognized macro node, a
+/// masked passthrough — is admitted where a family carries it *structurally*
+/// rather than reading its bytes: a **reference text** built with
+/// [`macro_text_children`] keeps the piece's own node as a child (see
+/// `xref::find_xref_matches`, so far the only family to take that lift), the
+/// way a footnote's content always has. Every value a family *computes* — a
+/// target, an attribute list, a display text baked into one `Text` — still
+/// defers on it, since the markup an opaque piece folds to exists only at fold
+/// time.
 pub(super) fn apply_macros<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -392,10 +401,17 @@ pub(super) fn rebuild_macro_level<'src>(
 /// back to the same bytes the string replacer's text carries, where one `Text`
 /// child holding the match string's `&lt;` (or `&copy;`) would be escaped a
 /// second time by
-/// the fold (design §3.4). A text crossing an *opaque* piece never reaches this
-/// function at all — each caller's own gate
-/// ([`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)) rejects
-/// it.
+/// the fold (design §3.4).
+///
+/// A text crossing an **opaque** piece (a rendered span, an
+/// earlier-recognized macro node, a masked passthrough) takes that same
+/// structured path, and is where it earns its keep: [`emit_range`] clones the
+/// piece's whole node into the children, so the text carries the construct
+/// itself rather than the markup it will fold to — the recovery a footnote's
+/// own content has always used. Only a caller that admits such a piece reaches
+/// this (see `xref::find_xref_matches`); the callers whose gate is still
+/// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece) throughout
+/// never hand one in.
 pub(super) fn macro_text_children<'src>(
     raw_text: &str,
     text_range: std::ops::Range<usize>,

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -106,11 +106,19 @@ pub(super) fn xref_macros_level<'src>(
 }
 
 /// Finds every recognized cross-reference at this level — the `xref:` macro
-/// form and the `<<id>>` shorthand — skipping any match that crosses an
-/// **opaque** piece (see
-/// [`range_has_no_opaque_piece`]). That gate is the family's *only* deferral:
-/// both builders claim every target and text shape an admitted match can
-/// carry.
+/// form and the `<<id>>` shorthand — skipping any match whose **computed
+/// values** cross an **opaque** piece (see [`range_has_no_opaque_piece`]).
+/// That gate is the family's *only* deferral: both builders claim every target
+/// and text shape an admitted match can carry.
+///
+/// The gate covers the bytes the node *reads*, not the whole match. A
+/// cross-reference computes two values from the level's match string — its
+/// **target** (the `xref:` macro's group 3, the shorthand's own id half) and,
+/// when the text carries an attribute list, that list's parsed positional value
+/// — and each needs a match string whose bytes are the string replacer's own.
+/// A **reference text**, by contrast, becomes *structured children*
+/// ([`macro_text_children`]), so it needs no recoverable bytes at all; see the
+/// rendered-span section below.
 ///
 /// A [`synthesized`](Piece::synthesized) run (an attribute expansion, or —
 /// reached at a tree's root — a filtered multi-line block's own joined seed)
@@ -140,10 +148,51 @@ pub(super) fn xref_macros_level<'src>(
 /// the leaf folds back to its own bytes instead of being escaped
 /// twice — and the attribute-list branch, whose value comes back from a parse
 /// rather than from a range, re-derives the same split with
-/// [`escaped_value_children`]. A **rendered span** stays deferred: it is one
-/// opaque placeholder here where the string pipeline's haystack holds its
-/// markup inline, and that markup — which only exists at fold time — is what
-/// the string replacer's own `=` probe and the pattern's `]` boundary read.
+/// [`escaped_value_children`].
+///
+/// # A rendered span inside the reference text
+///
+/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, an
+/// already-recognized macro node, a masked passthrough — is *not* recoverable:
+/// it is one opaque placeholder here where the string pipeline's haystack holds
+/// its markup (or its own passthrough mask) inline, and that markup exists only
+/// at fold time. It is nonetheless admitted **inside a reference text**,
+/// because a reference text is the one capture this family never reads as
+/// bytes: it becomes the node's children through [`macro_text_children`], whose
+/// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
+/// piece's own node whole into them — so the text is carried *structurally*,
+/// and the fold re-renders exactly the markup the string replacer captured
+/// there. This is the same "nesting is the point" recovery a footnote's own
+/// content has always used, applied to the display text of a reference.
+///
+/// What that admission cannot do is make the *recognition* agree in every case,
+/// because the string replacer matches over the markup itself where this
+/// matches over one placeholder standing in for it. The two read the same
+/// extent unless the markup carries a character the pattern is sensitive to,
+/// which leaves two documented divergences of *extent* (each pinned by its own
+/// test), both of them cases where the string pipeline's own reading is the
+/// markup-perturbed one and the tree's is the well-formed one — exactly as the
+/// quotes step's crossed-delimiter divergence is:
+///
+/// - a `]` inside the span (`xref:sec[*a ] b*]`), which ends the macro form's
+///   own lazy text capture early for the string replacer but not here;
+/// - a `&gt;&gt;` inside the span (`<<sec,*a >> b*>>`), the shorthand's own
+///   terminator, for the same reason.
+///
+/// A text carrying an **attribute list** keeps the stricter gate, and is
+/// therefore deferred whenever it crosses an opaque piece: its display text
+/// comes back from an [`Attrlist`] parse of the match string rather than from a
+/// range of it (see [`xref_macro_text`]), and a placeholder inside a *parsed*
+/// value cannot be mapped back to the node it stands in for — the same reason
+/// the image and link families defer their own `Attrlist`-bearing captures. The
+/// probe for that branch is `raw_text.contains('=')`, read here off the match
+/// string; the string replacer reads it off the markup, so a span whose markup
+/// carries an `=` (an attributed span, a link, an image) sends the string
+/// pipeline down its attribute-list branch where this one stays plain. That
+/// costs nothing wherever the parse finds the `=` incidental (an attribute list
+/// with no comma to split on yields one positional value equal to the whole
+/// text, which is every unattributed markup shape) and is a third documented
+/// divergence otherwise.
 fn find_xref_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -160,19 +209,44 @@ fn find_xref_matches<'src>(
 
         let full = whole.start()..whole.end();
 
-        // The `xref:` macro (group 3) and the `<<…>>` shorthand (group 2) differ
-        // in how much of the match the gate covers. The macro's whole match is
-        // read as one construct, so all of it must be admitted. The shorthand's
-        // `&lt;&lt;` / `&gt;&gt;` delimiters are always `CharRef`s that the node
-        // *consumes* rather than reads, so only its inner text (group 2) — the
-        // id and any reference text — is gated. (The gate now admits an escaped
-        // special anywhere, so the delimiters would pass the whole-match check
-        // too; keeping the inner-only form states which bytes the *node* reads.)
+        // The `xref:` macro (group 3) and the `<<…>>` shorthand (group 2) reach
+        // the same two computed values by different spellings. Whichever it is,
+        // the gate covers exactly the bytes the node *reads* — its target, and
+        // an attribute-list text's parsed value — and not the ones it carries
+        // structurally (a reference text) or consumes without reading (the
+        // shorthand's own `&lt;&lt;` / `&gt;&gt;` delimiters, always `CharRef`s
+        // by macro time).
         let shorthand_inner = caps.get(2).map(|inner| inner.start()..inner.end());
 
         let recoverable = match &shorthand_inner {
-            Some(inner) => range_has_no_opaque_piece(nodes, pieces, inner),
-            None => range_has_no_opaque_piece(nodes, pieces, &full),
+            Some(inner) => {
+                // The shorthand's id is its inner up to the first `,` — the very
+                // split `build_xref_shorthand_node` (and the string replacer)
+                // makes. A comma the *markup* of an opaque piece contributes
+                // cannot move that split unnoticed: such a piece would have to
+                // sit in the id half, which this gate then rejects.
+                range_has_no_opaque_piece(nodes, pieces, &shorthand_id_range(s, inner))
+            }
+
+            None => {
+                // The macro form's target (group 3) always participates in this
+                // branch. Its `xref:` prefix and brackets need no gate of their
+                // own: those bytes are literal, and no atomic piece — a
+                // placeholder, or an entity delimited by `&` and `;` — can
+                // supply them.
+                #[allow(clippy::unwrap_used)]
+                let target = caps.get(3).unwrap();
+
+                // A text carrying an `=` is read as an attribute list, whose
+                // parsed positional value no placeholder can be mapped back
+                // out of, so that one text shape keeps the gate too.
+                let attrlist_text = caps.get(4).filter(|text| text.as_str().contains('='));
+
+                range_has_no_opaque_piece(nodes, pieces, &(target.start()..target.end()))
+                    && attrlist_text.is_none_or(|text| {
+                        range_has_no_opaque_piece(nodes, pieces, &(text.start()..text.end()))
+                    })
+            }
         };
 
         // An escape (`\xref:` / `\<<`) is honored by dropping the backslash and
@@ -221,6 +295,23 @@ fn find_xref_matches<'src>(
     }
 
     matches
+}
+
+/// The match-string range of a `<<…>>` shorthand's **id half**: its inner up to
+/// the first `,`, or the whole inner when it carries none — the very split
+/// [`build_xref_shorthand_node`] then makes on the same bytes, and the string
+/// replacer's own `inner.split_once(',')`.
+///
+/// This is the half [`find_xref_matches`] gates, since the id is the one value
+/// the shorthand *reads* off the match string; the reference text after the
+/// comma is carried structurally and so needs no gate.
+fn shorthand_id_range(s: &str, inner: &std::ops::Range<usize>) -> std::ops::Range<usize> {
+    let inner_data = s.get(inner.start..inner.end).unwrap_or_default();
+
+    match inner_data.find(',') {
+        Some(comma) => inner.start..inner.start + comma,
+        None => inner.clone(),
+    }
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a verbatim `xref:`
@@ -508,18 +599,22 @@ fn special_of(rest: &str) -> Option<(char, usize)> {
 /// replacer's shorthand branch does so the fold reproduces the same bytes.
 ///
 /// `inner` is the shorthand's inner text (`INLINE_XREF` group 2) in
-/// match-string coordinates; the caller guarantees it crosses no **opaque**
-/// piece (see [`range_has_no_opaque_piece`]), so the match string carries its
-/// bytes exactly — whether they are source bytes (a verbatim run), an expanded
-/// attribute value's (a [`synthesized`](Piece::synthesized) run), or an escaped
-/// special's own entity. It is split
-/// on the first `,` into an id and an optional reference text, each trimmed —
-/// mirroring the string replacer's `inner.split_once(',')` with `id.trim()` /
-/// `text.trim()`, which runs over the very same bytes. The reference text
-/// becomes the node's children through [`macro_text_children`] — a single
-/// [`Text`](InlineNode::Text) borrowed from `'src` in the common verbatim case
-/// (§4.5), owned when it crosses a synthesized run, structured when it crosses
-/// an escaped special — and the whole `<<…>>` — its `CharRef` delimiters
+/// match-string coordinates. It is split on the first `,` into an id and an
+/// optional reference text, each trimmed — mirroring the string replacer's
+/// `inner.split_once(',')` with `id.trim()` / `text.trim()`, which runs over
+/// the very same bytes.
+///
+/// The caller guarantees the **id half** (see [`shorthand_id_range`]) crosses
+/// no **opaque** piece (see [`range_has_no_opaque_piece`]), so the match string
+/// carries the id's bytes exactly — whether they are source bytes (a verbatim
+/// run), an expanded attribute value's (a [`synthesized`](Piece::synthesized)
+/// run), or an escaped special's own entity — and so, therefore, does the
+/// comma that split them. The reference text after that comma carries no such
+/// guarantee: it becomes the node's children through [`macro_text_children`] —
+/// a single [`Text`](InlineNode::Text) borrowed from `'src` in the common
+/// verbatim case (§4.5), owned when it crosses a synthesized run, structured
+/// when it crosses an escaped special or an opaque piece (whose own node the
+/// children then carry). The whole `<<…>>` — its `CharRef` delimiters
 /// included — is the node's `location` (a synthesized run's coarse enclosing
 /// span, per design §4.4).
 ///
@@ -924,11 +1019,12 @@ mod tests {
     fn an_escaped_xref_the_gate_rejects_still_drops_its_backslash() {
         // The escape check runs *ahead* of the gate, mirroring the string
         // replacer's own `caps.get(1)`-first order: a macro the gate rejects
-        // (here, a display text crossing a rendered span) still drops its
+        // (here, an *attribute-list* display text crossing a rendered span,
+        // the one text shape that still needs its own bytes) still drops its
         // backslash and keeps the rest — the rendered span included — as its
         // own nodes, which fold to exactly what `caps[0][1..]` emits. Before
         // this order, such a match was left unrecognized, backslash and all.
-        let source = "\\xref:sec[with *bold* reftext]";
+        let source = "\\xref:sec[*bold*,role=hl]";
         let nodes = build_src(Span::new(source));
 
         let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
@@ -1180,21 +1276,37 @@ mod tests {
     }
 
     #[test]
-    fn an_xref_shorthand_over_a_rendered_span_is_a_documented_divergence() {
-        // A shorthand whose reference text is a rendered span (`<<x,*bold*>>`) has
-        // a non-verbatim inner — the span is opaque — so the builder cannot slice
-        // its text from `'src` and leaves the shorthand unrecognized, exactly as
-        // it defers a macro crossing a rendered span.
-        let source = "<<x,*bold*>>";
+    fn a_shorthand_reference_text_carries_a_rendered_span_as_its_own_child() {
+        // A reference text crossing a rendered span is carried *structurally*:
+        // the span is one opaque placeholder in the match string, but
+        // `macro_text_children` recovers the text with `emit_range`, which
+        // clones the span's own node whole into the reference's children. The
+        // fold then re-renders exactly the markup the string replacer captured
+        // in its own reference text.
+        let source = "<<x,a *bold* b>>";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a shorthand crossing a rendered span must be left unrecognized: {nodes:?}"
+        let reference = assert_xref(&nodes[0]);
+
+        // Three children: the text before the span, the span itself, the text
+        // after it — each borrowing its own precise `'src` slice, which the
+        // one-`Text`-child shape this replaced could not express.
+        assert_eq!(reference.children.len(), 3);
+        assert_text(&reference.children[0], "a ", 1, 5);
+
+        let styled = assert_styled(
+            &reference.children[1],
+            StyleVariant::Strong,
+            SpanForm::Constrained,
         );
 
-        // The string pipeline, by contrast, *does* build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        assert_text(&styled[0], "bold", 1, 8);
+        assert_text(&reference.children[2], " b", 1, 13);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]
@@ -1509,24 +1621,126 @@ mod tests {
     }
 
     #[test]
-    fn an_xref_macro_display_text_over_a_rendered_span_is_a_documented_divergence() {
-        // The macro form's own version of the boundary
-        // `an_xref_shorthand_over_a_rendered_span_is_a_documented_divergence`
-        // pins for the shorthand: a display text containing a quoted span
-        // (`*bold*`) has already become a `Styled` node by the time macros
-        // run, which the node's single `Text` child cannot absorb.
-        let source = "xref:sec[with *bold* reftext]";
+    fn fold_matches_the_string_pipeline_for_a_text_crossing_a_rendered_span() {
+        // The differential corpus for this increment: a display or reference
+        // text crossing an **opaque** piece — a rendered span, an
+        // already-recognized macro node, a masked passthrough — in both
+        // spellings. The text is carried structurally (each opaque piece's own
+        // node becomes a child), so the fold re-renders exactly the markup the
+        // string replacer captured in its own text.
+        let fixtures = [
+            // (A masked passthrough is opaque here too — and in the string
+            // pipeline, which restores passthroughs only after every step — but
+            // this oracle runs the steps directly, without the extraction the
+            // real `SubstitutionGroup::apply` performs around them, so those
+            // fixtures live in the whole-pipeline sweep instead; see
+            // `inline_builder::tests`.)
+            //
+            // The macro form: a span at the end, in the middle, at the start,
+            // and spanning the whole text.
+            "xref:sec[with *bold* reftext]",
+            "xref:sec[*bold* leads]",
+            "xref:sec[*bold*]",
+            "xref:sec[_em_ and `code` and #mark#]",
+            // Every quoted form the earlier step can have produced, including
+            // an attributed span (whose markup carries an `=` the string
+            // replacer's own attribute-list probe reads, and this one does not:
+            // with no comma to split on, the parse yields one positional value
+            // equal to the whole text, so both take the plain-text path).
+            "xref:sec[[.hl]#roled#]",
+            "xref:sec[super^script^ and sub~script~]",
+            // An already-recognized macro node of another family: an image, a
+            // link, an anchor, an index term.
+            "xref:sec[the image:logo.png[Logo] here]",
+            "xref:sec[a link:https://example.org[site] inside]",
+            "xref:sec[an ((index term)) inside]",
+            // A span *and* an escaped special / restored entity in one text —
+            // the recoverable and structural recoveries side by side.
+            "xref:sec[a < b and *bold*]",
+            "xref:sec[a &copy; b and *bold*]",
+            // Escaped: the backslash is dropped and the span stays in the flow.
+            "\\xref:sec[with *bold* reftext]",
+            // In surrounding flow, and inside a rendered span of its own.
+            "See xref:sec[the *bold* one] for details.",
+            "*see xref:sec[a _b_ c]*",
+            // The shorthand: the same shapes after the comma.
+            "<<x,*bold*>>",
+            "<<x,a *bold* b>>",
+            "<<x,_em_ then `code`>>",
+            "<<x,[.hl]#roled#>>",
+            "<<x,the image:logo.png[Logo] here>>",
+            "<<x, *trimmed* >>",
+            "<<x,a < b and *bold*>>",
+            "\\<<x,*bold*>>",
+            "a copyright (C) then <<x,*bold*>>",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_xref(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_text_crossing_a_rendered_span_is_a_documented_divergence() {
+        // The one text shape that keeps the stricter gate. A text carrying an
+        // `=` is read as an attribute list, and its display text comes back
+        // from that *parse* rather than from a range of the match string — so
+        // a placeholder inside the parsed value has no node to map back to,
+        // exactly as the image and link families' own `Attrlist`-bearing
+        // captures cannot be rebuilt from one. The reference is therefore left
+        // unrecognized where the string pipeline builds one over the markup.
+        let source = "xref:sec[*bold*,role=hl]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a display text crossing a rendered span must be left unrecognized: {nodes:?}"
+            "an attribute-list text crossing a rendered span must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, *does* build a reference here,
-        // with the span rendered inside the anchor text.
+        // The string pipeline, by contrast, does build a reference here.
         assert!(golden_xref(source).contains("<a href"));
-        assert!(golden_xref(source).contains("<strong>bold</strong>"));
+    }
+
+    #[test]
+    fn a_span_whose_markup_perturbs_the_string_pipeline_is_a_documented_divergence() {
+        // What the structural recovery cannot do is make the *recognition*
+        // agree in every case: the string replacer matches over the span's
+        // markup where this matches over the one placeholder standing in for
+        // it, so the two read the same extent only while that markup carries
+        // no character the pattern is sensitive to. These are the three shapes
+        // where it does — and in each the string pipeline's reading is the
+        // markup-perturbed one (a truncated text, a text the attribute-list
+        // parse cut in half) and the tree's the well-formed one, exactly as
+        // the quotes step's own crossed-delimiter divergence is.
+        for source in [
+            // A `]` inside the span ends the macro form's lazy text capture
+            // early for the string replacer, but not here.
+            "xref:sec[a *b ] c* d]",
+            // A `>>` inside the span is the shorthand's own terminator, seen
+            // as `&gt;&gt;` in the string pipeline's haystack.
+            "<<x,a *b >> c* d>>",
+            // Markup carrying an `=` (an attributed span) *and* a comma
+            // elsewhere in the text: the string replacer's attribute-list
+            // probe fires on the markup's own `=`, and the parse then splits
+            // the text at that comma, keeping only what precedes it.
+            "xref:sec[one, [.hl]#two#]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert_ne!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_xref(source),
+                "{source:?} now agrees with the string pipeline; fold it into the parity corpus"
+            );
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -1064,6 +1064,24 @@ mod tests {
             "See image:{logo}[Logo] and image:{logo}[] beside <https://{host}> and a (C) mark.",
             with_link_attributes,
         );
+
+        // A cross-reference whose reference text crosses a *rendered span*, in
+        // both spellings and beside the other families: the text is carried
+        // structurally (the span's own node becomes a child), so the fold
+        // re-renders exactly the markup the string replacer captured.
+        assert_parity_with(
+            "See xref:{id}[the *bold* steps] and <<{id},a _slanted_ label>> about {product}.",
+            with_xref_attributes,
+        );
+
+        // The same lift where the opaque piece is a **masked passthrough** —
+        // the one opaque class the string pipeline also holds as a placeholder
+        // of its own, since it restores passthroughs only after every step.
+        // These need the real `SubstitutionGroup::apply` (which brackets the
+        // steps with that extraction), so they cannot live in the family's own
+        // step-driven corpus.
+        assert_parity("See the <<tigers, `+[tigers]+`>> section about tigers.");
+        assert_parity("See xref:sec[a +[literal]+ text] and <<sec,a +++<b>x</b>+++ text>>.");
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1493,6 +1511,11 @@ mod tests {
                 // class, so `escaped_value_children` keeps the `&` as
                 // ordinary logical text.
                 "xref:sec[a & b,role=hl]",
+                // A cross-reference reference text crossing a *rendered span*,
+                // carried as structured children: under these orders the span
+                // is opaque exactly as it is under the normal one, and the
+                // classification must reach the children it recovered.
+                "xref:sec[a *bold* c] and a < b",
                 // Specials beside each construct these orders *can*
                 // recognize, so the classification is exercised inside and
                 // around a built node's own children.

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -1011,4 +1011,11 @@ fn shapes_match_across_combined_constructs() {
         "See image:{logo}[Logo] and image:{logo}[] beside a *bold* run.",
         with_link_attributes,
     );
+
+    // A cross-reference whose reference text crosses a **rendered span**, in
+    // both spellings: the builder now carries that text as structured children
+    // (the span's own node cloned into them), which is the shape the recorder
+    // recovers from the rendered markup, so the two constructions can finally
+    // be compared for this form.
+    assert_shapes("See xref:sec[the *bold* steps] and <<sec,a _slanted_ label>> here.");
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1202,14 +1202,16 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 
 #[test]
 fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
-    // `xref:sec[with *bold* reftext]` is a documented builder divergence (a
-    // display text crossing a rendered span is left unrecognized), so the
+    // `xref:sec[*bold*,role=hl]` is a documented builder divergence (an
+    // *attribute-list* display text crossing a rendered span is left
+    // unrecognized, since its display text comes back from a parse rather
+    // than from a range the span's node can be recovered out of), so the
     // tree holds *fewer* cross-reference nodes than the string pipeline
     // deferred. The positional resolution mirror must detect the count
     // mismatch and skip — leaving the tree in its honest unresolved state —
     // rather than assign destinations to the wrong nodes (or panic).
     let mut parser = Parser::default().with_inline_tree(true);
-    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[with *bold* reftext].");
+    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=hl].");
 
     // The rendered output is unaffected (the string pipeline is
     // authoritative), …
@@ -1236,9 +1238,12 @@ fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
     // subtree's slot count (1) differs from the re-homed segment count (2)
     // and the footnote mirror must skip rather than misassign. The block-side
     // mirror is unaffected and still resolves the block-level reference.
+    // (The deferred form here is a shorthand whose *id* crosses an opaque
+    // piece — a character replacement — since a footnote's own bracketed text
+    // ends at the first `]`, which rules out the bracket-carrying spellings.)
     let mut parser = Parser::default().with_inline_tree(true);
     let doc = parser
-        .parse("[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a,*b*>> and <<c>>]");
+        .parse("[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a -- b>> and <<c>>]");
 
     let refs = collect_refs(&doc);
 


### PR DESCRIPTION
With every recoverable piece now admitted (#1200), a **rendered span** — a `Styled` span, an already-recognized macro node, a masked passthrough — was the one class still deferring as a whole, and the audit map's last remaining *normal*-order item ("a display or reference text crossing a rendered span"). This closes it for the **cross-reference family**, in both spellings — the same family that went first for the escaped-special lift, and for the same reason: nothing on a `Ref{Xref}` node is `Span`-typed.

## The lift

Not another gate relaxation, but a change of *which bytes the gate covers*. A rendered span really is unrecoverable: `build_match_string` stands it in as one placeholder where the string pipeline's haystack holds markup that exists only at fold time — exactly what separates it from a `CharRef` leaf. So every value this family **computes** off the match string (its target, an attribute list's parsed positional value) still needs `range_has_no_opaque_piece`.

A **reference text** computes nothing. It becomes structured children through `macro_text_children`, whose `emit_range` path clones the opaque piece's own **node** whole into them — so the text carries the construct itself rather than the markup it will fold to, the "nesting is the point" recovery a footnote's content has always used, applied to a reference's display text.

`find_xref_matches` therefore gates the macro form's *target* (group 3) rather than its whole match, and the shorthand's *id half* (its inner up to the first `,`, factored out as `shorthand_id_range` so the gate and `build_xref_shorthand_node` split on the same byte) rather than its whole inner. That the shorthand's split cannot be moved unnoticed by a comma inside the markup falls straight out of that: such a piece would have to sit in the id half, which the gate then rejects. **No builder changed** — `macro_text_children` already routed a range it could not slice through `emit_range`, which already cloned an atomic piece whole.

## What still diverges, and why it must

This is the first increment where the recognition gap is real rather than avoidable: the string replacer matches over the markup where the builder matches over one placeholder standing in for it, and the builder cannot know what that markup carries without folding — which building a tree must never do (a fold is renderer-dependent; recognition must not be). Three shapes are documented divergences, each pinned by its own test, and in each the string pipeline's reading is the markup-perturbed one while the tree's is the well-formed one — the same shape of intended divergence the quotes step's crossed delimiters have:

- a `]` inside the span (`xref:sec[a *b ] c* d]`), which ends the macro form's lazy text capture early for the string replacer;
- a `&gt;&gt;` inside the span (`<<x,a *b >> c* d>>`), the shorthand's own terminator;
- markup carrying an `=` beside a comma elsewhere in the text (`xref:sec[one, [.hl]#two#]`), which sends the string replacer down its attribute-list branch, where the parse then keeps only what precedes the comma.

A text carrying its own **attribute list** keeps the stricter gate outright: its display text comes back from an `Attrlist` parse rather than from a range, and a placeholder inside a *parsed* value has no node to map back to — the same reason the image and link families defer their own `Attrlist`-bearing captures.

## Tests

- A differential corpus over the reference text crossing every opaque shape the earlier steps can produce (each quoted form including an attributed span, an image, a link, an anchor, an index term, a masked passthrough, a span beside an escaped special and beside a restored entity, escaped, in flow, inside a rendered span of its own), in both spellings, plus a structural test asserting the recovered children's own precise spans.
- Fixtures added to the whole-pipeline sweep (where the passthrough cases must live, since only the real `SubstitutionGroup::apply` brackets the steps with the extraction that makes a passthrough opaque on both sides), the group-parity corpus, and the structural recorder cross-check — where this form can finally be compared at all.
- The two former `…_over_a_rendered_span_is_a_documented_divergence` tests become parity tests, per their own "if lifted, fold this into a parity corpus" convention; two tests that used this divergence as their *vehicle* (the resolution mirror's count-mismatch skip, block-side and footnote-side) move to forms that still defer.

## Corpus-wide fold-parity audit

The divergence set strictly **shrank**: four previously-surviving sources are gone — both spellings of `xref:sec[with *bold* reftext]`, the image-nesting `See xref:sec[image:logo.png[Logo]] now.`, and the golden corpus's own `` See the <<tigers, `+[tigers]+`>> section… `` — and the set's only addition is this increment's own new divergence-pinning fixture.

Nothing further is wired in: `rendered_html()` remains the string pipeline's own string. The remaining families (`link:`/`mailto:`, auto-link / formal-URL, and the image family's attribute list) still defer a capture crossing a rendered span, each a later increment; the audit's one structurally different item (`subs=quotes,specialcharacters`) is unchanged.

Preflight: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items` all clean; `cargo-llvm-cov` shows the same missed-region/line counts in the touched files as before the change (every new line and branch covered).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D44ACLDNANDDPrEaPJP6pK)_