### PR TITLE
feat: Parse an attributed span's attribute list from the escaped text (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3667,6 +3667,68 @@ Each phase is a reviewable unit with a clear exit gate.
   is closed. As with every prep piece before it, nothing further is wired in: `rendered_html()`
   remains the string pipeline's own string.
 
+  *Step 6 prep landed as (an **attributed span's** attribute list, read from the escaped text):*
+  with the audit's map closed, re-running the corpus-wide fold-parity sweep turns up one more
+  **blocker** of the kind the map's own items were — not an unclaimed form the tree leaves literal,
+  but a *wrong* answer for content a golden test already exercises, and this one a **security**
+  test: `['a<b&c']*bold*`, whose rendered `class` the string pipeline escapes
+  (`class="'a&lt;b&amp;c'"`) and the fold did not. The cause is the one attribute list this module
+  still parsed from `'src`. Every macro family's list is parsed out of the level's **match
+  string** — an image's bracket, and both link families' display texts, by the two increments
+  directly above — but the *quotes* step's own attributed span kept the source slice, and by the
+  time that step runs `SpecialCharacters` has already escaped the author's `<`/`&`, so the
+  string replacer's haystack (and the `class`/`id` value it renders verbatim) carries the entity
+  where the source carries the character. Parsing the source slice put an **unescaped** `<`, `>`,
+  or `&` into rendered markup — one entity's worth of the escaping the `"`-escaping beside it
+  exists to provide.
+
+  [`quote_attributes`](../../parser/src/content/inline_builder/quotes.rs) is the same one move
+  those two increments made: a **verbatim** range's match-string bytes *are* its source bytes, so
+  it keeps the `'src` parse and its borrow (§4.5) — every ordinary `[.role]#text#` — and every
+  other range parses from a [`Span::new`](../../parser/src/span/primitives.rs) over the match-string
+  slice and [`into_owned`](../../parser/src/attributes/attrlist.rs)s the result onto §4.4's coarse
+  span. No node field changed: a `Styled` span already carried its `id`, `roles`, and own
+  `Attrlist<'src>`; only the bytes they are read from did.
+
+  Landing it closed a latent gap in
+  [`Attrlist::into_owned`](../../parser/src/attributes/attrlist.rs)'s own stated contract — "every
+  parsed field is a `CowStr`, so nothing but the location depends on the original span" — which one
+  accessor falsifies: [`quoted_text_fallback_role`](../../parser/src/attributes/attrlist.rs) reads
+  the list's own *text*, not a parsed attribute, because Asciidoctor's
+  `parse_quoted_text_attributes` takes a quote-delimited first positional (`['role']`) verbatim,
+  quote characters included, straight off the source. A re-tagged list would have read the coarse
+  span's raw bytes — precisely the security fixture's own spelling. `into_owned` now carries an
+  owned copy of the text it was parsed from and that accessor reads it, so the contract holds for
+  every family that owns a list off a temporary, not just this one.
+
+  Two shapes stay divergent, each pinned by its own test. An attribute list crossing an **opaque**
+  piece (`[.a+++x+++b]#y#`) is the boundary every macro family draws, drawn here for the first
+  time: the string pipeline parses its list with the passthrough's own placeholder inside it — one
+  atomic character no comma can hide behind — and restores that passthrough's text into the
+  rendered `class` afterwards, where splicing the text in at parse time would let a comma inside it
+  split the list. Such a match is now dropped from the level's match list rather than built into a
+  wrong node, leaving the construct literal and putting it exactly where a rejected look-ahead
+  leaves one (the surrounding gap reproduces its original nodes, and a later sub may still match
+  there). And an attribute list **rewritten by a later step** of the same order (`['{myrole}']`,
+  `[.a(C)c]`, `[.a&amp;b]`) is `flatten_prior_markup`'s own category seen from the other side: under
+  the *normal* order the steps after `quotes` go on matching over the whole rendered string, the
+  markup that step just wrote included, so they rewrite bytes that live only inside a rendered
+  attribute — which a tree, whose markup exists at fold time alone, has nowhere to hold. That one
+  needs its own policy rather than another parse-source choice.
+
+  The quotes differential corpus gains every attribute-list spelling carrying a special (a
+  shorthand role, an id, a block-style positional, a `role=` value, a quoted positional, several at
+  once, and the same on the unconstrained branch), alongside the `"`-escaping composing with it and
+  the escaped-with-attributes form; the passthrough corpus gains the mirror-image fixtures that
+  pin why *its* attrlist keeps the source parse (its extraction pass runs ahead of the escaping
+  step, so the string pipeline reads the author's raw bytes there too); and the staged
+  `apply_ref_side_effects` corpus gains an id-carrying fixture, since the id it registers is now
+  the escaped one the golden pipeline registers. Re-running the corpus-wide fold-parity audit (tree
+  building forced on for every parse in the suite) confirms the divergence set strictly **shrank**:
+  the security fixture's own source is gone and no pre-existing one appeared (the set's only
+  additions are this increment's own new divergence-pinning fixtures). As with every prep piece
+  before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4166,6 +4228,21 @@ Each phase is a reviewable unit with a clear exit gate.
        family's own pre-existing verbatim-marker rule), each with its own divergence test. See the
        step's own "landed as" note above. With this every item the corpus-wide audit's map named is
        closed.
+     - ✅ **prep (an attributed span's attribute list).** The last attribute list this module
+       parsed from `'src`, and — like `hardbreaks`, the unescaped-specials classification, and the
+       four blockers before it — a *wrong* answer rather than an unclaimed form, for content a
+       golden **security** test exercises: the quotes step runs after `SpecialCharacters`, so the
+       string replacer parses (and renders verbatim into the `class`/`id`) the **escaped** text,
+       where the source slice carries the author's raw `<`/`&`.
+       [`quote_attributes`](../../parser/src/content/inline_builder/quotes.rs) takes the same
+       match-string parse the image bracket and the two link display texts already took, keeping
+       the `'src` parse and its borrow for a verbatim list; and
+       [`Attrlist::into_owned`](../../parser/src/attributes/attrlist.rs) now keeps the text it was
+       parsed from, so `quoted_text_fallback_role` — the one accessor reading a list's own text
+       rather than a parsed attribute — goes on reading it. A list crossing an opaque piece is
+       dropped rather than built wrong, and one a *later* step of the same order rewrites inside
+       the emitted markup stays divergent, each with its own test; see the step's own "landed as"
+       note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -26,6 +26,19 @@ pub struct Attrlist<'src> {
     attributes: Vec<ElementAttribute<'src>>,
     anchor: Option<CowStr<'src>>,
     source: Span<'src>,
+
+    /// The attrlist text this list was parsed from, kept only when `source`'s
+    /// own bytes are *not* that text — which happens exactly when
+    /// [`into_owned`](Self::into_owned) rebuilt the list from a temporary and
+    /// re-tagged it with a coarser source span. `None` for every list parsed
+    /// straight from the source it describes, where `source.data()` already is
+    /// that text.
+    ///
+    /// Only [`source_text`](Self::source_text) reads it, for
+    /// [`quoted_text_fallback_role`](Self::quoted_text_fallback_role) — the one
+    /// accessor that reads the attrlist's own text rather than a parsed
+    /// attribute.
+    source_text: Option<CowStr<'src>>,
 }
 
 impl<'src> Attrlist<'src> {
@@ -41,7 +54,14 @@ impl<'src> Attrlist<'src> {
     /// from a [`Span::new`] over that temporary and calls this to keep the
     /// result, passing the coarser source span the text corresponds to as the
     /// list's own location tag. Every parsed field is a [`CowStr`], so nothing
-    /// but the location depends on the original span.
+    /// but the location depends on the original span — with one exception this
+    /// method itself handles:
+    /// [`quoted_text_fallback_role`](Self::quoted_text_fallback_role) reads the
+    /// attrlist's own *text*, which after the re-tag is no longer what `source`
+    /// holds (the temporary's escaped or expanded bytes are precisely what no
+    /// `'src` slice reproduces). An owned copy of the text this list was parsed
+    /// from therefore rides along in
+    /// [`source_text`](Self::source_text), so that accessor goes on reading it.
     pub(crate) fn into_owned<'dst>(self, source: Span<'dst>) -> Attrlist<'dst> {
         Attrlist {
             attributes: self
@@ -51,6 +71,7 @@ impl<'src> Attrlist<'src> {
                 .collect(),
             anchor: self.anchor.map(CowStr::into_owned),
             source,
+            source_text: Some(CowStr::from(self.source.data().to_string())),
         }
     }
 
@@ -85,6 +106,7 @@ impl<'src> Attrlist<'src> {
                         attributes,
                         anchor: Some(CowStr::from(anchor)),
                         source,
+                        source_text: None,
                     },
                     after: source.discard_all(),
                 },
@@ -200,6 +222,7 @@ impl<'src> Attrlist<'src> {
                     attributes,
                     anchor: None,
                     source,
+                    source_text: None,
                 },
                 after: source.discard_all(),
             },
@@ -229,6 +252,7 @@ impl<'src> Attrlist<'src> {
             ],
             anchor: None,
             source: language,
+            source_text: None,
         }
     }
 
@@ -305,6 +329,7 @@ impl<'src> Attrlist<'src> {
             attributes: later_attributes,
             anchor: later_anchor,
             source: _,
+            source_text: _,
         } = later;
 
         if later_anchor.is_some() {
@@ -564,6 +589,20 @@ impl<'src> Attrlist<'src> {
         roles
     }
 
+    /// The attrlist text this list was parsed from.
+    ///
+    /// For every list parsed straight from the source it describes, that is
+    /// its [`source`](Self::span) span's own bytes. For one rebuilt by
+    /// [`into_owned`](Self::into_owned) from a temporary — whose `source` is a
+    /// coarser *location tag* rather than the text (design §4.4) — it is the
+    /// owned copy that method kept.
+    fn source_text(&'src self) -> &'src str {
+        match &self.source_text {
+            Some(text) => text.as_ref(),
+            None => self.source.data(),
+        }
+    }
+
     /// Recovers the role from a quote-delimited first positional attribute (for
     /// example `['role']`) in a quoted-text attribute list.
     ///
@@ -592,7 +631,7 @@ impl<'src> Attrlist<'src> {
         // `['a,b']` yields the role `'a`) rather than being treated as quoted
         // content. A quote-delimited first positional always leaves at least its
         // opening quote here, so the slice is never empty.
-        let raw = self.source.data();
+        let raw = self.source_text();
         Some(raw.split_once(',').map_or(raw, |(first, _)| first).trim())
     }
 
@@ -2495,6 +2534,35 @@ mod tests {
             .unwrap_if_no_warnings();
 
             assert!(mi.item.quoted_text_fallback_role().is_none());
+        }
+
+        #[test]
+        fn an_owned_list_keeps_the_text_it_was_parsed_from() {
+            let p = Parser::default();
+
+            // `into_owned` re-tags a list parsed from a temporary with a
+            // *coarser* source span — the inline AST builder's case, where the
+            // attrlist text is the escaped or attribute-expanded bytes of a
+            // match string and the span is only a location tag (design §4.4).
+            // This is the one accessor that reads the list's own text rather
+            // than a parsed attribute, so it reads the kept copy: recovering
+            // the raw span's `'a<b'` here would drop the escaping the string
+            // pipeline's own rendered `class` carries.
+            let escaped = "'a&lt;b'";
+
+            let owned = crate::attributes::Attrlist::parse(
+                crate::Span::new(escaped),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings()
+            .item
+            .into_owned(crate::Span::new("'a<b'"));
+
+            assert_eq!(owned.quoted_text_fallback_role().unwrap(), escaped);
+
+            // The location tag is the span it was re-tagged with, unchanged.
+            assert_eq!(owned.span().data(), "'a<b'");
         }
     }
 

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1325,6 +1325,11 @@ mod tests {
             "[[install,Installation]]",
             "anchor:install[Installation]",
             "[#free_the_world]#free the world#",
+            // An id carrying a special character: both pipelines register the
+            // *escaped* id, since both parse the attribute list out of text
+            // the escaping step already ran over (see
+            // [`quote_attributes`](crate::content::inline_builder::quotes)).
+            "[#a&b]#x#",
             "[[a]] [[a]]",
             "[[[id]]]",
             "*see [[x]]* and footnote:[see [[y]]]",

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -35,7 +35,12 @@
 //!   [`Styled`](crate::inlines::Styled) span, **introducing nesting** — `*a _b_
 //!   c*` becomes a tree, not a flat run. It reuses the *exact* [`quote_subs`]
 //!   the string pipeline matches with (changing the recognition *sink*, not the
-//!   recognition), so its fold is byte-identical to the string step.
+//!   recognition), so its fold is byte-identical to the string step. An
+//!   attributed span's own attribute list (`['a<b']*bold*`) is parsed from the
+//!   level's **match string** — the escaped bytes the string replacer parses
+//!   out of its own haystack, since `specialcharacters` has already run — so
+//!   the entity, not the author's raw `<`, reaches the rendered `class`/`id`
+//!   (see [`quote_attributes`](quotes)).
 //! - [`apply_attribute_references`] recognizes attribute references (`{name}`),
 //!   splicing a set attribute's resolved value into the node stream, classified
 //!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs per
@@ -56,9 +61,10 @@
 //!   inside a [`synthesized`](quotes::Piece::synthesized) run instead of
 //!   treating it as opaque; and no **macro** family defers there any more. An
 //!   [`Attrlist`] a node carries needs no `'src` slice of its own — an image's
-//!   bracket and both link families' attribute-list-bearing display texts are
-//!   parsed from the level's own match string (the bytes the string replacer
-//!   parses too) and [`into_owned`](Attrlist::into_owned)ed off it — so
+//!   bracket, both link families' attribute-list-bearing display texts, and an
+//!   attributed span's own list are parsed from the level's own match string
+//!   (the bytes the string replacer parses too) and
+//!   [`into_owned`](Attrlist::into_owned)ed off it — so
 //!   [`range_is_verbatim`](macros::image::range_is_verbatim) survives only
 //!   where a *borrow* is still preferred, not as a boundary. And a macro
 //!   needing only its own *text* (no `Span`-typed field) — an anchor's id, a

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1065,6 +1065,17 @@ mod tests {
             "[#anchor]++text++",
             "['quoted role']++text++",
             "[.a.b#id]++text++",
+            // An attribute list carrying a special character. Unlike an
+            // attributed *quote's* — parsed from the escaped text, since the
+            // escaping step runs before the quotes step (see
+            // [`quote_attributes`](super::quotes)) — this extraction pass runs
+            // *ahead* of every step, so the string pipeline parses the
+            // author's raw bytes here and `attributes_of` matches it by
+            // parsing the source slice.
+            "[.a<b]++text++",
+            "[#a&b]++text++",
+            "['a<b&c']++text++",
+            "[.a<b]+text+",
             // `<`/`>`/`&` and quote-ish content inside the body: `+++`/`pass:`
             // stay raw, `++`/`$$` escape specials only, and quotes never run
             // over the body either way.

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1,5 +1,6 @@
 //! The quoted-text substitution step.
 
+use super::macros::image::{range_has_no_opaque_piece, range_is_verbatim};
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
@@ -115,13 +116,49 @@ fn match_level<'src>(
         return nodes;
     }
 
-    let matches = find_matches(sub, &s);
+    let matches: Vec<QuoteMatch> = find_matches(sub, &s)
+        .into_iter()
+        .filter(|m| attrlist_is_readable(&nodes, &pieces, m))
+        .collect();
 
     if matches.is_empty() {
         return nodes;
     }
 
     rebuild_level(&nodes, &pieces, &s, &matches, root, parser)
+}
+
+/// Reports whether a match's attribute list, if it has one, is one this step
+/// can read the same bytes out of that the string pipeline's own quote
+/// replacer reads out of its haystack — i.e. crosses no **opaque** piece (see
+/// [`range_has_no_opaque_piece`]).
+///
+/// A match with no attribute list is always readable, which is the
+/// overwhelmingly common case.
+///
+/// The one shape this rejects is an attribute list crossing a piece whose
+/// bytes exist only at fold time or behind a placeholder — a rendered span
+/// from an earlier sub, or a masked passthrough or STEM expression
+/// (`[.a+++x+++b]#y#`). The string pipeline parses its attribute list with the
+/// passthrough's own placeholder inside it, restoring the passthrough's text
+/// into the rendered `class` afterwards, which a tree that keeps that text as
+/// its own node cannot reproduce (splicing the text back in at parse time
+/// would let a comma inside it split the attribute list, where the string
+/// pipeline's one atomic placeholder never can). Leaving the whole construct
+/// unrecognized — literal text, never a *wrong* node — is the same boundary
+/// every macro family draws, and puts this match back in the same position a
+/// rejected look-ahead leaves one: out of the match list, so the surrounding
+/// gap reproduces its original nodes and a later sub may still match there.
+fn attrlist_is_readable(nodes: &[InlineNode<'_>], pieces: &[Piece], m: &QuoteMatch) -> bool {
+    let QuoteMatchKind::Wrap {
+        attrlist: Some(range),
+        ..
+    } = &m.kind
+    else {
+        return true;
+    };
+
+    range_has_no_opaque_piece(nodes, pieces, range)
 }
 
 /// Reconstructs the escaped match string for a level and the [`Piece`] map back
@@ -298,7 +335,7 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
 /// §3.4.1 leaves recognizing a macro *inside* one for a later increment (see
 /// [`apply_attribute_references`](super::attribute_refs::apply_attribute_references)'s
 /// doc comment) — distinct from
-/// [`range_is_verbatim`](super::macros::image::range_is_verbatim),
+/// [`range_is_verbatim`],
 /// which a family needing to *slice* `'src` (a target, an `Attrlist<'src>`)
 /// uses instead and which already rejects a synthesized piece outright.
 pub(in crate::content::inline_builder) fn range_overlaps_synthesized(
@@ -592,7 +629,7 @@ fn rebuild_level<'src>(
                 emit_range(nodes, pieces, body.clone(), &mut children);
 
                 let (id, roles, attrs) = match attrlist {
-                    Some(range) => attributes_of(source_slice(pieces, range.clone(), root), parser),
+                    Some(range) => quote_attributes(s, range.clone(), pieces, root, parser),
 
                     None => (None, Vec::new(), None),
                 };
@@ -620,14 +657,69 @@ fn rebuild_level<'src>(
     out
 }
 
-/// Parses an attributed quote's attribute list, returning the id, roles, and
-/// the full [`Attrlist`] (kept so the fold renders exactly as the string
-/// pipeline).
+/// Parses an **attributed quote's** attribute list out of the level's own
+/// match string, returning the id, roles, and the full [`Attrlist`] (kept so
+/// the fold renders exactly as the string pipeline).
+///
+/// Those match-string bytes are the ones the string pipeline's quote replacer
+/// parses: by the time the quotes step runs, its haystack holds the *escaped*
+/// text (`['a&lt;b&amp;c']*bold*`), so the role it parses — and renders into
+/// the `class` attribute verbatim — carries the entity, not the author's raw
+/// `<`. Parsing the source slice instead would put an unescaped `<`/`&` into
+/// rendered markup, which is both a divergence and, for a `"`-bearing value,
+/// exactly the injection the escaping is there to prevent (pinned by
+/// `quoted_positional_role_class_does_not_double_escape_special_characters` in
+/// the crate's own security tests).
+///
+/// A **verbatim** range's match-string bytes *are* its source bytes, so it
+/// parses straight from `'src` and its attribute names and values borrow
+/// (§4.5) — the shape every ordinary `[.role]#text#` takes. Any other range
+/// (an escaped special, a restored entity or typographic replacement, or a
+/// [`synthesized`](Piece::synthesized) expansion under an order that runs
+/// `attributes` before `quotes`) has no `'src` slice whose bytes are the
+/// attrlist text, so it parses from a [`Span::new`] over the match-string
+/// slice — whose `line`/`col`/`offset` are meaningless and never escape this
+/// function — and [`into_owned`](Attrlist::into_owned)s the result onto the
+/// range's coarse source span (design §4.4), exactly as
+/// [`bracket_attrlist`](super::macros::image) does for an image's bracket and
+/// [`text_attrlist`](super::macros::links) for a link's display text.
+///
+/// A range crossing an *opaque* piece never reaches here: such a match is
+/// dropped by [`attrlist_is_readable`] before the rebuild.
+fn quote_attributes<'src>(
+    s: &str,
+    range: std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+) -> (
+    Option<CowStr<'src>>,
+    Vec<CowStr<'src>>,
+    Option<Attrlist<'src>>,
+) {
+    let source = source_slice(pieces, range.clone(), root);
+
+    if range_is_verbatim(pieces, &range) {
+        return attributes_of(source, parser);
+    }
+
+    // `s[range]` is in bounds and on char boundaries: every range here comes
+    // from a capture over `s` itself.
+    let escaped = s.get(range).unwrap_or_default();
+
+    attributes_of_attrlist(parse_attrlist(Span::new(escaped), parser).into_owned(source))
+}
+
+/// Parses an attribute list from `source` and takes it apart, returning the
+/// id, roles, and the full [`Attrlist`].
 ///
 /// Shared with the attribute-list-prefixed passthrough forms
 /// ([`passthrough_step`](super::passthrough_step)), which parse their own
-/// attrlist the same way and fold through the same
-/// [`Styled`] node.
+/// attrlist the same way and fold through the same [`Styled`] node. Unlike an
+/// attributed quote's (see [`quote_attributes`]), a passthrough's attrlist is
+/// read from the source slice, and correctly so: the extraction pass that
+/// recognizes it runs *before* the escaping step, so the string pipeline
+/// parses the author's raw bytes there too.
 pub(super) fn attributes_of<'src>(
     source: Span<'src>,
     parser: &Parser,
@@ -636,10 +728,26 @@ pub(super) fn attributes_of<'src>(
     Vec<CowStr<'src>>,
     Option<Attrlist<'src>>,
 ) {
-    let attrlist = Attrlist::parse(source, parser, AttrlistContext::Inline)
-        .item
-        .item;
+    attributes_of_attrlist(parse_attrlist(source, parser))
+}
 
+/// Parses one inline attribute list, discarding the warnings — the shared
+/// spelling both of [`quote_attributes`]'s paths use.
+fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
+    Attrlist::parse(source, parser, AttrlistContext::Inline)
+        .item
+        .item
+}
+
+/// Takes an already-parsed attribute list apart into the id, roles, and the
+/// list itself.
+fn attributes_of_attrlist<'src>(
+    attrlist: Attrlist<'src>,
+) -> (
+    Option<CowStr<'src>>,
+    Vec<CowStr<'src>>,
+    Option<Attrlist<'src>>,
+) {
     // Extract owned id/roles before the attrlist is moved into the node, exactly
     // as the string pipeline's quote replacer does.
     //
@@ -923,11 +1031,11 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::test_support::{
-        assert_styled, assert_text, build_src, build_through_quotes, fold_html,
+        assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_passthroughs,
     };
     use crate::{
         HasSpan, Span,
-        content::{Content, SubstitutionStep},
+        content::{Content, SubstitutionGroup, SubstitutionStep},
         inlines::{CharRef, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -1043,6 +1151,32 @@ mod tests {
             "[.a.b]_x_",
             "['quoted role']#x#",
             "[.role1.role2]#x#",
+            // An attribute list carrying a special character. The escaping
+            // step runs *before* this one, so the string pipeline parses the
+            // already-escaped text and renders the entity straight into the
+            // `class`/`id` attribute; `quote_attributes` parses the same
+            // match-string bytes, in every spelling an attribute list has.
+            "[.a<b]*bold*",
+            "[#a&b]#x#",
+            "[a<b]#x#",
+            // The same, on the *unconstrained* branch, whose attribute list is
+            // its own capture group.
+            "[.role]##x##",
+            "[.a<b]##x##",
+            "[role=\"a<b\"]*bold*",
+            "['a<b&c']*bold*",
+            "[.a&b.c<d]_x_",
+            "[#i&d.r<le]*bold*",
+            "[.role]#a < b#",
+            // The `"`-escaping the built-in backend adds on top (a quoted
+            // positional role and a `role=` value alike) composes with it: the
+            // specials stay singly escaped either way.
+            "['x\" onmouseover=\"y']*bold*",
+            "[role='a\"b']#x#",
+            // Escaped-with-attributes: the `[…]` is kept literal (and escaped
+            // as ordinary text by the step before this one) while the body is
+            // still wrapped with no attribute list at all.
+            "\\[a<b]*bold*",
             // Deeper nesting and repeated spans.
             "nested *_`all three`_* here",
             "*a* *b* *c*",
@@ -1804,9 +1938,160 @@ mod tests {
                 assert_eq!(styled.variant, StyleVariant::Unquoted);
                 assert_eq!(styled.roles, vec![CowStr::from("lead")]);
                 assert!(styled.attrs.is_some(), "the attribute list is retained");
+
+                // A wholly verbatim attribute list is parsed from its own
+                // `'src` slice, so the node's list is located exactly there
+                // (its values borrow, per §4.5) rather than falling back to
+                // the coarse span an owned one takes.
+                let attrs = styled.attrs.as_ref().unwrap();
+                assert_eq!(attrs.span().data(), ".lead");
+                assert_eq!(attrs.span().line(), 1);
+                assert_eq!(attrs.span().col(), 2);
             }
 
             other => panic!("expected Styled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_attributed_spans_attribute_list_is_parsed_from_the_escaped_text() {
+        // The structural counterpart of the corpus fixtures above: the role
+        // and id a special-carrying attribute list yields are the *escaped*
+        // bytes — the ones the string pipeline's quote replacer parses out of
+        // its own (already-escaped) haystack and renders verbatim into the
+        // `class`/`id` attribute — not the author's raw `<`/`&`.
+        let source = "[#a&b.c<d]*bold*";
+        let nodes = build_src(Span::new(source));
+
+        match &nodes[0] {
+            InlineNode::Styled(styled) => {
+                assert_eq!(styled.id, Some(CowStr::from("a&amp;b")));
+                assert_eq!(styled.roles, vec![CowStr::from("c&lt;d")]);
+
+                // Those bytes have no `'src` slice of their own, so the list
+                // is owned and takes the bracket's coarse source span (design
+                // §4.4) as its location tag — the same fallback an image's
+                // bracket and a link's display-text list already take.
+                let attrs = styled.attrs.as_ref().unwrap();
+                assert_eq!(attrs.span().data(), "#a&b.c<d");
+                assert_eq!(attrs.span().line(), 1);
+                assert_eq!(attrs.span().col(), 2);
+
+                // The span itself still covers the whole construct, sliced
+                // from `'src`.
+                assert_eq!(styled.location.data(), source);
+            }
+
+            other => panic!("expected Styled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_crossing_an_opaque_piece_is_a_documented_divergence() {
+        // An *opaque* piece inside an attribute list — a masked passthrough
+        // (`[.a+++x+++b]#y#`) or a span an earlier sub already rendered
+        // (`[.a**b**c]#y#`) — is the one shape `attrlist_is_readable` rejects.
+        // The string pipeline parses its attribute list out of a haystack that
+        // holds the passthrough's own *placeholder* (one atomic character no
+        // comma can hide behind), or the earlier sub's rendered tags, and
+        // restores the passthrough's text into the rendered `class`
+        // afterwards. A tree cannot reproduce either: splicing a passthrough's
+        // text in at parse time would let a comma inside it split the list
+        // where the placeholder never can, and a span's markup exists at fold
+        // time alone. So the construct is left unrecognized — literal text,
+        // never a *wrong* node (which is what the raw source slice used to
+        // yield here: a `class` of `a**b**c`) — exactly as every macro family
+        // leaves its own opaque-piece boundary.
+        //
+        // If that boundary is ever lifted, fold these fixtures into the
+        // parity corpus above.
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for (source, golden_html) in [
+            ("[.a+++x+++b]#y#", "<span class=\"axb\">y</span>"),
+            ("[.a$$x$$b]#y#", "<span class=\"axb\">y</span>"),
+            (
+                "[.a**b**c]#y#",
+                "<span class=\"a<strong>b</strong>c\">y</span>",
+            ),
+            (
+                "[role=\"a *b* c\"]#y#",
+                "<span class=\"a <strong>b</strong> c\">y</span>",
+            ),
+        ] {
+            let nodes = build_src(Span::new(source));
+            let folded = super::super::fold_html(&nodes, &renderer, &crate::Parser::default());
+            let golden = golden_passthroughs(source);
+
+            assert_eq!(golden, golden_html);
+            assert_ne!(folded, golden, "expected a divergence for {source:?}");
+
+            // The attributed construct itself is gone from the tree: what the
+            // string pipeline renders as an attributed `<span>` is left as
+            // literal text (an earlier sub's own span, or the passthrough's
+            // `Raw` leaf, still sits inside it).
+            assert!(
+                !folded.contains("<span"),
+                "expected no attributed span for {source:?}, got {folded:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_rewritten_by_a_later_step_is_a_documented_divergence() {
+        // The complement of the boundary above, and not one this step can
+        // draw: under the *normal* order the steps that run **after** quotes
+        // (attribute references, character replacements) go on matching over
+        // the string pipeline's whole rendered string — the markup the quotes
+        // step just wrote included — so they rewrite bytes that live only
+        // inside a rendered `class`/`id` attribute. A later *sub* of this same
+        // step does it too (`[.a~b~c]#y#`, whose subscript sub runs after the
+        // unquoted one that consumed the attribute list). A tree's markup
+        // exists at fold time alone, and its later transducers see the nodes,
+        // not the tags, so an attribute list is whatever the sub that
+        // recognized it parsed, and nothing rewrites it afterwards.
+        //
+        // This is the same class as `flatten_prior_markup`'s own (design
+        // §5.2, Phase 4 step 6's late-escaping increment) — a step acting on
+        // another step's emitted markup — seen from the other side, and it
+        // costs four shapes: an attribute reference in a single-quoted role, a
+        // typographic replacement, a *restored* entity (whose escaped
+        // `&amp;amp;` the replacements step unwinds one level in the rendered
+        // markup), and a later sub's own span.
+        let parser = crate::Parser::default().with_intrinsic_attribute(
+            "myrole",
+            "highlight",
+            crate::parser::ModificationContext::Anywhere,
+        );
+
+        for (source, golden_html) in [
+            (
+                "['{myrole}']*bold*",
+                "<strong class=\"'highlight'\">bold</strong>",
+            ),
+            ("[.a(C)c]#x#", "<span class=\"a&#169;c\">x</span>"),
+            (
+                "[.a&amp;b]*bold*",
+                "<strong class=\"a&amp;b\">bold</strong>",
+            ),
+            ("[.a~b~c]#y#", "<span class=\"a<sub>b</sub>c\">y</span>"),
+        ] {
+            let mut content = Content::from(Span::new(source));
+            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+            assert_eq!(content.rendered_str(), golden_html);
+
+            let folded = super::super::fold_html(
+                &super::super::build(Span::new(source), &parser, None),
+                &HtmlSubstitutionRenderer {},
+                &parser,
+            );
+
+            assert_ne!(
+                folded,
+                content.rendered_str(),
+                "expected a divergence for {source:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
With the corpus-wide audit's itemized map closed (#1212), re-running the fold-parity sweep turns up one more **blocker** of the kind that map's own items were — not an unclaimed form the tree leaves literal, but a *wrong* answer for content a golden test already exercises, and this one a **security** test: `['a<b&c']*bold*`, whose rendered `class` the string pipeline escapes (`class="'a&lt;b&amp;c'"`) and the fold did not.

## The cause

The one attribute list this module still parsed from `'src`. Every macro family's list is parsed out of the level's **match string** — an image's bracket (#1208), and both link families' display texts (#1209) — but the *quotes* step's own attributed span kept the source slice, and by the time that step runs `SpecialCharacters` has already escaped the author's `<`/`&`. So the string replacer's haystack — and the `class`/`id` value it renders verbatim — carries the entity where the source carries the character. Parsing the source slice put an **unescaped** `<`, `>`, or `&` into rendered markup: one entity's worth of the escaping the `"`-escaping beside it exists to provide.

## The change

`quote_attributes` is the same one move those two increments made:

- a **verbatim** range's match-string bytes *are* its source bytes, so it keeps the `'src` parse and its borrow (§4.5) — every ordinary `[.role]#text#`;
- every other range parses from a `Span::new` over the match-string slice and `into_owned`s the result onto §4.4's coarse span.

No node field changed: a `Styled` span already carried its `id`, `roles`, and own `Attrlist<'src>`; only the bytes they are read from did.

Landing it closed a latent gap in `Attrlist::into_owned`'s own stated contract — "every parsed field is a `CowStr`, so nothing but the location depends on the original span" — which one accessor falsifies: `quoted_text_fallback_role` reads the list's own *text*, not a parsed attribute, because Asciidoctor's `parse_quoted_text_attributes` takes a quote-delimited first positional (`['role']`) verbatim, quote characters included, straight off the source. A re-tagged list would have read the coarse span's raw bytes — precisely the security fixture's own spelling. `into_owned` now carries an owned copy of the text it was parsed from and that accessor reads it, so the contract holds for every family that owns a list off a temporary, not just this one.

## What stays divergent

Two shapes, each pinned by its own test:

- **An attribute list crossing an opaque piece** (`[.a+++x+++b]#y#`, `[.a**b**c]#y#`) — the boundary every macro family draws, drawn here for the first time. The string pipeline parses its list out of a haystack holding the passthrough's own placeholder (one atomic character no comma can hide behind), or the earlier sub's rendered tags, and restores the passthrough's text into the rendered `class` afterwards. Such a match is now dropped from the level's match list rather than built into a wrong node (a `class` of `a**b**c`), leaving the construct literal and putting it exactly where a rejected look-ahead leaves one.
- **An attribute list rewritten by a later step (or later sub) of the same order** (`['{myrole}']`, `[.a(C)c]`, `[.a&amp;b]`, `[.a~b~c]`) — `flatten_prior_markup`'s own category seen from the other side: those steps go on matching over the whole rendered string, so they rewrite bytes that live only inside a rendered attribute, which a tree whose markup exists at fold time alone has nowhere to hold. That needs its own policy rather than another parse-source choice.

## Tests

- The quotes differential corpus gains every attribute-list spelling carrying a special (shorthand role, id, block-style positional, `role=` value, quoted positional, several at once, and the same on the unconstrained branch), alongside the `"`-escaping composing with it and the escaped-with-attributes form.
- The passthrough corpus gains the mirror-image fixtures pinning why *its* attrlist keeps the source parse (its extraction pass runs ahead of the escaping step, so the string pipeline reads the author's raw bytes there too).
- The staged `apply_ref_side_effects` corpus gains an id-carrying fixture, since the id it registers is now the escaped one the golden pipeline registers.
- New structural, divergence, and `Attrlist::into_owned` unit tests.

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence set strictly **shrank**: the security fixture's own source is gone and no pre-existing one appeared — the set's only additions are this increment's own new divergence-pinning fixtures.

As with every prep piece before it, **nothing further is wired in**: `rendered_html()` remains the string pipeline's own string.

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅ (clean)
- `cargo test --workspace` ✅ (5270 passed)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- `cargo llvm-cov` — `attributes/attrlist.rs` 100% lines/functions/regions; `content/inline_builder/quotes.rs` 100% functions, its only uncovered lines being `other => panic!(…)` arms in test assertions plus one pre-existing region in the untouched `emit_range`.

The design doc gains its "*Step 6 prep landed as (an attributed span's attribute list…)*" narrative paragraph and checklist entry, in the style of every prior increment on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMfaCxGG6gqjSeE8bm5siP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMfaCxGG6gqjSeE8bm5siP)_