### PR TITLE
feat: Recognize a construct crossing a character replacement (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3493,6 +3493,68 @@ Each phase is a reviewable unit with a clear exit gate.
   the `subs=quotes,specialcharacters` policy item and the opaque-piece boundary itself. As with
   every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (a **typographic replacement** as the third — and last — recoverable
+  piece):* the two increments that named the recoverable classes
+  — an escaped special, then a restored entity — both stopped short of the third leaf
+  [`CharacterReplacements`](../../parser/src/content/inline_builder/char_replacements.rs) produces:
+  a [`CharRef`](../../parser/src/inlines/char_ref.rs)`::Replacement` (`(C)` → ©, `'` → ’, `--`,
+  `...`, the arrows). Until now
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) stood one in as a single
+  opaque `SPAN_PLACEHOLDER`, so every macro family read across it as if it were a rendered span —
+  and a fresh corpus-wide audit showed exactly what that cost, in three *real* golden fixtures
+  rather than constructed ones: `image:pause.png[title=Pause (C) Resume]`,
+  `image:tiger-roar.png[A tiger's "roar" is < a bear's "growl"]` (an apostrophe *and* an escaped
+  special in one bracket), and `<<Cub => Tiger>>`, whose `=>` is an arrow by macro time.
+
+  It is closed the way the restored-entity increment was — once, for **every** family, since
+  recoverability is a property of the piece rather than of the family reading across it. A
+  `CharRef::Replacement` leaf now contributes the entity the **built-in** backend renders it as
+  ([`replacement_entity`](../../parser/src/content/inline_builder/quotes.rs): `&#169;` for `(C)`,
+  `&#8217;` for `'`), which is precisely what the string pipeline's own haystack holds at that
+  position from the replacements step onward; the leaf stays `atomic` (one indivisible node, never
+  sliced) but becomes *recoverable*, and
+  [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) admits it,
+  its recoverability test mirroring the new arm's own guard so a hand-built node carrying a value no
+  rule produces stays opaque on both sides. Nothing else changed: no builder, no family gate, no
+  node kind, and no side-effect pass — a target or computed value simply reads the replacement's
+  bytes off the match string, and a display text keeps the leaf as its own child through
+  `macro_text_children`'s `emit_range` path, folding back through the renderer to the same bytes.
+
+  One thing does separate this class from a restored entity, and it is the reason the increment is
+  its own step rather than a line in the last one: the fold routes a replacement **through the
+  renderer** (`render_character_replacement`), where an entity leaf is emitted verbatim. Using the
+  canonical rendering here is therefore the same deliberate compromise
+  [`special_entity`](../../parser/src/content/inline_builder/quotes.rs) has always made for an
+  escaped special — a custom backend changes what the fold *emits*, not the recognition the AsciiDoc
+  patterns were written against — and `replacement_entity_matches_the_built_in_renderer` pins the
+  table against `HtmlSubstitutionRenderer` so the two cannot drift. The replacements step's own rule
+  loop gains the same fidelity as a side effect: a later rule now matches over an earlier one's
+  emitted bytes exactly as the string pipeline's sequential passes do, instead of over a placeholder.
+
+  Three `…_is_a_documented_divergence` tests shed fixtures per the "if lifted, fold this into a
+  parity corpus" convention — the bibliography label over `(C)`/`'` (now its own parity test,
+  asserting the *registered* reference text as well as the fold), the UI family's opaque-piece test,
+  and the e-mail family's abutting test, where an address after a replacement (`a(C)b@example.com`,
+  whose `;` is no mismatch character) now links exactly as the string pipeline links it. The
+  footnote-mirror skip test, which had reached for a replacement as its deferred form, is re-pointed
+  at a masked passthrough. Differential corpora gain, per family, a target/id and a display or
+  reference text crossing a replacement, an image's and a link's **attribute list** crossing one,
+  a match crossing every recoverable class at once, doubled, in flow, inside a rendered span, beside
+  a sibling family, escaped, and beside — rather than crossing — a replacement; plus structural
+  companions pinning the recovered `CharRef::Replacement` child and the owned, coarsely-located
+  attribute list a match-string parse yields. Fixtures are added to the whole-pipeline broad sweep
+  and combined-constructs corpus, the synthesized-seed sweep, the attribute-reference corpus (a
+  replacement that exists only because an attribute expanded, read across by a macro), and the
+  structural recorder cross-check.
+
+  Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**: the
+  three real golden sources above are gone (its unique set falls from 45 to 42) and no new one
+  appeared. The categories that survive are unchanged from the last increment — the
+  `subs=quotes,specialcharacters` policy item, the forms individual families already document as
+  deferred, and the opaque-piece boundary itself, which is now purely a **rendered-markup**
+  boundary: every piece it still rejects is one whose bytes exist only at fold time. As with every
+  prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -3950,6 +4012,19 @@ Each phase is a reviewable unit with a clear exit gate.
        [`escaped_value_children`](../../parser/src/content/inline_builder/macros/mod.rs), now
        shared by all three families. See the step's own "landed as" note above. With this the only
        boundary any macro family still draws is the **opaque-piece** one every family shares.
+     - ✅ **prep (a typographic replacement, the third recoverable piece).** The last leaf
+       `build_match_string` stood in as an opaque placeholder — a
+       [`CharRef`](../../parser/src/inlines/char_ref.rs)`::Replacement` (`(C)` → ©, `'` → ’, the
+       arrows) — now contributes the entity the built-in backend renders it as
+       ([`replacement_entity`](../../parser/src/content/inline_builder/quotes.rs)), the string
+       pipeline's own haystack bytes there, and
+       [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs) admits
+       it. Lifted once for every family, as the restored-entity increment was; no builder, gate, or
+       node kind changed. Three real golden fixtures stop diverging
+       (`image:pause.png[title=Pause (C) Resume]`, `image:tiger-roar.png[A tiger's "roar" …]`,
+       `<<Cub => Tiger>>`). See the step's own "landed as" note above. With this the
+       **opaque-piece** boundary — the only one any macro family draws — rejects nothing but
+       pieces whose bytes exist at fold time alone.
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1448,6 +1448,27 @@ mod tests {
     }
 
     #[test]
+    fn a_macro_crossing_a_replacement_from_an_expanded_value_is_recognized() {
+        // The two lifts composed: the replacements step recognizes a `(C)`
+        // *inside* a spliced value (above), and the macro families now read
+        // across the `CharRef::Replacement` leaf it produces — so an image's
+        // attribute list and a link's display text, each crossing a
+        // replacement that exists only because an attribute expanded, are
+        // recognized with the string replacer's own bytes.
+        let parser = parser_with_attribute("note", "Pause (C) Resume");
+
+        for source in ["image:x.png[title={note}]", "link:x.html[{note}]"] {
+            let nodes = build(Span::new(source), &parser, None);
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_attributes_with(source, &parser),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
     fn a_reference_inside_a_span_is_recognized() {
         let parser = parser_with_attribute("greeting", "Hello");
         let nodes = build(Span::new("*{greeting}*"), &parser, None);

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -569,4 +569,76 @@ mod tests {
             other => panic!("expected Ref, got {other:?}"),
         }
     }
+    #[test]
+    fn a_later_rule_never_splits_an_earlier_replacement_leaf() {
+        // Now that a `CharRef::Replacement` leaf contributes its rendered
+        // entity to the match string, a *later* rule in the ordered sweep sees
+        // those bytes — the same ones the string pipeline's own sequential
+        // passes see, which is the point. What such a rule must never do is
+        // match *partially* into one: `rebuild_replacements`' gap would then
+        // clone the whole atomic leaf and emit the new leaf beside it,
+        // duplicating bytes the string pipeline emits once.
+        //
+        // It cannot, and the reason is structural. Every entity this table
+        // produces is `&#…;` — only `&`, `#`, digits and a terminating `;` —
+        // while every rule that could still run needs a character from outside
+        // that set immediately adjacent to its anchor: `(\w)--` needs a word
+        // character *directly* before the dashes (the entity's last byte is
+        // `;`, which is not one), the copyright/registered/trademark rules need
+        // parens, the ellipsis needs dots, the apostrophe rules need `'`, the
+        // arrows need a `-`/`=` beside `&lt;`/`&gt;`, and the entity-restore
+        // rule needs the literal `&amp;`. So a match can abut a replacement
+        // leaf but never begin inside one.
+        //
+        // This pins that as behavior rather than as an argument: every
+        // replacement-producing token is glued to every token that could
+        // extend a match, in both orders and with a word character between, and
+        // each pairing must fold to exactly what the string pipeline emits.
+        let replacements = [
+            "(C)",
+            "(R)",
+            "(TM)",
+            "a--",
+            " -- ",
+            "...",
+            "x'y",
+            "->",
+            "=>",
+            "<-",
+            "<=",
+            "&amp;copy;",
+        ];
+
+        let neighbors = [
+            "--",
+            "a--",
+            " -- ",
+            "...",
+            "'",
+            "x'y",
+            "->",
+            "<-",
+            "&amp;copy;",
+            "9",
+            "a",
+        ];
+
+        for replacement in replacements {
+            for neighbor in neighbors {
+                for source in [
+                    format!("x{replacement}{neighbor}y"),
+                    format!("x{neighbor}{replacement}y"),
+                    format!("x{replacement}z{neighbor}y"),
+                ] {
+                    let nodes = build_src(Span::new(&source));
+
+                    assert_eq!(
+                        fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                        golden_replacements(&source),
+                        "fold diverged from the string pipeline for {source:?}"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1532,25 +1532,67 @@ mod tests {
     }
 
     #[test]
+    fn a_bibliography_label_crossing_a_character_replacement_is_recognized() {
+        // A label crossing a *typographic replacement* — a `(C)` the
+        // replacements step turned into a copyright sign, a smart apostrophe —
+        // is recognized, because `build_match_string` gives such a leaf the
+        // entity the built-in backend renders it as (`&#169;`, `&#8217;`),
+        // which is the very byte sequence the string pipeline's own haystack
+        // holds there; `text_slice` therefore recovers exactly the
+        // already-substituted label the string replacer registers and shows.
+        // Once a documented divergence (a replacement was one opaque
+        // placeholder, like a rendered span); the "third recoverable piece"
+        // increment lifts it for every family at once.
+        let parser = biblio_parser();
+
+        for (source, id, label) in [
+            ("[[[gof,(C) 1995]]] Gamma.", "gof", "&#169; 1995"),
+            ("[[[oreilly,O'Reilly]]] Hunt.", "oreilly", "O&#8217;Reilly"),
+        ] {
+            let nodes = build_with(Span::new(source), &parser);
+
+            let anchor = assert_anchor(&nodes[0]);
+            assert!(anchor.is_bibliography);
+            assert_eq!(anchor.id.as_ref(), id);
+
+            let folded = crate::content::inline_builder::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser,
+            );
+
+            assert_eq!(folded, golden_passthroughs_with(source, &parser));
+
+            // The registered reference text is the already-substituted label,
+            // exactly as the string replacer registers it.
+            let side_effect_parser = biblio_parser();
+            apply_biblio_side_effects(&nodes, &side_effect_parser, Span::new(source));
+
+            let catalog = side_effect_parser.catalog();
+            let entry = catalog.get_ref(id).unwrap();
+            assert_eq!(
+                entry.reftext.as_deref(),
+                Some(format!("[{label}]").as_str())
+            );
+        }
+    }
+
+    #[test]
     fn a_bibliography_label_over_an_opaque_piece_is_a_documented_divergence() {
-        // A label crossing an opaque piece — a rendered span, a passthrough, or
-        // a character replacement, each a single placeholder in this level's
-        // match string rather than the markup/entity the string pipeline's
-        // haystack holds there — cannot be reconstructed as the
-        // already-substituted text the string replacer registers and shows, so
-        // the anchor is left unrecognized. The entry then keeps the shape it had
-        // before this increment (the inner `[[…]]` as an ordinary anchor), which
-        // is what diverges. This is exactly the boundary the index-term family's
-        // own visible term documents, and — for the character replacements —
-        // the same one every macro family already has at this point in the
-        // pipeline (a `(C)` or a smart apostrophe is atomic by macro time).
+        // A label crossing an opaque piece — a rendered span or a passthrough,
+        // each a single placeholder in this level's match string rather than
+        // the markup the string pipeline's haystack holds there — cannot be
+        // reconstructed as the already-substituted text the string replacer
+        // registers and shows, so the anchor is left unrecognized. The entry
+        // then keeps the shape it had before this increment (the inner `[[…]]`
+        // as an ordinary anchor), which is what diverges. This is exactly the
+        // boundary the index-term family's own visible term documents, and the
+        // one every macro family still has for a rendered span.
         let parser = biblio_parser();
 
         for source in [
             "[[[gof,*GoF*]]] Gamma.",
             "[[[gof,+++<b>GoF</b>+++]]] Gamma.",
-            "[[[gof,(C) 1995]]] Gamma.",
-            "[[[oreilly,O'Reilly]]] Hunt.",
         ] {
             let nodes = build_with(Span::new(source), &parser);
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -6,7 +6,9 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_IMAGE_MACRO, basename,
-        inline_builder::quotes::{Piece, build_match_string, source_slice, text_slice},
+        inline_builder::quotes::{
+            Piece, build_match_string, replacement_entity, source_slice, text_slice,
+        },
         normalize_text_lf_escaped_bracket,
     },
     inlines::{CharRef, Image, InlineNode},
@@ -175,26 +177,28 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
 /// The most relaxed of the three gates: accepts a range whose overlapping
 /// pieces are all ones the tree can reproduce **exactly** — a
 /// [`Text`](InlineNode::Text) run (verbatim or
-/// [`synthesized`](Piece::synthesized)) or either
-/// [`CharRef`](InlineNode::CharRef) leaf, an *escaped special*
-/// ([`Special`](CharRef::Special)) or a *restored entity*
-/// ([`Entity`](CharRef::Entity)) — rejecting only an **opaque** piece: a
-/// rendered [`Styled`](crate::inlines::Styled) span, an earlier-recognized
-/// macro node, a masked passthrough or STEM expression, or a character
-/// replacement, each of which
-/// [`build_match_string`] stands in as one
+/// [`synthesized`](Piece::synthesized)) or any of the three
+/// [`CharRef`](InlineNode::CharRef) leaves, an *escaped special*
+/// ([`Special`](CharRef::Special)), a *restored entity*
+/// ([`Entity`](CharRef::Entity)), or a *typographic replacement*
+/// ([`Replacement`](CharRef::Replacement)) — rejecting only an **opaque**
+/// piece: a rendered [`Styled`](crate::inlines::Styled) span, an
+/// earlier-recognized macro node, or a masked passthrough or STEM expression,
+/// each of which [`build_match_string`] stands in as one
 /// `SPAN_PLACEHOLDER` rather than the markup or entity the string pipeline's
 /// own haystack holds there.
 ///
-/// Both `CharRef` leaves are admissible for the same reason: their
+/// All three `CharRef` leaves are admissible for the same reason: their
 /// match-string bytes — a special's canonical entity (`&lt;`, `&gt;`,
-/// `&amp;`), a restored entity's own text (`&copy;`, `&#8217;`) — are the very
-/// byte sequence the string pipeline's own haystack carries at that position,
-/// so a family that reads its values out of the match string sees exactly what
-/// the string replacer sees. What such a family cannot do is *slice* those
-/// bytes from `'src` (the source holds one character where the match string
-/// holds an entity, and `&amp;copy;` where it holds `&copy;`), so a value that
-/// must ride on the node as an `'src` slice — an [`Attrlist`]`<'src>`, an
+/// `&amp;`), a restored entity's own text (`&copy;`, `&#8217;`), a
+/// replacement's built-in rendering (`&#169;` for `(C)`, `&#8217;` for `'`,
+/// via [`replacement_entity`]) — are the very byte sequence the string
+/// pipeline's own haystack carries at that position, so a family that reads its
+/// values out of the match string sees exactly what the string replacer sees.
+/// What such a family cannot do is *slice* those bytes from `'src` (the source
+/// holds one character, or `(C)`, where the match string holds an entity, and
+/// `&amp;copy;` where it holds `&copy;`), so a value that must ride on the node
+/// as an `'src` slice — an [`Attrlist`]`<'src>`, an
 /// [`Image`](InlineNode::Image)'s bracket — keeps [`range_is_verbatim`], and a
 /// *display text* recovered under this gate is rebuilt as structured children
 /// with [`emit_range`](super::super::quotes::emit_range) (the leaf staying its
@@ -219,15 +223,25 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
         }
 
         // The atomic pieces `build_match_string` gives real bytes to are the
-        // two `CharRef` leaves — an escaped special and a restored entity;
-        // everything else it stands in as one placeholder.
-        let recoverable = matches!(
-            nodes.get(piece.node_index),
+        // three `CharRef` leaves — an escaped special, a restored entity, and
+        // a typographic replacement the built-in backend has a rendering for;
+        // everything else it stands in as one placeholder. The
+        // `replacement_entity` test mirrors that arm's own guard, so a
+        // hand-built node carrying a value no rule produces stays opaque here
+        // exactly as it does there.
+        let recoverable = match nodes.get(piece.node_index) {
             Some(InlineNode::CharRef {
                 value: CharRef::Special(_) | CharRef::Entity(_),
                 ..
-            })
-        );
+            }) => true,
+
+            Some(InlineNode::CharRef {
+                value: CharRef::Replacement(value),
+                ..
+            }) => replacement_entity(value).is_some(),
+
+            _ => false,
+        };
 
         if !recoverable {
             return false;
@@ -994,6 +1008,79 @@ mod tests {
                 "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_macro_crossing_a_character_replacement() {
+        // A typographic replacement (`(C)`, `(R)`, `'`, `...`) is the third
+        // recoverable piece, admitted for the same reason the two `CharRef`
+        // entity leaves are: `build_match_string` gives it the entity the
+        // built-in backend renders it as, which is what the string pipeline's
+        // own haystack carries from the replacements step onward — so both the
+        // target read off that string and the bracket parsed from it are the
+        // string replacer's own bytes.
+        let fixtures = [
+            // A target crossing one, alone and beside an attribute list.
+            "image:a(C)b.png[]",
+            "image:a(C)b.png[Alt]",
+            "icon:a(C)b[]",
+            // An **attribute list** crossing one — the shape three real
+            // fixtures in this crate's own corpora write.
+            "image:pause.png[title=Pause (C) Resume]",
+            "image:x.png[A tiger's roar]",
+            "image:x.png[alt=a (C) b]",
+            "image:x.png[Wait...]",
+            "image:x.png[Tom (C) Jerry,200,100]",
+            "icon:home[Tom (C) Jerry]",
+            // A replacement in the bracket *and* in the target, and one
+            // beside an escaped special and a restored entity.
+            "image:a(C)b.png[Tom (C) Jerry]",
+            "image:x.png[a (C) b < c &copy; d]",
+            // In surrounding flow, inside a rendered span, doubled, and beside
+            // a sibling family that takes the same lift.
+            "before image:x.png[Tom (C) Jerry] after",
+            "*image:x.png[Tom (C) Jerry]*",
+            "image:a(C)b.png[] image:c(R)d.png[]",
+            "image:x.png[Tom (C) Jerry] and link:x(R)y.html[]",
+            // The escape still keeps the macro literal, backslash dropped.
+            "\\image:x.png[Tom (C) Jerry]",
+            // A replacement *beside* the macro rather than inside it.
+            "(C)image:sunset.jpg[](R)",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_crossing_a_character_replacement_reads_the_rendered_entity() {
+        // The structural companion: the bracket has no `'src` slice (the
+        // source holds `(C)` where the match string holds `&#169;`), so it is
+        // parsed from the match string and owned onto design §4.4's coarse
+        // span — carrying the already-substituted value the string replacer
+        // parses, entity and all.
+        let source = "image:x.png[title=Pause (C) Resume]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let image = assert_image(&nodes[0]);
+
+        let attrlist = image.attrs.as_ref().unwrap();
+        assert_eq!(
+            attrlist.named_attribute("title").unwrap().value(),
+            "Pause &#169; Resume"
+        );
+
+        assert_eq!(image.location.data(), source);
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -499,6 +499,14 @@ mod tests {
             "\\indexterm:[x]",
             "\\indexterm2:[x]",
             "\\((coffee))",
+            // A visible term crossing a *typographic replacement* — the third
+            // recoverable piece, whose match-string bytes are the entity the
+            // built-in backend renders it as, so the shown text is
+            // reconstructed exactly as the string replacer computes it.
+            "((Coffee (C) Beans))",
+            "((O'Reilly))",
+            "an indexterm2:[Tom (C) Jerry] in the flow",
+            "(((Coffee (C) Beans, robusta)))",
             // Embedded in surrounding flow and next to other constructs.
             "*bold* then ((x)) here",
             "a copyright (C) then ((x))",

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2812,9 +2812,10 @@ mod tests {
             "https://example.org[super^script^ and sub~script~]",
             "https://example.org[[.hl]#roled#]",
             // An already-recognized macro node of another family — an image, an
-            // icon, an index term — and a character replacement, which is
-            // opaque here for the same reason (`build_match_string` stands each
-            // in as one placeholder).
+            // icon, an index term — which is opaque here for the same reason
+            // (`build_match_string` stands each in as one placeholder), plus a
+            // character replacement, which is *not* opaque (it carries its own
+            // bytes) but is exercised beside a span all the same.
             "https://example.org[the image:logo.png[Logo] here]",
             "https://example.org[the icon:tags[] here]",
             "https://example.org[a ((index term)) *b*]",
@@ -3204,6 +3205,96 @@ mod tests {
                 "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_link_crossing_a_character_replacement() {
+        // A *typographic replacement* (`(C)` and `'`, which the
+        // character-replacements step turns into `CharRef::Replacement`
+        // leaves) is admitted for the same reason the two other `CharRef`
+        // leaves are: its match-string bytes — the entity the built-in backend
+        // renders it as (`&#169;`, `&#8217;`) — are the string pipeline's own
+        // haystack bytes there, and the fold routes the leaf back through the
+        // renderer to those same bytes. A display text carrying one keeps it
+        // as its own child rather than baking the entity into a `Text` the
+        // fold would escape.
+        let fixtures = [
+            // A display text crossing one, in each of the four link spellings.
+            "https://example.org[a (C) b]",
+            "https://example.org[O'Reilly]",
+            "link:index.html[a (C) b]",
+            "mailto:a@b.com[Tom (C) Jerry]",
+            "<https://example.org/a(C)b>",
+            // A *target* crossing one, bare and bracketed.
+            "link:a(C)b.html[]",
+            "link:a(C)b.html[Text]",
+            "https://example.org/?a=(C)b",
+            // A bare e-mail address abutting one — the `;` a replacement's
+            // entity ends in is no mismatch character, so the string pipeline
+            // links the address that follows it, and now so does the tree.
+            "a(C)b@example.com",
+            // A target crossing a replacement, an escaped special, and a
+            // restored entity at once.
+            "link:a(C)b&c&copy;d.html[]",
+            // In flow, doubled, inside a rendered span, and escaped.
+            "see link:a(C)b.html[Docs] now",
+            "link:a(C)b.html[] link:c(R)d.html[]",
+            "*link:a(C)b.html[Docs]*",
+            "\\link:a(C)b.html[Docs]",
+            // A replacement beside the macro rather than inside it.
+            "(C)link:x.html[Docs](R)",
+            // A text carrying an **attribute list** across one, in all three
+            // spellings: the parse reads the match string's own entity, and
+            // the positional value it returns is rebuilt through
+            // `escaped_value_children` so the entity folds back once.
+            "https://example.org[a (C) b,role=hl]",
+            "link:index.html[a (C) b,role=hl]",
+            "mailto:a@b.com[Tom (C) Jerry,Subject here]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_display_text_crossing_a_character_replacement_keeps_it_as_its_own_child() {
+        // The structural companion: the text is rebuilt through
+        // `macro_text_children`'s `emit_range` path, so the replacement stays
+        // the `CharRef::Replacement` leaf it already is — folding back through
+        // the renderer — with `Text` runs on either side borrowing `'src`.
+        let source = "https://example.org[a (C) b]";
+        let nodes = build_src(Span::new(source));
+
+        let reference = match &nodes[0] {
+            InlineNode::Ref(reference) => reference,
+            other => panic!("expected a Ref, got {other:?}"),
+        };
+
+        assert_eq!(reference.children.len(), 3, "{:?}", reference.children);
+        assert_text(&reference.children[0], "a ", 1, 21);
+
+        assert!(
+            matches!(
+                &reference.children[1],
+                InlineNode::CharRef {
+                    value: CharRef::Replacement(value),
+                    ..
+                } if *value == "\u{a9}"
+            ),
+            "{:?}",
+            reference.children[1]
+        );
+
+        assert_text(&reference.children[2], " b", 1, 26);
     }
 
     #[test]
@@ -3842,18 +3933,6 @@ mod tests {
         // markup without folding the preceding node while building, so all of
         // them defer — see `email_level`'s own scope note.
         use super::super::super::test_support::golden_passthroughs;
-
-        // A character replacement is the same class, reached without a macro
-        // at all: `(C)` renders to `&#169;`, whose trailing `;` is no mismatch
-        // character, so the string pipeline links the address that follows it.
-        let replacement = "a(C)b@example.com";
-        let nodes = build_src(Span::new(replacement));
-
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an address abutting an opaque construct must stay literal: {nodes:?}"
-        );
-        assert!(golden_macros(replacement).contains(r#"href="mailto:b@example.com""#));
 
         let concealed_term = "indexterm:[a]doc@example.com";
         let nodes = build_src(Span::new(concealed_term));

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -402,7 +402,8 @@ pub(super) fn rebuild_macro_level<'src>(
 /// does for the structured path below, cannot reintroduce it.
 ///
 /// A text crossing an **escaped special** (`xref:sec[a<b]`, `link:x[a<b]`) or a
-/// **restored entity** (`xref:sec[a &copy; b]`) — or, degenerately, one
+/// **restored entity** (`xref:sec[a &copy; b]`), or a **typographic
+/// replacement** (`xref:sec[a (C) b]`) — or, degenerately, one
 /// [`text_slice`] declines to recover — instead becomes
 /// **structured children**, recovered with [`emit_range`]: the
 /// leaf is its own [`CharRef`] child that folds

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -83,19 +83,20 @@ fn find_kbd_btn_matches<'src>(
         }
 
         // A match crossing an **opaque** piece — a rendered span, an
-        // earlier-recognized macro node, a masked passthrough, a character
-        // replacement — is left for a later increment: `build_match_string`
-        // stands each in as one placeholder where the string pipeline's own
-        // haystack holds the markup it will fold to, so the keys or label
-        // read out of the match string would not be the replacer's.
+        // earlier-recognized macro node, a masked passthrough — is left for a
+        // later increment: `build_match_string` stands each in as one
+        // placeholder where the string pipeline's own haystack holds the
+        // markup it will fold to, so the keys or label read out of the match
+        // string would not be the replacer's.
         //
         // Every *recoverable* piece is admitted: a
         // [`synthesized`](Piece::synthesized) run (an attribute expansion,
         // or — reached at a tree's root — a filtered multi-line block's own
-        // joined seed), an escaped special (`kbd:[Ctrl&C]`), and a restored
-        // entity (`kbd:[Ctrl&copy;C]`). This family never slices `'src` for a
-        // value at all — its keys and label come straight from the match
-        // string, which carries all three pieces' bytes exactly — so only the
+        // joined seed), an escaped special (`kbd:[Ctrl&C]`), a restored
+        // entity (`kbd:[Ctrl&copy;C]`), and a typographic replacement
+        // (`kbd:[a(C)b]`). This family never slices `'src` for a value at all
+        // — its keys and label come straight from the match string, which
+        // carries every one of those pieces' bytes exactly — so only the
         // node's `location` takes design §4.4's coarse fallback (see
         // [`build_kbd_btn_node`]). Nor can a boundary split such a leaf: the
         // match is delimited by `kbd:`/`btn:`, `[`, and `]`, and its keys by
@@ -183,8 +184,9 @@ fn build_kbd_btn_node<'src>(
 /// verbatim (see [`find_menu_matches`]). What is still deferred is a name or
 /// item text crossing an **opaque** piece — a rendered
 /// [`Styled`](crate::inlines::Styled) span, an earlier-recognized macro node,
-/// a masked passthrough, a character replacement — the one boundary every
-/// macro family keeps.
+/// a masked passthrough — the one boundary every macro family keeps. (A
+/// typographic replacement, `menu:File[Save (C) Exit]`, is admitted too, for
+/// the same reason a restored entity is: it carries its own bytes.)
 pub(super) fn menu_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -692,8 +694,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_for_ui_macros_crossing_a_recoverable_piece() {
         // A UI macro whose name, keys, label, or item list crosses an
-        // **escaped special** (`&`, `<`, `>`) or a **restored entity**
-        // (`&copy;`, `&#8942;`) is recognized: both are atomic pieces
+        // **escaped special** (`&`, `<`, `>`), a **restored entity**
+        // (`&copy;`, `&#8942;`), or a **typographic replacement** (`(C)`, a
+        // smart apostrophe) is recognized: all three are atomic pieces
         // `build_match_string` gives *real bytes* to — the very bytes the
         // string replacer's own escaped haystack carries there — and every
         // value a `Ui` node holds is read out of that match string and emitted
@@ -736,9 +739,21 @@ mod tests {
             "menu:F&copy;le[Save]",
             "menu:File[Save &copy; Exit]",
             "menu:File[Save As&#8230;]",
-            // A match crossing *both* kinds of recoverable piece at once.
+            // Typographic replacements, the third recoverable piece: a key,
+            // a label, a menu name, and an item, over both a `(C)`-style
+            // replacement and a smart apostrophe.
+            "kbd:[a(C)b]",
+            "btn:[Save (C) Close]",
+            "menu:File[Save (C) Exit]",
+            "menu:File[Save > A (C) B]",
+            "kbd:[O'Reilly]",
+            "btn:[O'Reilly]",
+            "menu:O'Reilly[Save]",
+            "menu:File[O'Reilly]",
+            // A match crossing every kind of recoverable piece at once.
             "kbd:[a&b&copy;c]",
             "menu:File[A & B &copy; C]",
+            "menu:File[A & B &copy; C (C) D]",
             // In flow, doubled, and beside a sibling macro family.
             "press kbd:[Ctrl&C] to copy",
             "kbd:[a&b] then kbd:[c&d]",
@@ -832,22 +847,17 @@ mod tests {
     fn a_ui_macro_crossing_an_opaque_piece_is_a_documented_divergence() {
         // The one boundary this family keeps, and the same one every other
         // macro family keeps: a match crossing an **opaque** piece — a
-        // rendered span, an already-recognized macro node, a character
-        // replacement — is left unrecognized. `build_match_string` stands each
-        // in as a single placeholder where the string pipeline's own haystack
-        // holds the markup or entity it will fold to, so a value read out of
-        // the match string would not be the replacer's, and reading the markup
-        // would mean folding while building the tree (which this module never
-        // does).
+        // rendered span, an already-recognized macro node — is left
+        // unrecognized. `build_match_string` stands each in as a single
+        // placeholder where the string pipeline's own haystack holds the
+        // markup it will fold to, so a value read out of the match string
+        // would not be the replacer's, and reading the markup would mean
+        // folding while building the tree (which this module never does).
         for source in [
             // A rendered span inside a keyboard, button, and menu macro.
             "kbd:[*a*]",
             "btn:[a `b` c]",
             "menu:File[*S* > As]",
-            // A character replacement — an atomic piece with no bytes of its
-            // own in the match string.
-            "kbd:[a(C)b]",
-            "menu:File[Save (C) Exit]",
         ] {
             let nodes = build_ui(Span::new(source));
 
@@ -994,13 +1004,18 @@ mod tests {
                 "press kbd:[Ctrl+T]\nor menu:View[Zoom > Reset]",
                 "  press kbd:[Ctrl+T]\n  or menu:View[Zoom > Reset]",
             ),
-            // The two recoverable pieces reached through a synthesized seed:
-            // a key crossing an escaped special and a menu name crossing a
-            // restored entity, neither of which has an `'src` slice of its own
-            // here — both values still come from the match string.
+            // The recoverable pieces reached through a synthesized seed: a key
+            // crossing an escaped special, a menu name crossing a restored
+            // entity, and a label crossing a typographic replacement, none of
+            // which has an `'src` slice of its own here — every value still
+            // comes from the match string.
             (
                 "press kbd:[Ctrl&C]\nor menu:&#8942;[Zoom > Reset]",
                 "  press kbd:[Ctrl&C]\n  or menu:&#8942;[Zoom > Reset]",
+            ),
+            (
+                "press kbd:[a(C)b]\nor btn:[O'Reilly]",
+                "  press kbd:[a(C)b]\n  or btn:[O'Reilly]",
             ),
         ] {
             let nodes = build_from_value(

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1375,6 +1375,52 @@ mod tests {
     }
 
     #[test]
+    fn fold_matches_the_string_pipeline_for_a_cross_reference_crossing_a_character_replacement() {
+        // A typographic replacement is the third recoverable piece, admitted
+        // for the same reason the two entity leaves are: the level's match
+        // string carries the entity the built-in backend renders it as — the
+        // string pipeline's own haystack bytes from the replacements step
+        // onward — and the fold routes the leaf back through the renderer to
+        // those same bytes.
+        let fixtures = [
+            // A reference text crossing one, in both spellings.
+            "xref:sec[Tom (C) Jerry]",
+            "<<sec,Tom (C) Jerry>>",
+            "xref:sec[O'Reilly]",
+            "xref:sec[Wait...]",
+            // A *target* crossing one, in both spellings — the second the
+            // shape a real fixture in this crate's own corpora writes.
+            "xref:s(C)c[Text]",
+            "<<s(C)c>>",
+            "<<Cub => Tiger>>",
+            // An attribute-list text crossing one.
+            "xref:sec[Tom (C) Jerry,role=hl]",
+            "xref:sec[O'Reilly,role=hl,window=_blank]",
+            // A text crossing a replacement, an escaped special, and a
+            // restored entity at once.
+            "xref:sec[a (C) b < c &copy; d]",
+            "xref:sec[a (C) b < c &copy; d,role=hl]",
+            // In flow, inside a rendered span, doubled, and escaped.
+            "see xref:sec[Tom (C) Jerry] now",
+            "*xref:sec[Tom (C) Jerry]*",
+            "xref:a[(C)] and xref:b[(R)]",
+            "\\xref:sec[Tom (C) Jerry]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_xref(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
     fn a_reference_text_crossing_a_restored_entity_keeps_the_entity_as_its_own_child() {
         // The plain-text path rebuilds the text through `emit_range`, so the
         // entity stays the leaf it already is rather than being baked into a

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -68,8 +68,8 @@
 //!   of the match string instead (see
 //!   [`range_is_verbatim_or_synthesized`](macros::image::range_is_verbatim_or_synthesized),
 //!   and [`range_has_no_opaque_piece`](macros::image::range_has_no_opaque_piece)
-//!   for the families whose gate also admits an escaped special or a restored
-//!   entity).
+//!   for the families whose gate also admits an escaped special, a restored
+//!   entity, or a typographic replacement).
 //! - [`apply_character_replacements`] recognizes [character replacements] —
 //!   `(C)`, `--`, `...`, arrows, apostrophes, and restored entities — replacing
 //!   each with a [`CharRef::Replacement`](crate::inlines::CharRef::Replacement)
@@ -142,7 +142,14 @@
 //!   sliced or baked `Text` — the special stays the `CharRef` it already is,
 //!   folding back to the same entity instead of being escaped twice — which for
 //!   a *bare* link (a macro's target-derived text, an auto-link's or an angle
-//!   link's URL) covers the text it shows as well. The
+//!   link's URL) covers the text it shows as well. A **restored entity**
+//!   (`&copy;`, `&#8217;`) and a **typographic replacement** (`(C)`, a smart
+//!   apostrophe, an arrow) are admitted on the same terms, for **every**
+//!   family at once, since recoverability is a property of the piece rather
+//!   than of the family reading across it: the match string carries the
+//!   entity's own bytes, and a replacement's built-in rendering
+//!   ([`replacement_entity`](quotes::replacement_entity)), which are the
+//!   string pipeline's own haystack bytes there. The
 //!   one capture still holding that boundary in these families is a display text
 //!   carrying an attribute list, parsed as a real
 //!   [`Attrlist`]`<'src>` from the source's own
@@ -760,6 +767,13 @@ mod tests {
             "an image:a&copy;b.png[Entity] target",
             "link:a&copy;b.html[a &copy; b] and xref:s&copy;c[a &copy; b]",
             "https://example.org/?a=&copy;b and doc&copy;a@example.org",
+            "an image:a(C)b.png[Replacement] target",
+            "image:pause.png[title=Pause (C) Resume] macro",
+            "link:a(C)b.html[a (C) b] and xref:s(C)c[a (C) b]",
+            "https://example.org/?a=(C)b and a(C)b@example.com",
+            "see <<Cub => Tiger>> now",
+            "a ((Coffee (C) Beans)) term and kbd:[a(C)b]",
+            "an O'Reilly link:x.html[O'Reilly] title",
             "<<a>> and <<b>> and <<c,C text>> and <<d,>>",
             "a ((flow term)) and (((c1, c2, c3))) end",
             "indexterm:[primary, secondary]",
@@ -818,6 +832,13 @@ mod tests {
 
         // Inline STEM beside a quoted span and a character replacement.
         assert_parity("Equation stem:[x^2+y^2=z^2] appears in *bold* text with (C) 2024.");
+
+        // A character replacement *inside* several families' captured values
+        // at once — the third recoverable piece, whose match-string bytes are
+        // the entity the built-in backend renders it as.
+        assert_parity(
+            "image:a(C)b.png[Pause (C) Resume] beside link:x(C)y.html[O'Reilly]              and <<s(C)c,Tom (C) Jerry>> and a ((Coffee (C) Beans)) term.",
+        );
 
         // UI macros (kbd/menu, gated on `experimental`) beside a quoted span.
         let with_experimental = || {
@@ -1298,6 +1319,14 @@ mod tests {
             (
                 "  a ((flow term)) here\n  and a (((c1, c2))) one",
                 "a ((flow term)) here\nand a (((c1, c2))) one",
+            ),
+            // A construct crossing a *typographic replacement* at a
+            // synthesized tree's root: the leaf carries the entity the
+            // built-in backend renders it as, so a value read off the match
+            // string is the string replacer's own.
+            (
+                "  a ((Coffee (C) Beans)) term\n  and <<s(C)c,Tom (C) Jerry>>",
+                "a ((Coffee (C) Beans)) term\nand <<s(C)c,Tom (C) Jerry>>",
             ),
             // A cross-reference in a wholly-synthesized seed, in both
             // spellings: nothing on a `Ref{Xref}` node is `Span`-typed, so its

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -129,10 +129,12 @@ fn match_level<'src>(
 ///
 /// A verbatim [`Text`](InlineNode::Text) run contributes its (special-free)
 /// value; a [`CharRef`](InlineNode::CharRef) contributes its canonical entity
-/// (a [`Special`](CharRef::Special)) or the entity itself (a *restored*
-/// [`Entity`](CharRef::Entity)), so the boundary classes the quote patterns key
-/// off (`&`, `;`) see exactly what the string pipeline's escaped text presents
-/// — and so does a later step reading a value across one; a *synthesized*
+/// (a [`Special`](CharRef::Special)), the entity itself (a *restored*
+/// [`Entity`](CharRef::Entity)), or the entity the built-in backend renders it
+/// as (a typographic [`Replacement`](CharRef::Replacement), via
+/// [`replacement_entity`]), so the boundary classes the quote patterns key off
+/// (`&`, `;`) see exactly what the string pipeline's escaped text presents —
+/// and so does a later step reading a value across one; a *synthesized*
 /// `Text` run (design §3.4.1 — an attribute expansion, a `counter` directive)
 /// contributes its `value` too, so [`apply_character_replacements`]
 /// (design §3.4.1: `replacements` still runs over an expanded value) can
@@ -229,6 +231,40 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                 });
             }
 
+            InlineNode::CharRef {
+                value: CharRef::Replacement(value),
+                location,
+            } if replacement_entity(value).is_some() => {
+                // A *typographic replacement* (`(C)` and `'`, which the
+                // replacements step turned into a copyright sign and a
+                // typographic apostrophe) contributes the entity the built-in
+                // backend renders it as, for the same reason the two other
+                // `CharRef` leaves contribute theirs: those bytes *are* what
+                // the string pipeline's own haystack holds at that position
+                // from the replacements step onward (`&#169;`, `&#8217;`), so
+                // a later step matching across one — or reading a value out of
+                // the match string — sees exactly what the string replacer
+                // sees. It stays `atomic` (the leaf is one indivisible node,
+                // never sliced) but is *recoverable*, which is the distinction
+                // [`range_has_no_opaque_piece`](super::macros::image::range_has_no_opaque_piece)
+                // draws.
+                //
+                // The guard has already established `Some`; the crate forbids
+                // `unwrap`, so the same lookup is spelled `unwrap_or_default`.
+                let entity = replacement_entity(value).unwrap_or_default();
+                s.push_str(entity);
+
+                pieces.push(Piece {
+                    node_index,
+                    s_start,
+                    s_len: entity.len(),
+                    src_offset: location.byte_offset(),
+                    src_len: location.data().len(),
+                    atomic: true,
+                    synthesized: false,
+                });
+            }
+
             other => {
                 // A span from an earlier sub (or any other synthesized-value
                 // node, e.g. a `Raw` leaf) is opaque: a single placeholder
@@ -292,6 +328,41 @@ pub(super) fn special_entity(ch: char) -> &'static str {
         // `&` and any other special the step recognizes.
         _ => "&amp;",
     }
+}
+
+/// The entity a [`CharRef::Replacement`] contributes to the match string: the
+/// bytes the **built-in** HTML backend renders that replacement as, which are
+/// exactly what the string pipeline's own haystack holds from the replacements
+/// step onward. Returns `None` for a value no replacement rule produces (only a
+/// hand-built node can carry one), which [`build_match_string`] then stands in
+/// as one opaque [`SPAN_PLACEHOLDER`], as it did for every replacement before
+/// this.
+///
+/// Like [`special_entity`], this is deliberately the *canonical* rendering
+/// rather than a call into the configured renderer: a custom backend changes
+/// what the fold emits, not the recognition the AsciiDoc patterns were written
+/// against. `replacement_entity_matches_the_built_in_renderer` pins the two
+/// against each other so they cannot drift.
+pub(super) fn replacement_entity(value: &str) -> Option<&'static str> {
+    // Keyed on the value rather than on
+    // [`replacement_type_of`](super::callouts::replacement_type_of)'s type so
+    // the two tables cover exactly the same set of values — this one's `None`
+    // and that one's are the same case, a value no replacement rule produces.
+    Some(match value {
+        "\u{a9}" => "&#169;",
+        "\u{ae}" => "&#174;",
+        "\u{2122}" => "&#8482;",
+        "\u{2009}\u{2014}\u{2009}" => "&#8201;&#8212;&#8201;",
+        "\u{2014}\u{200b}" => "&#8212;&#8203;",
+        "\u{2026}\u{200b}" => "&#8230;&#8203;",
+        "\u{2019}" => "&#8217;",
+        "\u{2190}" => "&#8592;",
+        "\u{21d0}" => "&#8656;",
+        "\u{2192}" => "&#8594;",
+        "\u{21d2}" => "&#8658;",
+
+        _ => return None,
+    })
 }
 
 /// One accepted quote match at a level, in absolute match-string byte offsets.
@@ -861,6 +932,47 @@ mod tests {
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
+
+    #[test]
+    fn replacement_entity_matches_the_built_in_renderer() {
+        // The table `build_match_string` reads is the built-in backend's own
+        // rendering of each replacement — the bytes the string pipeline's
+        // haystack holds from the replacements step onward — so the two cannot
+        // be allowed to drift. Every value the classifier recognizes is
+        // checked against the renderer that produces it, and a value no rule
+        // produces has no entity at all (`build_match_string` stands such a
+        // leaf in as one opaque placeholder, as it did for every replacement
+        // before this).
+        use super::super::callouts::replacement_type_of;
+        use crate::parser::InlineSubstitutionRenderer;
+
+        for value in [
+            "\u{a9}",
+            "\u{ae}",
+            "\u{2122}",
+            "\u{2009}\u{2014}\u{2009}",
+            "\u{2014}\u{200b}",
+            "\u{2026}\u{200b}",
+            "\u{2019}",
+            "\u{2190}",
+            "\u{21d0}",
+            "\u{2192}",
+            "\u{21d2}",
+        ] {
+            let type_ = replacement_type_of(value).unwrap();
+
+            let mut rendered = String::new();
+            HtmlSubstitutionRenderer {}.render_character_replacement(type_, &mut rendered);
+
+            assert_eq!(
+                super::replacement_entity(value),
+                Some(rendered.as_str()),
+                "match-string bytes drifted from the built-in rendering of {value:?}"
+            );
+        }
+
+        assert!(super::replacement_entity("not a replacement").is_none());
+    }
 
     /// The string pipeline's output through the **quotes** step for `source`,
     /// used as the golden oracle: `Content::from` then `SpecialCharacters` then

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -907,6 +907,12 @@ fn shapes_match_across_combined_constructs() {
     // the recorder reaches by re-reading the rendered anchor text).
     assert_shapes("See image:a&copy;b.png[Chart] and link:x.html[a &copy; b] today.");
 
+    // A *typographic replacement*, the third such piece: a target crossing
+    // one, and a display text crossing one (which the builder keeps as its own
+    // `CharRef::Replacement` child, the shape the recorder reaches by
+    // re-reading the rendered anchor text).
+    assert_shapes("See image:a(C)b.png[Chart] and link:x.html[a (C) b] today.");
+
     assert_shapes_with(
         "{counter:step}. Step one uses *{product}* and stem:[x+1].",
         with_product,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1239,11 +1239,12 @@ fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
     // and the footnote mirror must skip rather than misassign. The block-side
     // mirror is unaffected and still resolves the block-level reference.
     // (The deferred form here is a shorthand whose *id* crosses an opaque
-    // piece — a character replacement — since a footnote's own bracketed text
+    // piece — a masked passthrough — since a footnote's own bracketed text
     // ends at the first `]`, which rules out the bracket-carrying spellings.)
     let mut parser = Parser::default().with_inline_tree(true);
-    let doc = parser
-        .parse("[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a -- b>> and <<c>>]");
+    let doc = parser.parse(
+        "[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a +++b+++ c>> and <<c>>]",
+    );
 
     let refs = collect_refs(&doc);
 


### PR DESCRIPTION
The next increment on the `inline-ast` branch: a **typographic replacement** (`(C)` → ©, `'` → ’, `--`, `...`, the arrows) becomes the third — and last — *recoverable* piece the single-pass builder can read across.

## Why

Until now [`build_match_string`](https://github.com/asciidoc-rs/asciidoc-parser/blob/inline-ast/parser/src/content/inline_builder/quotes.rs) stood a `CharRef::Replacement` leaf in as one opaque `SPAN_PLACEHOLDER`, so every macro family treated it exactly like a rendered span and deferred. A corpus-wide fold-parity audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) showed what that cost, in three **real golden fixtures** rather than constructed ones:

- `image:pause.png[title=Pause (C) Resume]`
- `image:tiger-roar.png[A tiger's "roar" is < a bear's "growl"]` — an apostrophe *and* an escaped special in one bracket
- `<<Cub => Tiger>>` — whose `=>` is an arrow by macro time

## What changed

Closed the way the restored-entity increment (#1200) was — **once, for every family**, since recoverability is a property of the piece rather than of the family reading across it:

- `build_match_string` gives a `CharRef::Replacement` leaf the entity the **built-in** backend renders it as (new `replacement_entity`: `&#169;` for `(C)`, `&#8217;` for `'`), which is precisely what the string pipeline's own haystack holds there from the replacements step onward. The leaf stays `atomic` (one indivisible node, never sliced) but becomes *recoverable*.
- `range_has_no_opaque_piece` admits it, its recoverability test mirroring the new arm's own guard so a hand-built node carrying a value no rule produces stays opaque on both sides.
- Nothing else changed: no builder, no family gate, no node kind, no side-effect pass. A computed value reads the replacement's bytes off the match string; a display text keeps the leaf as its own child through `macro_text_children`'s `emit_range` path.

One thing separates this class from a restored entity, and is why it is its own increment: the fold routes a replacement **through the renderer** (`render_character_replacement`) where an entity leaf is emitted verbatim. Using the canonical rendering for recognition is the same deliberate compromise `special_entity` has always made for an escaped special — a custom backend changes what the fold *emits*, not the recognition the AsciiDoc patterns were written against — and a new `replacement_entity_matches_the_built_in_renderer` test pins the table against `HtmlSubstitutionRenderer` so the two cannot drift.

The replacements step's own rule loop gains the same fidelity as a side effect: a later rule now matches over an earlier one's emitted bytes exactly as the string pipeline's sequential passes do, instead of over a placeholder.

## Tests

Three `…_is_a_documented_divergence` tests shed fixtures per the branch's "if lifted, fold this into a parity corpus" convention:

- the **bibliography label** over `(C)`/`'` — now its own parity test, asserting the *registered* reference text as well as the fold
- the **UI family**'s opaque-piece test
- the **e-mail family**'s abutting test, where an address after a replacement (`a(C)b@example.com`, whose `;` is no mismatch character) now links exactly as the string pipeline links it

The footnote-mirror skip test, which had reached for a replacement as its deferred form, is re-pointed at a masked passthrough.

New/extended differential corpora: per family, a target/id and a display or reference text crossing a replacement, an image's and a link's attribute list crossing one, a match crossing every recoverable class at once, doubled, in flow, inside a rendered span, beside a sibling family, escaped, and beside — rather than crossing — a replacement; plus structural companions pinning the recovered `CharRef::Replacement` child and the owned, coarsely-located attribute list a match-string parse yields. Fixtures also added to the whole-pipeline broad sweep and combined-constructs corpus, the synthesized-seed sweep, the attribute-reference corpus, and the structural recorder cross-check.

Re-running the corpus-wide audit confirms the divergence set strictly **shrank** (its unique set falls from 45 to 42) with no new source appearing. The categories that survive are unchanged from the last increment — the `subs=quotes,specialcharacters` policy item, the forms individual families already document as deferred, and the opaque-piece boundary itself, which is now purely a **rendered-markup** boundary: every piece it still rejects is one whose bytes exist only at fold time.

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5260 passed, 0 failed
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov` — every new line/region covered; the only misses in the touched files are pre-existing `other => panic!(…)` test-assertion arms and regex-capture short circuits

The design doc (§5.2 Phase 4 step 6) gains its "landed as" narrative paragraph and checklist entry, matching prior increments.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JQjzjeMEuhfdBBwvpqfHb)_