### PR TITLE
feat: Read an enclosing span's boundary character in the macros step (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3808,6 +3808,77 @@ Each phase is a reviewable unit with a clear exit gate.
   gone and no pre-existing one appeared (the set's only additions are this increment's own new
   divergence-pinning fixtures). As with every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the same boundary characters, for the macros step's own families):*
+  the increment above closes the boundary question for the two steps whose *rules* read one, and
+  names the third — "the **macros** step's own families read a boundary character too … and each
+  finds its matches through its own `find_*_matches`, so giving them the context is a step-shaped
+  increment of its own" — as its own next piece. This is that piece.
+
+  Two of the step's families read the character immediately before a match: the auto-link's
+  boundary-prefix group (`( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )`) and the bare e-mail's
+  "prefix that causes a mismatch" one (`([\\>:/]?)`). Inside a span the string pipeline reads that
+  span's own rendered markup there, so `*doc@example.org*` keeps the address literal — `<strong>`
+  ends in `>`, one of the e-mail pattern's three mismatch characters — where a level matched in
+  isolation shows a start anchor and links it. That was the divergence the increment above pinned
+  with a test of its own; it is now parity, and its fixtures are folded into the corpora exactly as
+  that test's own note asked.
+
+  [`apply_macro_families`](../../parser/src/content/inline_builder/macros/mod.rs) therefore carries
+  the [`LevelContext`](../../parser/src/content/inline_builder/quotes.rs) down the same recursion
+  the two other steps take (a span's own rendering for its children, `INSIDE_REF` for a reference's,
+  the enclosing context inherited through a transparent span) and hands it to every family. What
+  differs is how a family *uses* it. `Quotes` and `CharacterReplacements` map each reported offset
+  back with [`unshift`](../../parser/src/content/inline_builder/quotes.rs); a macro family cannot,
+  because it does not merely report ranges — it reads the match string's own bytes through the
+  level's [`Piece`](../../parser/src/content/inline_builder/quotes.rs)s (`emit_range`,
+  `source_slice`, each of the three range gates), so haystack offsets and level offsets must not
+  coexist. A new [`LevelContext::shift`](../../parser/src/content/inline_builder/quotes.rs) removes
+  the second coordinate system instead of translating between them: it wraps the level's match
+  string and moves its pieces into the wrapped string's own coordinates, so nothing else in the
+  module changes signature and every gate and slice goes on reading one system. The context
+  characters belong to no piece — they are the *enclosing* construct's — so a range reaching one
+  contributes nothing, which is exactly what `unshift`'s own clip does (a boundary prefix is text
+  the enclosing span already carries).
+
+  Only the **opening** character is applied, and the asymmetry is the point. A *boundary* class
+  reads exactly one character, so one character answers it: `<strong>` ends in `>` and `&#8220;` in
+  `;`, which is precisely what these two groups inspect. A macro
+  *body* class consumes greedily instead — the bare URL's own `[^\s\[\]<]*` excludes a `<` (so a
+  tag-rendered span's closing markup already stops it in both pipelines) but admits an `&`, and at a
+  smart quote's closing `&#8220;…&#8221;` the string pipeline swallows the whole entity into the
+  target and leaves a stray `;` behind. Supplying the level one `&` would build a *third*,
+  differently wrong target, so the closing character is dropped rather than half-supplied and that
+  shape stays exactly as divergent as it already was, with a divergence test of its own. The other
+  spellings read no character before their match at all — each is anchored on a literal (`image:`,
+  `kbd:`, `menu:`, `indexterm`, `((`, `[[`, `anchor:`, `&lt;&lt;`, `xref:`, `link:`, `mailto:`) no
+  context character can begin — so for them the wrap is inert, and they take it for uniformity
+  rather than for effect. The bibliography anchor takes none: its pattern is `^`-anchored to the
+  content's own top level, the one level nothing encloses.
+
+  Two shapes stay divergent besides the closing half, each pinned by its own test. A **transparent**
+  span — one rendering to its body and nothing else — has its children inherit the context it
+  sits in, which is right when the span is all its parent's level holds and wrong when a
+  **sibling**
+  precedes it (`*x [width=10]#doc@example.org#*`, where the string pipeline reads the space that
+  sibling ends with): the transparent-span half of the class the increment above already documents
+  for its own steps, and closing it still means deriving a level's context from its siblings. And an
+  address **abutting** an opaque piece keeps the deferral
+  [`email_level`](../../parser/src/content/inline_builder/macros/links.rs) already documents — a
+  placeholder belongs to no mismatch class, one level out from what a context answers.
+
+  The e-mail and auto-link families each gain a differential corpus of their own construct written
+  against a span's edge in every variant's rendering shape (tag-rendered and entity-rendered), the
+  same constructs away from either edge, the escaped spellings, a replacement or restored entity in
+  the boundary position, and the same fixtures at the content's own top level, alongside a
+  structural assertion that the deferred address builds no node. Fixtures are added to the
+  whole-pipeline broad sweep and combined-constructs corpus, to the group-parity corpus (a span's
+  boundary comes from its rendering, which no effective order changes), and to the structural
+  recorder cross-check, where the recorder — recovering what actually rendered — reads the
+  string pipeline's own answer; a whole-document test drives both decisions end to end through the
+  real parse path. Re-running the corpus-wide fold-parity audit (tree building forced on for every
+  parse in the suite) confirms the divergence set strictly **shrank**: the two e-mail entries are
+  gone and no new one appeared. As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4341,6 +4412,23 @@ Each phase is a reviewable unit with a clear exit gate.
        level out (a construct *beside* a span, where the placeholder belongs to no boundary class),
        the macros step's own families, and a transparent span's siblings, each with its own
        divergence test.
+
+     - ✅ **prep (the same boundary, for the macros step).** The third of the categories the
+       increment above names — the **macros** step's own boundary-reading families, the
+       auto-link's prefix group and the bare e-mail's mismatch-prefix one — takes the context too,
+       closing
+       `*doc@example.org*` (which the string pipeline leaves literal, reading the `>` that ends
+       `<strong>`). `apply_macro_families` carries a `LevelContext` down its own recursion to every
+       family, but where the two other steps map each offset back with `unshift`, a macro family
+       reads the match string's *bytes* through the level's `Piece`s — so a new
+       [`LevelContext::shift`](../../parser/src/content/inline_builder/quotes.rs) moves those pieces
+       into the wrapped string's coordinates instead, leaving one coordinate system and no shared
+       signature changed. Only the **opening** character is applied: a boundary class reads one
+       character, while a macro body class consumes greedily and would swallow a half-supplied
+       closing one. See the step's own "landed as" note above. What still defers is that closing
+       half (a bare URL at an entity-rendered span's own closing edge), a transparent span's
+       siblings, and the abutting-placeholder class the e-mail family already documents, each with
+       its own divergence test.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -10,8 +10,8 @@ use crate::{
     content::{
         INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR,
         inline_builder::quotes::{
-            Piece, SPAN_PLACEHOLDER, build_match_string, emit_range, range_overlaps_synthesized,
-            source_slice, text_slice,
+            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
+            range_overlaps_synthesized, source_slice, text_slice,
         },
     },
     document::RefType,
@@ -187,6 +187,7 @@ pub(super) fn biblio_anchor_level<'src>(
 pub(super) fn anchor_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -196,6 +197,11 @@ pub(super) fn anchor_macros_level<'src>(
     if !s.contains("[[") && !s.contains("anchor:") {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_anchor_matches(&nodes, &s, &pieces, root);
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -7,7 +7,7 @@ use crate::{
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::quotes::{
-            Piece, build_match_string, replacement_entity, source_slice, text_slice,
+            LevelContext, Piece, build_match_string, replacement_entity, source_slice, text_slice,
         },
         normalize_text_lf_escaped_bracket,
     },
@@ -24,6 +24,7 @@ pub(super) fn image_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -32,6 +33,11 @@ pub(super) fn image_macros_level<'src>(
     if !((s.contains("image:") || s.contains("icon:")) && s.contains('[')) {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_image_matches(&s, &pieces, root, parser, &nodes);
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -6,7 +6,9 @@ use crate::{
     Span,
     content::{
         INLINE_INDEXTERM,
-        inline_builder::quotes::{Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+        inline_builder::quotes::{
+            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice,
+        },
         normalize_index_text, strip_see_and_seealso,
     },
     inlines::{IndexTerm, InlineNode},
@@ -21,6 +23,7 @@ use crate::{
 pub(super) fn indexterm_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -31,6 +34,11 @@ pub(super) fn indexterm_macros_level<'src>(
     if !((s.contains("((") && s.contains("))")) || (s.contains(":[") && s.contains("dexterm"))) {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_indexterm_matches(&s, &pieces, root);
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -11,7 +11,9 @@ use crate::{
     content::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
-        inline_builder::quotes::{Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+        inline_builder::quotes::{
+            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice,
+        },
     },
     inlines::{InlineNode, Ref, RefVariant},
     parser::has_dangerous_scheme,
@@ -135,6 +137,7 @@ pub(super) fn inline_link_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -143,6 +146,11 @@ pub(super) fn inline_link_level<'src>(
     if !s.contains("://") {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_inline_link_matches(&nodes, &s, &pieces, root, parser);
 
@@ -807,6 +815,7 @@ pub(super) fn link_macro_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -815,6 +824,11 @@ pub(super) fn link_macro_level<'src>(
     if !((s.contains("link:") || s.contains("mailto:")) && s.contains('[')) {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_link_macro_matches(&nodes, &s, &pieces, root, parser);
 
@@ -1378,6 +1392,7 @@ fn text_attrlist<'src>(
 pub(super) fn email_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -1386,6 +1401,11 @@ pub(super) fn email_level<'src>(
     if !s.contains('@') {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_email_matches(&nodes, &s, &pieces, root);
 
@@ -2555,6 +2575,76 @@ mod tests {
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
             golden_macros(source)
         );
+    }
+
+    #[test]
+    fn an_auto_link_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
+        // `INLINE_LINK`'s non-angle branch requires a boundary prefix
+        // (`( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )`), which inside a span the
+        // string pipeline reads out of that span's own rendered markup. Every
+        // shape a [`LevelContext`](super::super::quotes::LevelContext) can
+        // present — the `>` ending a tag and the `;` ending a smart quote's
+        // entity — is in that class, so the URL is recognized on both sides of
+        // the seam; this pins that the context the macros step now takes
+        // leaves that agreement intact rather than turning a start anchor into
+        // a prefix the class rejects.
+        for source in [
+            "*https://example.org*",
+            "_https://example.org_",
+            "`https://example.org`",
+            "[.hl]#https://example.org#",
+            "*https://example.org[Docs]*",
+            r#"He said "`https://example.org[Docs]`" ok."#,
+            r#"He said '`https://example.org[Docs]`' ok."#,
+            // Away from either edge, and with the boundary prefix the level
+            // itself supplies.
+            "*see https://example.org now*",
+            r#""`see https://example.org now`""#,
+            // An escaped scheme at a span's own edge still drops its backslash.
+            "*\\https://example.org*",
+            // The `link:`/`mailto:` macro and the angle-bracketed form read no
+            // boundary of their own, so they are unaffected either way.
+            "*link:index.html[Docs]*",
+            "*mailto:doc@example.org[Write]*",
+            "*<https://example.org>*",
+            // And the same at the content's own top level.
+            "https://example.org",
+            "see https://example.org now",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_url_at_an_entity_rendered_spans_closing_edge_is_a_documented_divergence() {
+        // The closing half of the same seam, which no single character can
+        // answer — and which the macros step therefore does not take (see
+        // [`LevelContext::shift`](super::super::quotes::LevelContext)).
+        // A boundary class reads exactly one character, but a bare URL's own
+        // body class (`[^\s\[\]<]*`) consumes greedily: it excludes a `<`, so
+        // a tag-rendered span's closing markup stops it in both pipelines, and
+        // it admits an `&`, so at a smart quote's closing `&#8220;…&#8221;` the
+        // string pipeline swallows the whole entity into the target and leaves
+        // a stray `;` behind. Supplying the level one `&` would build a third,
+        // differently wrong target, so the closing character is dropped rather
+        // than half-supplied and the tree keeps the well-formed reading — the
+        // same shape as the quotes step's own crossed-delimiter divergence.
+        let source = r#"He said "`https://example.org`" ok."#;
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_ne!(
+            golden_macros(source),
+            folded,
+            "expected the documented divergence to still reproduce"
+        );
+
+        // The string pipeline's own reading is the markup-perturbed one.
+        assert!(golden_macros(source).contains("https://example.org&#8221"));
+        assert!(folded.contains(r#"href="https://example.org""#));
     }
 
     #[test]
@@ -3983,6 +4073,148 @@ mod tests {
         );
 
         assert!(golden_macros(source).contains(r#"href="https://example.org""#));
+    }
+
+    #[test]
+    fn an_address_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
+        // The mismatch-prefix group reads the character immediately before the
+        // address, and inside a span the string pipeline reads that span's own
+        // *rendered* markup there: `<strong>` ends in `>`, one of the group's
+        // three mismatch characters, so `*doc@example.org*` keeps the address
+        // literal where a level matched in isolation sees a start anchor and
+        // links it. The macros step takes the same
+        // [`LevelContext`](super::super::quotes::LevelContext) the quotes and
+        // character-replacements steps do, so the two pipelines agree again.
+        for source in [
+            // Against a span's opening edge, in each variant's own rendering
+            // shape. Every tag-rendered variant ends its opening markup in `>`
+            // — a mismatch character — so the address stays literal in both.
+            "*doc@example.org*",
+            "_doc@example.org writes_",
+            "`doc@example.org`",
+            "#doc@example.org#",
+            "^doc@example.org^",
+            "~doc@example.org~",
+            "**doc@example.org**",
+            "[.hl]#doc@example.org#",
+            // The two smart-quote variants end theirs in the `;` of an entity,
+            // which is *not* a mismatch character — so both pipelines link the
+            // address there.
+            r#"He said "`doc@example.org`" today."#,
+            r#"He said '`doc@example.org`' today."#,
+            // Away from the opening edge, where the character before the
+            // address is the level's own text in both pipelines.
+            "*write to doc@example.org now*",
+            "*a doc@example.org b*",
+            r#""`write to doc@example.org now`""#,
+            // An escape at a span's own edge still drops its backslash: the
+            // prefix group takes the `\` rather than the context character.
+            "*\\doc@example.org*",
+            // A replacement or a restored entity before the address presents
+            // its own last character (`;` of the entity the built-in backend
+            // renders), which is no mismatch character in either pipeline.
+            "*(C)doc@example.org*",
+            "*&copy;doc@example.org*",
+            // And the same addresses at the content's own top level, where a
+            // level's start is exactly what the string pipeline presents.
+            "doc@example.org",
+            "write to doc@example.org now",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_address_at_a_tag_rendered_spans_edge_builds_no_node() {
+        // The parity above, read structurally: the address is left as literal
+        // text rather than recognized into a link the string pipeline does not
+        // build.
+        let nodes = build_src(Span::new("*doc@example.org*"));
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+
+        assert!(
+            children.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "an address at a span's own edge must stay literal: {children:?}"
+        );
+    }
+
+    #[test]
+    fn an_address_after_a_transparent_spans_sibling_is_a_documented_divergence() {
+        // An unquoted span whose attribute list resolves to neither a role nor
+        // an id renders to its body and nothing else, so its children inherit
+        // the context the span itself sits in
+        // ([`LevelContext::inside_styled`](super::super::quotes::LevelContext)).
+        // That is right whenever the span is all its parent's level holds and
+        // wrong when a *sibling* precedes it: the string pipeline's haystack
+        // shows what that sibling ends with (a space here) where the inherited
+        // context still shows the enclosing `<strong>`'s own `>`, so the
+        // address stays literal here and links there.
+        //
+        // This is the transparent-span half of the same class the quotes and
+        // character-replacements steps already document
+        // (`a_replacement_beside_a_transparent_span_is_a_documented_divergence`);
+        // closing it means deriving a level's context from its *siblings*
+        // rather than from its enclosing construct alone. If that lands, fold
+        // this fixture into the parity corpus above.
+        let source = "*x [width=10]#doc@example.org#*";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_ne!(
+            golden_macros(source),
+            folded,
+            "expected the documented divergence to still reproduce"
+        );
+
+        assert!(!folded.contains("mailto:"), "{folded:?}");
+        assert!(golden_macros(source).contains("mailto:doc@example.org"));
+    }
+
+    #[test]
+    fn a_real_documents_span_edge_addresses_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shapes that named
+        // this increment: an address written against a span's own edge must
+        // stay literal (as the string pipeline leaves it) and one written
+        // against a smart quote's must link, so a tree that decided either the
+        // other way would regress the moment `rendered_html()` becomes a fold
+        // of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "Mail *doc@example.org* or _doc@example.org writes_ here.\n",
+            "\n",
+            "He said \"`doc@example.org`\" and *https://example.org* too.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        // The two paragraphs; the section that contains them holds no inline
+        // content of its own and is skipped.
+        assert_eq!(folded_blocks, 2, "expected both paragraphs to be checked");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -14,7 +14,7 @@ use links::{email_level, inline_link_level, link_macro_level};
 use ui::{kbd_btn_macros_level, menu_macros_level};
 use xref::xref_macros_level;
 
-use super::quotes::{Piece, emit_range, source_slice, special_entity, text_slice};
+use super::quotes::{LevelContext, Piece, emit_range, source_slice, special_entity, text_slice};
 use crate::{
     Parser, Span,
     content::restored_entity_pattern,
@@ -137,33 +137,75 @@ pub(super) fn apply_macros<'src>(
     // is `^`-anchored, so it can only ever match the very start of the whole
     // content, never the start of a span's children (see
     // [`biblio_anchor_level`]) — which is why it sits outside
-    // [`apply_macro_families`]'s own recursion.
+    // [`apply_macro_families`]'s own recursion, and why it needs no
+    // [`LevelContext`] of its own: the top level is the one level nothing
+    // encloses.
     let nodes = biblio_anchor_level(nodes, root, parser);
 
-    apply_macro_families(nodes, root, parser)
+    apply_macro_families(nodes, root, parser, LevelContext::ROOT)
 }
 
 /// Applies each macro family at this level — and, first, at every level nested
 /// inside it — in the string step's own family order. See
 /// [`apply_macros`], which wraps this with the once-per-content
 /// bibliography-anchor pass.
+///
+/// # The boundary an enclosing construct presents
+///
+/// `ctx` is the [`LevelContext`] this level sits in — the character an
+/// enclosing construct's own rendering presents immediately before it, which
+/// the string pipeline's flat haystack holds there and a level matched in
+/// isolation does not. Two of this step's families read exactly that
+/// character: `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s
+/// "prefix that causes a mismatch" group (see
+/// [`links::inline_link_level`] and [`links::email_level`]). Without it,
+/// `*doc@example.org*` links here while the string pipeline — reading the `>`
+/// that ends `<strong>`, one of that group's own mismatch characters — leaves
+/// the address literal.
+///
+/// Each level's own match string is wrapped in that character before any
+/// family's pattern runs over it, and the level's [`Piece`]s are moved into the
+/// wrapped string's coordinates with [`LevelContext::shift`] — so a family
+/// reads one coordinate system throughout and nothing else in this module
+/// changes signature. Only the **opening** character is applied, for the
+/// reason [`LevelContext::shift`] itself documents: a boundary class reads one
+/// character, while a macro *body* class consumes greedily and would swallow a
+/// half-supplied closing one.
+///
+/// The seven other families read no character before their match — each is
+/// anchored on a literal (`image:`, `kbd:`, `menu:`, `indexterm`, `((`, `[[`,
+/// `anchor:`, `&lt;&lt;`, `xref:`, `link:`, `mailto:`) that no context
+/// character can begin — so for them the wrap is inert, and they take it for
+/// uniformity rather than for effect.
 fn apply_macro_families<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     // Recurse into spans/refs first, matching the string pipeline's
-    // whole-string pass.
+    // whole-string pass. Each nested level is matched in the context its own
+    // enclosing construct's rendering presents (see this function's own doc
+    // comment); a span the built-in backend renders with no markup of its own
+    // is transparent, so `inside_styled` hands its children whatever the span
+    // itself sees.
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
         .map(|node| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_macro_families(styled.children, root, parser);
+                let inner = LevelContext::inside_styled(&styled, ctx);
+
+                styled.children = apply_macro_families(styled.children, root, parser, inner);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_macro_families(reference.children, root, parser);
+                reference.children = apply_macro_families(
+                    reference.children,
+                    root,
+                    parser,
+                    LevelContext::INSIDE_REF,
+                );
                 InlineNode::Ref(reference)
             }
 
@@ -174,45 +216,45 @@ fn apply_macro_families<'src>(
     // The UI macros run before image/icon and only under `experimental`,
     // mirroring the string step's order and gate.
     let nodes = if parser.is_attribute_set("experimental") {
-        let nodes = kbd_btn_macros_level(nodes, root);
-        menu_macros_level(nodes, root)
+        let nodes = kbd_btn_macros_level(nodes, root, ctx);
+        menu_macros_level(nodes, root, ctx)
     } else {
         nodes
     };
 
-    let nodes = image_macros_level(nodes, root, parser);
+    let nodes = image_macros_level(nodes, root, parser, ctx);
 
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
     // `indexterm2:[…]`) run after image/icon and before the link families,
     // mirroring the string step's order.
-    let nodes = indexterm_macros_level(nodes, root);
+    let nodes = indexterm_macros_level(nodes, root, ctx);
 
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro, mirroring the string step's
     // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
-    let nodes = inline_link_level(nodes, root, parser);
+    let nodes = inline_link_level(nodes, root, parser, ctx);
 
     // The `link:`/`mailto:` macro runs after the auto-link pass, mirroring the
     // string step's order.
-    let nodes = link_macro_level(nodes, root, parser);
+    let nodes = link_macro_level(nodes, root, parser, ctx);
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
     // families and before the anchor pass, exactly where the string step runs
     // `InlineEmailReplacer` — so an address that is really the tail of a URL, or
     // a `mailto:` macro's own target, is already inside an opaque node (there,
     // already-rendered `<a …>` markup) and is not re-recognized.
-    let nodes = email_level(nodes, root);
+    let nodes = email_level(nodes, root, ctx);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
     // before cross-references, mirroring the string step's order. (The
     // bibliography-anchor pass the string step runs *first* — a `^`-anchored
     // `[[[id]]]`, recognized only inside a bibliography list item — runs in
     // [`apply_macros`], outside this recursion.)
-    let nodes = anchor_macros_level(nodes, root);
+    let nodes = anchor_macros_level(nodes, root, ctx);
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
-    xref_macros_level(nodes, root, parser)
+    xref_macros_level(nodes, root, parser, ctx)
 
     // Footnotes are **not** handled here. Every other family's recognition is
     // order-independent (no cross-node side effect), so it is safe for them to

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -5,7 +5,9 @@ use crate::{
     Span,
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
-        inline_builder::quotes::{Piece, build_match_string, source_slice, text_slice},
+        inline_builder::quotes::{
+            LevelContext, Piece, build_match_string, source_slice, text_slice,
+        },
         normalize_index_text, split_kbd_keys,
     },
     inlines::{InlineNode, Ui, UiKind},
@@ -30,12 +32,18 @@ const SUBMENU_DELIMITER: &str = "&gt;";
 pub(super) fn kbd_btn_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
     if !(s.contains(":[") && (s.contains("kbd:") || s.contains("btn:"))) {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_kbd_btn_matches(&nodes, &s, &pieces, root);
 
@@ -190,12 +198,18 @@ fn build_kbd_btn_node<'src>(
 pub(super) fn menu_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
     if !(s.contains("menu:") && s.contains('[')) {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_menu_matches(&nodes, &s, &pieces, root);
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -9,7 +9,7 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_XREF,
-        inline_builder::quotes::{Piece, build_match_string, source_slice},
+        inline_builder::quotes::{LevelContext, Piece, build_match_string, source_slice},
         xref_target::{
             XrefTarget, interpret_xref_target, other_document_reference, this_document_reference,
         },
@@ -82,6 +82,7 @@ pub(super) fn xref_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes);
 
@@ -94,6 +95,11 @@ pub(super) fn xref_macros_level<'src>(
     if !s.contains("xref:") && !s.contains("&lt;&lt;") {
         return nodes;
     }
+
+    // Matched over the level wrapped in the boundary character its enclosing
+    // construct presents, with the level's own pieces moved into that string's
+    // coordinates — see `apply_macro_families`'s own doc comment.
+    let (s, pieces) = ctx.shift(s, pieces);
 
     let matches = find_xref_matches(&nodes, &s, &pieces, root, parser);
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -856,6 +856,17 @@ mod tests {
             "[.r]#x --#",
             r#""`x --`""#,
             "*a -- b*",
+            // The macros step's own boundary-reading families at the same
+            // seam: the bare e-mail's mismatch prefix and the auto-link's
+            // boundary prefix.
+            "*doc@example.org*",
+            "_doc@example.org writes_",
+            "`doc@example.org`",
+            r#""`doc@example.org`""#,
+            "*write to doc@example.org now*",
+            "*https://example.org*",
+            "*https://example.org[Docs]*",
+            r#""`https://example.org[Docs]`""#,
             "   ",
             "a\nb\nc",
         ];
@@ -1330,39 +1341,18 @@ mod tests {
             with_product,
         );
         assert_parity("A [.r]#roled -- span# and a `code -- span` here.");
-    }
 
-    #[test]
-    fn a_macro_at_a_spans_own_edge_is_a_documented_divergence() {
-        // The macros step recurses into a `Styled`/`Ref` child of its own, and
-        // two of its families read the character immediately before a match —
-        // the auto-link's boundary-prefix group and the bare e-mail's
-        // mismatch-prefix one. Against a span's own opening edge the string
-        // pipeline reads that span's rendered markup there (`<strong>` ends in
-        // `>`, one of the e-mail pattern's own mismatch characters, so the
-        // address stays literal) where the level alone shows a start anchor.
-        //
-        // The [`LevelContext`](quotes::LevelContext) the quotes and
-        // character-replacements steps take answers exactly this, and applying
-        // it here is a step-shaped increment of its own: the macros step's
-        // families each find their matches through their own
-        // `find_*_matches`, so the context has to reach every one of them (and
-        // the two that read a prefix must then read the context character
-        // rather than defer on it, which is what the e-mail family's own
-        // placeholder-prefix rule does today).
-        //
-        // If that lands, fold these fixtures into the corpus above.
-        for source in ["*doc@example.org*", "_doc@example.org writes_"] {
-            let folded = built(source, &Parser::default());
-
-            assert_ne!(
-                golden(source, &Parser::default()),
-                folded,
-                "expected the documented divergence to still reproduce for {source:?}"
-            );
-
-            assert!(folded.contains("mailto:doc@example.org"), "{folded:?}");
-        }
+        // The same seam for the **macros** step, whose bare e-mail and
+        // auto-link families read a boundary character of their own: a
+        // tag-rendered span's opening `>` is one of the e-mail pattern's
+        // mismatch characters (so the address stays literal in both
+        // pipelines), while a smart quote's `;` is not (so both link it), and
+        // the auto-link's own prefix class accepts either.
+        assert_parity("*doc@example.org* and _doc@example.org writes_.");
+        assert_parity(r#"He said "`doc@example.org`" and `doc@example.org` too."#);
+        assert_parity("*write to doc@example.org now* and doc@example.org here.");
+        assert_parity("*https://example.org* and _https://example.org[Docs]_.");
+        assert_parity(r#"He said "`https://example.org[Docs]`" today."#);
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1876,6 +1866,11 @@ mod tests {
                 // decision holds for a group that never escapes.
                 r#""``end points``" and a < b"#,
                 "*x --* and a < b",
+                // The same for the macros step's own boundary-reading
+                // families, whose decision likewise comes from the enclosing
+                // span's rendering rather than from the order.
+                "*doc@example.org* and a < b",
+                "*https://example.org* and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -122,6 +122,63 @@ impl LevelContext {
         (Cow::Owned(hay), before.len_utf8())
     }
 
+    /// [`haystack`](Self::haystack)'s counterpart for a step that maps no
+    /// offsets back: it moves the level's own **pieces** into the haystack's
+    /// coordinates instead, so every offset a caller goes on to use — a match
+    /// range, a gate, a slice — is already in the one coordinate system the
+    /// haystack itself is in.
+    ///
+    /// This is what the [`macros`](super::macros) step takes, where
+    /// [`unshift`](Self::unshift) would not do: a macro family does not merely
+    /// *report* ranges, it reads the match string's own bytes through
+    /// [`Piece`]s ([`emit_range`], [`source_slice`],
+    /// [`range_has_no_opaque_piece`]), so haystack offsets and level offsets
+    /// cannot be allowed to coexist. Shifting the pieces removes the second
+    /// coordinate system rather than translating between them.
+    ///
+    /// The context character belongs to no piece — it is the *enclosing*
+    /// construct's, not this level's — so a range reaching it contributes
+    /// nothing: [`emit_range`] finds no piece overlapping it (which is exactly
+    /// [`unshift`](Self::unshift)'s own clip: a boundary prefix is text the
+    /// enclosing span already carries), and every gate skips it as
+    /// non-overlapping.
+    ///
+    /// # Only the opening character
+    ///
+    /// Unlike [`haystack`](Self::haystack), this applies the **opening** half
+    /// alone, and the asymmetry is the point. A pattern's *boundary class*
+    /// reads exactly one character, so one is all a level needs to answer it:
+    /// `<strong>` ends in `>` and `&#8220;` in `;`, which is precisely what
+    /// the auto-link's own `( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )` prefix
+    /// group and the bare e-mail's `([\\>:/]?)` mismatch-prefix group inspect
+    /// there.
+    ///
+    /// A macro *body* class, by contrast, consumes greedily rather than
+    /// reading one character: the auto-link's own bare-URL body
+    /// (`[^\s\[\]<]*`) excludes a `<` but not an `&`, so where the string
+    /// pipeline's haystack presents a whole closing `&#8221;` for it to
+    /// swallow, a level carrying one `&` would build a *different* wrong
+    /// target rather than the same one. The closing character is therefore
+    /// dropped rather than half-supplied — leaving that shape exactly as
+    /// divergent as it already is (see
+    /// `a_bare_url_at_an_entity_rendered_spans_closing_edge_is_a_documented_divergence`),
+    /// never newly wrong.
+    pub(super) fn shift(self, mut s: String, mut pieces: Vec<Piece>) -> (String, Vec<Piece>) {
+        let Some(before) = self.before else {
+            return (s, pieces);
+        };
+
+        // Wrapped in place rather than into a second string: the level owns
+        // its match string here, so this reuses that allocation.
+        s.insert(0, before);
+
+        for piece in &mut pieces {
+            piece.s_start += before.len_utf8();
+        }
+
+        (s, pieces)
+    }
+
     /// Maps a range of the [`haystack`](Self::haystack) back into the level's
     /// own match string, clamping it to the level.
     ///
@@ -1353,6 +1410,42 @@ mod tests {
         assert_eq!(LevelContext::unshift(prefix, 3, 0..2), 0..1);
         assert_eq!(LevelContext::unshift(prefix, 3, 3..5), 2..3);
         assert_eq!(LevelContext::unshift(prefix, 3, 4..5), 3..3);
+    }
+
+    #[test]
+    fn level_context_shifts_a_levels_pieces_into_the_haystack() {
+        use super::{LevelContext, Piece};
+
+        fn piece(s_start: usize, s_len: usize) -> Piece {
+            Piece {
+                node_index: 0,
+                s_start,
+                s_len,
+                src_offset: 100,
+                src_len: s_len,
+                atomic: false,
+                synthesized: false,
+            }
+        }
+
+        // The macros step maps no offsets back: it moves the level's own
+        // pieces into the haystack's coordinates instead, so one coordinate
+        // system reaches every gate and slice. Only the opening character is
+        // applied there, since a macro body class would swallow a
+        // half-supplied closing one.
+        let (haystack, pieces) =
+            LevelContext::INSIDE_REF.shift("abc".to_string(), vec![piece(0, 1), piece(1, 2)]);
+
+        assert_eq!(haystack, ">abc");
+        assert_eq!(pieces[0].s_start, 1);
+        assert_eq!(pieces[1].s_start, 2);
+
+        // At the content's own top level the level is its own haystack and no
+        // piece moves.
+        let (haystack, pieces) = LevelContext::ROOT.shift("abc".to_string(), vec![piece(0, 3)]);
+
+        assert_eq!(haystack, "abc");
+        assert_eq!(pieces[0].s_start, 0);
     }
 
     #[test]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -824,6 +824,16 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "*-- x*",
         "[.r]#x --#",
         r#""`x --`""#,
+        // The same seam for the macros step's own boundary-reading families —
+        // the bare e-mail's mismatch prefix and the auto-link's boundary
+        // prefix — where the recorder, recovering what actually rendered,
+        // reads the string pipeline's own answer.
+        "*doc@example.org*",
+        "_doc@example.org writes_",
+        r#""`doc@example.org`""#,
+        "*write to doc@example.org now*",
+        "*https://example.org*",
+        r#""`https://example.org[Docs]`""#,
         "   ",
         "a\nb\nc",
     ];


### PR DESCRIPTION
The previous increment (#1215) gave the `Quotes` and `CharacterReplacements` steps the boundary characters an enclosing construct's rendering presents, and named the third category it could not reach:

> The **macros** step's own families read a boundary character too (the auto-link's prefix group, the bare e-mail's mismatch-prefix one) and each finds its matches through its own `find_*_matches`, so giving them the context is a step-shaped increment of its own.

This is that increment.

## The divergence

Two of the step's families read the character immediately before a match: the auto-link's boundary-prefix group (`( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )`) and the bare e-mail's "prefix that causes a mismatch" one (`([\\>:/]?)`). Inside a span the string pipeline reads that span's own *rendered* markup there, so `*doc@example.org*` keeps the address literal — `<strong>` ends in `>`, one of the e-mail pattern's three mismatch characters — where a level matched in isolation shows a start anchor and links it. That was the divergence #1215 pinned with `a_macro_at_a_spans_own_edge_is_a_documented_divergence`; it is now parity, and that test's fixtures are folded into the corpora exactly as its own note asked.

## The change

`apply_macro_families` carries the `LevelContext` down the same recursion the two other steps take (a span's own rendering for its children, `INSIDE_REF` for a reference's, the enclosing context inherited through a transparent span) and hands it to every family.

What differs is how a family *uses* it. `Quotes` and `CharacterReplacements` map each reported offset back with `unshift`; a macro family cannot, because it does not merely report ranges — it reads the match string's own bytes through the level's `Piece`s (`emit_range`, `source_slice`, the three range gates), so haystack offsets and level offsets must not coexist. A new `LevelContext::shift` removes the second coordinate system instead of translating between them: it wraps the level's match string in place and moves its pieces into the wrapped string's coordinates, so nothing else in the module changes signature. The context character belongs to no piece — it is the enclosing construct's — so a range reaching it contributes nothing, which is exactly what `unshift`'s clip does.

Only the **opening** character is applied, and the asymmetry is the point. A boundary class reads exactly one character, so one answers it. A macro *body* class consumes greedily instead: the bare URL's own `[^\s\[\]<]*` excludes a `<` (so a tag-rendered span's closing markup already stops it in both pipelines) but admits an `&`, and at a smart quote's closing `&#8220;…&#8221;` the string pipeline swallows the whole entity into the target. Supplying the level one `&` would build a *third*, differently wrong target, so the closing character is dropped rather than half-supplied.

The seven other families read no character before their match — each is anchored on a literal (`image:`, `kbd:`, `menu:`, `indexterm`, `((`, `[[`, `anchor:`, `&lt;&lt;`, `xref:`, `link:`, `mailto:`) no context character can begin — so for them the wrap is inert. The bibliography anchor takes none: its pattern is `^`-anchored to the content's own top level.

## What stays divergent

Each pinned by its own test:

- the **closing half** at an entity-rendered span (`He said "` + backtick + `https://example.org` + backtick + `" ok.`), which no single character can answer;
- a **transparent** span with a *preceding sibling* (`*x [width=10]#doc@example.org#*`) — the transparent-span half of the class #1215 already documents for its own steps;
- an address **abutting** an opaque piece, the deferral `email_level` already documents.

## Testing

- The e-mail and auto-link families each gain a differential corpus of their construct written against a span's edge in every variant's rendering shape (tag-rendered and entity-rendered), the same constructs away from either edge, the escaped spellings, a replacement or restored entity in the boundary position, and the same fixtures at the content's own top level, plus a structural assertion that the deferred address builds no node.
- Fixtures added to the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check.
- A whole-document test drives both decisions end to end through the real parse path.
- A unit test for `LevelContext::shift`.
- Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) confirms the divergence set strictly **shrank**: the two e-mail entries are gone and no new one appeared.

Preflight per `CLAUDE.md`: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5,284 passing), `cargo +nightly doc --no-deps --document-private-items`, and `cargo llvm-cov` (no newly-uncovered line or region in the changed files) all clean.

As with every prep piece before it, **nothing further is wired in**: `rendered_html()` remains the string pipeline's own string.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JTCC3qyhWGuZbGFocbxSR)_