### PR TITLE
chore: Satisfy Clippy 1.98's chunks_exact_to_as_chunks lint

### DIFF
--- a/parser/src/internal/base64.rs
+++ b/parser/src/internal/base64.rs
@@ -23,11 +23,11 @@ pub(crate) fn strict_encode(input: &[u8]) -> String {
     // Every 3 input bytes become 4 output characters, rounding up.
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
 
-    let mut chunks = input.chunks_exact(3);
+    // `as_chunks::<3>()` splits the input into fixed-size arrays of three bytes
+    // plus whatever doesn't fill a final group.
+    let (chunks, remainder) = input.as_chunks::<3>();
 
-    for chunk in chunks.by_ref() {
-        // `chunks_exact(3)` yields exactly three bytes per chunk.
-        let &[a, b, c] = chunk else { continue };
+    for &[a, b, c] in chunks {
         let n = (u32::from(a) << 16) | (u32::from(b) << 8) | u32::from(c);
         out.push(sextet(n >> 18));
         out.push(sextet(n >> 12));
@@ -37,7 +37,7 @@ pub(crate) fn strict_encode(input: &[u8]) -> String {
 
     // The final 1 or 2 bytes are padded out to a full 4-character group with
     // `=`.
-    match chunks.remainder() {
+    match remainder {
         [a] => {
             let n = u32::from(*a) << 16;
             out.push(sextet(n >> 18));


### PR DESCRIPTION
Rust 1.98.0 (released 2026-08-20) adds a new Clippy lint, [`chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks). It fires on the one `chunks_exact` call in the tree, in the base64 encoder:

```
error: using `chunks_exact` with a constant chunk size
  --> parser/src/internal/base64.rs:26:28
   |
26 |     let mut chunks = input.chunks_exact(3);
   |                            ^^^^^^^^^^^^^^^
   |
help: consider using `as_chunks::<3>()` instead
```

Because `parser/src/lib.rs` carries `#[deny(warnings)]`, this fails the build outright on 1.98 rather than merely warning — so `cargo clippy --all-features --all-targets -- -Dwarnings` (the CI check) and a plain `cargo build` both break.

## The change

`strict_encode` now uses `as_chunks::<3>()`, which returns the full chunks as `&[[u8; 3]]` plus the trailing remainder, instead of a `ChunksExact` iterator queried for its `remainder()` afterward.

Because each chunk is a fixed-size array rather than a slice, the loop can destructure it directly in the `for` pattern. That removes the `let &[a, b, c] = chunk else { continue };` line, which existed only to convince the compiler that a `chunks_exact(3)` slice really did have three elements — the `continue` arm was unreachable in practice.

Encoder behavior is unchanged: same chunking, same padding arms, same output.

## MSRV

`slice::as_chunks` stabilized in Rust 1.88.0, which is exactly this crate's `rust-version`, so no MSRV bump is needed. Verified with `cargo +1.88.0 check --all-features --all-targets`.

## Verification

On the 1.98.0 toolchain:

- `cargo clippy --all-features --all-targets -- -Dwarnings` — clean (this is the CI `clippy_check` command verbatim)
- `cargo test --all-features` — 4714 passed, 0 failed, 68 ignored; 6 doc-tests passed. This includes `base64::tests::rfc4648_test_vectors` (the RFC 4648 §10 vectors, covering all three padding cases) and `encodes_full_byte_range`.
- `cargo +nightly fmt --all -- --check` — clean
- `cargo +1.88.0 check --all-features --all-targets` — clean (MSRV)

No changelog entry: `CHANGELOG.md` is generated by release-plz from commit messages, and `chore:` commits are configured to be omitted from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3PetrYryLYpj1jFJXu8Ek)_