### PR TITLE
feat: Read an enclosing span's boundary characters (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3729,6 +3729,85 @@ Each phase is a reviewable unit with a clear exit gate.
   additions are this increment's own new divergence-pinning fixtures). As with every prep piece
   before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the boundary characters an enclosing span presents to a nested
+  level):* re-running the corpus-wide fold-parity sweep after the increment above turns up one
+  more **blocker** of the same kind — a *wrong* answer for content a golden test already
+  exercises, rather than an unclaimed form: ``` `"``end points``"` ```, which the string
+  pipeline renders ``` `&#8220;`end points`&#8221;` ``` (the inner backticks staying literal)
+  where the fold wrapped them in a `<code>` span. Its cause is a category no increment had named,
+  and this closes it.
+
+  The string pipeline has no levels. A step matches over one flat string in which an earlier
+  step's construct is already **rendered markup**, so a pattern's boundary classes read that
+  markup's own characters — and this module's transducers match one *level* at a time, where the
+  same position is the start or end of the haystack. The two agree for a construct written at the
+  content's own top level and diverge for one written **inside** a span: the double-quote sub runs
+  before the monospace one, so by the time monospace matches, the string pipeline's haystack holds
+  `&#8220;` — whose `;` that sub's own `(^|[^\w&;:}])` boundary class excludes — where a level
+  matched in isolation shows `^`. The same fact reaches the character-replacements step through
+  the spaced em dash's `(^|\n| )--( |\n|$)`, at *either* edge of any span (`*x --*` renders
+  `<strong>x --</strong>`, the `--` staying literal because `<` follows it there).
+
+  A new [`LevelContext`](../../parser/src/content/inline_builder/quotes.rs) carries the pair of
+  characters an enclosing construct's rendering presents — the last of its opening markup and the
+  first of its closing markup — and a level is matched inside them: its own match string is
+  wrapped in the two before the pattern runs, and every offset the pattern reports is mapped back
+  with [`LevelContext::unshift`](../../parser/src/content/inline_builder/quotes.rs), clipped to the
+  level. So only *recognition* changes; every range a caller goes on to slice stays in the level's
+  own coordinates, no shared machinery
+  ([`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) and its 24 callers)
+  changes signature, and the root level borrows its haystack untouched. A pattern may legitimately
+  *consume* a context character — a constrained sub's boundary group is exactly that — and the
+  clip drops it rather than emitting it, which is right because that group is text the sub keeps
+  and the enclosing span already carries it.
+
+  Which characters a span presents is decided by its own rendering shape, from the **built-in**
+  backend: `>`/`<` for every variant that wraps its body in a tag, `;`/`&` for the two smart-quote
+  variants (`&#8220;…&#8221;`), and — for the one variant whose shape depends on what its
+  attribute list resolves to — by rendering it around a probe body. Reading the built-in backend
+  here is the same deliberate compromise
+  [`special_entity`](../../parser/src/content/inline_builder/quotes.rs) and
+  [`replacement_entity`](../../parser/src/content/inline_builder/quotes.rs) already make (a custom
+  backend changes what the fold *emits*, not the recognition the AsciiDoc patterns were written
+  against), and `styled_boundaries_match_the_built_in_renderer` pins the shapes against the
+  renderer itself so the two cannot drift. The
+  [`post_replacements`](../../parser/src/content/inline_builder/post_replacements.rs) step had
+  already reasoned this way for its own `$` — "a nested `Styled` or `Ref` level is always followed
+  by its own closing markup … so a ` +` ending a span is not at a line end there" — with a
+  boolean; this generalizes that one step's flag into a pair of characters every step's patterns
+  can read, and the two steps whose patterns read one (`Quotes` and `CharacterReplacements`) now
+  do.
+
+  Three shapes stay divergent, each pinned by its own test. A construct written **beside** an
+  entity-rendered span at its own level (``` `"`a`"`code` ```) reads the last character of that
+  span's *closing* markup in the string pipeline's haystack, where `build_match_string` stands
+  the whole span in as one `SPAN_PLACEHOLDER` belonging to no boundary class at all — the same
+  boundary class the bare-e-mail family already documents from the other direction
+  (`**bold**doc@example.org`); answering it means classifying the placeholder itself, which every
+  family reading one would then see. The **macros** step's own families read a boundary character
+  too (the auto-link's prefix group, the bare e-mail's mismatch-prefix one) and each finds its
+  matches through its own `find_*_matches`, so giving them the context is a step-shaped increment
+  of its own (`*doc@example.org*` links where the string pipeline, reading the `>` that ends
+  `<strong>`, leaves the address literal). And a **transparent** span — an unquoted one whose
+  attribute list resolves to neither a role nor an id, so it renders to its body and nothing else
+  — has its children inherit the context it sits in, which is right whenever the span is all its
+  parent's level holds and wrong when a sibling follows it (`*[width=10]#x --# --*`), since the
+  haystack then shows what that sibling begins with; modelling that means deriving a level's
+  context from its *siblings* rather than from its enclosing construct alone.
+
+  The quotes and character-replacements differential corpora gain each construct written against
+  an enclosing span's own edge in every variant's rendering shape, the same constructs away from
+  either edge (where both pipelines match), the rules that read no boundary of their own, and the
+  same fixtures at the content's own top level; fixtures are added to the whole-pipeline broad
+  sweep and combined-constructs corpus, to the group-parity corpus (the boundary a span presents
+  comes from its rendering, which no effective order changes), and to the structural recorder
+  cross-check — where the recorder, recovering what actually rendered, reads the string pipeline's
+  own answer. A whole-document test drives the golden fixture's own shape end to end through the
+  real parse path. Re-running the corpus-wide fold-parity audit (tree building forced on for every
+  parse in the suite) confirms the divergence set strictly **shrank**: the golden source above is
+  gone and no pre-existing one appeared (the set's only additions are this increment's own new
+  divergence-pinning fixtures). As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4243,6 +4322,25 @@ Each phase is a reviewable unit with a clear exit gate.
        dropped rather than built wrong, and one a *later* step of the same order rewrites inside
        the emitted markup stays divergent, each with its own test; see the step's own "landed as"
        note above.
+
+     - ✅ **prep (an enclosing span's boundary characters).** The sweep that followed the
+       increment above turned up one more blocker of the same kind — ``` `"``end points``"` ```,
+       a golden fixture whose inner backticks the string pipeline leaves literal and the fold
+       wrapped in a `<code>` span — and with it a category no increment had named: a pattern's
+       boundary classes
+       read the *rendered markup* an earlier step wrote, where a transducer matching one level at
+       a time reads that level's own start or end. A new
+       [`LevelContext`](../../parser/src/content/inline_builder/quotes.rs) wraps a level's match
+       string in the two characters its enclosing construct's rendering presents (`>`/`<` for a
+       tag, `;`/`&` for a smart quote, probed for the one variant whose shape its attribute list
+       decides — pinned against the built-in renderer) and maps every offset back with
+       [`unshift`](../../parser/src/content/inline_builder/quotes.rs), so only recognition changes
+       and no shared machinery changes signature. The two steps whose patterns read a boundary —
+       `Quotes` and `CharacterReplacements` (the spaced em dash, at either edge of any span) —
+       take it; see the step's own "landed as" note above. What still defers is the same class one
+       level out (a construct *beside* a span, where the placeholder belongs to no boundary class),
+       the macros step's own families, and a transparent span's siblings, each with its own
+       divergence test.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -1,6 +1,6 @@
 //! The character-replacements substitution step.
 
-use super::quotes::{Piece, build_match_string, emit_range, source_slice};
+use super::quotes::{LevelContext, Piece, build_match_string, emit_range, source_slice};
 use crate::{
     Span,
     content::{CharacterReplacement, character_replacements, maybe_has_replacements},
@@ -37,7 +37,7 @@ pub(super) fn apply_character_replacements<'src>(
     let mut nodes = nodes;
 
     for repl in character_replacements() {
-        nodes = apply_one_replacement(repl, nodes, root);
+        nodes = apply_one_replacement(repl, nodes, root, LevelContext::ROOT);
     }
 
     nodes
@@ -48,21 +48,32 @@ pub(super) fn apply_character_replacements<'src>(
 /// earlier steps created (a replacement inside a span is recognized just as the
 /// string pipeline recognizes one inside a rendered tag), then matching and
 /// replacing at this level.
+///
+/// `ctx` is the boundary context this level sits in
+/// ([`LevelContext`]): "just as the string pipeline recognizes one inside a
+/// rendered tag" is true of the tag's *inside* only once the tag's own
+/// characters are there to be read, which is what decides an em dash written
+/// against either edge of a span (`*x --*` renders `<strong>x --</strong>`,
+/// the `--` staying literal because `<` follows it in that haystack, not the
+/// end of a line).
 fn apply_one_replacement<'src>(
     repl: &CharacterReplacement,
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
         .map(|node| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_one_replacement(repl, styled.children, root);
+                let inner = LevelContext::inside_styled(&styled, ctx);
+                styled.children = apply_one_replacement(repl, styled.children, root, inner);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_one_replacement(repl, reference.children, root);
+                reference.children =
+                    apply_one_replacement(repl, reference.children, root, LevelContext::INSIDE_REF);
                 InlineNode::Ref(reference)
             }
 
@@ -70,7 +81,7 @@ fn apply_one_replacement<'src>(
         })
         .collect();
 
-    replace_level(repl, nodes, root)
+    replace_level(repl, nodes, root, ctx)
 }
 
 /// One character-replacement match at a level, in absolute match-string byte
@@ -81,6 +92,32 @@ struct ReplacementMatch {
 
     /// What to emit in place of `full`.
     kind: ReplacementKind,
+}
+
+impl ReplacementMatch {
+    /// Maps every offset in this match out of the
+    /// [`haystack`](LevelContext::haystack) it was found in and back into the
+    /// level's own match string (see [`LevelContext::unshift`]).
+    fn unshift(self, prefix: usize, len: usize) -> Self {
+        let map = |range: std::ops::Range<usize>| LevelContext::unshift(prefix, len, range);
+
+        Self {
+            full: map(self.full),
+
+            kind: match self.kind {
+                ReplacementKind::Unescape { backslash } => ReplacementKind::Unescape {
+                    backslash: map(backslash..backslash).start,
+                },
+
+                ReplacementKind::Replace { consumed, value } => ReplacementKind::Replace {
+                    consumed: map(consumed),
+                    value,
+                },
+
+                ReplacementKind::Entity { name } => ReplacementKind::Entity { name: map(name) },
+            },
+        }
+    }
 }
 
 enum ReplacementKind {
@@ -111,6 +148,7 @@ fn replace_level<'src>(
     repl: &CharacterReplacement,
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -120,7 +158,20 @@ fn replace_level<'src>(
         return nodes;
     }
 
-    let matches = find_replacement_matches(repl, &s);
+    // The rule runs over the level wrapped in its enclosing construct's own
+    // boundary characters, and every offset it reports is mapped back into the
+    // level's own coordinates (see [`LevelContext`]).
+    let (haystack, prefix) = ctx.haystack(&s);
+
+    // A match the clip emptied kept nothing of the level itself, so there is
+    // nothing here to replace. No rule's pattern can produce one — each needs
+    // at least two characters, and a context is one — so this is the clip's own
+    // invariant rather than a case any fixture reaches.
+    let matches: Vec<ReplacementMatch> = find_replacement_matches(repl, &haystack)
+        .into_iter()
+        .map(|m| m.unshift(prefix, s.len()))
+        .filter(|m| !m.full.is_empty())
+        .collect();
 
     if matches.is_empty() {
         return nodes;
@@ -312,6 +363,104 @@ mod tests {
         SubstitutionStep::CharacterReplacements.apply(&mut content, &parser, None);
         SubstitutionStep::PostReplacement.apply(&mut content, &parser, None);
         content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn a_replacement_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
+        // A rule whose pattern reads what surrounds its match — the spaced em
+        // dash's `(^|\n| )--( |\n|$)` is the one in this step — must see the
+        // enclosing span's own markup where the string pipeline's flat
+        // haystack holds it, not the start or end of a level. `*x --*` renders
+        // `<strong>x --</strong>`: the `--` stays literal because `<` follows
+        // it there, and a level matched in isolation would take its own end as
+        // the line end the rule wants.
+        for source in [
+            // Against either edge, in each variant's own rendering shape.
+            "*-- x*",
+            "*x --*",
+            "_x --_",
+            "`x --`",
+            "#x --#",
+            "[.r]#x --#",
+            "^x --^",
+            "~x --~",
+            "**x --**",
+            r#""`-- x`""#,
+            r#""`x --`""#,
+            r#"'`x --`'"#,
+            // Away from either edge, where the rule matches inside the span in
+            // both pipelines.
+            "*a -- b*",
+            "_a -- b_",
+            r#""`a -- b`""#,
+            // The rules that read no boundary of their own are unaffected.
+            "*(C) x*",
+            "*x ...*",
+            "*w'w*",
+            "*a -> b*",
+            "*&copy; x*",
+            // The word-anchored em dash keeps its own leading word character
+            // rather than a boundary one.
+            "*one--two*",
+            // And the same constructs at the content's own top level, where a
+            // pattern's `^`/`$` is exactly what the string pipeline presents.
+            "-- x",
+            "x --",
+            "a -- b",
+            // A span *beside* a replacement, where the placeholder standing in
+            // for it is not the space the rule requires — in either pipeline.
+            "*x*-- y",
+            "*x* -- y",
+        ] {
+            assert_eq!(
+                golden_replacements(source),
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_replacement_beside_a_transparent_span_is_a_documented_divergence() {
+        // An unquoted span whose attribute list resolves to neither a role nor
+        // an id renders to its body and nothing else, so its children inherit
+        // the context the span itself sits in
+        // ([`LevelContext::inside_styled`]). That is right whenever the span
+        // is all its parent's level holds — `[width=10]#x --#` at the top
+        // level replaces the dash in both pipelines — and wrong when a sibling
+        // follows it, because the string pipeline's haystack then shows what
+        // that sibling begins with (here a space, which is exactly the em
+        // dash's own trailing class) where the tree shows the parent's closing
+        // markup.
+        //
+        // Modelling that means deriving a level's context from its *siblings*
+        // rather than from its enclosing construct alone — a strictly larger
+        // walk, for the one span shape that renders nothing of its own.
+        //
+        // If it lands, fold this fixture into the corpus above.
+        let source = "*[width=10]#x --# --*";
+
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_ne!(
+            folded,
+            golden_replacements(source),
+            "expected the documented divergence to still reproduce for {source:?}"
+        );
+
+        // The string pipeline replaces the *first* dash (a space follows it,
+        // the transparent span having rendered nothing); the tree leaves both
+        // literal.
+        assert_eq!(folded, "<strong>x -- --</strong>");
+
+        // The same span with nothing after it agrees, since there is no
+        // sibling for the inherited context to be wrong about.
+        let source = "[width=10]#x --#";
+
+        assert_eq!(
+            golden_replacements(source),
+            fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -845,6 +845,17 @@ mod tests {
             "https://example.org[a *bold* label] auto-link",
             "<https://example.org[an _angle_ label] auto-link",
             "https://example.org[the image:logo.png[Logo] one] auto-link",
+            // A construct written against an enclosing span's own edge, where
+            // the string pipeline's haystack holds that span's rendered markup
+            // and the tree holds the level's own start or end.
+            r#""``end points``""#,
+            r#""`_e_`""#,
+            r#""`x `code` y`""#,
+            "*x --*",
+            "*-- x*",
+            "[.r]#x --#",
+            r#""`x --`""#,
+            "*a -- b*",
             "   ",
             "a\nb\nc",
         ];
@@ -1305,6 +1316,53 @@ mod tests {
         // **masked passthrough**.
         assert_parity("Visit https://example.org[a +[literal]+ label] now.");
         assert_parity("Visit https://example.org[a +++<b>x</b>+++ label] today.");
+
+        // A construct written against an enclosing span's own edge, where the
+        // string pipeline's haystack holds that span's rendered markup and a
+        // level matched in isolation holds its own start or end — the quotes
+        // and character-replacements steps' own boundary context, here running
+        // through the whole assembled pipeline (so the *other* steps see the
+        // spans these decisions leave behind).
+        assert_parity(r#"He said "``end points``" and then "`_left it_`" alone."#);
+        assert_parity("A *span ending in a dash --* and a _-- leading one_.");
+        assert_parity_with(
+            r#"The "`{product} -- *now*`" release ships (C) today."#,
+            with_product,
+        );
+        assert_parity("A [.r]#roled -- span# and a `code -- span` here.");
+    }
+
+    #[test]
+    fn a_macro_at_a_spans_own_edge_is_a_documented_divergence() {
+        // The macros step recurses into a `Styled`/`Ref` child of its own, and
+        // two of its families read the character immediately before a match —
+        // the auto-link's boundary-prefix group and the bare e-mail's
+        // mismatch-prefix one. Against a span's own opening edge the string
+        // pipeline reads that span's rendered markup there (`<strong>` ends in
+        // `>`, one of the e-mail pattern's own mismatch characters, so the
+        // address stays literal) where the level alone shows a start anchor.
+        //
+        // The [`LevelContext`](quotes::LevelContext) the quotes and
+        // character-replacements steps take answers exactly this, and applying
+        // it here is a step-shaped increment of its own: the macros step's
+        // families each find their matches through their own
+        // `find_*_matches`, so the context has to reach every one of them (and
+        // the two that read a prefix must then read the context character
+        // rather than defer on it, which is what the e-mail family's own
+        // placeholder-prefix rule does today).
+        //
+        // If that lands, fold these fixtures into the corpus above.
+        for source in ["*doc@example.org*", "_doc@example.org writes_"] {
+            let folded = built(source, &Parser::default());
+
+            assert_ne!(
+                golden(source, &Parser::default()),
+                folded,
+                "expected the documented divergence to still reproduce for {source:?}"
+            );
+
+            assert!(folded.contains("mailto:doc@example.org"), "{folded:?}");
+        }
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1812,6 +1870,12 @@ mod tests {
                 // `parser_with_product` sets for both sides.)
                 "kbd:[Ctrl&C] and a < b",
                 "line one < +\nline two > end",
+                // A construct written against an enclosing span's own edge:
+                // the boundary characters that span presents come from its
+                // rendering, which no effective order changes, so the same
+                // decision holds for a group that never escapes.
+                r#""``end points``" and a < b"#,
+                "*x --* and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1,12 +1,14 @@
 //! The quoted-text substitution step.
 
+use std::{borrow::Cow, ops::Range};
+
 use super::macros::image::{range_has_no_opaque_piece, range_is_verbatim};
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{QuoteSub, maybe_has_quotes, quote_subs},
     inlines::{CharRef, InlineNode, SpanForm, StyleVariant, Styled},
-    parser::{QuoteScope, QuoteType},
+    parser::{HtmlSubstitutionRenderer, InlineSubstitutionRenderer, QuoteScope, QuoteType},
     strings::CowStr,
 };
 
@@ -16,6 +18,185 @@ use crate::{
 /// the string pipeline — it is a single non-word, non-space boundary character
 /// that a quote pattern treats as opaque content.
 pub(super) const SPAN_PLACEHOLDER: char = '\u{E0F0}';
+
+/// The characters an enclosing construct's own rendering presents to the level
+/// nested inside it — the bytes the string pipeline's haystack holds
+/// immediately before and after that level's own text.
+///
+/// The string pipeline has no levels: a step matches over one flat string in
+/// which an earlier step's construct is already *rendered markup*, so a
+/// pattern's boundary classes read that markup's own characters. A transducer
+/// matches one level at a time, where the same position is the start (or end)
+/// of the haystack — which is what `^`, `$`, and a `(^|[^\w&;:}])`-style
+/// boundary group see instead. The two agree for a construct written at the
+/// content's own top level and diverge for one written *inside* a span, where
+/// the string pipeline reads the span's opening `<strong>` (or `&#8220;`)
+/// rather than a start anchor: ``` `"``end points``"` ``` renders
+/// ``` `&#8220;`end points`&#8221;` ``` there — the inner backticks stay
+/// literal, because the `;` ending the entity fails the monospace sub's own
+/// boundary class — where a level matched in isolation sees `^` and wraps them
+/// in a `<code>` span.
+///
+/// A `LevelContext` restores those two characters: the level's match string is
+/// wrapped in them before a pattern is run over it, and every resulting offset
+/// is mapped back with [`LevelContext::unshift`], so only *recognition*
+/// changes and every range a caller goes on to slice stays in the level's own
+/// coordinates.
+///
+/// [`post_replacements`](super::post_replacements) already reasoned this way
+/// for its own `$` — a nested level "is always followed by its own closing
+/// markup … so a ` +` ending a span is not at a line end there" — with a
+/// boolean; this generalizes that one step's flag into the pair of characters
+/// every step's patterns can read.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct LevelContext {
+    /// The last character of the enclosing construct's *opening* markup, or
+    /// `None` at the content's own top level (where a pattern's `^` is
+    /// exactly what the string pipeline's haystack presents).
+    before: Option<char>,
+
+    /// The first character of the enclosing construct's *closing* markup, or
+    /// `None` at the content's own top level.
+    after: Option<char>,
+}
+
+impl LevelContext {
+    /// The context a [`Ref`](InlineNode::Ref) node presents to its own display
+    /// children: every reference the fold renders — a link, and a
+    /// cross-reference in each of its resolved and unresolved forms — wraps
+    /// them in an `<a …>…</a>` element.
+    ///
+    /// Only an order that runs `macros` *before* a step that descends into a
+    /// reference's children reaches this at all (the built-in orders run it
+    /// last but one, ahead of `post_replacements` alone). A cross-reference
+    /// the string pipeline is still holding as a deferred placeholder at that
+    /// moment presents that placeholder's own characters rather than the
+    /// element's, which read the same to every boundary class in play: both
+    /// are non-word, and neither is one of the `&;:}` a constrained quote
+    /// excludes nor the space or line end a spaced em dash requires.
+    pub(super) const INSIDE_REF: Self = Self {
+        before: Some('>'),
+        after: Some('<'),
+    };
+    /// The content's own top level: nothing encloses it, so a pattern's `^`
+    /// and `$` anchor exactly where the string pipeline's do.
+    pub(super) const ROOT: Self = Self {
+        before: None,
+        after: None,
+    };
+
+    /// The context a [`Styled`] span presents to its own children, given the
+    /// context that span itself sits in.
+    ///
+    /// A span the built-in backend renders with **no markup of its own** — an
+    /// unquoted span that ends up carrying neither a role nor an id, whose
+    /// rendering is its body and nothing else — is transparent, so its
+    /// children see whatever the span itself sees.
+    pub(super) fn inside_styled(styled: &Styled<'_>, enclosing: Self) -> Self {
+        match styled_boundaries(styled) {
+            Some((before, after)) => Self {
+                before: Some(before),
+                after: Some(after),
+            },
+
+            None => enclosing,
+        }
+    }
+
+    /// The haystack a pattern should be matched against for a level whose own
+    /// match string is `s`, together with the byte length of the prefix
+    /// [`unshift`](Self::unshift) removes again.
+    ///
+    /// At the top level this borrows `s` untouched, so the overwhelmingly
+    /// common case allocates nothing.
+    pub(super) fn haystack<'a>(&self, s: &'a str) -> (Cow<'a, str>, usize) {
+        let (Some(before), Some(after)) = (self.before, self.after) else {
+            return (Cow::Borrowed(s), 0);
+        };
+
+        let mut hay = String::with_capacity(s.len() + before.len_utf8() + after.len_utf8());
+        hay.push(before);
+        hay.push_str(s);
+        hay.push(after);
+
+        (Cow::Owned(hay), before.len_utf8())
+    }
+
+    /// Maps a range of the [`haystack`](Self::haystack) back into the level's
+    /// own match string, clamping it to the level.
+    ///
+    /// A pattern may legitimately *consume* a context character — a
+    /// constrained sub's boundary group is exactly that — but the character is
+    /// not part of the level and has no node behind it, so it is clipped away
+    /// rather than emitted: the boundary group is text the sub keeps anyway,
+    /// and here the enclosing span already carries it.
+    pub(super) fn unshift(prefix: usize, len: usize, range: Range<usize>) -> Range<usize> {
+        let start = range.start.saturating_sub(prefix).min(len);
+        let end = range.end.saturating_sub(prefix).min(len);
+
+        start..end
+    }
+}
+
+/// The two characters the **built-in** HTML backend places immediately around
+/// a [`Styled`] span's body, or `None` when it wraps the body in nothing at
+/// all.
+///
+/// Reading the *built-in* backend here is the same deliberate compromise
+/// [`special_entity`] and [`replacement_entity`] already make: a custom
+/// backend changes what the fold *emits*, not the recognition the AsciiDoc
+/// patterns were written against, so recognition stays backend-independent.
+/// Every variant but the unquoted one is decided by its own rendering shape —
+/// a tag (`<strong>…</strong>`) or an entity pair (`&#8220;…&#8221;`) — rather
+/// than by rendering it, which `styled_boundaries_match_the_built_in_renderer`
+/// pins against the renderer itself; an unquoted span is the one whose shape
+/// depends on what its attribute list resolves to, so it is rendered.
+fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+    match styled.variant {
+        // `&#8220;…&#8221;` / `&#8216;…&#8217;`.
+        StyleVariant::DoubleQuote | StyleVariant::SingleQuote => Some((';', '&')),
+
+        // A `<span …>` when the attribute list resolves to a role or an id,
+        // and the body alone when it does not.
+        StyleVariant::Unquoted => probe_styled_boundaries(styled),
+
+        // Every other variant wraps the body in an HTML tag.
+        _ => Some(('>', '<')),
+    }
+}
+
+/// [`styled_boundaries`] for a span whose rendering shape is not decided by
+/// its variant alone: renders it through the built-in backend around a probe
+/// body and reads the characters that land beside it.
+fn probe_styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+    // A NUL never appears in a rendered attribute value, so the probe is
+    // unambiguous.
+    const PROBE: &str = "\u{0}";
+
+    let scope = match styled.form {
+        SpanForm::Constrained => QuoteScope::Constrained,
+        SpanForm::Unconstrained => QuoteScope::Unconstrained,
+    };
+
+    let mut rendered = String::new();
+
+    HtmlSubstitutionRenderer {}.render_quoted_substitution(
+        quote_type_of(styled.variant),
+        scope,
+        styled.attrs.clone(),
+        styled.id.as_ref().map(|id| id.to_string()),
+        PROBE,
+        &mut rendered,
+    );
+
+    // The renderer always emits the body, so the probe is always there; the
+    // `unwrap_or_default` spells that lookup without a branch no input reaches,
+    // and an absent probe would read as "no markup of its own" — the same
+    // answer a span that wraps its body in nothing already gives.
+    let (before, after) = rendered.split_once(PROBE).unwrap_or_default();
+
+    before.chars().next_back().zip(after.chars().next())
+}
 
 /// The quoted-text substitution, as a node transducer: each shared
 /// [`quote_subs`] rule is applied to the tree in order (its order encodes
@@ -31,7 +212,7 @@ pub(super) fn apply_quotes<'src>(
     let mut nodes = nodes;
 
     for sub in quote_subs() {
-        nodes = apply_quote_sub(sub, nodes, root, parser);
+        nodes = apply_quote_sub(sub, nodes, root, parser, LevelContext::ROOT);
     }
 
     nodes
@@ -40,11 +221,18 @@ pub(super) fn apply_quotes<'src>(
 /// Applies one [`QuoteSub`] to `nodes`, first descending into the [`Styled`]
 /// spans earlier subs created (so this sub can match *inside* them — the
 /// nesting case), then matching and wrapping at this level.
+///
+/// `ctx` is the boundary context this level sits in (see [`LevelContext`]);
+/// a span's own children are matched in the context that span's rendering
+/// presents, which is what keeps a sub matching *inside* an earlier sub's span
+/// reading the same characters the string pipeline's flat haystack holds
+/// there.
 fn apply_quote_sub<'src>(
     sub: &QuoteSub,
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     // Recurse into the spans produced by earlier subs *before* matching at this
     // level. A span this sub itself creates below is therefore never revisited
@@ -53,7 +241,8 @@ fn apply_quote_sub<'src>(
         .into_iter()
         .map(|node| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_quote_sub(sub, styled.children, root, parser);
+                let inner = LevelContext::inside_styled(&styled, ctx);
+                styled.children = apply_quote_sub(sub, styled.children, root, parser, inner);
                 InlineNode::Styled(styled)
             }
 
@@ -61,7 +250,7 @@ fn apply_quote_sub<'src>(
         })
         .collect();
 
-    match_level(sub, nodes, root, parser)
+    match_level(sub, nodes, root, parser, ctx)
 }
 
 /// One leaf/opaque node's placement in a level's reconstructed match string.
@@ -107,6 +296,7 @@ fn match_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -116,8 +306,14 @@ fn match_level<'src>(
         return nodes;
     }
 
-    let matches: Vec<QuoteMatch> = find_matches(sub, &s)
+    // The pattern runs over the level wrapped in its enclosing construct's own
+    // boundary characters, and every offset it reports is mapped back into the
+    // level's own coordinates (see [`LevelContext`]).
+    let (haystack, prefix) = ctx.haystack(&s);
+
+    let matches: Vec<QuoteMatch> = find_matches(sub, &haystack)
         .into_iter()
+        .map(|m| m.unshift(prefix, s.len()))
         .filter(|m| attrlist_is_readable(&nodes, &pieces, m))
         .collect();
 
@@ -405,10 +601,43 @@ pub(super) fn replacement_entity(value: &str) -> Option<&'static str> {
 /// One accepted quote match at a level, in absolute match-string byte offsets.
 struct QuoteMatch {
     /// The whole match, `[start, end)`.
-    full: std::ops::Range<usize>,
+    full: Range<usize>,
 
     /// What to emit in place of `full`.
     kind: QuoteMatchKind,
+}
+
+impl QuoteMatch {
+    /// Maps every range in this match out of the
+    /// [`haystack`](LevelContext::haystack) it was found in and back into the
+    /// level's own match string (see [`LevelContext::unshift`]).
+    fn unshift(self, prefix: usize, len: usize) -> Self {
+        let map = |range: Range<usize>| LevelContext::unshift(prefix, len, range);
+
+        Self {
+            full: map(self.full),
+
+            kind: match self.kind {
+                QuoteMatchKind::Unescape => QuoteMatchKind::Unescape,
+
+                QuoteMatchKind::Wrap {
+                    keep_literal,
+                    body,
+                    construct,
+                    attrlist,
+                    variant,
+                    form,
+                } => QuoteMatchKind::Wrap {
+                    keep_literal: keep_literal.map(map),
+                    body: map(body),
+                    construct: map(construct),
+                    attrlist: attrlist.map(map),
+                    variant,
+                    form,
+                },
+            },
+        }
+    }
 }
 
 enum QuoteMatchKind {
@@ -1040,6 +1269,214 @@ mod tests {
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
+
+    #[test]
+    fn styled_boundaries_match_the_built_in_renderer() {
+        // [`styled_boundaries`] decides all but one variant from its rendering
+        // *shape* rather than by rendering it. This pins that shape against the
+        // renderer itself, exactly as
+        // `replacement_entity_matches_the_built_in_renderer` pins the
+        // replacement table, so the two cannot drift.
+        use super::{LevelContext, probe_styled_boundaries, styled_boundaries};
+        use crate::inlines::Styled;
+
+        let span = |variant| Styled {
+            variant,
+            form: SpanForm::Constrained,
+            id: None,
+            roles: vec![],
+            attrs: None,
+            children: vec![],
+            location: Span::new("x"),
+        };
+
+        for variant in [
+            StyleVariant::Strong,
+            StyleVariant::Emphasis,
+            StyleVariant::Code,
+            StyleVariant::Mark,
+            StyleVariant::Superscript,
+            StyleVariant::Subscript,
+            StyleVariant::DoubleQuote,
+            StyleVariant::SingleQuote,
+        ] {
+            let styled = span(variant);
+
+            assert_eq!(
+                styled_boundaries(&styled),
+                probe_styled_boundaries(&styled),
+                "boundary characters drifted from the built-in rendering of {variant:?}"
+            );
+        }
+
+        // An unquoted span carrying neither a role nor an id renders to its
+        // body and nothing else, so it presents no boundary of its own and its
+        // children inherit whatever it sees.
+        let bare = span(StyleVariant::Unquoted);
+        assert_eq!(styled_boundaries(&bare), None);
+        assert_eq!(
+            LevelContext::inside_styled(&bare, LevelContext::INSIDE_REF),
+            LevelContext::INSIDE_REF
+        );
+
+        // One carrying an id renders a `<span …>`, like every other tag. (The
+        // node's own `roles` are not consulted: the fold hands the renderer
+        // the span's `attrs` and `id`, and the renderer derives its roles from
+        // that attribute list — so the probe reads exactly what the fold
+        // will.)
+        let mut identified = span(StyleVariant::Unquoted);
+        identified.id = Some(CowStr::from("anchor"));
+        assert_eq!(styled_boundaries(&identified), Some(('>', '<')));
+    }
+
+    #[test]
+    fn level_context_wraps_and_unshifts() {
+        use super::LevelContext;
+
+        // At the content's own top level the haystack is the level's own match
+        // string, borrowed rather than rebuilt, and every offset is its own.
+        let (haystack, prefix) = LevelContext::ROOT.haystack("abc");
+        assert!(matches!(haystack, std::borrow::Cow::Borrowed("abc")));
+        assert_eq!(prefix, 0);
+        assert_eq!(LevelContext::unshift(0, 3, 1..3), 1..3);
+
+        // Inside a construct the level is wrapped in the two characters that
+        // construct's rendering presents, and the prefix is mapped back off.
+        let (haystack, prefix) = LevelContext::INSIDE_REF.haystack("abc");
+        assert_eq!(haystack, ">abc<");
+        assert_eq!(prefix, 1);
+        assert_eq!(LevelContext::unshift(prefix, 3, 1..4), 0..3);
+
+        // A range reaching into either context character is clipped to the
+        // level: those characters belong to the enclosing construct, which
+        // already carries them.
+        assert_eq!(LevelContext::unshift(prefix, 3, 0..2), 0..1);
+        assert_eq!(LevelContext::unshift(prefix, 3, 3..5), 2..3);
+        assert_eq!(LevelContext::unshift(prefix, 3, 4..5), 3..3);
+    }
+
+    #[test]
+    fn a_sub_inside_a_span_reads_that_spans_own_boundary_characters() {
+        // The nesting cases the enclosing span's rendering decides, each
+        // pinned against the string pipeline's own flat haystack.
+        for source in [
+            // The shape that named this: the double-quote sub runs *before*
+            // the monospace one, so by the time monospace matches, the string
+            // pipeline's haystack holds `&#8220;` — whose `;` its boundary
+            // class excludes — where the level alone would show `^`.
+            r#""``end points``""#,
+            r#""`_e_`""#,
+            r#""`#m#`""#,
+            r#"'`_e_`'"#,
+            // The same span, where the sub *does* match on both sides: a
+            // boundary character of its own precedes the construct.
+            r#""`x `code` y`""#,
+            r#""`a _b_ c`""#,
+            // A sub that runs *before* the smart-quote subs is unaffected: it
+            // matched over the raw source, where no entity had been written
+            // yet.
+            r#""`*b*`""#,
+            // A tag-rendered span presents `>` and `<`, which read exactly as
+            // the start and end anchors they replace for these classes — so
+            // every ordinary nesting fixture is unchanged.
+            "*a `b` c*",
+            "*a _b_ c*",
+            "_`code` in em_",
+            "#a *b* c#",
+            "[.r]#a `b` c#",
+            // An unquoted span that renders to its body alone presents no
+            // boundary of its own.
+            "[width=10]#a `b` c#",
+        ] {
+            assert_eq!(
+                golden_quotes(source),
+                fold_html(
+                    &build_through_quotes(Span::new(source)),
+                    &HtmlSubstitutionRenderer {}
+                ),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_sub_after_a_span_at_its_own_level_is_a_documented_divergence() {
+        // The mirror image of the fixtures above, one level out: a construct
+        // written *beside* an entity-rendered span reads the last character of
+        // that span's own closing markup in the string pipeline's haystack
+        // (`&#8221;`, whose `;` the monospace sub's boundary class excludes),
+        // where [`build_match_string`] stands the whole span in as one
+        // [`SPAN_PLACEHOLDER`] — a private-use codepoint that belongs to no
+        // boundary class at all.
+        //
+        // That is the same boundary class the bare e-mail family already
+        // documents from the other direction (`**bold**doc@example.org`, whose
+        // `</strong>` ends in one of that pattern's own mismatch characters):
+        // a placeholder standing in for markup hides what the markup's own
+        // characters would say. A `LevelContext` answers it for a level's
+        // *interior*, where the enclosing construct is known; answering it at a
+        // level's own siblings means classifying the placeholder itself, which
+        // every family reading one would then see — a later increment.
+        //
+        // If that lands, fold these fixtures into the corpus above.
+        for source in [r#""`a`"`code`"#, r#"'`a`'`code`"#] {
+            let folded = fold_html(
+                &build_through_quotes(Span::new(source)),
+                &HtmlSubstitutionRenderer {},
+            );
+
+            assert_ne!(
+                folded,
+                golden_quotes(source),
+                "expected the documented divergence to still reproduce for {source:?}"
+            );
+
+            assert!(folded.contains("<code>code</code>"), "{folded:?}");
+        }
+    }
+
+    #[test]
+    fn a_real_documents_nested_span_tree_folds_to_its_rendered_string() {
+        // End-to-end, through the real parse path, on the shape that named
+        // this increment: `"``end points``"` is a golden fixture of its own
+        // (`tests::asciidoc_lang::text::troubleshoot_unconstrained_formatting`
+        // asserts the inner backticks stay literal), so a tree that recognized
+        // a `<code>` span there would regress it the moment `rendered_html()`
+        // becomes a fold of this tree.
+        use crate::{
+            Parser,
+            blocks::{FindBlocks, IsBlock},
+        };
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "That only gives you \"``end points``\".\n",
+            "\n",
+            "A *span ending in --* here.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        // The two paragraphs; the section that contains them holds no inline
+        // content of its own and is skipped.
+        assert_eq!(folded_blocks, 2, "expected both paragraphs to be checked");
+    }
 
     #[test]
     fn replacement_entity_matches_the_built_in_renderer() {

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -812,6 +812,18 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "latexmath:[x < y] inline",
         "an icon:home[] icon",
         "icon:star[2x,role=gold] rated",
+        // A construct written against an enclosing span's own edge, where the
+        // string pipeline's haystack holds that span's rendered markup: the
+        // recorder recovers what actually rendered, so this compares the
+        // builder's boundary-context decision against the string pipeline's
+        // own reading structurally as well as by the bytes it folds to.
+        r#""``end points``""#,
+        r#""`_e_`""#,
+        r#""`x `code` y`""#,
+        "*x --*",
+        "*-- x*",
+        "[.r]#x --#",
+        r#""`x --`""#,
         "   ",
         "a\nb\nc",
     ];


### PR DESCRIPTION
Continues the `inline-ast` Phase 4, step 6 prep sequence: closing the divergences that would regress a golden test once `rendered_html()` becomes an authoritative fold of the tree.

## The blocker

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) after #1214 turns up one more **blocker** of the same kind — not an unclaimed form the tree leaves literal, but a *wrong* answer for content a golden test already exercises:

| source | string pipeline | fold (before) |
| --- | --- | --- |
| `"``end points``"` | `&#8220;`end points`&#8221;` | `&#8220;<code>end points</code>&#8221;` |

(`tests::asciidoc_lang::text::troubleshoot_unconstrained_formatting` asserts the inner backticks stay literal.)

## The category

The string pipeline has no levels. A step matches over one flat string in which an earlier step's construct is already **rendered markup**, so a pattern's boundary classes read that markup's own characters — where this module's transducers match one *level* at a time and see that level's own start or end instead.

The two agree at the content's top level and diverge *inside* a span: the double-quote sub runs before the monospace one, so by the time monospace matches, the string pipeline's haystack holds `&#8220;` — whose `;` that sub's own `(^|[^\w&;:}])` class excludes — where a level matched in isolation shows `^`. The same fact reaches the character-replacements step through the spaced em dash's `(^|\n| )--( |\n|$)`, at *either* edge of any span (`*x --*` renders `<strong>x --</strong>`, the `--` staying literal because `<` follows it there).

## The change

A new `LevelContext` (`content/inline_builder/quotes.rs`) carries the pair of characters an enclosing construct's rendering presents — the last of its opening markup, the first of its closing markup — and a level is matched inside them: its match string is wrapped in the two before the pattern runs, and every offset is mapped back with `LevelContext::unshift`, clipped to the level.

- Only **recognition** changes: every range a caller goes on to slice stays in the level's own coordinates, `build_match_string` and its 24 callers keep their signatures, and the root level borrows its haystack untouched.
- A pattern may legitimately *consume* a context character (a constrained sub's boundary group is exactly that); the clip drops it rather than emitting it, which is right because the enclosing span already carries it.
- Which characters a span presents comes from its own rendering shape under the **built-in** backend — `>`/`<` for every tag-wrapping variant, `;`/`&` for the two smart-quote variants, and a probe render for the one variant whose shape its attribute list decides. Reading the built-in backend is the same deliberate compromise `special_entity`/`replacement_entity` already make (a custom backend changes what the fold *emits*, not the recognition the AsciiDoc patterns were written against), pinned by `styled_boundaries_match_the_built_in_renderer`.
- `post_replacements` had already reasoned this way for its own `$` ("a nested `Styled` or `Ref` level is always followed by its own closing markup…") with a boolean; this generalizes that one step's flag into a pair of characters. The two steps whose patterns read a boundary — `Quotes` and `CharacterReplacements` — now take it.

## Still deferred (each with its own divergence test)

- A construct written **beside** an entity-rendered span at its own level (``` `"`a`"`code` ```): the `SPAN_PLACEHOLDER` standing in for the span belongs to no boundary class at all — the same class the bare-e-mail family documents from the other direction (`**bold**doc@example.org`).
- The **macros** step's own families, which read a boundary character too (the auto-link's prefix group, the bare e-mail's mismatch-prefix one) and each find their matches through their own `find_*_matches` (`*doc@example.org*`).
- A **transparent** span (an unquoted one resolving to neither role nor id), whose children inherit the context the span sits in — right when the span is all its parent's level holds, wrong when a sibling follows it (`*[width=10]#x --# --*`).

## Tests

Differential corpora gain each construct written against an enclosing span's own edge in every variant's rendering shape, the same constructs away from either edge, the rules that read no boundary of their own, and the same fixtures at the top level; fixtures are added to the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check. A whole-document test drives the golden fixture's own shape end to end through the real parse path.

Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**: the golden source above is gone and no pre-existing one appeared (the set's only additions are this increment's own new divergence-pinning fixtures).

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5278 passed)
- `cargo +nightly doc --no-deps --document-private-items` clean
- `cargo llvm-cov`: `inline_builder/mod.rs` 100%, `quotes.rs` 99.27%, `char_replacements.rs` 99.02% — the only uncovered lines in the changed files are pre-existing `other => panic!(…)` arms in test assertions.

As with every prep piece before it, **nothing is wired into the parse path**: `rendered_html()` remains the string pipeline's own string. The design doc gains its "landed as" narrative and checklist entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ1MnwB5qQxdLs9Qh2q2Qj)_