### PR TITLE
feat: Read the boundary characters a span presents to its siblings (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3879,6 +3879,85 @@ Each phase is a reviewable unit with a clear exit gate.
   parse in the suite) confirms the divergence set strictly **shrank**: the two e-mail entries are
   gone and no new one appeared. As with every prep piece before it, nothing further is wired in.
 
+  *Step 6 prep landed as (the boundary characters a span presents to its siblings):* the two
+  increments above answer what an enclosing construct presents to the level *inside* it, and both
+  name the same remaining half — a construct written **beside** a rendered span at its own level,
+  where `build_match_string` stands the whole span in as one `SPAN_PLACEHOLDER` belonging to no
+  boundary class at all. This is that half, for the class where the answer is unambiguous.
+
+  The mechanism is the mirror image of a [`LevelContext`](../../parser/src/content/inline_builder/quotes.rs):
+  where that wraps a *level* in the two characters its enclosing construct's rendering presents,
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) now wraps an opaque
+  node's *placeholder* in the two its own rendering presents to a sibling — the **first** character
+  of its opening markup and the **last** of its closing one, read from the same probe
+  [`styled_boundaries`](../../parser/src/content/inline_builder/quotes.rs) takes its own pair from
+  (now factored into one
+  [`probe_styled_boundaries_markup`](../../parser/src/content/inline_builder/quotes.rs) the two read
+  from opposite ends, pinned against the built-in renderer by a test of its own). Those two
+  characters belong to **no piece** — they are the opaque node's markup, and the node already has
+  the placeholder's piece — so a range reaching one contributes nothing, exactly as a
+  `LevelContext`'s do: `emit_range` finds no piece overlapping it, and every gate skips it as
+  non-overlapping. Nothing else in the module changes signature, and no gate, slice, or rebuild
+  changes at all; the one adjustment is in
+  [`s_to_src`](../../parser/src/content/inline_builder/quotes.rs), where a **leading** boundary
+  character is the first offset that ever falls before the first piece and now resolves to that
+  piece's own source start rather than dropping through to the past-the-last fallback.
+
+  Only the **entity-rendered** variants are classified — the two smart quotes, `&#8220;…&#8221;`
+  — and the scope is not about what a variant renders but about what
+  [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) can *tell*. A
+  `Styled` node reaching `build_match_string` is not necessarily a span the string pipeline has
+  rendered: the passthrough-extraction pass builds one of its own for an attribute-list-prefixed
+  passthrough (`[quotes]++text++`), which the string pipeline is holding as its own
+  `\u{96}…\u{97}` sentinel rather than as markup for every step this module runs. A sibling reads
+  that sentinel — which is exactly what the bare placeholder already reads as to every class in
+  play (both are non-word, and in none of `&;:}`, `[>\(\)\[\];"']`, or `[\\>:/]`) — so leaving such
+  a wrapper unclassified is the *right* answer, not an approximation. Telling one apart from a
+  genuinely rendered span needs the identity
+  [`masked_locations`](../../parser/src/content/inline_builder/special_chars.rs) collects before any
+  step runs, which `build_match_string` does not have, and **both** wrappers that pass builds are
+  tag-rendered; a smart-quote span, which it never builds, can only have come from the quotes step.
+
+  Nothing is lost by drawing the line there, because a tag's `<`/`>` read exactly as the placeholder
+  they would replace does to every *quote* boundary class — the classes that separate a `>` from a
+  placeholder are the **macros** step's two prefix groups, and neither can reach an entity-rendered
+  span at all: the sub that builds one requires a non-word character after its closing `` `" ``,
+  while a URL and a bare address each begin with a word character. So this increment's whole effect
+  lands in the quotes step, which is exactly where the divergence was. Four shapes are closed:
+  ``` "`a`"`code` ```, ``` '`a`'`code` ```, `` "`a`"#mark# ``, and ``` "`a`"'`b`' ``` — each one
+  the string pipeline leaves literal (or, for the last, wraps differently), reading the `;` that
+  ends `&#8221;` where a placeholder said nothing.
+
+  The divergence test the first increment left behind becomes a **parity** corpus, exactly as its own
+  note asked, gaining each construct written against a smart-quote span's outer edge in both
+  directions, the same constructs one character further out (where a space intervenes and both
+  pipelines match), the tag-rendered shapes that were and remain at parity either way, and the same
+  constructs at the content's own top level; a companion test pins that a tag-rendered wrapper still
+  contributes the bare placeholder, asserted on the match string itself since no quote boundary class
+  could tell the two apart. Fixtures are added to the whole-pipeline broad sweep and
+  combined-constructs corpus and to the group-parity corpus (what a span presents to a sibling comes
+  from its rendering, which no effective order changes), and a whole-document test drives the shape
+  end to end through the real parse path. The **structural recorder cross-check** is the one corpus
+  these shapes do not join, and the reason is worth recording: a
+  [`RecordingRenderer`](../../parser/src/content/inline_tree.rs) emits its marker *outside* the
+  markup it wraps, so a later sub matching over the recorded string reads that marker where the real
+  pipeline reads the markup's own last character — the recorder builds a `<code>` span the real
+  pipeline never rendered. That is the same perturbation Phase 1 named when it left special
+  characters and replacements unmarked, it is one-sided (recognition *inside* a span is unaffected,
+  since the marker sits outside the tag or entity pair, which is why the two increments above are
+  cross-checked there normally), and it is now documented in that module's own header. Re-running the
+  corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the
+  divergence set **unchanged**: no golden source in the suite writes a construct against a
+  smart-quote span's outer edge, so unlike the six blockers before it this is an unclaimed form
+  rather than a wrong answer for content already under test — and, as every increment requires, no
+  new divergence appeared. As with every prep piece before it, nothing further is wired in.
+
+  What still defers is the rest of the same class: the **tag-rendered** half, which waits on a way to
+  carry `masked_locations`' identity into `build_match_string`; a **transparent** span's siblings
+  (the other half of the class the first increment documents, still needing a level's context derived
+  from its siblings rather than from its enclosing construct alone); and the **closing** character
+  the macros step declines to half-supply.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4429,6 +4508,20 @@ Each phase is a reviewable unit with a clear exit gate.
        half (a bare URL at an entity-rendered span's own closing edge), a transparent span's
        siblings, and the abutting-placeholder class the e-mail family already documents, each with
        its own divergence test.
+
+     - ✅ **prep (the same boundary, for a span's siblings).** The half both increments above name —
+       a construct written *beside* a rendered span, where
+       [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) stood the whole span
+       in as one placeholder — is closed for the class whose answer is unambiguous: that placeholder
+       is now wrapped in the two characters the span's own rendering presents to a sibling (the first
+       of its opening markup and the last of its closing one, the mirror image of the pair a
+       `LevelContext` carries), which belong to no piece and so change recognition alone. Only the two
+       **entity**-rendered variants are classified, because a `Styled` node here may be the
+       passthrough-extraction pass's own wrapper — which the string pipeline holds as a *sentinel*,
+       reading exactly as the bare placeholder does — and both wrappers that pass builds are
+       tag-rendered; see the step's own "landed as" note above. What still defers is the tag-rendered
+       half (which needs `masked_locations`' identity here), a transparent span's siblings, and the
+       macros step's own closing character, each with its own divergence note.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -856,6 +856,15 @@ mod tests {
             "[.r]#x --#",
             r#""`x --`""#,
             "*a -- b*",
+            // The same seam one level *out*: a construct written **beside** an
+            // entity-rendered span, where the string pipeline's haystack holds
+            // that span's own closing `&#8221;` and the tree holds one
+            // placeholder.
+            r#""`a`"`code`"#,
+            r#"'`a`'`code`"#,
+            r##""`a`"#mark#"##,
+            r#""`a`"'`b`'"#,
+            r#""`a`" `code`"#,
             // The macros step's own boundary-reading families at the same
             // seam: the bare e-mail's mismatch prefix and the auto-link's
             // boundary prefix.
@@ -1341,6 +1350,13 @@ mod tests {
             with_product,
         );
         assert_parity("A [.r]#roled -- span# and a `code -- span` here.");
+
+        // The same seam one level out, where the construct sits **beside** the
+        // span rather than inside it: the monospace and mark subs read the
+        // `;` ending that span's own `&#8221;`, so both pipelines leave them
+        // literal, and the surrounding constructs still resolve normally.
+        assert_parity(r##"He said "`hello`"`code` and then "`bye`"#mark# alone."##);
+        assert_parity(r#"Quoting "`one`"'`two`' back to back, plus a *bold* run."#);
 
         // The same seam for the **macros** step, whose bare e-mail and
         // auto-link families read a boundary character of their own: a
@@ -1866,6 +1882,10 @@ mod tests {
                 // decision holds for a group that never escapes.
                 r#""``end points``" and a < b"#,
                 "*x --* and a < b",
+                // The same, one level out: what a span presents to a
+                // **sibling** likewise comes from its rendering, not from the
+                // order.
+                r#""`a`"`code` and a < b"#,
                 // The same for the macros step's own boundary-reading
                 // families, whose decision likewise comes from the enclosing
                 // span's rendering rather than from the order.

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -222,10 +222,84 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
     }
 }
 
+/// The two characters a [`Styled`] span's own rendering presents to its
+/// **siblings** — the first character of its opening markup and the last of
+/// its closing markup — or `None` when this module cannot say what a sibling
+/// reads there.
+///
+/// This is [`styled_boundaries`]'s mirror image, one level out. That function
+/// answers what a span presents to the level *inside* it (the last character
+/// of its opening markup and the first of its closing one, carried by a
+/// [`LevelContext`]); this one answers what the same span presents to the
+/// nodes *beside* it at its own level, where
+/// [`build_match_string`] otherwise stands the whole span in as one opaque
+/// [`SPAN_PLACEHOLDER`] belonging to no boundary class at all. The string
+/// pipeline, having no levels, holds that span's rendered markup there — so a
+/// following construct reads `>` where the span rendered a tag and `;` where
+/// it rendered a smart quote's `&#8221;`, and a preceding one reads `<` or
+/// `&`.
+///
+/// # Only the entity-rendered variants
+///
+/// The two smart quotes are answered; every other variant keeps the bare
+/// placeholder, and the asymmetry is not about what a variant renders but
+/// about what this function can *tell*.
+///
+/// A [`Styled`] node reaching [`build_match_string`] is not necessarily a span
+/// the string pipeline has rendered at all: the passthrough-extraction pass
+/// builds one of its own for an attribute-list-prefixed passthrough
+/// (`[quotes]++text++`, `` [x-]`text` ``), which the string pipeline is
+/// holding as a **placeholder** — its own `\u{96}…\u{97}` sentinel pair —
+/// rather than as markup, for every step this module runs. A sibling reads
+/// that sentinel, which is exactly what the bare [`SPAN_PLACEHOLDER`] already
+/// reads as to every class in play (both are non-word, in none of `&;:}`,
+/// `[>\(\)\[\];"']`, or `[\\>:/]`), so leaving such a wrapper unclassified
+/// is not an approximation — it is the right answer.
+///
+/// Telling one apart from a genuinely rendered span needs the *identity* that
+/// [`masked_locations`](super::special_chars::masked_locations) collects
+/// before any step runs, which this function does not have — and both wrappers
+/// the extraction pass builds are tag-rendered
+/// ([`Unquoted`](StyleVariant::Unquoted) or [`Code`](StyleVariant::Code)), so
+/// classifying a tag-rendered span here would sometimes give a sibling a `>`
+/// the string pipeline does not present. An **entity**-rendered span carries
+/// no such ambiguity: the extraction pass builds neither smart-quote variant,
+/// so a [`DoubleQuote`](StyleVariant::DoubleQuote) or
+/// [`SingleQuote`](StyleVariant::SingleQuote) node can only have come from the
+/// quotes step, where the string pipeline really does hold `&#8220;…&#8221;`.
+/// The tag-rendered half waits on a way to carry that identity here.
+fn styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+    match styled.variant {
+        // `&#8220;…&#8221;` / `&#8216;…&#8217;`.
+        StyleVariant::DoubleQuote | StyleVariant::SingleQuote => Some(('&', ';')),
+
+        // Every other variant wraps its body in a tag — the same shape the
+        // passthrough-extraction pass's own wrapper takes, which the string
+        // pipeline is still holding as a placeholder. See this function's own
+        // scope note.
+        _ => None,
+    }
+}
+
 /// [`styled_boundaries`] for a span whose rendering shape is not decided by
 /// its variant alone: renders it through the built-in backend around a probe
 /// body and reads the characters that land beside it.
 fn probe_styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+    let (before, after) = probe_styled_boundaries_markup(styled);
+
+    before.chars().next_back().zip(after.chars().next())
+}
+
+/// The **opening** and **closing** markup the built-in backend places around a
+/// [`Styled`] span's body, recovered by rendering the span around a probe body
+/// and splitting on it.
+///
+/// Both boundary functions read this one pair from opposite ends:
+/// [`styled_boundaries`] takes the last character of the opening run and the
+/// first of the closing one (what the level *inside* the span sees), and
+/// [`styled_sibling_boundaries`] takes the first character of the opening run
+/// and the last of the closing one (what a *sibling* sees).
+fn probe_styled_boundaries_markup(styled: &Styled<'_>) -> (String, String) {
     // A NUL never appears in a rendered attribute value, so the probe is
     // unambiguous.
     const PROBE: &str = "\u{0}";
@@ -252,7 +326,7 @@ fn probe_styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
     // answer a span that wraps its body in nothing already gives.
     let (before, after) = rendered.split_once(PROBE).unwrap_or_default();
 
-    before.chars().next_back().zip(after.chars().next())
+    (before.to_string(), after.to_string())
 }
 
 /// The quoted-text substitution, as a node transducer: each shared
@@ -558,7 +632,32 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
             other => {
                 // A span from an earlier sub (or any other synthesized-value
                 // node, e.g. a `Raw` leaf) is opaque: a single placeholder
-                // that a quote pattern sees as one boundary character.
+                // that a quote pattern sees as one boundary character —
+                // wrapped, when this module can say what the string
+                // pipeline's own haystack holds *beside* the construct, in
+                // the two characters its rendering presents to a sibling (see
+                // [`styled_sibling_boundaries`]).
+                //
+                // Those two characters belong to no piece — they are the
+                // opaque node's own markup, and the node is already
+                // represented by the placeholder's piece — so a range
+                // reaching one contributes nothing, exactly as a
+                // [`LevelContext`]'s do: [`emit_range`] finds no piece
+                // overlapping it (which is right, since a boundary character
+                // a pattern keeps is markup the span itself carries), and
+                // every gate skips it as non-overlapping.
+                let boundaries = match other {
+                    InlineNode::Styled(styled) => styled_sibling_boundaries(styled),
+                    _ => None,
+                };
+
+                if let Some((before, _)) = boundaries {
+                    s.push(before);
+                }
+
+                // Re-taken after the opening character: the piece covers the
+                // placeholder alone.
+                let s_start = s.len();
                 s.push(SPAN_PLACEHOLDER);
 
                 let location = other.span();
@@ -572,6 +671,10 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                     atomic: true,
                     synthesized: false,
                 });
+
+                if let Some((_, after)) = boundaries {
+                    s.push(after);
+                }
             }
         }
     }
@@ -1222,8 +1325,15 @@ fn s_to_src(pieces: &[Piece], x: usize, bias: Bias) -> usize {
         let p_start = piece.s_start;
         let p_end = piece.s_start + piece.s_len;
 
+        // Before this piece begins: only a **boundary character** an opaque
+        // node contributes (see [`build_match_string`]) lies outside every
+        // piece, and only a leading one can be reached here — an offset
+        // inside a trailing one still falls at or before its own placeholder
+        // piece's end, and one between two pieces is resolved by the earlier
+        // piece below. Such an offset belongs to this piece's own node, whose
+        // source starts here.
         if x < p_start {
-            break;
+            return piece.src_offset;
         }
 
         // A boundary exactly at the *end* of a synthesized piece belongs to
@@ -1387,6 +1497,56 @@ mod tests {
     }
 
     #[test]
+    fn styled_sibling_boundaries_match_the_built_in_renderer() {
+        // [`styled_sibling_boundaries`] is the mirror image of
+        // [`styled_boundaries`], reading the *outer* end of the same two runs
+        // of markup — the first character of the opening one and the last of
+        // the closing one — so it is pinned against the same probe.
+        use super::{probe_styled_boundaries_markup, styled_sibling_boundaries};
+        use crate::inlines::Styled;
+
+        let span = |variant| Styled {
+            variant,
+            form: SpanForm::Constrained,
+            id: None,
+            roles: vec![],
+            attrs: None,
+            children: vec![],
+            location: Span::new("x"),
+        };
+
+        for variant in [StyleVariant::DoubleQuote, StyleVariant::SingleQuote] {
+            let styled = span(variant);
+
+            let (opening, closing) = probe_styled_boundaries_markup(&styled);
+
+            assert_eq!(
+                styled_sibling_boundaries(&styled),
+                opening.chars().next().zip(closing.chars().next_back()),
+                "sibling boundary characters drifted from the built-in rendering of {variant:?}"
+            );
+        }
+
+        // Every tag-rendered variant keeps the bare placeholder — not because
+        // its rendering has no outer characters (it has `<` and `>`), but
+        // because a `Styled` node reaching `build_match_string` may be the
+        // passthrough-extraction pass's own wrapper, which the string pipeline
+        // is still holding as a placeholder. See
+        // [`styled_sibling_boundaries`]'s own scope note.
+        for variant in [
+            StyleVariant::Strong,
+            StyleVariant::Emphasis,
+            StyleVariant::Code,
+            StyleVariant::Mark,
+            StyleVariant::Superscript,
+            StyleVariant::Subscript,
+            StyleVariant::Unquoted,
+        ] {
+            assert_eq!(styled_sibling_boundaries(&span(variant)), None);
+        }
+    }
+
+    #[test]
     fn level_context_wraps_and_unshifts() {
         use super::LevelContext;
 
@@ -1493,39 +1653,95 @@ mod tests {
     }
 
     #[test]
-    fn a_sub_after_a_span_at_its_own_level_is_a_documented_divergence() {
+    fn a_sub_beside_a_span_reads_that_spans_own_sibling_boundary_characters() {
         // The mirror image of the fixtures above, one level out: a construct
         // written *beside* an entity-rendered span reads the last character of
         // that span's own closing markup in the string pipeline's haystack
         // (`&#8221;`, whose `;` the monospace sub's boundary class excludes),
-        // where [`build_match_string`] stands the whole span in as one
+        // where [`build_match_string`] used to stand the whole span in as one
         // [`SPAN_PLACEHOLDER`] — a private-use codepoint that belongs to no
-        // boundary class at all.
-        //
-        // That is the same boundary class the bare e-mail family already
-        // documents from the other direction (`**bold**doc@example.org`, whose
-        // `</strong>` ends in one of that pattern's own mismatch characters):
-        // a placeholder standing in for markup hides what the markup's own
-        // characters would say. A `LevelContext` answers it for a level's
-        // *interior*, where the enclosing construct is known; answering it at a
-        // level's own siblings means classifying the placeholder itself, which
-        // every family reading one would then see — a later increment.
-        //
-        // If that lands, fold these fixtures into the corpus above.
-        for source in [r#""`a`"`code`"#, r#"'`a`'`code`"#] {
-            let folded = fold_html(
-                &build_through_quotes(Span::new(source)),
-                &HtmlSubstitutionRenderer {},
-            );
-
-            assert_ne!(
-                folded,
+        // boundary class at all. It now wraps that placeholder in the two
+        // characters the span's rendering presents to a sibling (see
+        // [`styled_sibling_boundaries`]), so both pipelines read the same
+        // character there.
+        for source in [
+            // The shapes that named this increment: a construct directly
+            // after a smart-quote span, which both pipelines now leave
+            // literal.
+            r#""`a`"`code`"#,
+            r#"'`a`'`code`"#,
+            r##""`a`"#mark#"##,
+            r#""`a`"_em_"#,
+            // The same, one character further out: a space intervenes, so
+            // both pipelines match.
+            r#""`a`" `code`"#,
+            r#"'`a`' _em_"#,
+            // A construct directly *before* a smart-quote span reads that
+            // span's opening `&`, which is non-word exactly as the
+            // placeholder it replaces is — so both pipelines match, as they
+            // did before.
+            r#"`code`"`a`""#,
+            r#"_em_'`a`'"#,
+            // Two smart-quote spans side by side: the second sub reads the
+            // first span's own closing `;`.
+            r#""`a`"'`b`'"#,
+            // A tag-rendered span keeps the bare placeholder, which reads as
+            // `>` does to every quote boundary class (both are non-word and
+            // in none of `&;:}`), so these are unchanged either way.
+            "*a*`code`",
+            "`code`*a*",
+            "[.r]#a#`code`",
+            // The same constructs at the content's own top level, where no
+            // span is involved at all.
+            "`code`",
+            "#mark#",
+        ] {
+            assert_eq!(
                 golden_quotes(source),
-                "expected the documented divergence to still reproduce for {source:?}"
+                fold_html(
+                    &build_through_quotes(Span::new(source)),
+                    &HtmlSubstitutionRenderer {}
+                ),
+                "fold diverged from the string pipeline for {source:?}"
             );
-
-            assert!(folded.contains("<code>code</code>"), "{folded:?}");
         }
+    }
+
+    #[test]
+    fn a_sub_beside_a_masked_passthrough_wrapper_keeps_the_bare_placeholder() {
+        // The half [`styled_sibling_boundaries`] deliberately does not
+        // answer. The passthrough-extraction pass builds a [`Styled`] wrapper
+        // of its own for an attribute-list-prefixed passthrough, which the
+        // string pipeline is holding as its `\u{96}…\u{97}` sentinel rather
+        // than as markup for every step this module runs — so a sibling reads
+        // that sentinel, which is exactly what the bare placeholder reads as.
+        // Both wrappers the pass builds are tag-rendered, and telling one from
+        // a genuinely rendered span needs an identity this function does not
+        // have, so no tag-rendered span is classified.
+        //
+        // Asserted directly on the match string rather than through a fold,
+        // since a quote boundary class cannot tell the two apart in the first
+        // place (which is the very reason the deferral is safe).
+        use super::{SPAN_PLACEHOLDER, build_match_string, styled_sibling_boundaries};
+        use crate::inlines::Styled;
+
+        let styled = Styled {
+            variant: StyleVariant::Unquoted,
+            form: SpanForm::Unconstrained,
+            id: None,
+            roles: vec![CowStr::from("x")],
+            attrs: None,
+            children: Vec::new(),
+            location: Span::new("[.x]##y##"),
+        };
+
+        assert_eq!(styled_sibling_boundaries(&styled), None);
+
+        let (s, pieces) = build_match_string(&[InlineNode::Styled(styled)]);
+
+        assert_eq!(s, SPAN_PLACEHOLDER.to_string());
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].s_start, 0);
     }
 
     #[test]
@@ -1547,6 +1763,47 @@ mod tests {
             "That only gives you \"``end points``\".\n",
             "\n",
             "A *span ending in --* here.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        // The two paragraphs; the section that contains them holds no inline
+        // content of its own and is skipped.
+        assert_eq!(folded_blocks, 2, "expected both paragraphs to be checked");
+    }
+
+    #[test]
+    fn a_real_documents_sibling_span_tree_folds_to_its_rendered_string() {
+        // End-to-end, through the real parse path, on the shape one level out
+        // from the test above: a construct written *beside* an entity-rendered
+        // span, whose `&#8221;` the string pipeline reads a `;` from where the
+        // tree holds one placeholder.
+        use crate::{
+            Parser,
+            blocks::{FindBlocks, IsBlock},
+        };
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "She said \"`hello`\"`code` and meant it.\n",
+            "\n",
+            "Then '`this`'`that` and \"`one`\"'`two`' in a row.\n",
         ));
 
         let mut folded_blocks = 0;
@@ -1745,9 +2002,10 @@ mod tests {
         use super::{Bias, Piece, s_to_src};
 
         // In practice every boundary `s_to_src` maps falls on a literal
-        // delimiter (a text position), so the atomic-snap, before-first, and
-        // past-last branches are defensive. Exercise them directly to document
-        // the intended fallback. Bias is irrelevant to an atomic piece, so
+        // delimiter (a text position) or on a **boundary character** an opaque
+        // node contributes, so the atomic-snap, before-first, and past-last
+        // branches are defensive. Exercise them directly to document the
+        // intended fallback. Bias is irrelevant to an atomic piece, so
         // `Bias::Start` is used throughout.
         let atomic = Piece {
             node_index: 0,
@@ -1766,14 +2024,15 @@ mod tests {
         // A boundary past the last piece falls back to the source end.
         assert_eq!(s_to_src(std::slice::from_ref(&atomic), 9, Bias::Start), 11);
 
-        // A boundary before the first piece begins breaks out to the same
-        // fallback.
+        // A boundary before the first piece begins — the leading boundary
+        // character an opaque node contributes, the one position no piece
+        // covers — resolves to that piece's own source start.
         let offset = Piece {
             s_start: 2,
             ..atomic
         };
 
-        assert_eq!(s_to_src(std::slice::from_ref(&offset), 0, Bias::Start), 11);
+        assert_eq!(s_to_src(std::slice::from_ref(&offset), 0, Bias::Start), 10);
 
         // No pieces (an empty level) anchors at the source start.
         assert_eq!(s_to_src(&[], 0, Bias::Start), 0);

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -120,6 +120,25 @@
 //!   fold renders just the number, dropping `id` — so the recorder cannot
 //!   recover it, while the builder still carries it as a structural fact (see
 //!   [`assert_node_equivalent`]'s own `Footnote` arm).
+//! - A construct written **beside** a span, where the sub that recognizes it
+//!   reads the character the span's own rendering ends with (``` "`a`"`code`
+//!   ```, whose `` `code` `` both the real pipeline and the builder leave
+//!   literal because `&#8221;` ends in a `;` the monospace sub's boundary class
+//!   excludes). This one is the recorder's own artifact rather than a builder
+//!   deferral, and it is the seam Phase 1 already named when it left special
+//!   characters and replacements unmarked ("their escaped output is re-consumed
+//!   by later steps, so bracketing it would perturb recognition"): a
+//!   [`RecordingRenderer`] emits its marker *outside* the markup it wraps, so a
+//!   later sub matching over the recorded string reads that marker — which
+//!   belongs to no boundary class — where the real pipeline reads the markup's
+//!   own last character. The recorder therefore builds a span the real pipeline
+//!   never rendered. Recognition **inside** a span is unaffected (the marker
+//!   sits outside the tag or entity pair, so the interior reads the same `>` or
+//!   `;` either way), which is why the sweep's own boundary fixtures one level
+//!   *in* are cross-checked here normally; the sibling shapes are pinned
+//!   instead by the parity corpora in
+//!   [`inline_builder`](crate::content::inline_builder), against the real
+//!   pipeline's own bytes.
 //! - A [`Link`](RefVariant::Link)'s `roles`/`window` fields are not populated
 //!   from its own attribute-list display text (`Ref::attrs`'s own doc comment)
 //!   — the fold reads those straight off `attrs` instead — so they are skipped


### PR DESCRIPTION
The two increments before this one (#1215, #1216) answer what an enclosing construct presents to the level *inside* it, and both name the same remaining half — a construct written **beside** a rendered span at its own level, where `build_match_string` stands the whole span in as one `SPAN_PLACEHOLDER` belonging to no boundary class at all. This is that half, for the class whose answer is unambiguous.

## The mechanism

`build_match_string` now wraps an opaque node's placeholder in the two characters its own rendering presents to a sibling — the **first** character of its opening markup and the **last** of its closing one, the mirror image of the pair a `LevelContext` carries. Both pairs come from the same probe, now factored into one `probe_styled_boundaries_markup` that `styled_boundaries` and the new `styled_sibling_boundaries` read from opposite ends, pinned against the built-in renderer by a test of its own.

Those two characters belong to **no piece** — they are the opaque node's markup, and the node already has the placeholder's piece — so a range reaching one contributes nothing, exactly as a `LevelContext`'s do: `emit_range` finds no piece overlapping it, and every gate skips it as non-overlapping. No gate, slice, or rebuild changes, and no shared signature does either. The one adjustment is in `s_to_src`, where a **leading** boundary character is the first offset that ever falls before the first piece and now resolves to that piece's own source start rather than dropping through to the past-the-last fallback.

## Why only the entity-rendered variants

The scope is not about what a variant renders but about what `styled_sibling_boundaries` can *tell*.

A `Styled` node reaching `build_match_string` is not necessarily a span the string pipeline has rendered: the passthrough-extraction pass builds one of its own for an attribute-list-prefixed passthrough (`[quotes]++text++`), which the string pipeline is holding as its `\u{96}…\u{97}` sentinel rather than as markup for every step this module runs. A sibling reads that sentinel — which is exactly what the bare placeholder already reads as to every class in play (both non-word, in none of `` &;:} ``, `` [>\(\)\[\];"'] ``, or `` [\\>:/] ``) — so leaving such a wrapper unclassified is the *right* answer, not an approximation. Telling one apart from a genuinely rendered span needs the identity `masked_locations` collects before any step runs, which `build_match_string` does not have, and **both** wrappers that pass builds are tag-rendered. A smart-quote span, which it never builds, can only have come from the quotes step.

Nothing is lost by drawing the line there: a tag's `<`/`>` read exactly as the placeholder they would replace does to every *quote* boundary class, and the classes that separate a `>` from a placeholder are the **macros** step's two prefix groups — neither of which can reach an entity-rendered span at all, since the sub that builds one requires a non-word character after its closing `` `" `` while a URL and a bare address each begin with a word character. So this increment's whole effect lands in the quotes step, which is where the divergence was.

## What reaches parity

Four shapes, each one the string pipeline reads the `;` ending `&#8221;` for where a placeholder said nothing:

| source | string pipeline (and now the fold) | fold before |
| --- | --- | --- |
| ``"`a`"`code``` | ``&#8220;a&#8221;`code``` | `&#8220;a&#8221;<code>code</code>` |
| ``'`a`'`code``` | ``&#8216;a&#8217;`code``` | `&#8216;a&#8217;<code>code</code>` |
| ``"`a`"#mark#`` | `&#8220;a&#8221;#mark#` | `&#8220;a&#8221;<mark>mark</mark>` |
| ``"`a`"'`b`'`` | `&#8220;a&#8221;'`b&#8217;` | `&#8220;a&#8221;&#8216;b&#8217;` |

## Tests

- The divergence test #1215 left behind becomes a **parity** corpus, exactly as its own note asked, gaining each construct written against a smart-quote span's outer edge in both directions, the same constructs one character further out (where a space intervenes and both pipelines match), the tag-rendered shapes that were and remain at parity either way, and the same constructs at the content's own top level.
- A companion test pins that a tag-rendered wrapper still contributes the bare placeholder, asserted on the match string itself since no quote boundary class could tell the two apart.
- Fixtures join the whole-pipeline broad sweep, the combined-constructs corpus, and the group-parity corpus (what a span presents to a sibling comes from its rendering, which no effective order changes); a whole-document test drives the shape end to end through the real parse path.
- The **structural recorder cross-check** is the one corpus these shapes do not join, and the reason is now documented in that module's header: a `RecordingRenderer` emits its marker *outside* the markup it wraps, so a later sub matching over the recorded string reads that marker where the real pipeline reads the markup's own last character — the recorder builds a `<code>` span the real pipeline never rendered. That is the same perturbation Phase 1 named when it left special characters and replacements unmarked, and it is one-sided: recognition *inside* a span is unaffected, which is why #1215's and #1216's own boundary fixtures are cross-checked there normally.
- Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the divergence set **unchanged**. No golden source in the suite writes a construct against a smart-quote span's outer edge, so unlike the six blockers before it this is an unclaimed form rather than a wrong answer for content already under test — and, as every increment requires, **no new divergence appeared**.

## Still deferred

The rest of the same class: the **tag-rendered** half (waiting on a way to carry `masked_locations`' identity into `build_match_string`), a **transparent** span's siblings (still needing a level's context derived from its siblings rather than from its enclosing construct alone), and the **closing** character the macros step declines to half-supply.

As with every prep piece before it, nothing further is wired in.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5,287 passing, 0 failing
- `cargo +nightly doc --no-deps --document-private-items` — clean
- `cargo llvm-cov -p asciidoc-parser --lib` — `quotes.rs` missed regions/lines unchanged from the base branch (13 regions, 4 lines, the same pre-existing ones)

The design doc gains its "*Step 6 prep landed as (…)*" narrative paragraph and checklist entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgAsT73zD7TiafdvVMkq32)_