### PR TITLE
feat: Escape a markup-producing step's own tags under a late-escaping order (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3596,6 +3596,77 @@ Each phase is a reviewable unit with a clear exit gate.
   strictly **shrank** — the four real golden sources are gone and no new one appeared. As with every
   prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (an order that escapes **after** a markup-producing step — the last
+  category the audit's own map named):* the corpus-wide audit's itemized map ended with one
+  category no recognition or classification increment could close: "an effective order that runs
+  `SpecialCharacters` **after** a step that already produced markup (`subs=quotes,
+  specialcharacters`), where the string pipeline escapes the very tags the earlier step emitted.
+  That last one is structurally different from the rest, and harder: a tree whose markup exists
+  only at fold time has no rendered tags for a later escaping step to act on, so it needs its own
+  policy rather than another recognition increment." That policy is settled here, and it is a
+  short one: **reach fold time for that one node, early.**
+
+  [`flatten_prior_markup`](../../parser/src/content/inline_builder/special_chars.rs) runs
+  immediately ahead of [`apply_special_characters`](../../parser/src/content/inline_builder/special_chars.rs)
+  whenever the escaping step is not the order's first — never for a built-in group, every one of
+  which escapes first, so this is a `subs=` list's question alone. Each node an earlier step of the
+  same order already turned into markup is folded through the configured renderer and the result
+  becomes one [`Text`](../../parser/src/inlines/inline_node.rs) node's value, which the escaping
+  step then splits like any other text. Nothing new is invented for it: a `Text` node is *logical*
+  text the fold escapes (§3.4), so the single escape lands exactly where the string pipeline's does,
+  and "a node's value is already-substituted text" is the same seam a delimited passthrough's and a
+  STEM expression's body already use — the only place this module consults the renderer while
+  building. It is also what the document genuinely says under such an order: the content is no
+  longer a strong span, it is text that reads like a tag, and the tree now holds it as such (pinned
+  by a structural test, not only by the fold's bytes).
+
+  The one subtlety is *which* bytes that early fold must produce. The string pipeline's haystack at
+  that moment holds `<strong>a < b</strong>` — the tags written, the author's own specials **not
+  yet escaped**, both escaped together by the one pass that follows. A finished fold would escape
+  the children on the way out, so `as_pre_escape` rewrites every `Text` run nested *inside* the node
+  as a [`Raw`](../../parser/src/inlines/inline_node.rs) leaf ("emit verbatim") first; every other
+  leaf already carries its own already-substituted bytes (a `CharRef` an earlier `replacements` step
+  built, a `LineBreak` `post_replacements` wrote) and needs no rewrite.
+
+  What must **not** be folded is what the string pipeline is holding as a *placeholder* rather than
+  as markup at that point, since no escaping step acts on those either: a passthrough body or inline
+  STEM expression (extracted ahead of every step, restored after the last one) and a **deferred
+  cross-reference** (recorded by the macros step as an `XrefSegment`, rendered by
+  [`Content::finalize_deferred`](../../parser/src/content/content.rs) once every step has run —
+  which is why `subs=macros,specialcharacters` emits an unescaped `<a href="#sec">` where it escapes
+  a link's). A leaf says which it is by its own node kind; the one *container* the extraction pass
+  builds — an attribute-list-prefixed passthrough's own `Styled` wrapper — is told from a
+  quotes-step span by `masked_locations`, a set of identities collected from the tree extraction
+  produced, before any step ran (sound because extraction recognizes only a wholly verbatim match,
+  so each such node carries an honest `'src` span no later step's node can claim).
+
+  Two shapes stay divergent, each pinned by its own test. A placeholder construct **nested inside**
+  such a node (`*a +++<x>+++ b*`, `*see xref:sec[S] now*`, `link:index.html[a +++<b>+++ c]`) leaves
+  the whole node unflattened: folding it would inline the placeholder's content into the escaped
+  text, where the string pipeline escapes *around* the placeholder and restores it unescaped
+  afterwards — and splitting one node's fold back around its placeholder descendants is the sentinel
+  mechanism itself, which this module deliberately does not have. And a `link:`/`mailto:` **macro**
+  written inside flattened markup (`*a link:index.html[Docs] b*` under
+  `subs=quotes,specialcharacters,macros`) is a boundary this policy *inherits* rather than
+  introduces: the flattened run is synthesized, and that one pass alone requires its own marker to be
+  verbatim so [`link_form`](../../parser/src/content/inline_builder/macros/links.rs) can replay the
+  string pipeline's family-pass registration order — the same boundary a wholly expanded `{m}` macro
+  already has. Every other family reads what it needs from the level's match string and is recognized
+  in flattened text exactly as the string pipeline recognizes it in the escaped tags (an auto-link, an
+  image, an anchor, an index term, and a footnote are each pinned doing so).
+
+  A differential corpus crosses markup-bearing fixtures with the real `subs=` lists that reverse the
+  two steps: each markup-producing step ahead of the escaping one on its own (`quotes`,
+  `replacements`, `macros`, `post_replacements`, `callouts`), several together, an expanding step
+  ahead of both, a multi-line content, and the orders that additionally run a step *after* the
+  escaping one — so the flattened text is what those later steps read, exactly as the string
+  pipeline's later steps read the escaped tags. Re-running the corpus-wide fold-parity audit (tree
+  building forced on for every parse in the suite) confirms the divergence set strictly **shrank**:
+  the category's own source is gone and no pre-existing one appeared (the set's only additions are
+  this increment's own new divergence-pinning fixtures). With it, every item the audit's map named
+  is closed. As with every prep piece before it, nothing further is wired in: `rendered_html()`
+  remains the string pipeline's own string.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4010,8 +4081,8 @@ Each phase is a reviewable unit with a clear exit gate.
        `SpecialCharacters` step to split — §3.4.1 applied to the step's *position*, not merely its
        presence; see the step's own "landed as" note above. The category's other half — a
        markup-producing step (`subs=quotes,specialcharacters`) whose emitted tags the escaping step
-       acts on — needs a policy of its own rather than another classification, and stays deferred
-       with its own divergence test.
+       acts on — needs a policy of its own rather than another classification, and is closed by the
+       increment directly below.
      - ✅ **prep (a footnote inside an expanded value).** The last family to make that lift, and the
        only one that was not deferring but building a **wrong node**: the footnote family has no
        gate, so it always recognized such a macro and read its id through `source_slice`, whose
@@ -4078,6 +4149,23 @@ Each phase is a reviewable unit with a clear exit gate.
        the two families cannot drift on which backslashes pair off; see the step's own "landed as"
        note above. The `footnoteref:` form's **id** half keeps its backslash on both sides (the
        string replacer never normalizes it), pinned by its own parity test.
+     - ✅ **prep (an order that escapes after a markup-producing step).** The audit map's last
+       item, and the one category no recognition or classification increment could close: under
+       `subs=quotes,specialcharacters` the string pipeline escapes the tags the quotes step already
+       wrote, while a tree's markup exists only at fold time. The policy is to reach fold time for
+       that one node early —
+       [`flatten_prior_markup`](../../parser/src/content/inline_builder/special_chars.rs) folds each
+       node an earlier step of the same order turned into markup and keeps the result as one
+       [`Text`](../../parser/src/inlines/inline_node.rs) node's value, which the escaping step then
+       splits like any other text, so §3.4's single escape lands exactly where the string
+       pipeline's does. Nodes the string pipeline holds as a *placeholder* at that moment — a
+       passthrough or STEM body, and a **deferred cross-reference** — are excluded, told apart by
+       node kind or (for an attribute-list-prefixed passthrough's own `Styled` wrapper) by
+       `masked_locations`, collected before any step ran. What defers is such a construct *nested
+       inside* a flattened node, and a `link:`/`mailto:` macro written inside flattened markup (the
+       family's own pre-existing verbatim-marker rule), each with its own divergence test. See the
+       step's own "landed as" note above. With this every item the corpus-wide audit's map named is
+       closed.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -367,7 +367,9 @@ use macros::apply_macros;
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
-use special_chars::{apply_special_characters, classify_unescaped_specials};
+use special_chars::{
+    apply_special_characters, classify_unescaped_specials, flatten_prior_markup, masked_locations,
+};
 use stem_step::apply_stem;
 
 use crate::{
@@ -514,9 +516,41 @@ pub(crate) fn build_for_group<'src>(
         nodes = apply_stem(nodes, location, parser);
     }
 
+    // A `subs=` list can put the escaping step *after* a step that already
+    // produced markup, and there the string pipeline escapes the tags that
+    // step wrote. Recording what the extraction pass masked — before any step
+    // runs — is what lets `flatten_prior_markup` tell those tags from a
+    // passthrough body the escaping step never touches; see its own doc
+    // comment. The walk is skipped entirely for the overwhelmingly common
+    // order that escapes first (or never).
+    let escapes_late = steps
+        .iter()
+        .position(|step| step == &SubstitutionStep::SpecialCharacters)
+        .is_some_and(|position| position > 0);
+
+    let masked = if escapes_late {
+        masked_locations(&nodes)
+    } else {
+        vec![]
+    };
+
     for (position, step) in steps.iter().enumerate() {
         nodes = match step {
-            SubstitutionStep::SpecialCharacters => apply_special_characters(nodes),
+            SubstitutionStep::SpecialCharacters => {
+                // Design §3.4.1, applied to this step's own *position*:
+                // anything an earlier step of this order already turned into
+                // markup is logical text by the time the escaping step reaches
+                // it (see `flatten_prior_markup`). A no-op when this step runs
+                // first — every built-in group's order — and equally when the
+                // steps ahead of it produced nothing but text.
+                let nodes = if position == 0 {
+                    nodes
+                } else {
+                    flatten_prior_markup(nodes, &masked, &*parser.renderer, parser)
+                };
+
+                apply_special_characters(nodes)
+            }
 
             SubstitutionStep::Quotes => apply_quotes(nodes, location, parser),
 
@@ -1888,38 +1922,310 @@ mod tests {
             }
         }
 
-        /// The other half of "an order that escapes late", pinned as a
-        /// documented divergence rather than closed: a step that produces
-        /// **markup** ahead of the escaping one.
+        /// The other half of "an order that escapes late", closed by
+        /// [`flatten_prior_markup`](super::super::special_chars::flatten_prior_markup):
+        /// a step that produces **markup** ahead of the escaping one.
         ///
         /// `subs=quotes,specialcharacters` runs the quotes step first, so the
         /// string pipeline holds `<strong>bold</strong>` by the time
         /// `specialcharacters` runs — and escapes those very tags, emitting
         /// `&lt;strong&gt;bold&lt;/strong&gt;`. A tree has no rendered tags at
         /// that point: a [`Styled`](crate::inlines::Styled) span's markup
-        /// exists only at fold time, so there is nothing for the escaping
-        /// transducer to act on and the fold emits a real `<strong>` element.
+        /// exists only at fold time. The policy is to reach fold time for that
+        /// one node early — folding it through the configured renderer and
+        /// keeping the result as one [`Text`](InlineNode::Text) node's value,
+        /// which the escaping step then splits like any other text.
         ///
-        /// That is structurally unlike the spliced-value case the corpus above
-        /// closes, where the fragment *is* text at the moment the step runs and
-        /// §3.4.1 only has to say which leaf kind it becomes. Deciding what a
-        /// tree should even hold here — a `Styled` node whose fold is escaped,
-        /// or pre-rendered text that abandons the structure — is a policy
-        /// question of its own, and the design doc names it as such (§5.2,
-        /// Phase 4 step 6). Both spellings of the order are pinned here,
-        /// including the nested one a `pass:q,c[…]` passthrough reaches.
-        ///
-        /// The author's own specials are already right on both sides, so the
-        /// fixture asserts exactly where the two part company.
+        /// The corpus crosses markup-producing fixtures with the real `subs=`
+        /// lists that can reverse the two: each markup-producing step ahead of
+        /// the escaping one on its own, several of them together, and the
+        /// orders that additionally run a step *after* it (so the flattened
+        /// text is what those later steps see, exactly as the string
+        /// pipeline's own later steps read the escaped tags).
         #[test]
-        fn a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence() {
+        fn a_markup_producing_step_before_the_escaping_one_folds_its_markup_escaped() {
+            let custom = |subs: &str| {
+                let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs);
+                assert!(invalid.is_empty(), "unexpected invalid subs in {subs:?}");
+                group
+            };
+
+            // The fixture that pinned this as a divergence until the policy
+            // landed: the author's own `<b>` was already escaped on both
+            // sides; only the quotes step's own markup differed.
+            let quotes_first = custom("quotes,specialcharacters");
+            assert_eq!(
+                golden_for_group(&quotes_first, "<b> *bold*"),
+                "&lt;b&gt; &lt;strong&gt;bold&lt;/strong&gt;"
+            );
+            assert_group_parity(&quotes_first, "<b> *bold*");
+
+            let cases: [(&str, &[&str]); 9] = [
+                (
+                    "quotes,specialcharacters",
+                    &[
+                        "*bold*",
+                        "plain text with no markup at all",
+                        "*a* and _b_ and `c`",
+                        "*a < b* & _c > d_",
+                        "*a _b_ c*",
+                        "[.role]#roled#",
+                        "[#id]#anchored#",
+                        "\"`smart`\" quotes",
+                        "H~2~O and E = mc^2^",
+                        "a *b* c",
+                    ],
+                ),
+                (
+                    "replacements,specialcharacters",
+                    &[
+                        "(C) 2024",
+                        "a -- b",
+                        "it's",
+                        "a -> b",
+                        "and so on...",
+                        "&copy;",
+                    ],
+                ),
+                (
+                    "macros,specialcharacters",
+                    &[
+                        "image:a.png[Alt]",
+                        "an image:a.png[Alt] inline",
+                        "link:index.html[Docs]",
+                        "https://example.org auto-link",
+                        "a footnote:[the note] here",
+                        "kbd:[Ctrl+T] pressed",
+                        "((coffee)) term",
+                        "[[an-id]]anchored",
+                        "xref:sec[Section] here",
+                    ],
+                ),
+                (
+                    "post_replacements,specialcharacters",
+                    &["first +\nsecond", "no break here"],
+                ),
+                (
+                    "callouts,specialcharacters",
+                    &["a line of code <1>", "no callout here"],
+                ),
+                (
+                    // Several markup-producing steps ahead of the escaping
+                    // one.
+                    "quotes,replacements,specialcharacters",
+                    &["*bold* and (C)", "*a (C) b*", "*a -- b* and it's"],
+                ),
+                (
+                    // A step whose own output is text (an expansion) ahead of
+                    // the markup-producing one, so the flattening runs over a
+                    // level that already holds a synthesized run.
+                    "attributes,quotes,specialcharacters",
+                    &["*{product}*", "{tag} and *bold*", "*a {amp} b*"],
+                ),
+                (
+                    // Multi-line, so a flattened span sits on one line of
+                    // several.
+                    "quotes,specialcharacters",
+                    &["a < b\n*bold*\nc & d", "*spanning\ntwo lines*"],
+                ),
+                (
+                    // Two markup-producing steps ahead of the escaping one, so
+                    // the flattened node is a span whose own *children* are
+                    // already macro nodes — every container the fold descends
+                    // into, reached before the escaping step rather than after
+                    // it.
+                    "quotes,macros,specialcharacters",
+                    &[
+                        "*a https://example.org b*",
+                        "*a link:index.html[Docs] b*",
+                        "*a image:sunset.jpg[Sunset] b*",
+                        "*a footnote:[the note] b*",
+                        "*a [[an-id,the ref text]] b*",
+                        "*a ((coffee)) b*",
+                        "*a kbd:[Ctrl+T] b*",
+                    ],
+                ),
+            ];
+
+            for (subs, fixtures) in cases {
+                let group = custom(subs);
+                for source in fixtures {
+                    assert_group_parity(&group, source);
+                }
+            }
+
+            // Orders that run a step *after* the escaping one, so the
+            // flattened text is what that later step reads — exactly as the
+            // string pipeline's later steps read the escaped tags. The
+            // extraction pass runs for each of these (they name `macros`), so
+            // they also exercise the masked/unmasked split
+            // `flatten_prior_markup` draws.
+            for subs in [
+                "quotes,specialcharacters,macros",
+                "quotes,specialcharacters,macros,post_replacements",
+            ] {
+                let group = custom(subs);
+                for source in [
+                    "*bold* then link:index.html[Docs]",
+                    "*a https://example.org b*",
+                    "*a image:sunset.jpg[Sunset] b*",
+                    "*a footnote:[the note] b*",
+                    "*a ((coffee)) b*",
+                    "*a [[an-id]] b*",
+                    "[quotes]++*not bold*++ and *bold*",
+                    "pass:[<raw>] and *bold*",
+                    "*bold* and stem:[x + y]",
+                ] {
+                    assert_group_parity(&group, source);
+                }
+            }
+        }
+
+        /// The flattened markup is *text*, not a span whose fold happens to be
+        /// escaped: the tree a late-escaping order produces carries no
+        /// [`Styled`](crate::inlines::Styled) node at all, and the tags are
+        /// ordinary [`Text`](InlineNode::Text) runs and
+        /// [`CharRef`](InlineNode::CharRef) leaves the fold escapes once
+        /// (§3.4). That is what the document genuinely says under such an
+        /// order — the content is no longer a strong span, it is text that
+        /// reads like a tag.
+        #[test]
+        fn a_late_escaping_order_leaves_the_flattened_markup_as_text() {
             let (group, invalid) =
                 SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters");
             assert!(invalid.is_empty());
 
-            let source = "<b> *bold*";
+            let parser = parser_with_product();
+            let nodes = build_group(&group, "*bold*", &parser);
+
+            assert!(
+                !nodes.iter().any(|n| matches!(n, InlineNode::Styled(_))),
+                "the quotes step's span must not survive a late escaping step: {nodes:?}"
+            );
+
+            let text: String = nodes
+                .iter()
+                .map(|node| match node {
+                    InlineNode::Text { value, .. } => value.to_string(),
+                    InlineNode::CharRef {
+                        value: crate::inlines::CharRef::Special(ch),
+                        ..
+                    } => ch.to_string(),
+                    other => panic!("unexpected node kind: {other:?}"),
+                })
+                .collect();
+
+            assert_eq!(text, "<strong>bold</strong>");
+        }
+
+        /// A documented divergence, not a bug: a construct the string
+        /// pipeline is holding as a **placeholder** at escaping time, nested
+        /// *inside* a node an earlier step turned into markup.
+        ///
+        /// There are two such constructs, and the fixtures pin one of each: a
+        /// passthrough (or inline-STEM) body, extracted ahead of every step
+        /// and restored after the last one, and a deferred cross-reference,
+        /// recorded by the macros step and rendered by
+        /// [`Content::finalize_deferred`](crate::content::Content) once every
+        /// step has run. The string pipeline's escaping step acts on neither,
+        /// so it escapes *around* the placeholder and the construct comes back
+        /// unescaped: `&lt;strong&gt;a <x> b&lt;/strong&gt;`.
+        ///
+        /// Folding the enclosing span whole would inline the construct into
+        /// the escaped text instead. Splitting one node's fold back around its
+        /// placeholder descendants is the sentinel mechanism itself, which
+        /// this module deliberately does not have — so such a node is left
+        /// alone, exactly as an unrecognized construct is elsewhere here.
+        ///
+        /// Either construct on its *own* — not nested inside a
+        /// markup-producing step's node — is unaffected and stays parity; the
+        /// corpus above pins both.
+        #[test]
+        fn a_placeholder_construct_inside_a_markup_node_is_a_documented_divergence() {
+            let cases = [
+                (
+                    "quotes,specialcharacters,macros",
+                    "*a +++<x>+++ b*",
+                    "&lt;strong&gt;a <x> b&lt;/strong&gt;",
+                    "<strong>a <x> b</strong>",
+                ),
+                (
+                    "quotes,macros,specialcharacters",
+                    "*see xref:sec[S] now*",
+                    "&lt;strong&gt;see <a href=\"#sec\">S</a> now&lt;/strong&gt;",
+                    "<strong>see <a href=\"#sec\">S</a> now</strong>",
+                ),
+                // The same, where the enclosing markup node is a macro rather
+                // than a quoted span — every container the walk descends into.
+                (
+                    "macros,specialcharacters",
+                    "link:index.html[a +++<b>+++ c]",
+                    "&lt;a href=\"index.html\"&gt;a <b> c&lt;/a&gt;",
+                    "<a href=\"index.html\">a <b> c</a>",
+                ),
+                (
+                    "macros,specialcharacters",
+                    "footnote:[a +++<b>+++ c]",
+                    "&lt;sup class=\"footnote\"&gt;[&lt;a id=\"_footnoteref_1\" class=\"footnote\" \
+                     href=\"#_footnotedef_1\" title=\"View footnote.\"&gt;1&lt;/a&gt;]&lt;/sup&gt;",
+                    "<sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" \
+                     href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>",
+                ),
+            ];
+
+            for (subs, source, expected_golden, expected_built) in cases {
+                let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs);
+                assert!(invalid.is_empty());
+
+                let golden = golden_for_group(&group, source);
+                assert_eq!(golden, expected_golden);
+
+                let built_parser = parser_with_product();
+                let nodes = build_group(&group, source, &built_parser);
+                let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+
+                assert_ne!(
+                    built, golden,
+                    "expected the documented divergence to still reproduce for {source:?}; the \
+                     boundary may have been lifted — if so, fold this fixture into the parity \
+                     corpus above"
+                );
+                assert_eq!(built, expected_built);
+            }
+        }
+
+        /// A documented divergence the flattening policy inherits rather than
+        /// introduces: a `link:`/`mailto:` **macro** written inside a node an
+        /// earlier step turned into markup.
+        ///
+        /// The flattened markup is a *synthesized* run — its value is the
+        /// fold, which has no `'src` slice of its own — and that pass alone
+        /// among the macro families requires its own `link:`/`mailto:` marker
+        /// to be verbatim, because
+        /// [`link_form`](macros::links::link_form) tells this pass's nodes
+        /// from the other link passes' by whether the node's `location` starts
+        /// with that literal marker (the "no new node field" signal that
+        /// replays the string pipeline's family-pass registration order). It
+        /// is the same boundary a wholly expanded `{m}` macro already has —
+        /// reached here through a flattened span instead of an attribute
+        /// expansion.
+        ///
+        /// Every other family reads what it needs from the level's match
+        /// string and is recognized in flattened text just as the string
+        /// pipeline recognizes it in the escaped tags; the corpus above pins
+        /// an auto-link, an image macro, and a footnote doing exactly that.
+        #[test]
+        fn a_link_macro_inside_flattened_markup_is_a_documented_divergence() {
+            let (group, invalid) =
+                SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters,macros");
+            assert!(invalid.is_empty());
+
+            let source = "*a link:index.html[Docs] b*";
             let golden = golden_for_group(&group, source);
-            assert_eq!(golden, "&lt;b&gt; &lt;strong&gt;bold&lt;/strong&gt;");
+            assert_eq!(
+                golden,
+                "&lt;strong&gt;a <a href=\"index.html\">Docs</a> b&lt;/strong&gt;"
+            );
 
             let built_parser = parser_with_product();
             let nodes = build_group(&group, source, &built_parser);
@@ -1927,13 +2233,13 @@ mod tests {
 
             assert_ne!(
                 built, golden,
-                "expected the documented divergence to still reproduce; the policy may have \
-                 been settled — if so, fold this fixture into the parity corpus above"
+                "expected the documented divergence to still reproduce; the boundary may have \
+                 been lifted — if so, fold this fixture into the parity corpus above"
             );
-
-            // The author's own `<b>` is escaped on both sides; only the quotes
-            // step's own markup differs.
-            assert_eq!(built, "&lt;b&gt; <strong>bold</strong>");
+            assert_eq!(
+                built,
+                "&lt;strong&gt;a link:index.html[Docs] b&lt;/strong&gt;"
+            );
         }
     }
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -1452,7 +1452,7 @@ mod tests {
         use crate::{
             Parser, Span,
             content::{Content, SubstitutionGroup},
-            inlines::InlineNode,
+            inlines::{CharRef, InlineNode},
             parser::{HtmlSubstitutionRenderer, ModificationContext},
             strings::CowStr,
         };
@@ -2089,33 +2089,45 @@ mod tests {
         /// (§3.4). That is what the document genuinely says under such an
         /// order — the content is no longer a strong span, it is text that
         /// reads like a tag.
+        ///
+        /// The whole node list is asserted rather than only the text it folds
+        /// to, so it pins the spans as well: a flattened node's value is the
+        /// fold, which has no `'src` slice of its own, so every fragment the
+        /// escaping step splits it into takes design §4.4's coarse
+        /// enclosing-span fallback — here the `*bold*` the quotes step
+        /// consumed, which is this fixture's whole source.
         #[test]
         fn a_late_escaping_order_leaves_the_flattened_markup_as_text() {
             let (group, invalid) =
                 SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters");
             assert!(invalid.is_empty());
 
+            let source = "*bold*";
             let parser = parser_with_product();
-            let nodes = build_group(&group, "*bold*", &parser);
+            let nodes = build_group(&group, source, &parser);
 
-            assert!(
-                !nodes.iter().any(|n| matches!(n, InlineNode::Styled(_))),
-                "the quotes step's span must not survive a late escaping step: {nodes:?}"
+            let coarse = Span::new(source);
+            let text = |value: &'static str| InlineNode::Text {
+                value: CowStr::from(value),
+                location: coarse,
+            };
+            let special = |ch| InlineNode::CharRef {
+                value: CharRef::Special(ch),
+                location: coarse,
+            };
+
+            assert_eq!(
+                nodes,
+                vec![
+                    special('<'),
+                    text("strong"),
+                    special('>'),
+                    text("bold"),
+                    special('<'),
+                    text("/strong"),
+                    special('>'),
+                ]
             );
-
-            let text: String = nodes
-                .iter()
-                .map(|node| match node {
-                    InlineNode::Text { value, .. } => value.to_string(),
-                    InlineNode::CharRef {
-                        value: crate::inlines::CharRef::Special(ch),
-                        ..
-                    } => ch.to_string(),
-                    other => panic!("unexpected node kind: {other:?}"),
-                })
-                .collect();
-
-            assert_eq!(text, "<strong>bold</strong>");
         }
 
         /// A documented divergence, not a bug: a construct the string

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -1,10 +1,12 @@
-//! The special-characters substitution step, and its §3.4.1 counterpart for an
-//! effective order that never runs it.
+//! The special-characters substitution step, and its §3.4.1 counterparts for an
+//! effective order that never runs it — or that runs it *late*, after a step
+//! that already produced markup.
 
-use super::passthrough_step::is_special;
+use super::{fold_html, passthrough_step::is_special};
 use crate::{
-    Span,
-    inlines::{CharRef, InlineNode},
+    HasSpan, Parser, Span,
+    inlines::{CharRef, InlineNode, RefVariant},
+    parser::InlineSubstitutionRenderer,
     strings::CowStr,
 };
 
@@ -91,8 +93,7 @@ pub(super) fn apply_special_characters<'src>(
 /// [`Styled`](crate::inlines::Styled) span, a [`Ref`](crate::inlines::Ref)'s
 /// own display children, an [`Anchor`](crate::inlines::Anchor)'s reference
 /// text, and a [`Footnote`](crate::inlines::Footnote)'s own children —
-/// mirroring the containers [`fold_html`](super::fold_html) itself descends
-/// into.
+/// mirroring the containers [`fold_html`] itself descends into.
 pub(super) fn classify_unescaped_specials<'src>(
     nodes: Vec<InlineNode<'src>>,
 ) -> Vec<InlineNode<'src>> {
@@ -210,6 +211,195 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
             location: rest,
         });
     }
+}
+
+/// Rewrites every node an **earlier step of this same order** already turned
+/// into markup as the logical [`Text`](InlineNode::Text) that markup is, so the
+/// `SpecialCharacters` step that is about to run escapes it exactly as the
+/// string pipeline escapes the tags that earlier step already wrote.
+///
+/// This is design §3.4.1 applied to the escaping step's own *position* rather
+/// than to a spliced value's classification (which
+/// `split_attribute_value` already keys on the same question). Every built-in
+/// group runs `specialcharacters` first, so this is a `subs=` list's question
+/// alone — `subs=quotes,specialcharacters` runs the quotes step first, and the
+/// string pipeline is holding `<strong>bold</strong>` by the time the escaping
+/// step reaches it, emitting `&lt;strong&gt;bold&lt;/strong&gt;`.
+///
+/// A tree has no rendered tags at that point: a
+/// [`Styled`](crate::inlines::Styled) span's markup exists only at fold time.
+/// So the policy is to *reach* fold time for that one node, early: the node is
+/// folded through the configured renderer and the result becomes one `Text`
+/// node's value. That is the same "a node's value is already-substituted text"
+/// seam a delimited passthrough's and a STEM expression's body already use —
+/// the only place this module consults the renderer while building — and it is
+/// what the document genuinely says under such an order: the content is no
+/// longer a strong span, it is text that reads like a tag, which is exactly
+/// what a `Text` node the fold escapes means (§3.4).
+///
+/// The nodes that must **not** be folded are the ones the string pipeline is
+/// holding as a *placeholder* rather than as markup at this point, since no
+/// escaping step acts on those either — see [`covers_masked`] for which they
+/// are and how each is told apart, and [`masked_locations`] for the one that
+/// needs an identity rather than a node kind to say so.
+///
+/// A node whose own subtree *contains* one of those is left alone too, and is
+/// this policy's own documented divergence: folding it whole would inline the
+/// placeholder's content into the escaped text, where the string pipeline
+/// escapes *around* the placeholder and restores it unescaped afterwards.
+/// Splitting one node's fold back around its placeholder descendants is the
+/// sentinel mechanism itself, which this module deliberately does not have.
+pub(super) fn flatten_prior_markup<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    masked: &[(usize, usize)],
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+) -> Vec<InlineNode<'src>> {
+    nodes
+        .into_iter()
+        .map(|node| {
+            if matches!(node, InlineNode::Text { .. }) || covers_masked(&node, masked) {
+                return node;
+            }
+
+            let location = node.span();
+            let value = fold_html(std::slice::from_ref(&as_pre_escape(node)), renderer, parser);
+
+            InlineNode::Text {
+                value: CowStr::from(value),
+                location,
+            }
+        })
+        .collect()
+}
+
+/// Rewrites every [`Text`](InlineNode::Text) run *nested inside* `node` as a
+/// [`Raw`](InlineNode::Raw) leaf, so folding `node` reproduces the markup the
+/// string pipeline's haystack holds at this point — **before** its escaping
+/// step runs — rather than the fully-escaped markup a finished fold emits.
+///
+/// A `Text` node is logical text the fold escapes (§3.4), which is what makes
+/// it the right kind for the *result* of this flattening: the escaping step
+/// that is about to run does that escaping, once. But the same rule applied to
+/// the node's own children would escape them a second time, since the string
+/// pipeline has not escaped them either at the moment its markup-producing
+/// step wrote those tags (`*a < b*` is `<strong>a < b</strong>` there, and the
+/// one escaping pass that follows turns both the tags and the `<` into
+/// entities together). `Raw` is exactly "emit this verbatim", so the fold
+/// reproduces that pre-escape haystack.
+///
+/// Every other leaf already carries its own already-substituted bytes — a
+/// [`CharRef`](InlineNode::CharRef) an earlier `replacements` step built folds
+/// to the entity that step wrote, a [`LineBreak`](InlineNode::LineBreak) to
+/// the break `post_replacements` wrote — so only `Text` needs the rewrite.
+fn as_pre_escape<'src>(node: InlineNode<'src>) -> InlineNode<'src> {
+    match node {
+        InlineNode::Text { value, location } => InlineNode::Raw { value, location },
+
+        InlineNode::Styled(mut styled) => {
+            styled.children = styled.children.into_iter().map(as_pre_escape).collect();
+            InlineNode::Styled(styled)
+        }
+
+        InlineNode::Ref(mut reference) => {
+            reference.children = reference.children.into_iter().map(as_pre_escape).collect();
+            InlineNode::Ref(reference)
+        }
+
+        InlineNode::Anchor(mut anchor) => {
+            anchor.reftext = anchor
+                .reftext
+                .map(|reftext| reftext.into_iter().map(as_pre_escape).collect());
+            InlineNode::Anchor(anchor)
+        }
+
+        InlineNode::Footnote(mut footnote) => {
+            footnote.children = footnote.children.into_iter().map(as_pre_escape).collect();
+            InlineNode::Footnote(footnote)
+        }
+
+        other => other,
+    }
+}
+
+/// The `(offset, len)` identity of every [`Styled`](crate::inlines::Styled)
+/// node in `nodes` — the one *container* the passthrough-extraction pass
+/// builds (an attribute-list-prefixed passthrough, `[quotes]++text++`).
+///
+/// A location is a sound identity for these: extraction recognizes only a
+/// wholly *verbatim* match (see
+/// [`range_is_verbatim`](super::macros::image::range_is_verbatim)), so each
+/// carries an honest, precise `'src` span rather than design §4.4's coarse
+/// fallback — and a later step's own node can never claim the identical range,
+/// since a masked node is one opaque piece to
+/// [`build_match_string`](super::quotes::build_match_string) and any match
+/// containing it extends past it on at least one side.
+///
+/// Extraction's *leaf* artifacts need no entry here, because their node kind
+/// already says what they are: under an order that has a `SpecialCharacters`
+/// step at all, a [`Raw`](InlineNode::Raw) leaf can only have come from this
+/// pass (a spliced attribute value classifies as `Text` while that step is
+/// still ahead — see
+/// [`SplicedSpecials`](super::attribute_refs::SplicedSpecials) — and
+/// [`classify_unescaped_specials`] runs only for an order with no such step),
+/// and a [`Stem`](crate::inlines::Stem) node has no other origin at all.
+pub(super) fn masked_locations(nodes: &[InlineNode<'_>]) -> Vec<(usize, usize)> {
+    nodes
+        .iter()
+        .filter(|node| matches!(node, InlineNode::Styled(_)))
+        .map(|node| identity(node))
+        .collect()
+}
+
+/// Reports whether `node` — or anything nested inside it — is hidden from the
+/// escaping step.
+///
+/// Three constructs are: a passthrough body and an inline-STEM expression,
+/// extracted ahead of every step and restored after the last one (told by
+/// their node kind, or — for an attribute-list-prefixed passthrough's own
+/// wrapper — by a `masked` entry), and a **deferred cross-reference**, which
+/// the macros step records as an `XrefSegment` rather than as markup and
+/// [`Content::finalize_deferred`](crate::content::Content) renders once every
+/// step has run. No escaping step ever acts on any of their tags.
+fn covers_masked(node: &InlineNode<'_>, masked: &[(usize, usize)]) -> bool {
+    let hidden = match node {
+        InlineNode::Raw { .. } | InlineNode::Stem(_) => true,
+        InlineNode::Ref(reference) => reference.variant == RefVariant::Xref,
+        _ => masked.contains(&identity(node)),
+    };
+
+    if hidden {
+        return true;
+    }
+
+    // The containers a hidden construct can be nested inside. An
+    // [`Anchor`](crate::inlines::Anchor)'s reference text is not one: it holds
+    // a single verbatim `Text` child or nothing at all, since a reference text
+    // crossing an opaque piece leaves the field `None` (see
+    // `build_anchor_reftext`).
+    match node {
+        InlineNode::Styled(styled) => styled
+            .children
+            .iter()
+            .any(|child| covers_masked(child, masked)),
+
+        InlineNode::Ref(reference) => reference
+            .children
+            .iter()
+            .any(|child| covers_masked(child, masked)),
+
+        InlineNode::Footnote(footnote) => footnote
+            .children
+            .iter()
+            .any(|child| covers_masked(child, masked)),
+
+        _ => false,
+    }
+}
+
+fn identity(node: &InlineNode<'_>) -> (usize, usize) {
+    let location = node.span();
+    (location.byte_offset(), location.data().len())
 }
 
 /// Splits a synthesized `value` — text with no source span of its own — into


### PR DESCRIPTION
The corpus-wide fold-parity audit's itemized map ended with one category no recognition or classification increment could close: an effective order that runs `SpecialCharacters` **after** a step that already produced markup (`subs=quotes,specialcharacters`), where the string pipeline escapes the very tags the earlier step emitted. A tree whose markup exists only at fold time has no rendered tags for a later escaping step to act on, so — as the design doc itself says — it needs its own policy rather than another recognition increment.

That policy is settled here, and it is a short one: **reach fold time for that one node, early.**

## The policy

[`flatten_prior_markup`](https://github.com/asciidoc-rs/asciidoc-parser/blob/claude/inline-ast-implementation-93n617/parser/src/content/inline_builder/special_chars.rs) runs immediately ahead of `apply_special_characters` whenever the escaping step is not the order's first — never for a built-in group, every one of which escapes first, so this is a `subs=` list's question alone. Each node an earlier step of the same order already turned into markup is folded through the configured renderer and the result becomes one `Text` node's value, which the escaping step then splits like any other text.

Nothing new is invented for it:

- A `Text` node is *logical* text the fold escapes (§3.4), so the single escape lands exactly where the string pipeline's does.
- "A node's value is already-substituted text" is the same seam a delimited passthrough's and a STEM expression's body already use — the only place this module consults the renderer while building.
- It is what the document genuinely says under such an order: the content is no longer a strong span, it is text that reads like a tag, and the tree now holds it as such (pinned by a structural test, not only by the fold's bytes).

## Which bytes the early fold must produce

The string pipeline's haystack at that moment holds `<strong>a < b</strong>` — the tags written, the author's own specials **not yet escaped**, both escaped together by the one pass that follows. A finished fold would escape the children on the way out, so `as_pre_escape` rewrites every `Text` run nested *inside* the node as a `Raw` leaf ("emit verbatim") first. Every other leaf already carries its own already-substituted bytes (a `CharRef` an earlier `replacements` step built, a `LineBreak` `post_replacements` wrote) and needs no rewrite.

## What must not be folded

Whatever the string pipeline is holding as a *placeholder* rather than as markup at that point, since no escaping step acts on those either:

- a **passthrough body** or **inline STEM expression** (extracted ahead of every step, restored after the last one), and
- a **deferred cross-reference** (recorded by the macros step as an `XrefSegment`, rendered by `finalize_deferred` once every step has run — which is why `subs=macros,specialcharacters` emits an unescaped `<a href="#sec">` where it escapes a link's).

A leaf says which it is by its own node kind; the one *container* the extraction pass builds — an attribute-list-prefixed passthrough's own `Styled` wrapper — is told from a quotes-step span by `masked_locations`, a set of identities collected from the tree extraction produced, before any step ran (sound because extraction recognizes only a wholly verbatim match, so each such node carries an honest `'src` span no later step's node can claim).

## What still defers

Two shapes, each pinned by its own test:

1. **A placeholder construct nested inside a flattened node** (`*a +++<x>+++ b*`, `*see xref:sec[S] now*`, `link:index.html[a +++<b>+++ c]`) leaves the whole node unflattened — folding it would inline the placeholder's content into the escaped text, where the string pipeline escapes *around* the placeholder and restores it unescaped afterwards. Splitting one node's fold back around its placeholder descendants is the sentinel mechanism itself, which this module deliberately does not have.
2. **A `link:`/`mailto:` macro written inside flattened markup** — a boundary this policy *inherits* rather than introduces: the flattened run is synthesized, and that one pass alone requires its own marker to be verbatim so `link_form` can replay the string pipeline's family-pass registration order (the same boundary a wholly expanded `{m}` macro already has). Every other family reads what it needs from the level's match string and is recognized in flattened text exactly as the string pipeline recognizes it in the escaped tags — an auto-link, an image, an anchor, an index term, and a footnote are each pinned doing so.

## Testing

A differential corpus crosses markup-bearing fixtures with the real `subs=` lists that reverse the two steps: each markup-producing step ahead of the escaping one on its own (`quotes`, `replacements`, `macros`, `post_replacements`, `callouts`), several together, an expanding step ahead of both, a multi-line content, and the orders that additionally run a step *after* the escaping one — so the flattened text is what those later steps read, exactly as the string pipeline's later steps read the escaped tags.

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence set strictly **shrank**: the category's own source is gone and no pre-existing one appeared (the set's only additions are this increment's own new divergence-pinning fixtures). **With it, every item the audit's map named is closed.**

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green (5266 passed)
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov` — the new code's regions/lines are fully covered; the changed files' missed-line sets are unchanged from the pre-change baseline apart from one `other => panic!(…)` fallback arm inside a test assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oaqKfSLbQH6jEyNJzKXNq

---
_Generated by [Claude Code](https://claude.ai/code/session_016oaqKfSLbQH6jEyNJzKXNq)_