### PR TITLE
feat: Recognize an auto-link display text crossing a rendered span (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3113,6 +3113,73 @@ Each phase is a reviewable unit with a clear exit gate.
   nothing further is wired in. The auto-link / formal-URL family and the image family's own
   attribute list still defer a capture crossing a rendered span, each a later increment.
 
+  *Step 6 prep landed as (a display text crossing a rendered span — the auto-link / formal-URL
+  family, third and last of the reference-bearing families):* the same lift once more, applied to
+  the family the increment above left holding the boundary, and by the same move: a change of
+  *which bytes the gate covers*, not a relaxation of the gate itself. `INLINE_LINK`'s formal
+  spelling (`https://example.org[a *b* c]`, and the ANGLE branch's `[…]` alternative
+  `<https://example.org[a *b* c]`, which keeps its `&lt;` and takes the same general path) reads
+  every value it computes — the boundary prefix it inspects for an invalid quoted URL, the scheme,
+  and the URL that becomes the **target** — out of bytes that all lie *before* the bracketed
+  display text, so
+  [`build_inline_link_node`](../../parser/src/content/inline_builder/macros/links.rs) now applies
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) to the
+  match up to that text rather than to the whole match. The text itself reads nothing: it becomes
+  the node's children through the shared
+  [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs), whose
+  [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) path clones the opaque piece's
+  own node whole into them. The closing `]` needs no gate — that byte is literal, and no atomic
+  piece (a placeholder, or an entity delimited by `&` and `;`) can supply it. **No builder changed
+  at all**, and neither did `apply_link_side_effects`: a node's target, which is what it registers,
+  is exactly the value that kept the gate.
+
+  Two of this family's forms have no bracketed text to carry structurally, and so keep the gate over
+  every byte they cover: a **bare** auto-link, whose shown text is a slice of the target's own range
+  (`https://example.org/*bold*x`), and the `<url>` form, whose whole interior the target is computed
+  from — the half of the boundary [`build_angle_link_node`](../../parser/src/content/inline_builder/macros/links.rs)
+  has always kept, now the only one of the two halves left. What defers beyond them is what the two
+  predecessor increments predicted: a **target** crossing an opaque piece, and a display text
+  carrying its own **attribute list** (`https://example.org[a *b* c,role=hl]`), whose value comes
+  back from an `Attrlist` parse of the source's bytes, where a placeholder inside a *parsed* value
+  has no node to be mapped back to. Each gets its own divergence test; the audit's own real-corpus
+  instance of the second (`https://chat.asciidoc.org[*project chat*^,role=green]`) survives with it.
+
+  The recognition-agreement gap this class introduces takes two of the three shapes it took for the
+  `link:`/`mailto:` macro, read through this pattern's own captures — a `]` inside the span (which
+  ends `INLINE_LINK`'s lazy text capture early for the string replacer), and markup carrying an `=`
+  beside a comma elsewhere in the text (the replacer's attribute-list probe, fired on markup this
+  side never sees). There is no third: `INLINE_LINK` has no `mailto:` spelling with a comma probe of
+  its own. Each is pinned by its own test, which asserts *both* that the two pipelines disagree and
+  that the tree still builds the well-formed node.
+
+  A differential corpus pins the display text crossing every opaque shape the earlier steps can
+  produce — each quoted form (including an attributed span, whose markup carries the `=` the string
+  replacer's own probe reads and this one does not), an image, an icon, an index term, a character
+  replacement, a UI macro (under `experimental`, the gate the string step and the builder share), a
+  span beside an escaped special and beside a restored entity, a span beside the target's own
+  escaped special, under the `\]` unescape and the `^` window suffix, escaped, in flow, beside a
+  sibling link of the other spelling, and inside a rendered span of its own — in the plain spelling
+  and in the ANGLE branch's `[…]` alternative, alongside a structural test asserting the recovered
+  children's own precise spans. As before, the passthrough fixtures live in the whole-pipeline sweep
+  rather than the family's own step-driven corpus, since only the real `SubstitutionGroup::apply`
+  brackets the steps with the extraction that makes a passthrough opaque on *both* sides. Fixtures
+  are added to that sweep, the broad general-purpose sweep, the group-parity corpus, and the
+  structural recorder cross-check.
+
+  Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**:
+  **seven** previously-surviving sources are gone — among them three real golden-corpus fixtures
+  (`Ask questions in the https://chat.asciidoc.org[*community chat*].`,
+  `http://example.org/community/team.html[Ze_**Project** team]`, and
+  `I advise you to https://google.com[Google for +\+]`), the image-nesting
+  `See https://example.org[the image:logo.png[Logo] here].`, and a multi-line attributed span
+  (`https://example.com[[.role]#Foo\nBar#]`) — and no new one appeared. As with every prep piece
+  before it, nothing further is wired in. A display or reference text crossing a rendered span is
+  now closed as a whole class: what still defers is one **computed** capture per family — a target,
+  and the image family's own attribute list — plus the audit's one structurally different item (an
+  effective order that runs `SpecialCharacters` *after* a step that already produced markup,
+  `subs=quotes,specialcharacters`), which still needs its own policy rather than another recognition
+  increment.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3482,6 +3549,23 @@ Each phase is a reviewable unit with a clear exit gate.
        `=` beside a comma in a `link:` text, a comma inside the span of a `mailto:` text). See the
        step's own "landed as" note above. The auto-link / formal-URL family and the image family's
        own attribute list keep the boundary, each a later increment.
+     - ✅ **prep (a display text crossing a rendered span — the auto-link / formal-URL family).**
+       The third and last reference-bearing family of that class, by the identical move:
+       [`build_inline_link_node`](../../parser/src/content/inline_builder/macros/links.rs) applies
+       [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) to the
+       match *up to* the bracketed display text — every value this family computes (the boundary
+       prefix, the scheme, the URL that becomes the target) lies before it — while the text itself,
+       which computes nothing, is carried structurally through the shared
+       [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs). No builder
+       changed, and neither did `apply_link_side_effects`. The family's two textless forms keep the
+       gate over everything they cover: a **bare** auto-link, whose shown text is a slice of its own
+       target, and the `<url>` form, whose whole interior the target is computed from. What defers is
+       a target crossing an opaque piece and a display text carrying its own `Attrlist`, each with
+       its own divergence test; the recognition-agreement gap takes two of the three shapes the
+       `link:`/`mailto:` family's did (a `]` inside the span, an `=` beside a comma in the text —
+       this pattern has no `mailto:` comma probe of its own). See the step's own "landed as" note
+       above. Only the **image** family's attribute list — the one capture with no display text to
+       carry — still keeps the boundary.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -48,10 +48,11 @@ use crate::{
 ///   no embedded newline *and* no [`synthesized`](Piece::synthesized) run in it
 ///   has an `'src` slice that copy coincides with — the one thing an
 ///   [`Attrlist`]`<'src>` cannot do without.
-/// - A match crossing an **opaque** piece — a rendered
+/// - A **target** — or, for a bare link, the whole match, whose shown text is a
+///   slice of that same target — crossing an **opaque** piece: a rendered
 ///   [`Styled`](crate::inlines::Styled) span, or any other construct
-///   [`build_match_string`] stands in as one [`SPAN_PLACEHOLDER`] — is
-///   deferred, exactly as every family in this module defers one.
+///   [`build_match_string`] stands in as one [`SPAN_PLACEHOLDER`]. A
+///   **bracketed display text** crossing one is admitted (see below).
 /// - A **bare URL whose stripped trailing punctuation is not its own**: the
 ///   strip keys off the target's final character (`;` or `:`, plus an adjacent
 ///   `)`), and a bare URL ending in an escaped special has an entity there
@@ -84,6 +85,48 @@ use crate::{
 /// instead of being escaped twice — for a bare URL too, whose shown text is a
 /// slice of the URL's own range rather than a computed string.
 ///
+/// # A rendered span inside the display text
+///
+/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, an
+/// already-recognized macro node of another family, a masked passthrough — is
+/// *not* recoverable: [`build_match_string`] stands it in as one
+/// [`SPAN_PLACEHOLDER`] where the string pipeline's haystack holds its markup
+/// (or its own passthrough mask) inline, and that markup exists only at fold
+/// time. It is nonetheless admitted **inside the bracketed display text** of a
+/// formal URL link (`https://example.org[a *b* c]`, and the angle spelling
+/// `<https://example.org[a *b* c]` that keeps its `&lt;`), because that text is
+/// the one capture this family never reads as bytes: it becomes the node's
+/// children through [`macro_text_children`], whose
+/// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
+/// piece's own node whole into them — so the text is carried *structurally*,
+/// and the fold re-renders exactly the markup the string replacer captured
+/// there. Everything this pass *computes* stays gated: the **target**, and
+/// with it a **bare** link's shown text (a slice of the target's own range)
+/// and the `<url>` form's whole interior (see [`build_angle_link_node`]), as
+/// does an attribute-list text, for the reason above. This is the third family
+/// to take that lift, after the cross-reference one
+/// (`xref::find_xref_matches`) and the `link:`/`mailto:` macro
+/// ([`find_link_macro_matches`]).
+///
+/// What the admission cannot do is make the *recognition* agree in every case,
+/// because the string replacer matches over the markup itself where this
+/// matches over one placeholder standing in for it — and this pass cannot know
+/// what that markup carries without folding, which building a tree must never
+/// do. The two read the same extent unless the markup carries a character the
+/// pattern (or the replacer's own attribute-list probe) is sensitive to, which
+/// leaves two documented divergences of *extent*, each pinned by its own test
+/// and each one where the string pipeline's reading is the markup-perturbed one
+/// and the tree's the well-formed one — exactly as the quotes step's own
+/// crossed-delimiter divergence is:
+///
+/// - a `]` inside the span (`https://example.org[a *b ] c* d]`), which ends
+///   [`INLINE_LINK`]'s own lazy text capture early for the string replacer but
+///   not here;
+/// - markup carrying an `=` beside a comma elsewhere in the text
+///   (`…example.org[one, [.hl]#two#]`): the replacer's attribute-list probe
+///   fires on the markup's own `=`, and the parse then keeps only what precedes
+///   that comma.
+///
 /// An invalid quoted bare URL (`"https://example.org`) and a bare scheme with no
 /// body (`http://;`) are left literal by the string step *and* the builder, so
 /// they render identically and are covered by the differential corpus rather
@@ -114,10 +157,10 @@ pub(super) fn inline_link_level<'src>(
 
 /// Finds every recognized auto-link / formal-URL / angle-bracketed link at this
 /// level, skipping a `link:` macro match and any form
-/// [`build_inline_link_node`] defers — including a match crossing an opaque
-/// piece, whose gate lives inside that function (it needs the branch's own
-/// capture groups to know which sub-range the gate covers, and must run after
-/// the escape checks; see [`inline_link_level`]).
+/// [`build_inline_link_node`] defers — including one whose *computed* bytes
+/// cross an opaque piece, whose gate lives inside that function (it needs the
+/// branch's own capture groups to know which sub-range the gate covers, and
+/// must run after the escape checks; see [`inline_link_level`]).
 fn find_inline_link_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -174,13 +217,18 @@ fn find_inline_link_matches<'src>(
 ///
 /// # The gate lives here
 ///
-/// A match crossing an **opaque** piece — a rendered
-/// [`Styled`](crate::inlines::Styled) span, or anything else
-/// [`build_match_string`] stands in as one [`SPAN_PLACEHOLDER`] — is deferred.
-/// The check sits here, not in [`find_inline_link_matches`], for two reasons:
-/// it must run *after* the escape checks (so an escaped link the gate would
-/// reject still drops its backslash, mirroring the replacer's own check order),
-/// and the ANGLE branch gates only its own interior (see
+/// The bytes this pass *computes* off the match string — the boundary prefix it
+/// inspects, the scheme, and the URL that becomes the target — must not cross
+/// an **opaque** piece: a rendered [`Styled`](crate::inlines::Styled) span, or
+/// anything else [`build_match_string`] stands in as one [`SPAN_PLACEHOLDER`].
+/// The gate therefore covers the match up to the bracketed display text, which
+/// reads nothing and is carried structurally (see [`inline_link_level`]'s own
+/// rendered-span section) — and, for a **bare** link, the whole match, whose
+/// shown text is a slice of the target's own range. The check sits here, not in
+/// [`find_inline_link_matches`], for two reasons: it must run *after* the
+/// escape checks (so an escaped link the gate would reject still drops its
+/// backslash, mirroring the replacer's own check order), and the ANGLE
+/// branch's `<url>` form gates only its own interior (see
 /// [`build_angle_link_node`]).
 ///
 /// A [`synthesized`](Piece::synthesized) run and an *escaped special* (a
@@ -244,12 +292,26 @@ fn build_inline_link_node<'src>(
         });
     }
 
-    // A match crossing a rendered span is left for a later increment; one
-    // crossing an expanded attribute value or an escaped special is admitted,
-    // since every value below is read from the match string — whose bytes are,
-    // for both, exactly the ones the string replacer's own haystack carries
-    // there.
-    if !range_has_no_opaque_piece(nodes, pieces, full) {
+    // The gate covers the bytes this pass *reads*, not the whole match. Every
+    // value it computes lies before the bracketed display text: the boundary
+    // prefix it inspects, the scheme, and the URL that becomes the target — out
+    // of which a *bare* link's shown text is sliced too, which is why that form
+    // keeps the whole match gated. The bracketed **display text** reads
+    // nothing: it becomes structured children through `macro_text_children`,
+    // whose `emit_range` path carries an opaque piece's own node, so it is
+    // admitted — see [`inline_link_level`]'s own rendered-span note. Its
+    // closing `]` needs no gate of its own: that byte is literal, and no atomic
+    // piece — a placeholder, or an entity delimited by `&` and `;` — can supply
+    // it. (A text carrying an attribute list keeps its own stricter, verbatim
+    // gate below, for `Attrlist<'src>`'s sake.)
+    //
+    // An expanded attribute value and an escaped special are admitted
+    // throughout, since every value read here comes off the match string —
+    // whose bytes are, for both, exactly the ones the string replacer's own
+    // haystack carries there.
+    let computed_end = n.attrlist().map_or(full.end, |m| m.start());
+
+    if !range_has_no_opaque_piece(nodes, pieces, &(full.start..computed_end)) {
         return None;
     }
 
@@ -458,7 +520,8 @@ fn build_inline_link_node<'src>(
         // borrows it from `'src` in the common verbatim case (§4.5), owns it
         // when it crosses an expanded attribute value, and rebuilds it as
         // structured children — each escaped special staying the `CharRef` it
-        // already is — when it crosses one, applying the same `\]` unescape
+        // already is, each **opaque** piece staying its own node — when it
+        // crosses either, applying the same `\]` unescape
         // `InlineLinkReplacer` performs. The `^` window suffix is one ASCII
         // byte at the end of the bracketed text, so the range simply stops
         // short of it.
@@ -529,8 +592,11 @@ fn build_inline_link_node<'src>(
 /// the scheme and the URL. As in the general path an escaped special inside
 /// that interior is admitted — the target is read off the match string, and the
 /// display text derived from it is recovered as structured children — while an
-/// **opaque** piece defers. The two escape checks above run ahead of the gate,
-/// for the same reason the general path's does.
+/// **opaque** piece defers. This form has no *bracketed* display text to carry
+/// structurally, so every byte the gate covers is one the target is computed
+/// from and the gate stays whole, where its `[…]` sibling — handled by the
+/// general path — admits an opaque piece inside its text. The two escape checks
+/// above run ahead of the gate, for the same reason the general path's does.
 ///
 /// Like the rest of this additive builder it performs no `register_link` side
 /// effect; [`apply_link_side_effects`] stages that for the cutover, and needs
@@ -1509,6 +1575,19 @@ mod tests {
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
+
+    /// A parser with the `experimental` attribute set, so a UI macro inside a
+    /// link's display text is recognized (the string step gates the UI family
+    /// on it, and the builder mirrors that gate).
+    fn experimental_parser() -> Parser {
+        use crate::parser::ModificationContext;
+
+        Parser::default().with_intrinsic_attribute_bool(
+            "experimental",
+            true,
+            ModificationContext::Anywhere,
+        )
+    }
 
     #[test]
     fn fold_matches_the_string_pipeline_through_link_macros() {
@@ -2636,20 +2715,227 @@ mod tests {
     }
 
     #[test]
-    fn an_angle_bracketed_link_text_over_a_rendered_span_is_a_documented_divergence() {
-        // The `[…]` alternative inherits the general path's own deferral: a
-        // display text containing a quoted span is a `Styled` node by macro
-        // time, so the match is not verbatim.
-        let source = "<https://example.org[*bold*]";
+    fn fold_matches_the_string_pipeline_for_a_formal_url_display_text_crossing_a_rendered_span() {
+        // The differential corpus for this increment: a formal URL link whose
+        // bracketed display text crosses an **opaque** piece — a rendered span,
+        // an already-recognized macro node of another family, a masked
+        // passthrough. The text is carried structurally (each opaque piece's
+        // own node becomes a child), so the fold re-renders exactly the markup
+        // the string replacer captured in its own text.
+        let fixtures = [
+            // (A masked passthrough is opaque here too — and in the string
+            // pipeline, which restores passthroughs only after every step — but
+            // this oracle runs the steps directly, without the extraction the
+            // real `SubstitutionGroup::apply` performs around them, so those
+            // fixtures live in the whole-pipeline sweep instead; see
+            // `inline_builder::tests`.)
+            //
+            // A span at the end of the text, at the start, in the middle, and
+            // spanning the whole of it.
+            "https://example.org[with *bold* text]",
+            "https://example.org[*bold* leads]",
+            "https://example.org[a *b* c]",
+            "https://example.org[*bold*]",
+            // Every quoted form the earlier step can have produced, including
+            // an attributed span (whose markup carries an `=` the string
+            // replacer's own attribute-list probe reads, and this one does not:
+            // with no comma to split on, the parse yields one positional value
+            // equal to the whole text, so both take the plain-text path).
+            "https://example.org[_em_ and `code` and #mark#]",
+            "https://example.org[super^script^ and sub~script~]",
+            "https://example.org[[.hl]#roled#]",
+            // An already-recognized macro node of another family — an image, an
+            // icon, an index term — and a character replacement, which is
+            // opaque here for the same reason (`build_match_string` stands each
+            // in as one placeholder).
+            "https://example.org[the image:logo.png[Logo] here]",
+            "https://example.org[the icon:tags[] here]",
+            "https://example.org[a ((index term)) *b*]",
+            "https://example.org[Acme(C) *now*]",
+            // A span *and* an escaped special / restored entity in one text —
+            // the recoverable and structural recoveries side by side — and a
+            // span beside the target's own escaped special.
+            "https://example.org[a < b and *bold*]",
+            "https://example.org[a &copy; b and _em_]",
+            "https://example.org/a&b[*bold* text]",
+            // The `\]` unescape and the `^` window suffix still apply around a
+            // span, as does a text that is only whitespace around one.
+            "https://example.org[a\\] *b* c]",
+            "https://example.org[*Open*^]",
+            "https://example.org[ *b* ]",
+            // The ANGLE branch's `[…]` alternative, which keeps its `&lt;` and
+            // takes this same general path.
+            "<https://example.org[*bold*]",
+            "<https://example.org[a *b* c]",
+            // Escaped: the backslash is dropped and the span stays in the flow.
+            "\\https://example.org[*bold*]",
+            // In surrounding flow, beside a sibling link of each spelling, and
+            // inside a rendered span of its own.
+            "See https://example.org[the *bold* one] for details.",
+            "See https://x.org[*a*] and https://y.org[_b_].",
+            "See https://x.org[*a*] and link:y.html[_b_].",
+            "_a https://x.org[*b*] c_",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+
+        // The UI family is recognized only under `experimental`, so its own
+        // fixtures take a parser that sets it — on both sides of the
+        // comparison.
+        let parser = experimental_parser();
+
+        for fixture in [
+            // The UI pass runs *before* this one, so the macro's own `]` is
+            // already inside the placeholder by the time the link's lazy text
+            // capture runs — exactly as it is inside `<kbd>…</kbd>` on the
+            // string side.
+            "https://example.org[a kbd:[Ctrl+T] b]",
+            "https://example.org[a btn:[Save] *b*]",
+            "https://example.org[a menu:File[Save] b]",
+        ] {
+            let folded = fold_html(&build(Span::new(fixture), &parser, None), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_formal_url_display_text_carries_a_rendered_span_as_its_own_child() {
+        // A display text crossing a rendered span is carried *structurally*:
+        // the span is one opaque placeholder in the match string, but
+        // `macro_text_children` recovers the text with `emit_range`, which
+        // clones the span's own node whole into the link's children. The fold
+        // then re-renders exactly the markup the string replacer captured in
+        // its own display text.
+        let source = "https://example.org[a *bold* b]";
         let nodes = build_src(Span::new(source));
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an angle link text crossing a rendered span must stay literal: {nodes:?}"
+        let reference = assert_link(&nodes[0]);
+
+        // Three children: the text before the span, the span itself, the text
+        // after it — each borrowing its own precise `'src` slice, which the
+        // one-`Text`-child shape this replaced could not express.
+        assert_eq!(reference.children.len(), 3);
+        assert_text(&reference.children[0], "a ", 1, 21);
+
+        let styled = assert_styled(
+            &reference.children[1],
+            StyleVariant::Strong,
+            SpanForm::Constrained,
         );
 
-        // The string pipeline, by contrast, *does* build a link here.
-        assert!(golden_macros(source).contains("<a href"));
+        assert_text(&styled[0], "bold", 1, 24);
+        assert_text(&reference.children[2], " b", 1, 29);
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
+        );
+    }
+
+    #[test]
+    fn a_formal_url_target_over_a_rendered_span_is_a_documented_divergence() {
+        // The **target** is a value this pass computes off the match string,
+        // where a rendered span is one opaque placeholder standing in for
+        // markup that exists only at fold time — so the target keeps
+        // `range_has_no_opaque_piece` while the display text lifts it.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        for source in [
+            "https://example.org/a``b``c[x]",
+            "<https://example.org/a``b``c[x]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a target crossing a rendered span must stay literal: {nodes:?}"
+            );
+
+            // The string pipeline, by contrast, *does* build a link here.
+            assert!(golden_macros(source).contains("<a href"));
+        }
+    }
+
+    #[test]
+    fn a_formal_url_attribute_list_text_over_a_rendered_span_is_a_documented_divergence() {
+        // A text carrying an attribute list is parsed as a real
+        // `Attrlist<'src>` from the source's own bytes, and a placeholder
+        // inside a *parsed* value has no node it can be mapped back to — the
+        // same reason the cross-reference and `link:`/`mailto:` macro families
+        // defer their own `Attrlist`-bearing capture. That one text shape keeps
+        // the stricter gate outright.
+        //
+        // If this boundary is ever lifted, fold these fixtures into the parity
+        // corpus above.
+        for source in [
+            "https://example.org[a *b* c,role=hl]",
+            "https://example.org[a *b* c,window=_blank]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "an attribute-list text crossing a rendered span must stay literal: {nodes:?}"
+            );
+
+            // The string pipeline, by contrast, *does* build a link here.
+            assert!(golden_macros(source).contains("<a href"));
+        }
+    }
+
+    #[test]
+    fn a_span_whose_markup_perturbs_the_inline_link_pattern_is_a_documented_divergence() {
+        // What the structural recovery cannot do is make the *recognition*
+        // agree in every case: the string replacer matches over the span's
+        // markup where this matches over the one placeholder standing in for
+        // it, so the two read the same extent only while that markup carries
+        // no character the pattern (or the replacer's own attribute-list
+        // probe) is sensitive to. These are the two shapes where it does — and
+        // in each the string pipeline's reading is the markup-perturbed one (a
+        // truncated text, a text the attribute-list parse cut in half) and the
+        // tree's the well-formed one, exactly as the quotes step's own
+        // crossed-delimiter divergence is.
+        for source in [
+            // A `]` inside the span ends `INLINE_LINK`'s own lazy text capture
+            // early for the string replacer, but not here.
+            "https://example.org[a *b ] c* d]",
+            // Markup carrying an `=` (an attributed span) *and* a comma
+            // elsewhere in the text: the string replacer's attribute-list probe
+            // fires on the markup's own `=`, and the parse then splits the text
+            // at that comma, keeping only what precedes it.
+            "https://example.org[one, [.hl]#two#]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert_ne!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "{source:?} now agrees with the string pipeline; fold it into the parity corpus"
+            );
+
+            // The tree's own reading is the well-formed one: one link node
+            // whose text carries the whole span.
+            assert!(
+                nodes.iter().any(|n| matches!(n, InlineNode::Ref(_))),
+                "the tree's own reading must still build a link: {nodes:?}"
+            );
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -113,8 +113,9 @@ use crate::{Parser, Span, inlines::InlineNode, strings::CowStr};
 /// masked passthrough — is admitted where a family carries it *structurally*
 /// rather than reading its bytes: a **display or reference text** built with
 /// [`macro_text_children`] keeps the piece's own node as a child (see
-/// `xref::find_xref_matches` and `links::find_link_macro_matches`, the two
-/// families to have taken that lift), the way a footnote's content always has.
+/// `xref::find_xref_matches`, `links::find_link_macro_matches`, and
+/// `links::build_inline_link_node`, the three reference-bearing families to
+/// have taken that lift), the way a footnote's content always has.
 /// Every value a family *computes* — a target, an attribute list, a display
 /// text baked into one `Text` — still defers on it, since the markup an opaque
 /// piece folds to exists only at fold time.
@@ -409,7 +410,8 @@ pub(super) fn rebuild_macro_level<'src>(
 /// piece's whole node into the children, so the text carries the construct
 /// itself rather than the markup it will fold to — the recovery a footnote's
 /// own content has always used. Only a caller that admits such a piece reaches
-/// this (see `xref::find_xref_matches` and `links::find_link_macro_matches`);
+/// this (see `xref::find_xref_matches`, `links::find_link_macro_matches`, and
+/// `links::build_inline_link_node`);
 /// the callers whose gate is still
 /// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece) throughout
 /// never hand one in.

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -144,23 +144,27 @@
 //!   (`https://example.org/a&`, whose match-string tail `&amp;` ends in the
 //!   very `;` the strip keys off) — a boundary no node list can be split at.
 //!   A display/reference text crossing a rendered *span*
-//!   (`xref:id[*bold*]`, `<<id,*bold*>>`, `link:x[*bold*]`) is admitted for the
-//!   **cross-reference** and **`link:`/`mailto:` macro** families, which carry
-//!   it *structurally*: a span really is unrecoverable — it is one opaque
-//!   placeholder here where the string pipeline's haystack holds markup that
-//!   only exists at fold time — but a display text is never read as bytes, and
+//!   (`xref:id[*bold*]`, `<<id,*bold*>>`, `link:x[*bold*]`,
+//!   `https://example.org[*bold*]`) is admitted for every
+//!   **reference-bearing** family — the cross-reference one, the
+//!   `link:`/`mailto:` macro, and the auto-link / formal-URL family — each of
+//!   which carries it *structurally*: a span really is unrecoverable — it is
+//!   one opaque placeholder here where the string pipeline's haystack holds
+//!   markup that only exists at fold time — but a display text is never read as
+//!   bytes, and
 //!   [`macro_text_children`](macros::macro_text_children)'s
 //!   [`emit_range`](quotes::emit_range) path clones the piece's own **node**
 //!   into the children, the way a footnote's content always has. What each
 //!   family *computes* off the match string — a target, an attribute list's
-//!   parsed value — keeps the gate, and so does the recognition's own
+//!   parsed value, a bare link's shown text (a slice of its own target) —
+//!   keeps the gate, and so does the recognition's own
 //!   agreement: the string replacer matches over the markup where this matches
 //!   over one placeholder, which leaves a handful of documented divergences of
 //!   extent (a `]` or a `&gt;&gt;` inside the span, markup carrying the
 //!   replacer's own attribute-list `=`/`,` probe beside a comma), each the
-//!   markup-perturbed reading against the tree's well-formed one. The
-//!   auto-link / formal-URL family and an image's attribute list still defer it
-//!   outright. An anchor
+//!   markup-perturbed reading against the tree's well-formed one. An image's
+//!   attribute list — the one capture with no display text to carry — still
+//!   defers it outright. An anchor
 //!   renders from its id alone, so it is recognized whenever that id does not
 //!   cross a rendered span — its character class rules out an escaped special
 //!   entirely. Unlike every other reference-bearing family, an anchor is now
@@ -751,6 +755,9 @@ mod tests {
             "link:index.html[a *bold* label] macro",
             "mailto:a@example.org[write _now_] address",
             "link:index.html[the image:logo.png[Logo] one] macro",
+            "https://example.org[a *bold* label] auto-link",
+            "<https://example.org[an _angle_ label] auto-link",
+            "https://example.org[the image:logo.png[Logo] one] auto-link",
             "   ",
             "a\nb\nc",
         ];
@@ -1111,6 +1118,22 @@ mod tests {
         // **masked passthrough**.
         assert_parity("Read link:index.html[a +[literal]+ label] now.");
         assert_parity("Mail mailto:team@example.org[a +++<b>x</b>+++ label] today.");
+
+        // The auto-link / formal-URL family's own version of that lift — the
+        // third family to take it — with the target still expanded from an
+        // attribute reference, so the display text's structural recovery and
+        // the target's own synthesized-run lift are exercised together, in the
+        // plain spelling and in the ANGLE branch's `[…]` alternative (which
+        // keeps its `&lt;`).
+        assert_parity_with(
+            "Visit https://{host}/docs[the *bold* {label}] or <https://{host}[_here_].",
+            with_link_attributes,
+        );
+
+        // And the same, where the opaque piece inside the display text is a
+        // **masked passthrough**.
+        assert_parity("Visit https://example.org[a +[literal]+ label] now.");
+        assert_parity("Visit https://example.org[a +++<b>x</b>+++ label] today.");
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1546,8 +1569,10 @@ mod tests {
                 // classification must reach the children it recovered.
                 "xref:sec[a *bold* c] and a < b",
                 // The same, for the `link:`/`mailto:` macro's own display text
-                // — the second family to carry an opaque piece structurally.
+                // — the second family to carry an opaque piece structurally —
+                // and for the auto-link / formal-URL family's, the third.
                 "link:index.html[a *bold* c] and a < b",
+                "https://example.org[a *bold* c] and a < b",
                 // Specials beside each construct these orders *can*
                 // recognize, so the classification is exercised inside and
                 // around a built node's own children.

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -1022,4 +1022,10 @@ fn shapes_match_across_combined_constructs() {
     // The `link:`/`mailto:` macro's own version of that lift, the second family
     // to take it — comparable here for the same reason.
     assert_shapes("Read link:index.html[the *bold* docs] or mailto:a@example.org[write _now_].");
+
+    // And the auto-link / formal-URL family's, the third — in the plain
+    // spelling and in the ANGLE branch's `[…]` alternative, which keeps its
+    // `&lt;`.
+    assert_shapes("Visit https://example.org[the *bold* docs] now.");
+    assert_shapes("Visit <https://example.org[an _angle_ label] now.");
 }


### PR DESCRIPTION
The cross-reference family closed the last remaining *normal*-order divergence class — a display or reference text crossing a rendered span — for its own two spellings (#1202), and the `link:`/`mailto:` macro followed (#1203). This closes it for the third and last reference-bearing family, the auto-link / formal-URL one.

## The move

The one those increments introduced: not a gate relaxation but a change of *which bytes the gate covers*. A rendered span stays unrecoverable (`build_match_string` stands it in as one placeholder where the string pipeline's haystack holds markup that exists only at fold time), so every value a family computes off the match string keeps `range_has_no_opaque_piece`.

For `INLINE_LINK`'s formal spelling — and the ANGLE branch's `[…]` alternative, which keeps its `&lt;` and takes the same general path — every such value (the boundary prefix it inspects for an invalid quoted URL, the scheme, and the URL that becomes the **target**) lies *before* the bracketed display text. `build_inline_link_node` therefore gates the match up to that text rather than the whole match. The text itself reads nothing: it becomes the node's children through the shared `macro_text_children`, whose `emit_range` path clones the opaque piece's own node whole into them. The closing `]` needs no gate — that byte is literal, and no atomic piece (a placeholder, or an entity delimited by `&` and `;`) can supply it.

**No builder changed at all**, and neither did `apply_link_side_effects`: a node's target, which is what it registers, is exactly the value that kept the gate.

## What still defers

The family's two textless forms keep the gate over every byte they cover: a **bare** auto-link, whose shown text is a slice of its own target (`https://example.org/*bold*x`), and the `<url>` form, whose whole interior the target is computed from — the half of the boundary `build_angle_link_node` has always kept, now the only one of the two halves left.

Beyond them, a **target** crossing an opaque piece and a display text carrying its own **attribute list** (`https://example.org[a *b* c,role=hl]`) still defer, each with its own divergence test; the audit's own real-corpus instance of the second (`https://chat.asciidoc.org[*project chat*^,role=green]`) survives with it.

The recognition-agreement gap takes two of the three shapes the `link:`/`mailto:` family's did, read through this pattern's own captures — a `]` inside the span (which ends `INLINE_LINK`'s lazy text capture early for the string replacer), and markup carrying an `=` beside a comma elsewhere in the text (the replacer's attribute-list probe, fired on markup this side never sees). There is no third: `INLINE_LINK` has no `mailto:` spelling with a comma probe of its own. Each is pinned by a test that asserts *both* that the two pipelines disagree and that the tree still builds the well-formed node.

## Tests

A differential corpus pins the display text crossing every opaque shape the earlier steps can produce — each quoted form (including an attributed span, whose markup carries the `=` the string replacer's own probe reads and this one does not), an image, an icon, an index term, a character replacement, a UI macro (under `experimental`, the gate the string step and the builder share), a span beside an escaped special and beside a restored entity, a span beside the target's own escaped special, under the `\]` unescape and the `^` window suffix, escaped, in flow, beside a sibling link of the other spelling, and inside a rendered span of its own — in the plain spelling and in the ANGLE branch's `[…]` alternative, alongside a structural test asserting the recovered children's own precise spans.

As before, the passthrough fixtures live in the whole-pipeline sweep rather than the family's own step-driven corpus, since only the real `SubstitutionGroup::apply` brackets the steps with the extraction that makes a passthrough opaque on *both* sides. Fixtures are added to that sweep, the broad general-purpose sweep, the group-parity corpus, and the structural recorder cross-check.

## Corpus-wide fold-parity audit

Re-running the sweep confirms the divergence set strictly **shrank**: **seven** previously-surviving sources are gone — among them three real golden-corpus fixtures (`Ask questions in the https://chat.asciidoc.org[*community chat*].`, `http://example.org/community/team.html[Ze_**Project** team]`, and ``I advise you to https://google.com[Google for +\+]``), the image-nesting `See https://example.org[the image:logo.png[Logo] here].`, and a multi-line attributed span (`https://example.com[[.role]#Foo\nBar#]`) — and no new one appeared.

A display or reference text crossing a rendered span is now closed as a whole class: what still defers is one **computed** capture per family — a target, and the image family's own attribute list — plus the audit's one structurally different item (an effective order that runs `SpecialCharacters` *after* a step that already produced markup, `subs=quotes,specialcharacters`), which still needs its own policy rather than another recognition increment.

Nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

`cargo test --all-features`, `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo +nightly fmt --check`, and `cargo +nightly doc --document-private-items` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9hA3dPY5AKSzJrNupw1C9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9hA3dPY5AKSzJrNupw1C9)_