### PR TITLE
feat: Classify a spliced attribute value by where the escaping step sits (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3249,6 +3249,70 @@ Each phase is a reviewable unit with a clear exit gate.
   name and item carry a restored entity — and no new one appeared. As with every prep piece before
   it, nothing further is wired in.
 
+  *Step 6 prep landed as (`AttributeReferences` under an order that escapes **after** expanding,
+  closing the last category the audit map named):* the corpus-wide audit that surfaced the
+  `hardbreaks` and unescaped-specials blockers left step 6 an itemized list of divergences to close,
+  and named one category as not previously seen: "an effective order that runs `SpecialCharacters`
+  **after** a step that already produced markup (`subs=quotes, specialcharacters`), where the string
+  pipeline escapes the very tags the earlier step emitted". Re-running that audit now that every
+  itemized *normal*-order divergence is closed leaves exactly two sources in it, and they turn out to
+  be two different problems wearing one label. This closes the first, and pins the second.
+
+  The first is **not** about markup at all: it is `AttributeReferences`, whose spliced value is
+  ordinary *text* at the moment the step runs. [`split_attribute_value`](../../parser/src/content/inline_builder/attribute_refs.rs)
+  has always classified a literal `<`/`>`/`&` in a resolved value as a
+  [`Raw`](../../parser/src/inlines/inline_node.rs) leaf, on the stated ground that
+  "`apply_special_characters` has already run and will not run again over spliced-in content". That
+  ground holds for every *built-in* group that runs both steps — `Normal`, `Title`, `Header`, and
+  `AttributeEntryValue` all escape first and expand later — but a `subs=` list can reverse the two,
+  and **`subs=attributes+`**, which *prepends* the step, is the documented AsciiDoc idiom for
+  inspecting what a `pass:quotes[…]` attribute entry actually stores. So `MyApp<sup>2</sup>` renders
+  as `MyApp&lt;sup&gt;2&lt;/sup&gt;` — a wrong answer for content a golden test already exercises,
+  making this a **blocker** like `hardbreaks`, the unescaped-specials classification, the
+  `attribute-missing` drop modes, and `<<id,>>`'s present-but-empty text before it, not an unclaimed
+  form.
+
+  The fix is §3.4.1 read the same way that policy has been read at every other seam — "the kind a
+  fragment becomes is decided by which substitution steps still act on it under the group's effective
+  order" — applied here to one question: does a `SpecialCharacters` step still run *after* this one?
+  A new [`SplicedSpecials`](../../parser/src/content/inline_builder/attribute_refs.rs) carries the
+  answer, decided in [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) where the
+  order is in hand and threaded down to the classifier. Under `Verbatim` (every built-in order, and
+  every order that never escapes at all) nothing changes. Under `EscapedLater` the value is spliced
+  as one ordinary [`Text`](../../parser/src/inlines/inline_node.rs) run and **left unsplit**, for
+  [`apply_special_characters`](../../parser/src/content/inline_builder/special_chars.rs) to split at
+  its own position in the order — the same "classify where the step actually sits" discipline
+  [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs) follows by
+  running last. Deferring the split there rather than doing it here is also what keeps the
+  *intervening* steps faithful: a `Raw` leaf is opaque to
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) where a `Text` run's bytes
+  are not, so a macro reading across a spliced `&` (`link:{host}/x[go]` with `host` set to
+  `a&b.example.org`) is now recognized exactly as the string pipeline's own macros pass recognizes it
+  over the already-escaped text. The value's spliced nodes keep the §4.4 coarse fallback span they
+  always had.
+
+  The second source is the one the map's own example names, and it stays deferred with a divergence
+  test of its own: `subs=quotes,specialcharacters`, where the quotes step's `<strong>` tags are what
+  the escaping step acts on. That is structurally different — a tree's markup exists only at fold
+  time, so there is nothing for the escaping transducer to act on — and settling it means deciding
+  what the tree should even hold (a `Styled` node whose fold is escaped, or pre-rendered text that
+  abandons the structure), which is a policy question rather than another classification. It is
+  reachable both as a block's own `subs=` list and, nested, through a `pass:q,c[…]` passthrough,
+  and both spellings are pinned.
+
+  A differential corpus crosses specials-bearing fixtures — the stored value alone and in flow, an
+  author's own special beside a spliced one, adjacent splices, a value-less `Set` attribute that
+  splices nothing, an escaped and a missing reference, a `counter` directive, a multi-line seed, and
+  a macro recognized *across* a spliced special — with every real group that takes this path:
+  `attributes+` over each of the two base groups it is written on (a paragraph's `Normal` and a
+  listing block's `Verbatim`) and the explicit `subs=` lists naming the two steps in that order.
+  Structural tests pin the leaf kinds from both directions (`CharRef` under the reversed order,
+  `Raw` under the built-in one, the same coarse span either way), and a whole-document test drives
+  the AsciiDoc docs' own `subs=attributes+` listing block end to end through the real parse path.
+  Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**: the
+  real golden fixture `{app-name}` under `subs=attributes+` is gone, and no new divergence appeared.
+  As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3649,6 +3713,22 @@ Each phase is a reviewable unit with a clear exit gate.
        rewritten as a two-independent-parsers parity corpus. See the step's own "landed as" note
        above. What remains is the opaque-piece boundary every family keeps, plus the three
        `Attrlist<'src>` captures.
+     - ✅ **prep (an order that escapes after expanding).** The last category the corpus-wide audit
+       named — "an effective order that runs `SpecialCharacters` **after** a step that already
+       produced markup" — is closed for the half that is not about markup at all, and a **blocker**
+       like the four before it since a golden test exercises it: under `subs=attributes+` (the
+       documented idiom for inspecting a `pass:quotes[…]` attribute entry) the string pipeline
+       escapes the spliced value, so
+       [`split_attribute_value`](../../parser/src/content/inline_builder/attribute_refs.rs) can no
+       longer assume the escaping step already ran. A new
+       [`SplicedSpecials`](../../parser/src/content/inline_builder/attribute_refs.rs), decided in
+       [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) where the effective order
+       is in hand, splices the value as one ordinary `Text` run for the still-ahead
+       `SpecialCharacters` step to split — §3.4.1 applied to the step's *position*, not merely its
+       presence; see the step's own "landed as" note above. The category's other half — a
+       markup-producing step (`subs=quotes,specialcharacters`) whose emitted tags the escaping step
+       acts on — needs a policy of its own rather than another classification, and stays deferred
+       with its own divergence test.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -56,6 +56,14 @@ use crate::{
 /// Phase 4, step 6). The same applies to `Warn` mode's warning, whose output
 /// this step already reproduces.
 ///
+/// A literal `<`, `>`, or `&` **in the expanded value** is classified by
+/// design §3.4.1 — "the kind a fragment becomes is decided by which
+/// substitution steps still act on it under the group's effective order" —
+/// which for this step means one question: does a
+/// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters)
+/// step still run *after* this one? [`SplicedSpecials`] carries the answer,
+/// and [`split_attribute_value`] acts on it.
+///
 /// A **character replacement** *inside* an expanded value ((C) → © and
 /// friends) is, by contrast, recognized: [`build_match_string`] (shared by
 /// [`apply_character_replacements`](super::char_replacements::apply_character_replacements),
@@ -105,6 +113,7 @@ pub(super) fn apply_attribute_references<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    specials: SplicedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let mut counters = HashMap::new();
     resolve_counters(&nodes, root, parser, &mut counters);
@@ -120,13 +129,55 @@ pub(super) fn apply_attribute_references<'src>(
         Vec::new()
     };
 
-    apply_attribute_references_recursive(nodes, root, parser, &counters, missing, &span_drops)
+    apply_attribute_references_recursive(
+        nodes,
+        root,
+        parser,
+        &counters,
+        missing,
+        &span_drops,
+        specials,
+    )
+}
+
+/// Whether a
+/// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters)
+/// step still runs **after** the attribute-references step under the group's
+/// effective order — the one thing that decides what a literal `<`, `>`, or
+/// `&` in a spliced attribute value becomes (design §3.4.1).
+///
+/// In every *built-in* group that runs both steps the answer is
+/// [`Verbatim`](Self::Verbatim):
+/// [`Normal`](crate::content::SubstitutionGroup::Normal),
+/// [`Title`](crate::content::SubstitutionGroup::Title),
+/// [`Header`](crate::content::SubstitutionGroup::Header), and
+/// [`AttributeEntryValue`](crate::content::SubstitutionGroup::AttributeEntryValue)
+/// all escape first and expand later. Only a
+/// [`Custom`](crate::content::SubstitutionGroup::Custom) `subs=` list can put
+/// the two the other way round — and the shorthand `subs=attributes+`, which
+/// *prepends* the step, is the documented AsciiDoc idiom for inspecting a
+/// stored attribute value ("Internally, the value is stored as
+/// `MyApp<sup>2</sup>`"), so this is a real order, not a corner case.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SplicedSpecials {
+    /// A `SpecialCharacters` step is still ahead, so it will escape the
+    /// spliced value exactly as it escapes the author's own text: the value is
+    /// spliced as one ordinary [`Text`](InlineNode::Text) run and left for that
+    /// step to split.
+    EscapedLater,
+
+    /// No `SpecialCharacters` step runs after this one — because it already
+    /// ran (the built-in orders) or because the group never runs it at all —
+    /// so the string pipeline emits the value's specials untouched, and each
+    /// becomes a [`Raw`](InlineNode::Raw) leaf the fold emits verbatim.
+    Verbatim,
 }
 
 /// `span_drops` names this level's own [`Styled`](crate::inlines::Styled)
 /// nodes that force a line drop (see [`styled_drop_indices`]); a nested level
 /// never has any of its own, since a drop is only ever decided at the
 /// content's top level.
+#[allow(clippy::too_many_arguments)]
 fn apply_attribute_references_recursive<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -134,6 +185,7 @@ fn apply_attribute_references_recursive<'src>(
     counters: &HashMap<usize, String>,
     missing: MissingHandling,
     span_drops: &[usize],
+    specials: SplicedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
@@ -146,6 +198,7 @@ fn apply_attribute_references_recursive<'src>(
                     counters,
                     missing.nested(),
                     &[],
+                    specials,
                 );
                 InlineNode::Styled(styled)
             }
@@ -154,7 +207,7 @@ fn apply_attribute_references_recursive<'src>(
         })
         .collect();
 
-    attribute_references_level(nodes, root, parser, counters, missing, span_drops)
+    attribute_references_level(nodes, root, parser, counters, missing, span_drops, specials)
 }
 
 /// How a level treats a reference to a **missing** attribute — this module's
@@ -410,6 +463,7 @@ fn attribute_references_level<'src>(
     counters: &HashMap<usize, String>,
     missing: MissingHandling,
     span_drops: &[usize],
+    specials: SplicedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -458,7 +512,7 @@ fn attribute_references_level<'src>(
     // a mistyped `(0..n).collect()`.)
     let lines = lines.unwrap_or_else(|| std::iter::once(0..s.len()).collect());
 
-    rebuild_attribute_level(&nodes, &pieces, &matches, root, counters, &lines)
+    rebuild_attribute_level(&nodes, &pieces, &matches, root, counters, &lines, specials)
 }
 
 /// The indices into `nodes` of every [`Styled`](crate::inlines::Styled) span
@@ -814,6 +868,7 @@ fn find_attribute_matches(
 /// lines *were* dropped, each survivor is emitted in turn with one `\n` — the
 /// very byte that terminated the previous *survivor* in the source — re-emitted
 /// between consecutive survivors.
+#[allow(clippy::too_many_arguments)]
 fn rebuild_attribute_level<'src>(
     nodes: &[InlineNode<'src>],
     pieces: &[Piece],
@@ -821,6 +876,7 @@ fn rebuild_attribute_level<'src>(
     root: Span<'src>,
     counters: &HashMap<usize, String>,
     lines: &[std::ops::Range<usize>],
+    specials: SplicedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let mut out = Vec::new();
     let mut previous_end: Option<usize> = None;
@@ -862,7 +918,7 @@ fn rebuild_attribute_level<'src>(
                     emit_range(nodes, pieces, cursor..m.full.start, &mut out);
 
                     let location = source_slice(pieces, m.full.clone(), root);
-                    split_attribute_value(value, location, &mut out);
+                    split_attribute_value(value, location, specials, &mut out);
                 }
 
                 AttributeMatchKind::Counter { display } => {
@@ -874,7 +930,7 @@ fn rebuild_attribute_level<'src>(
                     if *display {
                         let location = source_slice(pieces, m.full.clone(), root);
                         let value = counter_value(pieces, &m.full, root, counters);
-                        split_attribute_value(value, location, &mut out);
+                        split_attribute_value(value, location, specials, &mut out);
                     }
                 }
 
@@ -899,25 +955,53 @@ fn rebuild_attribute_level<'src>(
     out
 }
 
-/// Splits a resolved attribute `value` into [`Text`](InlineNode::Text) and
-/// [`Raw`](InlineNode::Raw) runs (design §3.4.1). By the time this step runs,
-/// [`apply_special_characters`](super::special_chars::apply_special_characters)
-/// has already run and will not run again over spliced-in content, so a literal
-/// `<`, `>`, or `&` in `value` must **not** be re-escaped by the fold: it
-/// becomes a `Raw` leaf (verbatim). Everything else stays `Text` — logical
-/// content that design §3.4.1 says
-/// [`apply_character_replacements`](super::char_replacements::apply_character_replacements) and [`apply_macros`](super::macros::apply_macros) (still ahead in the
-/// effective order) should recognize normally (a `(C)` in the value becomes
-/// a `CharRef`, a `link:` in it becomes a `Ref`) — true today for the former
-/// (a follow-up to this step extended [`build_match_string`] to look inside a
-/// synthesized run, so no change was needed here), still deferred for the
-/// latter (see [`apply_attribute_references`]'s doc comment for why).
+/// Splices a resolved attribute `value` into the node stream, classifying its
+/// literal `<`, `>`, and `&` by design §3.4.1 — which, here, is exactly the
+/// question [`SplicedSpecials`] answers.
 ///
-/// Both node kinds carry the reference's own `location` as their coarse
+/// Under [`SplicedSpecials::Verbatim`] — every built-in group that runs both
+/// steps, plus any order that never runs `SpecialCharacters` at all —
+/// [`apply_special_characters`](super::special_chars::apply_special_characters)
+/// will not act on this spliced-in content, so a literal special must **not**
+/// be escaped by the fold: it becomes a [`Raw`](InlineNode::Raw) leaf
+/// (verbatim) and the surrounding runs stay [`Text`](InlineNode::Text). That is
+/// the classification this step has always emitted.
+///
+/// Under [`SplicedSpecials::EscapedLater`] the step is still ahead, so the
+/// string pipeline *does* escape the spliced value — `subs=attributes+` on a
+/// verbatim block renders `pass:quotes[MyApp^2^]`'s stored
+/// `MyApp<sup>2</sup>` as `MyApp&lt;sup&gt;2&lt;/sup&gt;`. The value is
+/// therefore spliced as one ordinary `Text` run and **left unsplit**, for
+/// `apply_special_characters` to split at its own position in the order. Doing
+/// it there rather than here is what keeps the intervening steps faithful: the
+/// string pipeline's own `quotes`/`replacements`/`macros` passes match over
+/// text whose specials are still literal, and a `Raw` leaf is *opaque* to
+/// [`build_match_string`] where a `Text` run's bytes are not — the same
+/// argument
+/// [`classify_unescaped_specials`](super::special_chars::classify_unescaped_specials)
+/// makes for running last.
+///
+/// Every node emitted carries the reference's own `location` as its coarse
 /// fallback span (design §4.4: a synthesized value has no source of its own).
 /// A run is never emitted empty, and an empty `value` (a value-less
 /// `InterpretedValue::Set` attribute) emits no node at all.
-fn split_attribute_value<'src>(value: &str, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+fn split_attribute_value<'src>(
+    value: &str,
+    location: Span<'src>,
+    specials: SplicedSpecials,
+    out: &mut Vec<InlineNode<'src>>,
+) {
+    if specials == SplicedSpecials::EscapedLater {
+        if !value.is_empty() {
+            out.push(InlineNode::Text {
+                value: CowStr::from(value.to_string()),
+                location,
+            });
+        }
+
+        return;
+    }
+
     let mut rest = value;
 
     while let Some(pos) = rest.find(is_special) {
@@ -954,12 +1038,18 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::test_support::{assert_raw, assert_styled, assert_text, fold_html};
+    use super::super::test_support::{
+        assert_raw, assert_special_char, assert_styled, assert_text, fold_html,
+    };
     use crate::{
         Parser, Span,
-        content::{Content, SubstitutionStep, inline_builder::build},
+        content::{
+            Content, SubstitutionGroup, SubstitutionStep,
+            inline_builder::{build, build_for_group},
+        },
         inlines::{InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
+        strings::CowStr,
     };
 
     /// A default parser with `name` set to `value` (an
@@ -1167,6 +1257,75 @@ mod tests {
 
         // The fold emits the tag verbatim, unescaped.
         assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "<b>");
+    }
+
+    #[test]
+    fn a_reference_expanding_to_a_special_character_stays_text_when_escaping_follows() {
+        // The mirror image of the test above, under the one order that
+        // reverses the two steps: `subs=attributes+` on a verbatim block
+        // resolves to `[attributes, specialcharacters, callouts]`, so the
+        // `SpecialCharacters` step is still *ahead* when the value is spliced
+        // and the string pipeline escapes it like any other text.
+        //
+        // Design §3.4.1: what the fragment becomes is decided by which steps
+        // still act on it, so the value is spliced as one ordinary `Text` run
+        // (`SplicedSpecials::EscapedLater`) and `apply_special_characters`
+        // splits it at its own position in the order — leaving the `CharRef`
+        // leaves an author-written `<b>` would get under the same order, not
+        // the `Raw` leaves the built-in orders produce.
+        let (group, invalid) = SubstitutionGroup::from_custom_string(
+            Some(&SubstitutionGroup::Verbatim),
+            "attributes+",
+        );
+        assert!(invalid.is_empty());
+        assert_eq!(
+            group,
+            SubstitutionGroup::Custom(vec![
+                SubstitutionStep::AttributeReferences,
+                SubstitutionStep::SpecialCharacters,
+                SubstitutionStep::Callouts,
+            ])
+        );
+
+        let parser = parser_with_attribute("tag", "<b>");
+        let source = "{tag}";
+        let nodes = build_for_group(
+            &group,
+            CowStr::from(source),
+            Span::new(source),
+            &parser,
+            None,
+        );
+
+        // `CharRef("<")`, `Text("b")`, `CharRef(">")` — not the `Raw` mix the
+        // normal order yields for the same value.
+        assert_eq!(nodes.len(), 3);
+        let char_ref_location = assert_special_char(&nodes[0], '<');
+
+        match &nodes[1] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "b");
+                // Still the coarse §4.4 fallback: a synthesized value has no
+                // source of its own, whichever leaf kind its specials take.
+                assert_eq!(*location, char_ref_location);
+            }
+
+            other => panic!("expected Text(\"b\"), got {other:?}"),
+        }
+
+        assert_special_char(&nodes[2], '>');
+
+        // And the fold escapes the tag, byte-for-byte as the real pipeline
+        // does — the documented `subs=attributes+` trick for inspecting a
+        // stored attribute value.
+        let mut content = Content::from(Span::new(source));
+        group.apply(&mut content, &parser_with_attribute("tag", "<b>"), None);
+
+        assert_eq!(content.rendered_str(), "&lt;b&gt;");
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            content.rendered_str()
+        );
     }
 
     #[test]
@@ -1691,6 +1850,37 @@ mod tests {
         let inlines = blocks[0].inlines().unwrap();
 
         assert_eq!(rendered, "First line.\nThird line.");
+
+        assert_eq!(
+            super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+            rendered,
+            "fold diverged from the rendered string for {inlines:?}"
+        );
+    }
+
+    #[test]
+    fn a_real_documents_prepended_attributes_step_reaches_its_tree() {
+        // End-to-end, through the real parse path, for the AsciiDoc docs' own
+        // `subs=attributes+` trick: a listing block whose substitution list
+        // puts `attributes` *first* renders `pass:quotes[…]`'s stored markup
+        // escaped, and the tree `SubstitutionGroup::apply` builds alongside it
+        // must fold to exactly those bytes. This is the shape that makes the
+        // reversed order a *blocker* for the authoritative fold rather than an
+        // unclaimed form: a golden test already exercises it (design §5.3's
+        // oracle — see `attribute_entry_substitutions`).
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(
+            ":app-name: pass:quotes[MyApp^2^]\n\n[subs=attributes+]\n------\n{app-name}\n------\n",
+        );
+
+        let blocks: Vec<_> = doc.descendant_blocks().collect();
+        assert_eq!(blocks.len(), 1, "expected one listing block: {blocks:?}");
+
+        let rendered = blocks[0].rendered_html_content().unwrap();
+        let inlines = blocks[0].inlines().unwrap();
+
+        assert_eq!(rendered, "MyApp&lt;sup&gt;2&lt;/sup&gt;");
 
         assert_eq!(
             super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -40,23 +40,26 @@
 //!   splicing a set attribute's resolved value into the node stream, classified
 //!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs per
 //!   design §3.4.1 — a literal `<`/`>`/`&` in the value is *not* re-escaped,
-//!   since [`apply_special_characters`] has already run. It reuses the shared
-//!   [`ATTRIBUTE_REFERENCE`](crate::content::ATTRIBUTE_REFERENCE) pattern, so
-//!   only the recognition *sink* differs. A `counter`/`counter2` directive
-//!   resolves *and advances* the named counter via [`Parser::counter`], the
-//!   same required side effect [`apply_footnotes`] performs for footnote
-//!   numbering. A missing-attribute reference under `AttributeMissing::Drop` /
-//!   `::DropLine` is deferred (see [`apply_attribute_references`] for why). A
-//!   character replacement *inside* an expanded value ((C) → ©, `--`, …) is
-//!   recognized, a follow-up increment having taught
-//!   [`build_match_string`](quotes::build_match_string) to look inside a
-//!   [`synthesized`](quotes::Piece::synthesized) run instead of treating it as
-//!   opaque; a **macro** needing an honest `'src` slice for its own
-//!   target/attribute list (a link or an image, the two that are left) still
-//!   defers when that slice sits inside one, since a synthesized run's bytes
-//!   have no source counterpart to slice for a type that requires a real `Span`
-//!   (see [`range_is_verbatim`](macros::image::range_is_verbatim)) — but a
-//!   macro needing only its own *text* (no `Span`-typed field) — an anchor's
+//!   since [`apply_special_characters`] has already run, unless the group's
+//!   effective order puts that step *after* this one (only a `subs=` list can,
+//!   and `subs=attributes+` does), in which case the value is spliced as one
+//!   ordinary `Text` run for it to escape (see [`SplicedSpecials`]). It reuses
+//!   the shared [`ATTRIBUTE_REFERENCE`](crate::content::ATTRIBUTE_REFERENCE)
+//!   pattern, so only the recognition *sink* differs. A `counter`/`counter2`
+//!   directive resolves *and advances* the named counter via
+//!   [`Parser::counter`], the same required side effect [`apply_footnotes`]
+//!   performs for footnote numbering. A missing-attribute reference under
+//!   `AttributeMissing::Drop` / `::DropLine` is deferred (see
+//!   [`apply_attribute_references`] for why). A character replacement *inside*
+//!   an expanded value ((C) → ©, `--`, …) is recognized, a follow-up increment
+//!   having taught [`build_match_string`](quotes::build_match_string) to look
+//!   inside a [`synthesized`](quotes::Piece::synthesized) run instead of
+//!   treating it as opaque; a **macro** needing an honest `'src` slice for its
+//!   own target/attribute list (a link or an image, the two that are left)
+//!   still defers when that slice sits inside one, since a synthesized run's
+//!   bytes have no source counterpart to slice for a type that requires a real
+//!   `Span` (see [`range_is_verbatim`](macros::image::range_is_verbatim)) — but
+//!   a macro needing only its own *text* (no `Span`-typed field) — an anchor's
 //!   id, a bare e-mail address, a UI macro's keys/label/menu path, an index
 //!   term's shown text, or a cross-reference's target and reference text — can
 //!   now be recovered exactly via [`text_slice`](quotes::text_slice) or
@@ -330,7 +333,7 @@ mod stem_step;
 #[cfg(test)]
 mod test_support;
 
-use attribute_refs::apply_attribute_references;
+use attribute_refs::{SplicedSpecials, apply_attribute_references};
 use callouts::apply_callouts;
 use char_replacements::apply_character_replacements;
 // Consumed only by `cfg(test)` callers and future external callers until the
@@ -495,7 +498,7 @@ pub(crate) fn build_for_group<'src>(
         nodes = apply_stem(nodes, location, parser);
     }
 
-    for step in steps {
+    for (position, step) in steps.iter().enumerate() {
         nodes = match step {
             SubstitutionStep::SpecialCharacters => apply_special_characters(nodes),
 
@@ -506,8 +509,24 @@ pub(crate) fn build_for_group<'src>(
             // point `<`/`>`/`&` are already `CharRef` leaves and quoted spans
             // are already `Styled` nodes, and whatever this step splices in
             // is exactly what the steps still ahead see and refine.
+            //
+            // A `Custom` order can put `SpecialCharacters` *after* this step
+            // instead — `subs=attributes+` prepends it — and then the string
+            // pipeline escapes the spliced value like any other text. That is
+            // the one thing a spliced value's classification turns on, so it
+            // is decided here, where the order is in hand, and carried down as
+            // `SplicedSpecials`.
             SubstitutionStep::AttributeReferences => {
-                apply_attribute_references(nodes, location, parser)
+                let specials = if steps
+                    .get(position + 1..)
+                    .is_some_and(|ahead| ahead.contains(&SubstitutionStep::SpecialCharacters))
+                {
+                    SplicedSpecials::EscapedLater
+                } else {
+                    SplicedSpecials::Verbatim
+                };
+
+                apply_attribute_references(nodes, location, parser, specials)
             }
 
             SubstitutionStep::CharacterReplacements => {
@@ -1283,12 +1302,21 @@ mod tests {
 
         /// The parser both sides of every parity assertion in this module
         /// are configured with: `product` for the fixtures carrying an
-        /// attribute reference, and `experimental` for the one carrying a UI
-        /// macro (the gate the string step and the builder share).
+        /// attribute reference, `experimental` for the one carrying a UI macro
+        /// (the gate the string step and the builder share), and three values
+        /// carrying a literal `<`, `>`, or `&` for the corpus that pins how a
+        /// spliced value's specials are classified under an order that escapes
+        /// *after* expanding (see
+        /// [`a_group_that_escapes_after_expanding_folds_its_spliced_specials_escaped`]).
         fn parser_with_product() -> Parser {
             Parser::default()
                 .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
                 .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
+                // The very shape the AsciiDoc docs use to show what
+                // `pass:quotes[…]` stores in an attribute entry.
+                .with_intrinsic_attribute("tag", "MyApp<sup>2</sup>", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("amp", "a & b", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("host", "a&b.example.org", ModificationContext::Anywhere)
         }
 
         fn build_group<'src>(
@@ -1618,6 +1646,158 @@ mod tests {
                     assert_group_parity(group, source);
                 }
             }
+        }
+
+        /// The complement of the corpus above, for the *other* order §3.4.1
+        /// has to answer for: not a group that never escapes, but one that
+        /// escapes **after** expanding an attribute reference.
+        ///
+        /// Every built-in group that runs both steps escapes first and expands
+        /// later, which is why a spliced value's literal `<`/`>`/`&` has always
+        /// been a `Raw` leaf here (nothing left to escape it). Only a `subs=`
+        /// list can reverse the two — and `subs=attributes+`, which *prepends*
+        /// the step, is the documented AsciiDoc idiom for inspecting what a
+        /// `pass:quotes[…]` attribute entry actually stores, so the reversed
+        /// order is a real one. Under it the string pipeline escapes the
+        /// spliced value like any other text (`MyApp<sup>2</sup>` renders as
+        /// `MyApp&lt;sup&gt;2&lt;/sup&gt;`), which every fixture below folded
+        /// verbatim — and so diverged — before `SplicedSpecials` landed.
+        ///
+        /// The corpus crosses specials-bearing fixtures with the real groups
+        /// that take this path: `attributes+` over each of the two base groups
+        /// it is written on (a paragraph's `Normal` and a listing block's
+        /// `Verbatim`), and the explicit `subs=` lists that name the two steps
+        /// in that order. Each list keeps `specialcharacters` ahead of every
+        /// *markup-producing* step, because a step that emits markup before
+        /// the escaping one is a different question — the string pipeline
+        /// escapes the tags that step already wrote, while a tree's markup
+        /// exists only at fold time — and is pinned as its own divergence by
+        /// [`a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence`].
+        #[test]
+        fn a_group_that_escapes_after_expanding_folds_its_spliced_specials_escaped() {
+            let custom = |subs: &str| {
+                let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs);
+                assert!(invalid.is_empty(), "unexpected invalid subs in {subs:?}");
+                group
+            };
+
+            let prepended = |base: &SubstitutionGroup| {
+                let (group, invalid) =
+                    SubstitutionGroup::from_custom_string(Some(base), "attributes+");
+                assert!(invalid.is_empty());
+                group
+            };
+
+            let groups = [
+                // `[attributes, specialcharacters, quotes, replacements,
+                // macros, post_replacements]` — the step appears once, first,
+                // because `from_custom_string` dedupes.
+                prepended(&SubstitutionGroup::Normal),
+                // `[attributes, specialcharacters, callouts]` — the listing
+                // block the AsciiDoc docs use for the inspection trick.
+                prepended(&SubstitutionGroup::Verbatim),
+                custom("attributes,specialcharacters"),
+                custom("attributes,specialcharacters,quotes"),
+                custom("attributes,specialcharacters,macros"),
+                custom("attributes,specialcharacters,callouts"),
+                custom("attributes,specialcharacters,quotes,replacements,macros,post_replacements"),
+            ];
+
+            let fixtures = [
+                // The stored value on its own, and in flow.
+                "{tag}",
+                "before {tag} after",
+                "{amp}",
+                // The author's own specials beside a spliced one: both are
+                // escaped, by the one step, in one pass.
+                "a < {tag} > b",
+                "{amp} & {amp}",
+                // Adjacent splices, so a run boundary falls between two
+                // synthesized values rather than against source text.
+                "{tag}{amp}",
+                // A *value-less* `Set` attribute expands to nothing, so the
+                // splice emits no node at all — the one path through the
+                // classifier that pushes nothing. (`experimental` is set as a
+                // bare flag by `parser_with_product`.)
+                "{experimental}",
+                "a < {experimental} > b",
+                // A reference the step leaves alone still reaches the escaping
+                // step as ordinary text.
+                "{undefined-thing} < b",
+                "\\{tag} stays literal",
+                // A `counter` directive splices through the same classifier.
+                "{counter:step} < {counter:step}",
+                // Multi-line, so a spliced value sits on one line of several.
+                "a < b\n{tag}\nc & d",
+                // A construct *recognized over* a spliced special — the
+                // fidelity half of this policy, not just the classification
+                // half. A `Raw` leaf is opaque to `build_match_string`, so
+                // splicing one here would have hidden the `&` from the macros
+                // step that runs later in the order; a `Text` run the escaping
+                // step turns into a `CharRef` is exactly what that step's own
+                // gate admits, matching the string pipeline (whose macros pass
+                // likewise runs over the already-escaped `a&amp;b.example.org`).
+                "link:{host}/x[go]",
+                "https://{host}/docs auto-link",
+                // The same, for the two steps that read a spliced run's own
+                // bytes rather than a macro's captures.
+                "*{tag}* and _{amp}_",
+                "{amp} (C) {tag}",
+            ];
+
+            for group in &groups {
+                for source in fixtures {
+                    assert_group_parity(group, source);
+                }
+            }
+        }
+
+        /// The other half of "an order that escapes late", pinned as a
+        /// documented divergence rather than closed: a step that produces
+        /// **markup** ahead of the escaping one.
+        ///
+        /// `subs=quotes,specialcharacters` runs the quotes step first, so the
+        /// string pipeline holds `<strong>bold</strong>` by the time
+        /// `specialcharacters` runs — and escapes those very tags, emitting
+        /// `&lt;strong&gt;bold&lt;/strong&gt;`. A tree has no rendered tags at
+        /// that point: a [`Styled`](crate::inlines::Styled) span's markup
+        /// exists only at fold time, so there is nothing for the escaping
+        /// transducer to act on and the fold emits a real `<strong>` element.
+        ///
+        /// That is structurally unlike the spliced-value case the corpus above
+        /// closes, where the fragment *is* text at the moment the step runs and
+        /// §3.4.1 only has to say which leaf kind it becomes. Deciding what a
+        /// tree should even hold here — a `Styled` node whose fold is escaped,
+        /// or pre-rendered text that abandons the structure — is a policy
+        /// question of its own, and the design doc names it as such (§5.2,
+        /// Phase 4 step 6). Both spellings of the order are pinned here,
+        /// including the nested one a `pass:q,c[…]` passthrough reaches.
+        ///
+        /// The author's own specials are already right on both sides, so the
+        /// fixture asserts exactly where the two part company.
+        #[test]
+        fn a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence() {
+            let (group, invalid) =
+                SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters");
+            assert!(invalid.is_empty());
+
+            let source = "<b> *bold*";
+            let golden = golden_for_group(&group, source);
+            assert_eq!(golden, "&lt;b&gt; &lt;strong&gt;bold&lt;/strong&gt;");
+
+            let built_parser = parser_with_product();
+            let nodes = build_group(&group, source, &built_parser);
+            let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+
+            assert_ne!(
+                built, golden,
+                "expected the documented divergence to still reproduce; the policy may have \
+                 been settled — if so, fold this fixture into the parity corpus above"
+            );
+
+            // The author's own `<b>` is escaped on both sides; only the quotes
+            // step's own markup differs.
+            assert_eq!(built, "&lt;b&gt; <strong>bold</strong>");
         }
     }
 


### PR DESCRIPTION
The corpus-wide audit that surfaced the `hardbreaks` and unescaped-specials blockers left step 6 an itemized list of divergences to close, and named one category as not previously seen: "an effective order that runs `SpecialCharacters` **after** a step that already produced markup (`subs=quotes,specialcharacters`), where the string pipeline escapes the very tags the earlier step emitted". Re-running that audit now that every itemized *normal*-order divergence is closed leaves exactly **two** sources in it — and they turn out to be two different problems wearing one label. This closes the first, and pins the second.

## The half this closes

The first is **not** about markup at all: it is `AttributeReferences`, whose spliced value is ordinary *text* at the moment the step runs. `split_attribute_value` has always classified a literal `<`/`>`/`&` in a resolved value as a `Raw` leaf, on the stated ground that "`apply_special_characters` has already run and will not run again over spliced-in content".

That ground holds for every **built-in** group that runs both steps — `Normal`, `Title`, `Header`, and `AttributeEntryValue` all escape first and expand later — but a `subs=` list can reverse the two, and **`subs=attributes+`**, which *prepends* the step, is the documented AsciiDoc idiom for inspecting what a `pass:quotes[…]` attribute entry actually stores:

```asciidoc
:app-name: pass:quotes[MyApp^2^]

[subs=attributes+]
------
{app-name}
------
```

The pipeline renders `MyApp&lt;sup&gt;2&lt;/sup&gt;`; the fold emitted `MyApp<sup>2</sup>`. That is a **wrong answer** for content a golden test already exercises (`attribute_entry_substitutions`), making this a *blocker* — like `hardbreaks`, the unescaped-specials classification, the `attribute-missing` drop modes, and `<<id,>>`'s present-but-empty text before it — rather than an unclaimed form.

## The fix

§3.4.1 read the same way that policy has been read at every other seam — "the kind a fragment becomes is decided by which substitution steps still act on it under the group's effective order" — applied here to one question: **does a `SpecialCharacters` step still run *after* this one?**

A new `SplicedSpecials` carries the answer, decided in `build_for_group` where the order is in hand and threaded down to the classifier:

- **`Verbatim`** — every built-in order, and every order that never escapes at all. Nothing changes.
- **`EscapedLater`** — the value is spliced as one ordinary `Text` run and **left unsplit**, for `apply_special_characters` to split at its own position in the order.

Deferring the split there rather than doing it here is also what keeps the *intervening* steps faithful: a `Raw` leaf is opaque to `build_match_string` where a `Text` run's bytes are not, so a macro reading across a spliced `&` (`link:{host}/x[go]` with `host` set to `a&b.example.org`) is now recognized exactly as the string pipeline's own macros pass recognizes it over the already-escaped text. This mirrors `classify_unescaped_specials`'s own "classify where the step actually sits" argument for running last. The value's spliced nodes keep the §4.4 coarse fallback span they always had.

## The half that stays deferred

The second source is the one the map's own example names, and it keeps a divergence test of its own: `subs=quotes,specialcharacters`, where the quotes step's `<strong>` tags are what the escaping step acts on. That is structurally different — a tree's markup exists only at fold time, so there is nothing for the escaping transducer to act on — and settling it means deciding what the tree should even *hold* (a `Styled` node whose fold is escaped, or pre-rendered text that abandons the structure), a policy question rather than another classification. It is reachable both as a block's own `subs=` list and, nested, through a `pass:q,c[…]` passthrough; both spellings are pinned.

## Tests

- A **differential corpus** crossing specials-bearing fixtures — the stored value alone and in flow, an author's own special beside a spliced one, adjacent splices, a value-less `Set` attribute that splices nothing, an escaped and a missing reference, a `counter` directive, a multi-line seed, and a macro recognized *across* a spliced special — with every real group that takes this path: `attributes+` over each of the two base groups it is written on (a paragraph's `Normal` and a listing block's `Verbatim`) and the explicit `subs=` lists naming the two steps in that order.
- **Structural tests** pinning the leaf kinds from both directions (`CharRef` under the reversed order, `Raw` under the built-in one, the same coarse span either way).
- A **whole-document test** driving the AsciiDoc docs' own `subs=attributes+` listing block end to end through the real parse path.
- A **divergence test** for the deferred half.

## Audit

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) confirms the divergence set strictly **shrank**: the real golden fixture `{app-name}` under `subs=attributes+` is gone, and **no new divergence appeared**.

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5244 passed, 0 failed
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov` — `inline_builder/mod.rs` 100%; the only uncovered region in the touched part of `attribute_refs.rs` is a pre-existing test `panic!` arm

---
_Generated by [Claude Code](https://claude.ai/code/session_016AfN1xvJUmZ7w9UyfNBPZ2)_