### PR TITLE
feat: Recognize an image attribute list with no source slice (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3376,6 +3376,56 @@ Each phase is a reviewable unit with a clear exit gate.
   is now only the three `Attrlist<'src>` captures and the `subs=quotes,specialcharacters` policy
   item. As with every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (an **image's attribute list** with no `'src` slice — the first of the
+  three `Attrlist<'src>` captures):* with every family's own gate now the shared opaque-piece one,
+  what the audit still names beside the `subs=quotes,specialcharacters` policy item is the
+  **three attribute-list captures** — an image's non-empty bracket, and the `link:`/`mailto:` and
+  auto-link families' attribute-list-bearing display texts — each of which every previous increment
+  held back for the same structural reason: [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs)
+  reads its `source: Span<'src>`'s bytes **as content**, not merely as a location tag, so a capture
+  with no honest `'src` slice had nothing to parse from. That reason turns out to be about
+  *parsing*, not about *holding*: an [`Attrlist`](../../parser/src/attributes/attrlist.rs) keeps
+  nothing `Span`-typed but its own location — its
+  [`ElementAttribute`](../../parser/src/attributes/element_attribute.rs)s are
+  [`CowStr`](../../parser/src/strings.rs)s and everything else is plain data — so a list parsed from
+  a temporary can be *kept* if its strings are detached from it.
+
+  A new [`Attrlist::into_owned`](../../parser/src/attributes/attrlist.rs) is that detachment (built
+  on [`ElementAttribute::into_owned`](../../parser/src/attributes/element_attribute.rs) and
+  [`CowStr::into_owned`](../../parser/src/strings.rs), which prefers the inline representation for a
+  short string exactly as `Clone` does): it rebuilds the list with every borrowed string copied and
+  a caller-supplied span as its new location tag. The image family is the first capture to use it.
+  [`bracket_attrlist`](../../parser/src/content/inline_builder/macros/image.rs) keeps the `'src`
+  slice — and so the borrow (§4.5) — for a verbatim bracket, and for every other one parses the
+  **match string's** own bytes instead, which is not a substitute for the source but the *exact*
+  thing `InlineImageMacroReplacer` parses (`Attrlist::parse(Span::new(&caps[2]), …)`, over its own
+  escaped, already-expanded haystack), then owns the result onto the bracket's coarse source span —
+  design §4.4's fallback, the same one the node's `location` already takes. So
+  `image:sunset.jpg[{caption}]`, `image:tiger.svg[A <b> & "c",opts=interactive]`, and
+  `image:x.png[Tom &amp; Jerry]` are now recognized, the family's remaining `range_is_verbatim`
+  call disappears with them, and `build_image_node` becomes **total** — the whole match keeping
+  only [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs), the
+  boundary every family keeps, since a rendered span's markup exists only at fold time and the
+  string replacer parses that markup where this would parse one placeholder.
+
+  Nothing about the family's staged side effects changes: `register_image` reads the node's
+  `target`, and the `link=` dangerous-scheme warning reads the very attribute list this increment
+  makes available, so a `link=` in a bracket with no `'src` slice now records its warning too (its
+  own test). The three `…_is_a_documented_divergence` tests this closes — for an escaped special, a
+  restored entity, and an expanded value — become parity corpora per the "if lifted, fold this into
+  a parity corpus" convention, joined by structural companions pinning the owned values and the
+  coarse location tag; `attribute_refs.rs`'s own "an attrlist-bearing macro inside a spliced value"
+  divergence is re-pointed at the link family, which still holds it, with the image half rewritten
+  as a recognition test. Fixtures are added to the whole-pipeline combined-constructs corpus, the
+  synthesized-seed sweep (where an image's *non-empty* bracket now joins the empty one), the
+  group-parity corpus, and the structural recorder cross-check — comparable there for the first
+  time, since both constructions now read the same `caps[2]`. Re-running the corpus-wide
+  fold-parity audit confirms the divergence set strictly **shrank**: seven sources are gone, four of
+  them real golden ones (`image:tiger.svg[…]`, `image:missing.svg[…]`, and two
+  `image:pause.png[title=…]` forms), and no new one appeared. What survives is the two remaining
+  `Attrlist<'src>` captures, the `subs=quotes,specialcharacters` policy item, and the opaque-piece
+  boundary itself. As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3808,6 +3858,19 @@ Each phase is a reviewable unit with a clear exit gate.
        [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs), so a
        rendered span in it defers with its own divergence test. See the step's own "landed as" note
        above.
+     - ✅ **prep (an image's attribute list).** The first of the three `Attrlist<'src>` captures —
+       the last boundary drawn around a *capture* rather than around an opaque piece — is lifted:
+       an [`Attrlist`](../../parser/src/attributes/attrlist.rs) holds nothing `Span`-typed but its
+       own location tag, so a new
+       [`Attrlist::into_owned`](../../parser/src/attributes/attrlist.rs) lets a list parsed from a
+       temporary be kept, and
+       [`bracket_attrlist`](../../parser/src/content/inline_builder/macros/image.rs) parses a
+       bracket with no `'src` slice from the level's **match string** — the same
+       `Attrlist::parse(Span::new(&caps[2]), …)` the string replacer performs — owning the result
+       onto §4.4's coarse span. `image:sunset.jpg[{caption}]` and
+       `image:tiger.svg[A <b> & "c",opts=interactive]` are recognized; the family's last
+       `range_is_verbatim` call is gone and `build_image_node` is total. See the step's own "landed
+       as" note above. The two link-family display-text captures are later increments.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -29,6 +29,31 @@ pub struct Attrlist<'src> {
 }
 
 impl<'src> Attrlist<'src> {
+    /// Rebuilds this attribute list with every borrowed string copied into an
+    /// owned one and `source` as its new span, so it can outlive the text it
+    /// was parsed from.
+    ///
+    /// [`parse`](Self::parse) reads its `source` span's bytes **as content**,
+    /// so an attribute list can only be parsed from a span that actually holds
+    /// the attrlist text. A caller that has those bytes only in a temporary
+    /// string — the inline AST builder, whose match string carries an escaped
+    /// or attribute-expanded value that no `'src` slice reproduces — parses
+    /// from a [`Span::new`] over that temporary and calls this to keep the
+    /// result, passing the coarser source span the text corresponds to as the
+    /// list's own location tag. Every parsed field is a [`CowStr`], so nothing
+    /// but the location depends on the original span.
+    pub(crate) fn into_owned<'dst>(self, source: Span<'dst>) -> Attrlist<'dst> {
+        Attrlist {
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(ElementAttribute::into_owned)
+                .collect(),
+            anchor: self.anchor.map(CowStr::into_owned),
+            source,
+        }
+    }
+
     /// **IMPORTANT:** This `source` span passed to this function should NOT
     /// include the opening or closing square brackets for the attrlist.
     /// This is because the rules for closing brackets differ when parsing

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -63,6 +63,25 @@ impl std::fmt::Debug for ElementAttribute<'_> {
 }
 
 impl<'src> ElementAttribute<'src> {
+    /// Rebuilds this attribute with every borrowed string copied into an owned
+    /// one, so it can outlive the text it was parsed from.
+    ///
+    /// Nothing here is a [`Span`]: an attribute's name and value are already
+    /// [`CowStr`]s and every other field is plain data, so the conversion is a
+    /// per-string [`CowStr::into_owned`] and nothing more. See
+    /// [`Attrlist::into_owned`](crate::attributes::Attrlist::into_owned) for
+    /// why the crate needs one.
+    pub(crate) fn into_owned<'dst>(self) -> ElementAttribute<'dst> {
+        ElementAttribute {
+            name: self.name.map(CowStr::into_owned),
+            value: self.value.into_owned(),
+            shorthand_item_indices: self.shorthand_item_indices,
+            positional_index: self.positional_index,
+            value_is_quoted: self.value_is_quoted,
+            value_is_substituted: self.value_is_substituted,
+        }
+    }
+
     pub(crate) fn parse(
         source_text: &CowStr<'src>,
         start_index: usize,

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1398,23 +1398,39 @@ mod tests {
     }
 
     #[test]
-    fn an_attrlist_bearing_macro_inside_an_expanded_value_is_a_documented_divergence() {
-        // Most macro families are now recognized inside a spliced value (see
-        // this module's own doc comment, and each family's own parity corpus).
-        // What still defers is a construct needing an `Attrlist<'src>`, which
-        // reads its own source span's bytes *as content*: an image macro's
-        // non-empty attribute list here, alongside a link's own
-        // attribute-list-bearing display text (pinned in `macros/links.rs`).
+    fn an_attrlist_bearing_display_text_inside_an_expanded_value_is_a_documented_divergence() {
+        // Every macro family is now recognized inside a spliced value (see
+        // this module's own doc comment, and each family's own parity corpus)
+        // — an image macro's own attribute list included, since a bracket with
+        // no `'src` slice is parsed from the match string and owned off it
+        // (`macros/image.rs`). What still defers is a **display text** that
+        // carries its own attribute list, which the link families must split
+        // apart before they can build their node.
+        let parser = parser_with_attribute("label", "Docs");
+        let source = "see link:index.html[{label},role=hl] now";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "an attrlist-bearing display text inside a spliced value must not yet be \
+             recognized: {nodes:?}"
+        );
+
+        assert!(golden_attributes_with(source, &parser).contains("<a href"));
+    }
+
+    #[test]
+    fn an_attrlist_bearing_image_inside_an_expanded_value_is_recognized() {
+        // The counterpart of the divergence above, and the case this test used
+        // to pin: an image macro's non-empty attribute list no longer needs an
+        // `'src` slice, so a wholly-spliced `image:…[…]` is recognized.
         let parser = parser_with_attribute("imgtext", "image:sunset.jpg[Sunset]");
         let nodes = build(Span::new("see {imgtext} now"), &parser, None);
 
         assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-            "an attrlist-bearing macro inside a spliced value must not yet be recognized: \
-             {nodes:?}"
+            nodes.iter().any(|n| matches!(n, InlineNode::Image(_))),
+            "an image inside a spliced value should be recognized: {nodes:?}"
         );
-
-        assert!(golden_attributes_with("see {imgtext} now", &parser).contains("<img"));
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -42,8 +42,7 @@ pub(super) fn image_macros_level<'src>(
 
 /// Finds every image/icon macro at this level, skipping any whose match crosses
 /// an [`opaque`](range_has_no_opaque_piece) piece (see
-/// [`apply_macros`](super::apply_macros)) or whose attribute list
-/// [`build_image_node`] cannot slice from `'src`.
+/// [`apply_macros`](super::apply_macros)).
 fn find_image_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -83,25 +82,17 @@ fn find_image_matches<'src>(
             continue;
         }
 
-        // A match crossing a rendered span is left for a later increment; one
-        // crossing an expanded attribute value or an escaped special is
-        // admitted here and gated more narrowly — on its attribute list alone —
-        // inside `build_image_node`, since the macro name and target are read
-        // from the match string, whose bytes are, for both, exactly the ones
-        // the string replacer's own haystack carries there.
+        // A match crossing a rendered span is left for a later increment;
+        // every other piece the match string reproduces exactly — an expanded
+        // attribute value, an escaped special, a restored entity — is
+        // admitted, since the macro name, the target, and now the attribute
+        // list are all read from bytes the string replacer's own haystack
+        // carries there too.
         if !range_has_no_opaque_piece(nodes, pieces, &full) {
             continue;
         }
 
-        let Some(node) =
-            build_image_node(&caps, whole.as_str(), &full, pieces, root, parser, nodes)
-        else {
-            // A non-empty attribute list crossing a synthesized run or an
-            // escaped special: an `Attrlist<'src>` reads its own source span's
-            // bytes as content, so there is nothing honest to parse it from.
-            // Left as literal source for a later increment.
-            continue;
-        };
+        let node = build_image_node(&caps, whole.as_str(), &full, pieces, root, parser, nodes);
 
         matches.push(MacroMatch {
             kind: MacroMatchKind::Node {
@@ -263,14 +254,19 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
 /// [`apply_image_side_effects`] registers). Only the node's `location` then
 /// takes design §4.4's coarse fallback.
 ///
-/// The **attribute list** is the one part that cannot follow: an
+/// The **attribute list** follows the same rule, one step removed. An
 /// [`Attrlist`]`<'src>` reads its own `Span<'src>`'s bytes *as content*, not
-/// merely as a location tag, so it needs a real source slice. A non-empty
-/// bracket crossing a synthesized run or an escaped special therefore returns
-/// `None` — the macro is left literal for a later increment, exactly as the
-/// other boundaries in this module are. An **empty** bracket
-/// (`image:{logo}[]`) needs no bytes at all and parses from the same
-/// zero-length span an absent group already uses, so it is recognized.
+/// merely as a location tag, so a bracket with no honest `'src` slice — one
+/// crossing a [`synthesized`](Piece::synthesized) run
+/// (`image:sunset.jpg[{caption}]`), an escaped special
+/// (`image:x.png[a < b]`), or a restored entity (`image:x.png[Tom &amp;
+/// Jerry]`) — cannot be parsed from the source. It is parsed from the **match
+/// string** instead, through [`bracket_attrlist`], which is what the string
+/// replacer itself parses (`Attrlist::parse(Span::new(&caps[2]), …)`, over its
+/// own escaped, already-expanded haystack); the resulting list is then
+/// [`into_owned`](Attrlist::into_owned)ed off that temporary and tagged with
+/// design §4.4's coarse span. A bracket that *is* verbatim keeps its `'src`
+/// slice, so its attribute values still borrow (§4.5).
 fn build_image_node<'src>(
     caps: &regex::Captures<'_>,
     whole: &str,
@@ -279,7 +275,7 @@ fn build_image_node<'src>(
     root: Span<'src>,
     parser: &Parser,
     nodes: &[InlineNode<'src>],
-) -> Option<InlineNode<'src>> {
+) -> InlineNode<'src> {
     let location = source_slice(pieces, full.clone(), root);
 
     // The macro name (past any — here absent — escape) is `image:` or `icon:`.
@@ -303,29 +299,14 @@ fn build_image_node<'src>(
     };
 
     // Group 2 always participates — its own pattern carries an empty
-    // alternative — so the degenerate fallback range here is unreachable, and
-    // stands in for the same empty attribute list an absent group would mean
-    // rather than adding a branch of its own that no input can take.
-    let bracket_range = caps
-        .get(2)
-        .map_or(full.end..full.end, |m| m.start()..m.end());
+    // alternative — so the degenerate fallback here is unreachable, and stands
+    // in for the same empty attribute list an absent group would mean rather
+    // than adding a branch of its own that no input can take.
+    let (bracket_text, bracket_range) = caps.get(2).map_or(("", full.end..full.end), |m| {
+        (m.as_str(), m.start()..m.end())
+    });
 
-    let bracket = if range_is_verbatim(pieces, &bracket_range) {
-        source_slice(pieces, bracket_range, root)
-    } else if bracket_range.is_empty() {
-        // An empty attribute list carries no bytes to slice, so it parses from
-        // a zero-length span wherever the macro sits.
-        location.slice(0..0)
-    } else {
-        // A non-empty attribute list crossing a synthesized run or an escaped
-        // special: deferred (see this function's own "what must be verbatim"
-        // note).
-        return None;
-    };
-
-    let attrlist = Attrlist::parse(bracket, parser, AttrlistContext::Inline)
-        .item
-        .item;
+    let attrlist = bracket_attrlist(bracket_text, bracket_range, pieces, root, parser);
 
     // The default alt text derives from the target's basename, with `_`/`-`
     // read as spaces — exactly the string replacer's `default_alt`.
@@ -359,7 +340,7 @@ fn build_image_node<'src>(
         (Some(CowStr::from(alt)), width, height)
     };
 
-    Some(InlineNode::Image(Image {
+    InlineNode::Image(Image {
         is_icon,
         target,
         alt,
@@ -367,7 +348,58 @@ fn build_image_node<'src>(
         height,
         attrs: Some(attrlist),
         location,
-    }))
+    })
+}
+
+/// Parses the macro's bracket into the [`Attrlist`]`<'src>` its node carries.
+///
+/// A **verbatim** bracket is parsed straight from its `'src` slice, so its
+/// attribute names and values borrow from the source (§4.5) — the shape every
+/// ordinary `image:x.png[Alt,200]` takes.
+///
+/// Any other bracket has no `'src` slice whose bytes are the attrlist text: a
+/// [`synthesized`](Piece::synthesized) run holds the expansion's bytes where
+/// the source holds `{caption}`, and a
+/// [`CharRef`](InlineNode::CharRef) leaf holds one character (`<`) or the
+/// entity as written (`&amp;copy;`) where the match string holds the escaped
+/// or restored form (`&lt;`, `&copy;`). Those *match-string* bytes are exactly
+/// the ones `InlineImageMacroReplacer` parses out of its own haystack, so this
+/// parses the same bytes — from a [`Span::new`] over the capture, whose
+/// `line`/`col`/`offset` are meaningless and never escape this function —
+/// and [`into_owned`](Attrlist::into_owned)s the result onto the bracket's
+/// coarse source span (design §4.4), the same fallback the node's `location`
+/// takes.
+///
+/// An **empty** bracket carries no bytes either way and parses from a
+/// zero-length slice of the macro's own span.
+fn bracket_attrlist<'src>(
+    bracket_text: &str,
+    bracket_range: std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> Attrlist<'src> {
+    let bracket = source_slice(pieces, bracket_range.clone(), root);
+
+    if bracket_range.is_empty() {
+        // An empty attribute list carries no bytes to slice, so it parses from
+        // a zero-length span wherever the macro sits.
+        return parse_attrlist(bracket.slice(0..0), parser);
+    }
+
+    if range_is_verbatim(pieces, &bracket_range) {
+        return parse_attrlist(bracket, parser);
+    }
+
+    parse_attrlist(Span::new(bracket_text), parser).into_owned(bracket)
+}
+
+/// Parses one inline attribute list, discarding the warnings — the shared
+/// spelling both of [`bracket_attrlist`]'s paths use.
+fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
+    Attrlist::parse(source, parser, AttrlistContext::Inline)
+        .item
+        .item
 }
 
 /// Performs the recognition side effects the string pipeline's own
@@ -476,7 +508,7 @@ mod tests {
         golden_macros_with,
     };
     use crate::{
-        Parser, Span,
+        HasSpan, Parser, Span,
         content::inline_builder::{
             build, char_replacements::apply_character_replacements, macros::apply_macros,
         },
@@ -783,34 +815,78 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_crossing_an_escaped_special_is_a_documented_divergence() {
-        // The attribute list is the one capture that still needs an honest
-        // `'src` slice: `Attrlist::parse` reads its own source span's bytes
-        // *as content*, and the source holds one character where the match
-        // string holds an entity. A non-empty bracket crossing one is
-        // therefore left literal rather than parsed from the wrong bytes —
-        // the same boundary the expanded-value divergence test below pins for
-        // a synthesized run.
-        //
-        // If this boundary is ever lifted, fold these fixtures into the parity
-        // corpus above.
-        for source in [
+    fn fold_matches_the_string_pipeline_for_an_attribute_list_crossing_an_escaped_special() {
+        // The bracket has no `'src` slice here — the source holds one
+        // character where the match string holds an entity — so it is parsed
+        // from the match string, which is the very `caps[2]` the string
+        // replacer parses out of its own escaped haystack, and owned off that
+        // temporary. Every attribute the two read is therefore the same.
+        let fixtures = [
+            // A special in a positional alt, in a named value, and in both a
+            // named value and the target at once.
             "image:x.png[a < b]",
             "image:x.png[alt=a & b]",
             "image:a&b.png[a < b]",
-        ] {
-            let nodes = build_src(Span::new(source));
+            // Every special, and more than one in the same bracket.
+            "image:x.png[a > b]",
+            "image:x.png[a < b & c > d]",
+            // Beside the positional width/height, and with a role.
+            "image:x.png[a & b,200,100]",
+            "image:x.png[a & b,role=thumb]",
+            // The `icon:` spelling, whose size is read back from `attrs` at
+            // fold time rather than pre-extracted.
+            "icon:home[a & b]",
+            "icon:home[2x,role=a & b]",
+            // In surrounding flow, inside a rendered span, and doubled.
+            "before image:x.png[a < b] after",
+            "*image:x.png[a < b]*",
+            "image:x.png[a & b] image:y.png[c & d]",
+            // The escape still keeps the macro literal, backslash dropped.
+            "\\image:x.png[a < b]",
+        ];
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image whose bracket crosses an escaped special must stay literal: {nodes:?}"
-            );
+        let renderer = HtmlSubstitutionRenderer {};
 
-            assert!(
-                golden_macros(source).contains("<img"),
-                "the golden fixture stopped recognizing the image for {source:?}"
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
+
+    #[test]
+    fn an_attribute_list_crossing_an_escaped_special_is_owned_and_coarsely_located() {
+        // The parsed values are the *escaped* ones the string replacer reads
+        // (`a &lt; b`, not `a < b`), they own their bytes rather than
+        // borrowing from the temporary they were parsed from, and the list's
+        // own span falls back to the bracket's coarse source range (design
+        // §4.4) — the same split the node's `location` already takes for a
+        // synthesized run.
+        let source = "image:x.png[a < b,role=hl]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.alt.as_deref(), Some("a &lt; b"));
+
+        let attrs = image.attrs.as_ref().unwrap();
+        assert_eq!(attrs.nth_attribute(1).unwrap().value(), "a &lt; b");
+        assert_eq!(attrs.named_attribute("role").unwrap().value(), "hl");
+
+        // The location tag is the bracket's own source text, which is *not*
+        // what was parsed — the coarse fallback, kept honest as a location.
+        assert_eq!(attrs.span().data(), "a < b,role=hl");
+
+        // The whole macro's span is still precise: neither the match's start
+        // nor its end can fall inside an entity.
+        assert_eq!(image.location.data(), source);
+        assert_eq!(image.location.line(), 1);
+        assert_eq!(image.location.col(), 1);
     }
 
     #[test]
@@ -884,28 +960,38 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_crossing_a_restored_entity_is_a_documented_divergence() {
-        // The bracket keeps `range_is_verbatim` for a restored entity too, and
-        // for the same reason it keeps it for an escaped special: the source
-        // holds `&amp;copy;` where the match string holds `&copy;`, so
-        // `Attrlist::parse` would read the wrong bytes as content.
-        //
-        // If this boundary is ever lifted, fold these fixtures into the parity
-        // corpus above.
-        for source in [
+    fn fold_matches_the_string_pipeline_for_an_attribute_list_crossing_a_restored_entity() {
+        // A restored entity takes the same lift as an escaped special, for the
+        // same reason: the source holds `&amp;copy;` where the match string
+        // holds `&copy;`, so the bracket has no `'src` slice — and the match
+        // string's bytes are the ones the string replacer parses.
+        let fixtures = [
             "image:x.png[Tom &amp; Jerry]",
             "image:x.png[alt=a &copy; b]",
-        ] {
-            let nodes = build_src(Span::new(source));
+            "image:x.png[a &#8217; b]",
+            // An entity in the bracket *and* in the target.
+            "image:a&copy;b.png[Tom &amp; Jerry]",
+            // An entity and an escaped special in the same bracket.
+            "image:x.png[a &copy; b < c]",
+            // Beside the positional width/height, and the `icon:` spelling.
+            "image:x.png[Tom &amp; Jerry,200,100]",
+            "icon:home[Tom &amp; Jerry]",
+            // In surrounding flow and inside a rendered span.
+            "before image:x.png[Tom &amp; Jerry] after",
+            "*image:x.png[Tom &amp; Jerry]*",
+            // The escape still keeps the macro literal, backslash dropped.
+            "\\image:x.png[Tom &amp; Jerry]",
+        ];
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image whose bracket crosses a restored entity must stay literal: {nodes:?}"
-            );
+        let renderer = HtmlSubstitutionRenderer {};
 
-            assert!(
-                golden_macros(source).contains("<img"),
-                "the golden fixture stopped recognizing the image for {source:?}"
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
             );
         }
     }
@@ -1104,6 +1190,11 @@ mod tests {
             "image:sunset.jpg[Sunset]{sp}image:other.png[]",
             "image without a bracket image:foo.png stays literal",
             "\\image:sunset.jpg[Sunset]",
+            // A bracket with no `'src` slice of its own: the attribute list
+            // is parsed from the match string, but `register_image` reads the
+            // node's `target`, so the catalogs must still agree.
+            "image:sunset.jpg[a < b]",
+            "image:a&b.png[Tom &amp; Jerry,200]",
         ];
 
         for fixture in fixtures {
@@ -1129,6 +1220,27 @@ mod tests {
 
             assert_eq!(got, want, "registered images diverged for {fixture:?}");
         }
+    }
+
+    #[test]
+    fn records_the_dangerous_scheme_warning_from_a_bracket_with_no_source_slice() {
+        // The `link=` warning reads the node's stored attribute list, so a
+        // bracket parsed from the match string must carry it exactly as a
+        // verbatim one does — here reached through an escaped special earlier
+        // in the same bracket, which is what denies it an `'src` slice.
+        let source = "image:safe.png[a < b,link=javascript:alert(1)]";
+        let parser = Parser::default();
+        let nodes = build_with(Span::new(source), &parser);
+
+        let before = parser.substitution_warnings_len();
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let warnings = parser.drain_substitution_warnings_since(before);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string())
+        );
     }
 
     #[test]
@@ -1395,37 +1507,81 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_inside_an_expanded_value_is_a_documented_divergence() {
-        // A non-empty attribute list crossing a synthesized run is the one
-        // part of an image macro that cannot follow the lift: an
-        // `Attrlist<'src>` reads its own `Span<'src>`'s bytes *as content*, and
-        // an expanded value has no source slice carrying them. The macro is
-        // left literal rather than built with a wrong attribute list.
-        //
-        // If this boundary is ever lifted, fold these fixtures into the parity
-        // corpus above.
+    fn fold_matches_the_string_pipeline_for_an_attribute_list_inside_an_expanded_value() {
+        // A non-empty attribute list crossing a synthesized run takes the same
+        // lift: the expansion's bytes live only in the level's match string —
+        // which is exactly the already-substituted haystack the string
+        // replacer parses its own `caps[2]` out of — so the bracket is parsed
+        // from there and owned off it.
         let parser = expanding_parser();
 
-        for source in [
+        let fixtures = [
+            // An expanded alt, whole and in part, with and without an
+            // expanded target beside it.
             "image:sunset.jpg[{caption}]",
+            "image:{logo}[{caption}]",
+            "image:sunset.jpg[The {caption} photo]",
+            // An expanded value in a *named* attribute, and beside the
+            // positional width/height.
+            "image:sunset.jpg[alt={caption}]",
             "image:{logo}[{caption},200]",
+            "image:{logo}[{caption},role=thumb]",
             // The whole macro arriving from an expanded value, this time with
             // a non-empty bracket — the empty-bracket spelling of the same
-            // shape *is* recognized (see the parity corpus above).
+            // shape was already recognized.
             "see {img-src-alt} here",
-        ] {
-            let nodes = build(Span::new(source), &parser, None);
+            // An expansion and an escaped special in the same bracket, so
+            // neither the source nor the expansion alone carries its bytes.
+            "image:sunset.jpg[{caption} < x]",
+            // The `icon:` spelling, in surrounding flow, and inside a
+            // rendered span.
+            "icon:{iconname}[{caption}]",
+            "See image:sunset.jpg[{caption}] here.",
+            "*image:sunset.jpg[{caption}]*",
+            // An escape still keeps the macro literal.
+            "\\image:sunset.jpg[{caption}]",
+        ];
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image whose attribute list crosses an expansion must stay literal: {nodes:?}"
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = crate::content::inline_builder::fold_html(
+                &build(Span::new(fixture), &parser, None),
+                &renderer,
+                &parser,
             );
 
-            assert!(
-                golden_normal(source, &parser).contains("<img"),
-                "the golden fixture stopped recognizing the image for {source:?}"
+            assert_eq!(
+                folded,
+                golden_normal(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
+
+    #[test]
+    fn an_attribute_list_inside_an_expanded_value_is_owned_and_coarsely_located() {
+        // The attribute values are the expansion's own bytes, owned rather
+        // than borrowed from the temporary they were parsed from; the list's
+        // span takes design §4.4's coarse fallback — here the whole enclosing
+        // synthesized run — exactly as the node's `location` does.
+        let parser = expanding_parser();
+        let source = "image:sunset.jpg[{caption},role=hl]";
+        let nodes = build(Span::new(source), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.alt.as_deref(), Some("Sunset"));
+
+        let attrs = image.attrs.as_ref().unwrap();
+        assert_eq!(attrs.nth_attribute(1).unwrap().value(), "Sunset");
+        assert_eq!(attrs.named_attribute("role").unwrap().value(), "hl");
+
+        // The location tag covers the bracket's own source, `{caption}`
+        // included — the coarse fallback, not the parsed text.
+        assert_eq!(attrs.span().data(), "{caption},role=hl");
+        assert_eq!(image.location.data(), source);
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -54,16 +54,21 @@
 //!   an expanded value ((C) → ©, `--`, …) is recognized, a follow-up increment
 //!   having taught [`build_match_string`](quotes::build_match_string) to look
 //!   inside a [`synthesized`](quotes::Piece::synthesized) run instead of
-//!   treating it as opaque; a **macro** needing an honest `'src` slice for its
-//!   own target/attribute list (a link or an image, the two that are left)
-//!   still defers when that slice sits inside one, since a synthesized run's
-//!   bytes have no source counterpart to slice for a type that requires a real
-//!   `Span` (see [`range_is_verbatim`](macros::image::range_is_verbatim)) — but
-//!   a macro needing only its own *text* (no `Span`-typed field) — an anchor's
-//!   id, a bare e-mail address, a UI macro's keys/label/menu path, an index
-//!   term's shown text, or a cross-reference's target and reference text — can
-//!   now be recovered exactly via [`text_slice`](quotes::text_slice) or
-//!   straight out of the match string instead (see
+//!   treating it as opaque; a **macro** needing an honest `'src` slice for a
+//!   value that must ride on its node as one — now only a **link's**
+//!   attribute-list-bearing display text, whose residual text the same slice is
+//!   split out of — still defers when that slice sits inside one, since a
+//!   synthesized run's bytes have no source counterpart to slice for a type
+//!   that requires a real `Span` (see
+//!   [`range_is_verbatim`](macros::image::range_is_verbatim)). An [`Attrlist`]
+//!   that *is* the whole capture — an image's bracket — needs no such slice: it
+//!   is parsed from the level's own match string (the bytes the string replacer
+//!   parses too) and [`into_owned`](Attrlist::into_owned)ed off it. And a macro
+//!   needing only its own *text* (no `Span`-typed field) — an anchor's id, a
+//!   bare e-mail address, a UI macro's keys/label/menu path, an index term's
+//!   shown text, or a cross-reference's target and reference text — can now be
+//!   recovered exactly via [`text_slice`](quotes::text_slice) or straight out
+//!   of the match string instead (see
 //!   [`range_is_verbatim_or_synthesized`](macros::image::range_is_verbatim_or_synthesized),
 //!   and [`range_has_no_opaque_piece`](macros::image::range_has_no_opaque_piece)
 //!   for the families whose gate also admits an escaped special or a restored
@@ -1134,9 +1139,11 @@ mod tests {
         // families to make that lift, and the two that hold a real
         // `Attrlist<'src>`. Their targets and display texts come from the
         // match string like every other family's values; what still defers is
-        // an image's non-empty attribute list, a link's attribute-list-bearing
-        // display text, and a wholly expanded `link:` macro (each pinned by
-        // its own divergence test in `macros/image.rs` and `macros/links.rs`).
+        // a link's attribute-list-bearing display text and a wholly expanded
+        // `link:` macro (each pinned by its own divergence test in
+        // `macros/links.rs`). An image's own attribute list no longer does:
+        // a bracket with no `'src` slice is parsed from the match string —
+        // the same bytes the string replacer parses — and owned off it.
         let with_link_attributes = || {
             Parser::default()
                 .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
@@ -1153,6 +1160,14 @@ mod tests {
 
         assert_parity_with(
             "See image:{logo}[Logo] and image:{logo}[] beside <https://{host}> and a (C) mark.",
+            with_link_attributes,
+        );
+
+        // An image whose *attribute list* has no `'src` slice of its own, in
+        // both spellings of that: crossing an expansion and crossing an
+        // escaped special, with the other families live around it.
+        assert_parity_with(
+            "See image:{logo}[{label},200] and image:x.png[a < b,role=hl] about *{product}*.",
             with_link_attributes,
         );
 
@@ -1284,10 +1299,11 @@ mod tests {
                 "see <<target>> and\nxref:other[the other one]",
             ),
             // The URL-link family in a wholly-synthesized seed, and an image
-            // macro with an *empty* bracket: neither needs an `'src` slice
-            // (the empty attribute list parses from a zero-length span). An
-            // image with a non-empty bracket, and the `link:`/`mailto:` macro
-            // in any spelling, still defer — see
+            // macro in either spelling of its bracket: neither needs an `'src`
+            // slice — an empty attribute list parses from a zero-length span,
+            // and a non-empty one is parsed from the match string and owned
+            // off it. The `link:`/`mailto:` macro, whose own literal marker
+            // must be verbatim, still defers — see
             // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
             // below.
             (
@@ -1297,6 +1313,10 @@ mod tests {
             (
                 "  see image:sunset.jpg[] and\n  icon:home[] here",
                 "see image:sunset.jpg[] and\nicon:home[] here",
+            ),
+            (
+                "  see image:sunset.jpg[Sunset,200] and\n  icon:home[2x,role=gold] here",
+                "see image:sunset.jpg[Sunset,200] and\nicon:home[2x,role=gold] here",
             ),
         ];
 
@@ -1667,6 +1687,12 @@ mod tests {
                 "keep *bold < text* and a < b",
                 "a < b {product} > c",
                 "an <b>image</b> image:pic.png[Alt] here",
+                // An image whose *attribute list* comes from an expansion, so
+                // the bracket is parsed from the match string and owned off
+                // it: under an order that omits `specialcharacters` the
+                // classification pass runs last, over a tree that already
+                // holds that owned list, and must leave it alone.
+                "image:x.png[{product} < y] here",
                 "a footnote:[note < text] and a < b",
                 // A UI macro whose key crosses a bare `&`, which only an order
                 // *without* `specialcharacters` can present: the family reads

--- a/parser/src/strings.rs
+++ b/parser/src/strings.rs
@@ -242,6 +242,25 @@ impl Borrow<str> for CowStr<'_> {
 }
 
 impl CowStr<'_> {
+    /// Rebuilds this string with no borrow left, so it can outlive the text it
+    /// was read from.
+    ///
+    /// A [`Boxed`](CowStr::Boxed) or [`Inlined`](CowStr::Inlined) value already
+    /// owns its bytes and is returned as-is (only its *declared* lifetime
+    /// changes); a [`Borrowed`](CowStr::Borrowed) one is copied, preferring the
+    /// inline representation for a short string exactly as
+    /// [`Clone`](CowStr::clone) does.
+    pub(crate) fn into_owned<'dst>(self) -> CowStr<'dst> {
+        match self {
+            CowStr::Boxed(b) => CowStr::Boxed(b),
+            CowStr::Inlined(s) => CowStr::Inlined(s),
+            CowStr::Borrowed(b) => match InlineStr::try_from(b) {
+                Ok(inline) => CowStr::Inlined(inline),
+                Err(..) => CowStr::Boxed(b.into()),
+            },
+        }
+    }
+
     /// Convert the `CowStr` into an owned `String`.
     pub fn into_string(self) -> String {
         match self {
@@ -410,6 +429,38 @@ mod tests {
             let size = std::mem::size_of::<CowStr>();
             let word_size = std::mem::size_of::<isize>();
             assert_eq!(3 * word_size, size);
+        }
+
+        #[test]
+        fn into_owned() {
+            // A borrowed short string is copied into the inline
+            // representation, a borrowed long one into a box, and a value that
+            // already owns its bytes is passed straight through — so the
+            // result never borrows, whichever variant it started as.
+            fn detach<'a>(s: CowStr<'_>) -> CowStr<'a> {
+                s.into_owned()
+            }
+
+            let short = String::from("0123456789abcde");
+            let long = String::from("0123456789abcdefghijklmnopqrstuvwxyz");
+
+            assert!(matches!(
+                detach(CowStr::Borrowed(&short)),
+                CowStr::Inlined(_)
+            ));
+
+            assert!(matches!(detach(CowStr::Borrowed(&long)), CowStr::Boxed(_)));
+
+            assert!(matches!(
+                detach(CowStr::Boxed(long.clone().into_boxed_str())),
+                CowStr::Boxed(_)
+            ));
+
+            assert!(matches!(detach(CowStr::from('x')), CowStr::Inlined(_)));
+
+            // The bytes survive every route.
+            assert_eq!(detach(CowStr::Borrowed(&short)).as_ref(), short);
+            assert_eq!(detach(CowStr::Borrowed(&long)).as_ref(), long);
         }
 
         #[test]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -998,11 +998,11 @@ fn shapes_match_across_combined_constructs() {
     );
 
     // Links and images spliced in by attribute references — the last two
-    // families to make that lift. What each still defers (an image's non-empty
-    // attribute list, a link's attribute-list-bearing display text, and a
-    // wholly expanded `link:` macro) is deliberately absent here: the recorder
-    // recognizes those, so a fixture carrying one would compare a node against
-    // literal text rather than two constructions of the same node.
+    // families to make that lift. What the link family still defers (an
+    // attribute-list-bearing display text, and a wholly expanded `link:`
+    // macro) is deliberately absent here: the recorder recognizes those, so a
+    // fixture carrying one would compare a node against literal text rather
+    // than two constructions of the same node.
     let with_link_attributes = || {
         Parser::default()
             .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
@@ -1019,6 +1019,16 @@ fn shapes_match_across_combined_constructs() {
 
     assert_shapes_with(
         "See image:{logo}[Logo] and image:{logo}[] beside a *bold* run.",
+        with_link_attributes,
+    );
+
+    // An image whose *attribute list* has no `'src` slice — crossing an
+    // expansion, and crossing an escaped special. The builder now parses the
+    // bracket from its match string, which is the same haystack the string
+    // replacer the recorder wraps reads its own `caps[2]` out of, so the two
+    // constructions carry the same attributes and can be compared.
+    assert_shapes_with(
+        "See image:{logo}[{label},200] and image:x.png[a < b,role=hl] here.",
         with_link_attributes,
     );
 


### PR DESCRIPTION
Continues the `inline-ast` branch's Phase 4, step 6 prep (design doc §5.2). Additive: nothing new is wired into the parse path, and `rendered_html()` remains the string pipeline's own string.

## The boundary this lifts

The corpus-wide fold-parity audit names **three `Attrlist<'src>` captures** as the last boundaries drawn around a *capture* rather than around an opaque piece: an image's non-empty bracket, and the `link:`/`mailto:` and auto-link families' attribute-list-bearing display texts. Every previous increment held them back for the same structural reason — `Attrlist::parse` reads its `source: Span<'src>`'s bytes **as content**, not merely as a location tag, so a capture with no honest `'src` slice had nothing to parse from.

That reason turns out to be about *parsing*, not about *holding*. An `Attrlist` keeps nothing `Span`-typed but its own location tag: its `ElementAttribute`s are `CowStr`s and everything else is plain data. So a list parsed from a temporary can be kept, once its strings are detached from it.

## What changed

- **`Attrlist::into_owned`** (`attributes/attrlist.rs`), built on **`ElementAttribute::into_owned`** and **`CowStr::into_owned`** (the latter preferring the inline representation for a short string, exactly as `Clone` does): rebuilds a list with every borrowed string copied and a caller-supplied span as its new location tag.
- **`bracket_attrlist`** (`content/inline_builder/macros/image.rs`) keeps the `'src` slice — and so the borrow (§4.5) — for a verbatim bracket. Every other bracket is parsed from the level's **match string**, which is not a substitute for the source but the *exact* thing `InlineImageMacroReplacer` parses (`Attrlist::parse(Span::new(&caps[2]), …)`, over its own escaped, already-expanded haystack), then owned onto the bracket's coarse source span — design §4.4's fallback, the same one the node's `location` already takes.
- The family's last `range_is_verbatim` call disappears and **`build_image_node` becomes total**. The whole match keeps only `range_has_no_opaque_piece`, the boundary every family keeps: a rendered span's markup exists only at fold time, and the string replacer parses that markup where this would parse one placeholder.

So `image:sunset.jpg[{caption}]`, `image:tiger.svg[A <b> & "c",opts=interactive]`, and `image:x.png[Tom &amp; Jerry]` are now recognized.

Staged side effects are unchanged: `register_image` reads the node's `target`, and the `link=` dangerous-scheme warning reads the very attribute list this makes available — so a `link=` in a bracket with no `'src` slice now records its warning too (its own test).

## Tests

- The three `…_is_a_documented_divergence` tests this closes — escaped special, restored entity, expanded value — become **parity corpora**, per the "if lifted, fold this into a parity corpus" convention, joined by structural companions pinning the owned attribute values and the coarse location tag.
- `attribute_refs.rs`'s "an attrlist-bearing macro inside a spliced value" divergence is re-pointed at the link family, which still holds it; the image half is rewritten as a recognition test.
- Fixtures added to the whole-pipeline combined-constructs corpus, the synthesized-seed sweep (an image's *non-empty* bracket now joins the empty one), the group-parity corpus, and the structural recorder cross-check — comparable there for the first time, since both constructions now read the same `caps[2]`.

## Audit

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) confirms the divergence set strictly **shrank** — 47 → 40 unique sources, with **no** new one appearing. Gone:

- `image:tiger.svg[A <b> & "c",opts=interactive]`
- `image:missing.svg[A <b> & "c",opts=inline]`
- `Click image:pause.png[title=Pause & Resume] when you need a break.`
- `Click image:pause.png[title=Pause{sp}Resume] when you need a break.`
- `image:sunset.jpg[{caption}]`, `image:{logo}[{caption},200]`, `see {img-src-alt} here`

The first four are real golden fixtures. What survives is the two remaining `Attrlist<'src>` captures, the `subs=quotes,specialcharacters` policy item, and the opaque-piece boundary itself.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5255 passed, 0 failed
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov` — every new line/region covered (the two remaining flags in touched files are a test-only `other => panic!` arm and a pre-existing `attrs: None` branch in `rejected_link_target`)

Design doc updated with a "*Step 6 prep landed as (…)*" narrative paragraph and its checklist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCEfip71zecAaacXo8MiXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCEfip71zecAaacXo8MiXK)_