### PR TITLE
feat: Recognize a footnote whose text carries an escaped bracket (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3555,6 +3555,47 @@ Each phase is a reviewable unit with a clear exit gate.
   boundary: every piece it still rejects is one whose bytes exist only at fold time. As with every
   prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (a footnote's own escaped closing bracket):* with the opaque-piece
+  boundary reduced to fold-time-only markup, the next audit item is not a *piece* class at all but
+  one family's own last deferred **form**: a footnote whose bracket content carries an escaped
+  closing bracket (`footnote:[a note ending in a\]bracket]`). The string replacer unescapes it to a
+  literal `]` ([`normalize_footnote_text`](../../parser/src/content/macros.rs)); the builder left the
+  whole macro unrecognized, its own note reasoning that "unescaping it would mean splicing a literal
+  `]` into the middle of a `Text` piece the content range slices, which … would require rebuilding
+  part of the content's own node structure around the splice". A **blocker**, like the six audit
+  items before it, since four real golden sources exercise the form — including
+  `text footnote:[a [[b]] [[c\]\] d]` and an id-carrying definition whose two later
+  `footnote:id[]` references inherit its number, so failing to recognize the first left every one of
+  them unresolved.
+
+  What closes it is that the rebuild the note calls for was *already written*, for a different
+  family: the reference-bearing families' own
+  [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs) has expressed the
+  identical unescape as a **gap in the emitted ranges** — every byte but the backslash is emitted —
+  since the increment that gave a display text structured children. That loop is lifted out as the
+  shared [`emit_range_unescaping_brackets`](../../parser/src/content/inline_builder/macros/mod.rs)
+  and [`footnote_children`](../../parser/src/content/inline_builder/footnotes.rs) emits through it,
+  so the two families cannot drift on which backslashes pair off (`match_indices` scans
+  non-overlapping and left to right, exactly as the replacer's `replace` does). `footnote:[a \] b]`
+  becomes the two `'src`-borrowing `Text` children `a ` and `] b` — a gap, never an owned rebuild —
+  and the three `\]` gates (both `footnote:` branches and the `footnoteref:` form's whole bracket)
+  are deleted rather than relaxed. The catalog `text` this pass registers already went through
+  `normalize_footnote_text`, so it agreed with the string pipeline all along; a test now pins that
+  the subtree agrees with it. The one asymmetry is the `footnoteref:` form's **id** half, which the
+  string replacer takes from the raw bracket's first-comma split and never normalizes: an id
+  carrying a `\]` keeps its backslash on both sides, pinned by its own parity test.
+
+  Two `…_is_a_documented_divergence` tests shed their fixtures per the "if lifted, fold this into a
+  parity corpus" convention, becoming parity-plus-structure tests for both spellings. The footnote
+  differential corpus gains the escape in every position (interior, leading, trailing), doubled,
+  twice in one content, beside a construct the content captures as a node, beside an escaped
+  special, in a definition whose number a later reference reuses, in a pair whose second footnote's
+  number depends on the first being recognized, and under the macro's *own* escape; fixtures are
+  added to the whole-pipeline broad sweep, the combined-constructs corpus, and the structural
+  recorder cross-check. Re-running the corpus-wide fold-parity audit confirms the divergence set
+  strictly **shrank** — the four real golden sources are gone and no new one appeared. As with every
+  prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4025,6 +4066,19 @@ Each phase is a reviewable unit with a clear exit gate.
        `<<Cub => Tiger>>`). See the step's own "landed as" note above. With this the
        **opaque-piece** boundary — the only one any macro family draws — rejects nothing but
        pieces whose bytes exist at fold time alone.
+     - ✅ **prep (a footnote's escaped closing bracket).** The footnote family's own last deferred
+       form — a bracket content carrying a `\]`, which four real golden sources exercise — is
+       closed by the rebuild it had said it lacked: the reference-bearing families' own
+       gap-emitting unescape, lifted out of
+       [`macro_text_children`](../../parser/src/content/inline_builder/macros/mod.rs) as the shared
+       [`emit_range_unescaping_brackets`](../../parser/src/content/inline_builder/macros/mod.rs)
+       and emitted through by
+       [`footnote_children`](../../parser/src/content/inline_builder/footnotes.rs), so the
+       backslash is a gap between two `'src`-borrowing children rather than an owned rebuild and
+       the two families cannot drift on which backslashes pair off; see the step's own "landed as"
+       note above. The `footnoteref:` form's **id** half keeps its backslash on both sides (the
+       string replacer never normalizes it), pinned by its own parity test.
+
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1,8 +1,11 @@
 //! The footnote substitution step.
 
 use super::{
-    macros::{MacroMatch, MacroMatchKind, image::range_has_no_opaque_piece},
-    quotes::{Piece, build_match_string, emit_range, source_slice, text_slice},
+    macros::{
+        MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
+        image::range_has_no_opaque_piece,
+    },
+    quotes::{Piece, build_match_string, source_slice, text_slice},
 };
 use crate::{
     Parser, Span,
@@ -46,7 +49,7 @@ use crate::{
 /// before the first / after the last) — see [`rebuild_footnote_level`] and
 /// [`emit_range_recursing_footnotes`], which recurse in place of the generic
 /// [`rebuild_macro_level`](super::macros::rebuild_macro_level) /
-/// [`emit_range`]'s verbatim clone.
+/// [`emit_range`](super::quotes::emit_range)'s verbatim clone.
 pub(super) fn apply_footnotes<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -112,7 +115,8 @@ fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
 
 /// Like [`rebuild_macro_level`](super::macros::rebuild_macro_level), but for
 /// [`apply_footnotes`]: rebuilds a level's node list from its footnote matches,
-/// using [`emit_range_recursing_footnotes`] (not [`emit_range`]) for every gap,
+/// using [`emit_range_recursing_footnotes`] (not
+/// [`emit_range`](super::quotes::emit_range)) for every gap,
 /// so a [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref) child
 /// encountered between two matches is recursed into — in source order — rather
 /// than cloned whole.
@@ -181,7 +185,7 @@ fn rebuild_footnote_level<'src>(
     out
 }
 
-/// Like [`emit_range`], but recurses into a
+/// Like [`emit_range`](super::quotes::emit_range), but recurses into a
 /// [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref) piece's
 /// children with [`apply_footnotes`] instead of cloning the node whole — the
 /// piece that makes [`apply_footnotes`] a true whole-tree, source-order walk
@@ -232,7 +236,7 @@ fn emit_range_recursing_footnotes<'src>(
         }
 
         // A verbatim or synthesized text run: slice it to the overlap (see
-        // [`emit_range`]'s own synthesized branch).
+        // [`emit_range`](super::quotes::emit_range)'s own synthesized branch).
         let lo = range.start.max(p_start) - p_start;
         let hi = range.end.min(p_end) - p_start;
 
@@ -365,16 +369,15 @@ fn find_footnote_matches<'src>(
 /// `Document::catalog().footnotes()` entry is not yet byte-faithful; only the
 /// returned *number*, this pass's one load-bearing side effect, is relied on.
 ///
-/// # Deferred forms
+/// # Content carrying an escaped closing bracket
 ///
-/// - Content containing an escaped closing bracket (`\]`): unescaping it would
-///   mean splicing a literal `]` into the middle of a `Text` piece the content
-///   range slices, which — unlike a single-node substitution such as `xref`'s
-///   escaped text — would require rebuilding part of the content's own node
-///   structure around the splice; deferred, exactly as the anchor and
-///   cross-reference macros defer their own escaped-bracket forms when they
-///   cannot represent them without a similar rebuild (divergence test:
-///   `a_footnote_with_an_escaped_bracket_is_a_documented_divergence`).
+/// A content bracket may carry an escaped closing bracket (`\]`), which the
+/// string replacer unescapes to a literal `]` ([`normalize_footnote_text`]).
+/// The subtree carries it the same way: [`footnote_children`] emits the
+/// content through the reference-bearing families' own
+/// [`emit_range_unescaping_brackets`], which drops each backslash as a *gap*
+/// in the ranges it emits rather than rebuilding the pieces around it — see
+/// that helper for why a per-node `replace` cannot express the same unescape.
 fn build_footnote_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
@@ -416,11 +419,7 @@ fn build_footnote_node<'src>(
         return match content_match {
             Some(content) => {
                 // A defining occurrence that also carries an id.
-                if s[content.range()].contains("\\]") {
-                    return None;
-                }
-
-                let children = footnote_children(content.range(), pieces, nodes);
+                let children = footnote_children(content.range(), s, pieces, nodes);
                 let number = register_footnote_number(
                     parser,
                     Some(id.as_ref()),
@@ -454,11 +453,7 @@ fn build_footnote_node<'src>(
     // An anonymous defining occurrence.
     let content = content_match?;
 
-    if s[content.range()].contains("\\]") {
-        return None;
-    }
-
-    let children = footnote_children(content.range(), pieces, nodes);
+    let children = footnote_children(content.range(), s, pieces, nodes);
     let number = register_footnote_number(parser, None, &s[content.range()], location);
 
     Some(InlineNode::Footnote(Footnote {
@@ -485,9 +480,12 @@ fn build_footnote_node<'src>(
 /// [`build_footnote_node`] does (reuse an already-defined id's number, define
 /// a new id-carrying occurrence, or fall back to an unresolved reference) —
 /// see that function's own doc comment for the shared reasoning (the
-/// required `footnote_index_for_id`/`define_footnote` side effect, and why a
-/// content-side `\]` is deferred, which applies here identically since `raw`
-/// is matched by the very same bracket group).
+/// required `footnote_index_for_id`/`define_footnote` side effect, and how a
+/// content-side `\]` is unescaped, which applies here identically since `raw`
+/// is matched by the very same bracket group). The **id** half is the one
+/// place the two differ: the string replacer splits the *raw* bracket on its
+/// first comma and never normalizes what precedes it, so an id carrying a `\]`
+/// keeps its backslash — as the id [`footnote_id_text`] recovers does.
 ///
 /// The one thing this increment does **not** yet do is the deprecation
 /// warning `InlineFootnoteMacroReplacer` records outside `compat-mode`: like
@@ -505,10 +503,6 @@ fn build_footnoteref_node<'src>(
     parser: &Parser,
 ) -> Option<InlineNode<'src>> {
     let location = source_slice(pieces, full.clone(), root);
-
-    if s[raw.range()].contains("\\]") {
-        return None;
-    }
 
     // Split on the first comma: `id` is everything before it (the whole raw
     // text when there is no comma at all), `content` is everything after it
@@ -549,7 +543,7 @@ fn build_footnoteref_node<'src>(
     match content_range {
         Some(content_range) => {
             // A defining occurrence that also carries an id.
-            let children = footnote_children(content_range.clone(), pieces, nodes);
+            let children = footnote_children(content_range.clone(), s, pieces, nodes);
             let number =
                 register_footnote_number(parser, Some(id.as_ref()), &s[content_range], location);
 
@@ -611,26 +605,45 @@ fn footnote_id_text<'src>(
 }
 
 /// Builds a footnote's `children` from its bracket content's match-string
-/// `range` via [`emit_range`] — *not*
+/// `range` via [`emit_range_unescaping_brackets`] — *not*
 /// [`range_is_verbatim`](super::macros::image::range_is_verbatim) the way every
 /// other macro family's target/text slicing does. A footnote's content
 /// becomes structured children rather than a literal attribute value, so a
 /// range crossing an already-recognized construct is not a boundary to defer
-/// on; it is the whole point — `emit_range` clones that construct's node
+/// on; it is the whole point — the emitter clones that construct's node
 /// whole into the footnote's subtree, exactly mirroring how the string
 /// pipeline's footnote text captures an already-substituted macro verbatim
-/// (see [`apply_footnotes`]'s doc comment on ordering). This uses the plain
-/// [`emit_range`], not the recursing [`emit_range_recursing_footnotes`] —
-/// footnotes do not nest (the string pipeline's own lazy bracket match cannot
-/// recognize one inside another's content either, since it always stops at
-/// the *first* unescaped `]`), so a footnote's own content is captured as-is.
+/// (see [`apply_footnotes`]'s doc comment on ordering). It emits through the
+/// plain [`emit_range`](super::quotes::emit_range), not the recursing
+/// [`emit_range_recursing_footnotes`] — footnotes do not nest (the string
+/// pipeline's own lazy bracket match cannot recognize one inside another's
+/// content either, since it always stops at the *first* unescaped `]`), so a
+/// footnote's own content is captured as-is.
+///
+/// # The `\]` unescape
+///
+/// A bracket's content may carry an **escaped closing bracket** (`\]`), which
+/// [`normalize_footnote_text`] — the string replacer's own normalization, and
+/// the one this pass registers the catalog `text` through — turns back into a
+/// literal `]`. The subtree must carry the same text, so the shared
+/// [`emit_range_unescaping_brackets`] drops each backslash as a *gap* in the
+/// ranges it emits: `footnote:[a \] b]` becomes the two `'src`-borrowing
+/// [`Text`](InlineNode::Text) children `a ` and `] b`, never an owned rebuild.
+/// Sharing the reference-bearing families' own helper is what keeps the two
+/// readings of "which backslashes pair off" from drifting; it is also why this
+/// form is no longer deferred (recognizing it once meant splicing a literal
+/// `]` into the middle of a `Text` piece, which nothing here could then
+/// express).
 fn footnote_children<'src>(
     range: std::ops::Range<usize>,
+    s: &str,
     pieces: &[Piece],
     nodes: &[InlineNode<'src>],
 ) -> Vec<InlineNode<'src>> {
     let mut children = Vec::new();
-    emit_range(nodes, pieces, range, &mut children);
+
+    emit_range_unescaping_brackets(&s[range.clone()], range, nodes, pieces, &mut children);
+
     children
 }
 
@@ -840,6 +853,34 @@ mod tests {
             "footnoteref:[]",
             "\\footnoteref:[disc,a discussion]",
             "footnoteref:[disc,the *strong* evidence]",
+            // An escaped closing bracket (`\\]`) in the content: the bracket
+            // group runs past it and both sides unescape it the same way — in
+            // every position (interior, leading, trailing), doubled, more than
+            // once in one content, in both spellings, and beside a construct
+            // the content captures as a node rather than as text.
+            "footnote:[a note ending in a\\]bracket]",
+            "footnote:disc[a note ending in a\\]bracket]",
+            "footnote:[\\]]",
+            "footnote:[\\]leading]",
+            "footnote:[trailing\\]]",
+            "footnote:[a \\]\\] b]",
+            "footnote:[a \\] b \\] c]",
+            "footnoteref:[disc,a note ending in a\\]bracket]",
+            // No comma at all: the whole (still-escaped) bracket is the id of
+            // an unresolved reference, which the string replacer never
+            // normalizes.
+            "footnoteref:[a note ending in a\\]bracket]",
+            "footnote:[the *strong* \\] evidence]",
+            "footnote:[an escaped \\] beside a < special]",
+            // A defining occurrence carrying one, then a bare reference to it:
+            // the number the first assigns is the one the second reuses.
+            "Named.footnote:disc[a \\] note] then footnote:disc[].",
+            // Two anonymous ones, the first carrying an escaped bracket:
+            // recognizing it is what keeps the second numbered `2`.
+            "one footnote:[a \\] note] two footnote:[b]",
+            // The escape of the *macro itself* still wins over the bracket's
+            // own escape.
+            "\\footnote:[a \\] note]",
         ];
 
         let renderer = HtmlSubstitutionRenderer {};
@@ -1088,45 +1129,95 @@ mod tests {
     }
 
     #[test]
-    fn a_footnoteref_macro_with_an_escaped_bracket_is_a_documented_divergence() {
-        // The same escaped-closing-bracket boundary
-        // `a_footnote_with_an_escaped_bracket_is_a_documented_divergence`
-        // documents for `footnote:`, since `build_footnoteref_node` checks
-        // its own captured `raw` text the same way.
+    fn a_footnoteref_macro_with_an_escaped_bracket_unescapes_its_content() {
+        // The same unescape
+        // `a_footnote_with_an_escaped_bracket_unescapes_it_into_the_subtree`
+        // pins for `footnote:`, through `build_footnoteref_node`'s own
+        // (identical) bracket group.
         let source = "footnoteref:[disc,a note ending in a\\]bracket]";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, golden_macros(source));
+
         let nodes = build_src(Span::new(source));
-
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
-            "a footnoteref: macro with an escaped bracket must be left unrecognized: {nodes:?}"
-        );
-
-        assert!(golden_macros(source).contains("class=\"footnote\""));
+        let footnote = assert_footnote(&nodes[0]);
+        assert_eq!(footnote.id.as_deref(), Some("disc"));
+        assert_eq!(footnote.children.len(), 2);
+        assert_text(&footnote.children[0], "a note ending in a", 1, 19);
+        assert_text(&footnote.children[1], "]bracket", 1, 38);
     }
 
     #[test]
-    fn a_footnote_with_an_escaped_bracket_is_a_documented_divergence() {
-        // Content carrying an escaped closing bracket (`\]`) needs it unescaped
-        // to a literal `]` in the middle of the content's own node structure —
-        // deferred, exactly as the anchor and cross-reference macros defer
-        // their own escaped-bracket forms when they cannot represent the
-        // unescape without a similar rebuild. Both the anonymous form and the
-        // id-carrying form share the same check (see `build_footnote_node`),
-        // so both are exercised here.
-        for source in [
-            "footnote:[a note ending in a\\]bracket]",
-            "footnote:disc[a note ending in a\\]bracket]",
-        ] {
-            let nodes = build_src(Span::new(source));
+    fn a_footnoteref_id_keeps_its_own_escaped_bracket() {
+        // The id half is the one place the two forms differ: the string
+        // replacer splits the *raw* bracket on its first comma and never
+        // normalizes what precedes it, so an id carrying a `\]` keeps its
+        // backslash — and, with no comma at all, the whole bracket is that id
+        // (an unresolved reference, rendered as written).
+        let source = "footnoteref:[a note ending in a\\]bracket]";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Footnote(_))),
-                "a footnote with an escaped bracket must be left unrecognized: {nodes:?}"
+        assert_eq!(folded, golden_macros(source));
+
+        let nodes = build_src(Span::new(source));
+        let footnote = assert_footnote(&nodes[0]);
+        assert_eq!(footnote.id.as_deref(), Some("a note ending in a\\]bracket"));
+        assert!(footnote.is_reference);
+        assert!(footnote.number.is_none());
+    }
+
+    #[test]
+    fn a_footnote_with_an_escaped_bracket_unescapes_it_into_the_subtree() {
+        // Content carrying an escaped closing bracket (`\]`) is recognized:
+        // the string replacer unescapes it to a literal `]`
+        // (`normalize_footnote_text`) and the subtree carries the same text,
+        // `footnote_children` dropping the backslash as a *gap* in the ranges
+        // it emits (see `emit_range_unescaping_brackets`). Both the anonymous
+        // form and the id-carrying form share that path, so both are
+        // exercised here.
+        for (source, text_col) in [
+            ("footnote:[a note ending in a\\]bracket]", 11),
+            ("footnote:disc[a note ending in a\\]bracket]", 15),
+        ] {
+            let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+            assert_eq!(
+                folded,
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
             );
 
-            // The string pipeline, by contrast, does build a footnote marker here.
-            assert!(golden_macros(source).contains("class=\"footnote\""));
+            let nodes = build_src(Span::new(source));
+            let footnote = assert_footnote(&nodes[0]);
+            assert!(!footnote.is_reference);
+            assert_eq!(footnote.number.as_deref(), Some("1"));
+
+            // The backslash is a gap between two `'src`-borrowing runs, not an
+            // owned rebuild of the whole text.
+            assert_eq!(footnote.children.len(), 2);
+            assert_text(&footnote.children[0], "a note ending in a", 1, text_col);
+            assert_text(&footnote.children[1], "]bracket", 1, text_col + 19);
         }
+    }
+
+    #[test]
+    fn an_escaped_bracket_reaches_the_footnote_catalog_unescaped() {
+        // The catalog `text` this pass registers goes through the string
+        // replacer's own `normalize_footnote_text`, so it carries the literal
+        // `]` the subtree now does — the two readings of the same content
+        // agree.
+        let parser = crate::Parser::default();
+        let _nodes = super::super::build(
+            Span::new("footnote:[a note ending in a\\]bracket]"),
+            &parser,
+            None,
+        );
+
+        let catalog = parser.catalog();
+        let footnotes = catalog.footnotes();
+
+        assert_eq!(footnotes.len(), 1);
+        assert_eq!(footnotes[0].text, "a note ending in a]bracket");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -454,36 +454,59 @@ pub(super) fn macro_text_children<'src>(
             // callers' gate admits) — or, degenerately, is a range `text_slice`
             // declined to recover. Rebuild it out of the nodes it covers, so each
             // special stays the `CharRef` it already is.
-            //
-            // The macro forms' `\]` unescape is expressed here as a *gap* in the
-            // emitted ranges — every byte but the backslash is emitted — rather
-            // than as a `replace` over each recovered node. Doing it per node would
-            // miss a pair astride two adjacent runs, which two `Text` nodes can be
-            // without an atomic piece between them: an attribute expansion splices
-            // its value as its own node, so a value ending in a backslash followed
-            // by a literal `]` (`:t: b\`, then `xref:foo[a<{t}]x]`) puts the two
-            // characters in different runs. Skipping the backslash by range is
-            // boundary-agnostic, and leaves every surviving fragment borrowing
-            // `'src` (§4.5) where a rebuilt value would have had to own its bytes.
             let mut children = Vec::new();
-            let mut cursor = text_range.start;
 
             if unescape_bracket {
-                // `match_indices` scans non-overlapping and left to right, exactly
-                // as `str::replace` does, so a run of backslashes pairs off
-                // identically.
-                for (offset, _) in raw_text.match_indices("\\]") {
-                    let backslash = text_range.start + offset;
-                    emit_range(nodes, pieces, cursor..backslash, &mut children);
-                    cursor = backslash + 1;
-                }
+                emit_range_unescaping_brackets(raw_text, text_range, nodes, pieces, &mut children);
+            } else {
+                emit_range(nodes, pieces, text_range, &mut children);
             }
-
-            emit_range(nodes, pieces, cursor..text_range.end, &mut children);
 
             children
         }
     }
+}
+
+/// Emits the nodes `range` covers into `out` (as [`emit_range`] does), with
+/// each **escaped closing bracket**'s backslash dropped — the `\]` unescape
+/// every bracket-bearing macro form performs, expressed structurally.
+///
+/// `raw_text` is the level's own match-string slice for `range` (the bytes the
+/// string replacer's `replace("\\]", "]")` runs over), so the two agree on
+/// which backslashes pair off: [`str::match_indices`] scans non-overlapping and
+/// left to right, exactly as [`str::replace`] does, so a run of backslashes
+/// resolves identically on both sides.
+///
+/// The unescape is a *gap* in the emitted ranges — every byte but the backslash
+/// is emitted — rather than a `replace` over each recovered node. Doing it per
+/// node would miss a pair astride two adjacent runs, which two
+/// [`Text`](InlineNode::Text) nodes can be without an atomic piece between
+/// them: an attribute expansion splices its value as its own node, so a value
+/// ending in a backslash followed by a literal `]` (`:t: b\`, then
+/// `xref:foo[a<{t}]x]`) puts the two characters in different runs. Skipping the
+/// backslash by range is boundary-agnostic, and leaves every surviving fragment
+/// borrowing `'src` (§4.5) where a rebuilt value would have had to own its
+/// bytes.
+///
+/// Shared with the footnote family — whose content is *always* structured
+/// children, so it has no one-`Text` fast path to take the unescape through —
+/// so the two cannot drift on it.
+pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
+    raw_text: &str,
+    range: std::ops::Range<usize>,
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+    out: &mut Vec<InlineNode<'src>>,
+) {
+    let mut cursor = range.start;
+
+    for (offset, _) in raw_text.match_indices("\\]") {
+        let backslash = range.start + offset;
+        emit_range(nodes, pieces, cursor..backslash, out);
+        cursor = backslash + 1;
+    }
+
+    emit_range(nodes, pieces, cursor..range.end, out);
 }
 
 /// Rebuilds an **already-escaped computed value** — a value a family read off

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -218,13 +218,20 @@
 //!   `build_footnote_node`). Its content becomes structured children via
 //!   [`emit_range`](quotes::emit_range) rather than a literal attribute value,
 //!   so — unlike the other families — a content crossing an already-recognized
-//!   construct is not deferred: nesting is the point. The deprecated
-//!   `footnoteref:[id,text]` / `footnoteref:[id]` form
+//!   construct is not deferred: nesting is the point. A content carrying an
+//!   **escaped closing bracket** (`\]`) is recognized too, the backslash
+//!   dropped as a *gap* in the emitted ranges by the reference-bearing
+//!   families' own
+//!   [`emit_range_unescaping_brackets`](macros::emit_range_unescaping_brackets),
+//!   so the subtree carries the literal `]` the string replacer's
+//!   [`normalize_footnote_text`](crate::content::normalize_footnote_text)
+//!   produces. The deprecated `footnoteref:[id,text]` / `footnoteref:[id]` form
 //!   (`build_footnoteref_node`) is recognized too, splitting its one bracket on
-//!   the first comma rather than taking an id from the macro target; only its
-//!   own deprecation warning (a diagnostic, deferred to the cutover like every
-//!   other family's) and a content carrying an escaped closing bracket (`\]`)
-//!   remain deferred. The bibliography-anchor form is a later increment.
+//!   the first comma rather than taking an id from the macro target (an id, the
+//!   one half the string replacer never normalizes, keeps its own `\]`); only
+//!   its own deprecation warning (a diagnostic, deferred to the cutover like
+//!   every other family's) remains deferred. The bibliography-anchor form is a
+//!   later increment.
 //! - [`apply_stem`] recognizes **inline STEM macros** (`stem:[…]`,
 //!   `asciimath:[…]`, `latexmath:[…]`), replacing each with a
 //!   [`Stem`](InlineNode::Stem) leaf. Like [`apply_passthroughs`], it is an
@@ -729,6 +736,8 @@ mod tests {
             "Named.footnote:disc[a discussion] then footnote:disc[].",
             "A claim.footnote:[the *strong* evidence and a link:https://e.org[source]]",
             "Two notes.footnote:[first] and again.footnote:[second]",
+            r"A claim.footnote:[see \[the appendix\]] here.",
+            r"footnoteref:[disc,a note ending in a\]bracket]",
             "Press kbd:[Ctrl+T] now.",
             "Press kbd:[Ctrl,Shift,N] now.",
             "Click btn:[Save] please.",
@@ -826,6 +835,11 @@ mod tests {
             "See <<intro>> for details.footnote:[Also check the {product} docs.]",
             with_product,
         );
+
+        // A footnote whose text carries an escaped closing bracket, beside a
+        // second one that carries none: the bracket group runs past the escape
+        // on both sides, so the two are numbered alike.
+        assert_parity("A claim.footnote:[see \\[the appendix\\]] and one more.footnote:[q.e.d.]");
 
         // A delimited passthrough beside a quoted span and an image macro.
         assert_parity("+++<u>raw</u>+++ combined with *bold* and image:foo.png[Alt Text].");

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -758,6 +758,8 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "Named.footnote:disc[a discussion] then footnote:disc[].",
         "A claim.footnote:[the *strong* evidence and a link:https://e.org[source]]",
         "Two notes.footnote:[first] and again.footnote:[second]",
+        r"A claim.footnote:[see \[the appendix\]] here.",
+        r"footnoteref:[disc,a note ending in a\]bracket]",
         "Press kbd:[Ctrl+T] now.",
         "Press kbd:[Ctrl,Shift,N] now.",
         "Click btn:[Save] please.",


### PR DESCRIPTION
The next increment on the `inline-ast` branch: the **footnote family's own last deferred form** — a bracket content carrying an escaped closing bracket (`footnote:[a note ending in a\]bracket]`).

## Why

With #1210 the opaque-piece boundary rejects nothing but pieces whose bytes exist at fold time alone, so the next corpus-wide fold-parity audit item is not a *piece* class at all but one family's own deferred **form**. The string replacer unescapes a content-side `\]` to a literal `]` (`normalize_footnote_text`); the builder left the whole macro unrecognized, its own note reasoning that

> unescaping it would mean splicing a literal `]` into the middle of a `Text` piece the content range slices, which … would require rebuilding part of the content's own node structure around the splice

A **blocker**, like the six audit items before it, since four **real golden sources** exercise the form:

- `footnote:[a \] b].`
- `footnote:[\]]` / `footnote:[a \] b]` / `footnote:[a \]\] b]`
- `text footnote:[a [[b]] [[c\]\] d]` — the escape beside a captured anchor node
- `notable text.footnote:id[about this [text\]], footnote:id[], footnote:id[]` — an id-carrying definition whose two later references inherit its number, so failing to recognize the first left **all three** unresolved

## What changed

The rebuild that note called for was **already written**, for a different family: `macro_text_children` has expressed the identical unescape as a **gap in the emitted ranges** — every byte but the backslash is emitted — since the increment that gave a display text structured children.

- That loop is lifted out as the shared `emit_range_unescaping_brackets` (`macros/mod.rs`), and `footnote_children` emits through it, so the two families cannot drift on which backslashes pair off (`match_indices` scans non-overlapping and left to right, exactly as the replacer's `replace` does).
- `footnote:[a \] b]` becomes the two `'src`-borrowing `Text` children `a ` and `] b` — a gap, never an owned rebuild.
- The three `\]` gates (both `footnote:` branches and the `footnoteref:` form's whole bracket) are **deleted** rather than relaxed.

The catalog `text` this pass registers already went through `normalize_footnote_text`, so it agreed with the string pipeline all along; a test now pins that the subtree agrees with it too.

The one asymmetry is the `footnoteref:` form's **id** half, which the string replacer takes from the raw bracket's first-comma split and never normalizes: an id carrying a `\]` keeps its backslash on both sides, pinned by its own parity test.

No node kind, no family gate, and no side-effect pass changed.

## Tests

Two `…_is_a_documented_divergence` tests shed their fixtures per the branch's "if lifted, fold this into a parity corpus" convention, becoming parity-plus-structure tests for both spellings, alongside a new catalog-agreement test and a `footnoteref:` id test.

The footnote differential corpus gains the escape in every position (interior, leading, trailing), doubled, twice in one content, beside a construct the content captures as a node, beside an escaped special, in a definition whose number a later reference reuses, in a pair whose second footnote's number depends on the first being recognized, and under the macro's *own* escape. Fixtures are also added to the whole-pipeline broad sweep, the combined-constructs corpus, and the structural recorder cross-check.

Re-running the corpus-wide audit (tree building forced on for every parse in the suite, each content's tree folded and compared against its own rendered string) confirms the divergence set strictly **shrank**: the four real golden sources are gone and no new one appeared.

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5263 passed, 0 failed
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov` — every new line/region covered; the only misses in the touched files are pre-existing defensive `continue` guards and `other => panic!(…)` test-assertion arms

The design doc (§5.2 Phase 4 step 6) gains its "landed as" narrative paragraph and checklist entry, matching prior increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HVpSHfczxkanSZEnMbGTB

---
_Generated by [Claude Code](https://claude.ai/code/session_016HVpSHfczxkanSZEnMbGTB)_