### PR TITLE
feat: Read the boundary characters a transparent span's siblings present (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -3958,6 +3958,82 @@ Each phase is a reviewable unit with a clear exit gate.
   from its siblings rather than from its enclosing construct alone); and the **closing** character
   the macros step declines to half-supply.
 
+  *Step 6 prep landed as (the boundary a **transparent** span's own siblings present):* the three
+  increments above answer what an enclosing construct presents to the level inside it, what the
+  macros step's families read there, and what a rendered span presents to a sibling — and all three
+  name the same remaining shape: a span that renders to its **body and nothing else** (an unquoted
+  span whose attribute list resolves to neither a role nor an id), where
+  [`LevelContext::inside_styled`](../../parser/src/content/inline_builder/quotes.rs) hands the
+  children whatever the span itself sees. That is right while the span is all its level holds, and
+  wrong the moment a **sibling** precedes it: the string pipeline, having no levels, shows what that
+  sibling rendered where the inherited context still shows the enclosing construct's markup.
+
+  A new [`LevelContext::child_contexts`](../../parser/src/content/inline_builder/quotes.rs) answers a
+  whole level at once — one context per node, so the three recursions that had each spelled out
+  `inside_styled` and `INSIDE_REF` now zip a vector instead — and derives a transparent span's own
+  half from the level's **match string**. That is the point of the mechanism rather than an
+  implementation detail: the match string is the one place every node kind's presented bytes are
+  already spelled out (a text run's, a `CharRef`'s entity, and the `SPAN_PLACEHOLDER` wrapped in
+  whatever the increment above can say), so the character is *read* rather than recomputed per node
+  kind and the two cannot drift. Each side falls back to the enclosing context where the level ends,
+  which is exactly where the span really is the first thing its level holds. Building that match
+  string is worth it only when such a span is present, so it is built on demand and every other level
+  answers from `styled_boundaries` alone, allocating nothing new.
+
+  Two limits are drawn deliberately, and both are the previous increments' own rules applied again.
+  Only the **opening** character is carried, for the reason
+  [`LevelContext::shift`](../../parser/src/content/inline_builder/quotes.rs) gives one level in and
+  then some: a *boundary* class reads one character and, where it consumes one, the replacer writes
+  it back — which [`unshift`](../../parser/src/content/inline_builder/quotes.rs)'s clip reproduces by
+  leaving the character with the sibling that owns it — while a *delimiter* swallows it instead, and
+  what the replacer swallows it **deletes**, which a level's rebuild cannot do to a node another
+  level owns (`x[width=10]##d #c###`, whose closing `#` is the sibling, keeps its own divergence
+  test). And a **bare placeholder** reports *nothing* rather than a character: it is what
+  `build_match_string` writes for a node this module cannot describe, so reporting it would
+  manufacture an answer where the level previously read its own `^` — and `^` is what the auto-link's
+  prefix group accepts there anyway, so `*x*[width=10]#https://example.org#` would have gone from
+  parity to divergence. An unclassified neighbour leaves the span inheriting, the same line
+  [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) draws for the same
+  reason, and `haystack` gains the one generalization this needs — the two halves applied
+  independently, since a sibling can supply an opening character to a level whose closing one is
+  still the content's own end.
+
+  The [`character replacements`](../../parser/src/content/inline_builder/char_replacements.rs) step
+  is deliberately **not** given this. Its one boundary-reading rule is the spaced em dash, whose
+  replacement consumes the spaces it matches on both sides rather than writing them back — so even an
+  opening character a sibling owns would be emitted here *and* left there. Supplying it would make
+  `*x [width=10]#-- y#*` differently wrong rather than right, so that step goes on inheriting and
+  `a_replacement_beside_a_transparent_span_is_a_documented_divergence` keeps its shape, its note now
+  carrying the sharper reason (not "a strictly larger walk" but "one level's rebuild would have to
+  consume a node another level owns"). The two steps that *can* take it do: the macros step's bare
+  e-mail and auto-link families (`*x [width=10]#doc@example.org#*`, the shape the first of these
+  increments pinned, whose test is now a parity corpus exactly as its own note asked), and the quotes
+  step's constrained `#mark#` — the only boundary-reading sub that can run after a transparent span
+  exists, since the span it looks across must have been built by the unconstrained `##mark##` one
+  place ahead of it (`x[width=10]###c# d##`).
+
+  Each family's construct gains a differential corpus written against a transparent span's edge with
+  a word character, a space, an entity-rendered span and a tag-rendered one beside it, the same
+  constructs with no sibling at all (where the enclosing context is still the answer), the same at
+  the content's own top level, and a sibling *after* the span (which supplies nothing), alongside a
+  unit test of `child_contexts` itself and a structural assertion that the address builds a real
+  link. Fixtures are added to the whole-pipeline broad sweep and combined-constructs corpus, to the
+  group-parity corpus (what a sibling renders comes from its own rendering, which no effective order
+  changes), and to the structural recorder cross-check, and a whole-document test drives both shapes
+  end to end through the real parse path. Re-running the corpus-wide fold-parity audit (tree building
+  forced on for every parse in the suite) shows the divergence set **unchanged** — no golden source
+  writes a construct inside a transparent span, so like the increment above this is an unclaimed form
+  rather than a wrong answer for content already under test — and, as every increment requires, no
+  new divergence appeared. As with every prep piece before it, nothing further is wired in.
+
+  What still defers is the rest of the same class: the **tag-rendered** half, which waits on a way to
+  carry `masked_locations`' identity into `build_match_string` (and which now shows up in two places
+  — what a rendered span presents to a sibling, and what an unclassified neighbour presents to a
+  transparent span); the **closing** character both the macros step and this increment decline to
+  half-supply; a **transparent** span read *as* a sibling, which presents its own body's last
+  character where the placeholder says nothing; and the character-replacements step's own
+  consume-across-levels case above.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4522,6 +4598,22 @@ Each phase is a reviewable unit with a clear exit gate.
        tag-rendered; see the step's own "landed as" note above. What still defers is the tag-rendered
        half (which needs `masked_locations`' identity here), a transparent span's siblings, and the
        macros step's own closing character, each with its own divergence note.
+
+     - ✅ **prep (the same boundary, for a transparent span's own siblings).** The shape all three
+       increments above name — a span rendering to its **body and nothing else**, whose children had
+       inherited the enclosing construct's markup rather than reading what stands beside the span —
+       is closed for the two steps that can act on it. A new
+       [`LevelContext::child_contexts`](../../parser/src/content/inline_builder/quotes.rs) answers a
+       whole level at once and derives a transparent span's own context from the level's **match
+       string**, the one place every node kind's presented bytes are already spelled out, so nothing
+       is recomputed per node kind. Only the **opening** character is carried (a delimiter swallows a
+       closing one, and what the replacer swallows it deletes — which a level's rebuild cannot do to
+       a node another level owns), and a bare placeholder reports nothing rather than manufacturing a
+       character the level had not been reading. The `character replacements` step is deliberately
+       excluded: its one boundary-reading rule *consumes* the spaces it matches, so even an opening
+       character would be written twice. See the step's own "landed as" note above. What still defers
+       is the tag-rendered half, the closing character, a transparent span read *as* a sibling, and
+       that consume-across-levels case.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -433,11 +433,17 @@ mod tests {
         // dash's own trailing class) where the tree shows the parent's closing
         // markup.
         //
-        // Modelling that means deriving a level's context from its *siblings*
-        // rather than from its enclosing construct alone — a strictly larger
-        // walk, for the one span shape that renders nothing of its own.
+        // [`LevelContext::child_contexts`] derives exactly that character from
+        // a level's siblings for the two steps that can take it, and this step
+        // is deliberately not one of them: its one boundary-reading rule is
+        // the spaced em dash, whose replacement **consumes** the spaces it
+        // matches rather than writing them back. A character a sibling owns
+        // lives in another level's node, which this level's rebuild cannot
+        // delete — so supplying it would emit the space here *and* leave it
+        // there, a differently wrong answer rather than the right one.
         //
-        // If it lands, fold this fixture into the corpus above.
+        // Closing it means letting one level's rebuild consume a node another
+        // level owns. If that lands, fold this fixture into the corpus above.
         let source = "*[width=10]#x --# --*";
 
         let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -4115,6 +4115,30 @@ mod tests {
             // renders), which is no mismatch character in either pipeline.
             "*(C)doc@example.org*",
             "*&copy;doc@example.org*",
+            // A **transparent** span between the two — one rendering to its
+            // body and nothing else — presents no markup of its own, so what
+            // the address reads is whatever stands beside the *span*
+            // ([`LevelContext::child_contexts`](super::super::quotes::LevelContext)):
+            // the space a preceding sibling ends with, not the enclosing
+            // `<strong>`'s own `>`.
+            "*x [width=10]#doc@example.org#*",
+            "x [width=10]#doc@example.org#",
+            "*a > b [width=10]#doc@example.org#*",
+            "*(C)[width=10]#doc@example.org#*",
+            "*[width=10]#x# [width=10]#doc@example.org#*",
+            // With nothing before the span, the enclosing context is still
+            // the right answer — `>` inside a tag-rendered span, `^` at the
+            // content's own top level.
+            "*[width=10]#doc@example.org#*",
+            "[width=10]#doc@example.org#",
+            // The auto-link family reads the same character through its own
+            // boundary-prefix group.
+            "*x [width=10]#https://example.org#*",
+            // A **tag-rendered** span beside the transparent one says nothing
+            // this module can act on, so the span goes on inheriting: `^` here,
+            // which the auto-link's prefix group accepts exactly as it accepts
+            // the `>` the string pipeline reads there.
+            "*x*[width=10]#https://example.org#",
             // And the same addresses at the content's own top level, where a
             // level's start is exactly what the string pipeline presents.
             "doc@example.org",
@@ -4143,24 +4167,53 @@ mod tests {
     }
 
     #[test]
-    fn an_address_after_a_transparent_spans_sibling_is_a_documented_divergence() {
-        // An unquoted span whose attribute list resolves to neither a role nor
-        // an id renders to its body and nothing else, so its children inherit
-        // the context the span itself sits in
-        // ([`LevelContext::inside_styled`](super::super::quotes::LevelContext)).
-        // That is right whenever the span is all its parent's level holds and
-        // wrong when a *sibling* precedes it: the string pipeline's haystack
-        // shows what that sibling ends with (a space here) where the inherited
-        // context still shows the enclosing `<strong>`'s own `>`, so the
-        // address stays literal here and links there.
+    fn an_address_after_a_transparent_spans_sibling_builds_a_link() {
+        // The parity above, read structurally, for the shape that named this
+        // increment: an unquoted span whose attribute list resolves to neither
+        // a role nor an id renders to its body and nothing else, so its
+        // children read what stands beside the *span* rather than the
+        // enclosing `<strong>`'s own `>` — a space here, which is no mismatch
+        // character, so the address links exactly as the string pipeline links
+        // it.
+        let nodes = build_src(Span::new("*x [width=10]#doc@example.org#*"));
+        let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
+
+        let span = children.iter().find_map(|node| match node {
+            InlineNode::Styled(styled) if styled.variant == StyleVariant::Unquoted => {
+                Some(&styled.children)
+            }
+
+            _ => None,
+        });
+
+        match span {
+            Some(children) => assert_eq!(
+                assert_link(&children[0]).target.as_ref(),
+                "mailto:doc@example.org"
+            ),
+
+            None => panic!("expected the transparent span to survive: {children:?}"),
+        }
+    }
+
+    #[test]
+    fn an_address_after_a_transparent_spans_tag_rendered_sibling_is_a_documented_divergence() {
+        // The half a transparent span's own siblings cannot answer. What
+        // precedes the span here is a **tag-rendered** span, which
+        // [`build_match_string`](super::super::quotes::build_match_string)
+        // stands in as a bare [`SPAN_PLACEHOLDER`] belonging to no boundary
+        // class — so
+        // [`LevelContext::child_contexts`](super::super::quotes::LevelContext)
+        // reports nothing and the transparent span inherits `^`, where the
+        // string pipeline reads the `>` that ends `<strong>` — one of the bare
+        // e-mail pattern's three mismatch characters.
         //
-        // This is the transparent-span half of the same class the quotes and
-        // character-replacements steps already document
-        // (`a_replacement_beside_a_transparent_span_is_a_documented_divergence`);
-        // closing it means deriving a level's context from its *siblings*
-        // rather than from its enclosing construct alone. If that lands, fold
-        // this fixture into the parity corpus above.
-        let source = "*x [width=10]#doc@example.org#*";
+        // This is the same tag-rendered half `styled_sibling_boundaries`
+        // already defers one level out, for the same reason: telling a
+        // genuinely rendered span from the passthrough-extraction pass's own
+        // wrapper needs `masked_locations`' identity, which neither has. If
+        // that lands, fold this fixture into the parity corpus above.
+        let source = "*x*[width=10]#doc@example.org#";
         let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
 
         assert_ne!(
@@ -4169,8 +4222,8 @@ mod tests {
             "expected the documented divergence to still reproduce"
         );
 
-        assert!(!folded.contains("mailto:"), "{folded:?}");
-        assert!(golden_macros(source).contains("mailto:doc@example.org"));
+        assert_eq!(golden_macros(source), "<strong>x</strong>doc@example.org");
+        assert!(folded.contains("mailto:doc@example.org"), "{folded:?}");
     }
 
     #[test]
@@ -4189,6 +4242,8 @@ mod tests {
             "Mail *doc@example.org* or _doc@example.org writes_ here.\n",
             "\n",
             "He said \"`doc@example.org`\" and *https://example.org* too.\n",
+            "\n",
+            "Then *write to [width=10]#doc@example.org# now* and x [width=10]#doc@example.org# here.\n",
         ));
 
         let mut folded_blocks = 0;
@@ -4212,9 +4267,9 @@ mod tests {
             folded_blocks += 1;
         }
 
-        // The two paragraphs; the section that contains them holds no inline
+        // The three paragraphs; the section that contains them holds no inline
         // content of its own and is skipped.
-        assert_eq!(folded_blocks, 2, "expected both paragraphs to be checked");
+        assert_eq!(folded_blocks, 3, "expected every paragraph to be checked");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -177,6 +177,11 @@ pub(super) fn apply_macros<'src>(
 /// `anchor:`, `&lt;&lt;`, `xref:`, `link:`, `mailto:`) that no context
 /// character can begin — so for them the wrap is inert, and they take it for
 /// uniformity rather than for effect.
+///
+/// A span that renders **no markup of its own** encloses nothing, so its
+/// children read what stands beside the *span* instead; that is
+/// [`LevelContext::child_contexts`]'s own job, and this function takes the
+/// answer it gives without caring which of the two it is.
 fn apply_macro_families<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -187,25 +192,21 @@ fn apply_macro_families<'src>(
     // whole-string pass. Each nested level is matched in the context its own
     // enclosing construct's rendering presents (see this function's own doc
     // comment); a span the built-in backend renders with no markup of its own
-    // is transparent, so `inside_styled` hands its children whatever the span
-    // itself sees.
+    // is transparent, so `child_contexts` hands its children the character its
+    // own *siblings* present instead.
+    let contexts = LevelContext::child_contexts(&nodes, ctx);
+
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
-        .map(|node| match node {
+        .zip(contexts)
+        .map(|(node, inner)| match node {
             InlineNode::Styled(mut styled) => {
-                let inner = LevelContext::inside_styled(&styled, ctx);
-
                 styled.children = apply_macro_families(styled.children, root, parser, inner);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_macro_families(
-                    reference.children,
-                    root,
-                    parser,
-                    LevelContext::INSIDE_REF,
-                );
+                reference.children = apply_macro_families(reference.children, root, parser, inner);
                 InlineNode::Ref(reference)
             }
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -876,6 +876,17 @@ mod tests {
             "*https://example.org*",
             "*https://example.org[Docs]*",
             r#""`https://example.org[Docs]`""#,
+            // A **transparent** span between the construct and its enclosing
+            // one: rendering to its body and nothing else, it presents no
+            // markup, so what a construct inside it reads is whatever stands
+            // beside the *span*.
+            "*x [width=10]#doc@example.org#*",
+            "x [width=10]#doc@example.org#",
+            "*[width=10]#doc@example.org#*",
+            "*x [width=10]#https://example.org#*",
+            "x[width=10]###c# d##",
+            "x [width=10]###c# d##",
+            "*x[width=10]###c# d##*",
             "   ",
             "a\nb\nc",
         ];
@@ -1369,6 +1380,14 @@ mod tests {
         assert_parity("*write to doc@example.org now* and doc@example.org here.");
         assert_parity("*https://example.org* and _https://example.org[Docs]_.");
         assert_parity(r#"He said "`https://example.org[Docs]`" today."#);
+
+        // The same seam through a **transparent** span, which renders to its
+        // body and nothing else: a construct inside one reads what stands
+        // beside the span, not the enclosing construct's own markup.
+        assert_parity(
+            "Mail *write to [width=10]#doc@example.org# now* or x [width=10]#doc@example.org# here.",
+        );
+        assert_parity("Beside x[width=10]###c# d## and x [width=10]###c# d## in one line.");
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1891,6 +1910,12 @@ mod tests {
                 // span's rendering rather than from the order.
                 "*doc@example.org* and a < b",
                 "*https://example.org* and a < b",
+                // And through a **transparent** span, whose children read
+                // what stands beside the span: what a sibling renders comes
+                // from its own rendering, which no effective order changes
+                // either.
+                "*x [width=10]#doc@example.org#* and a < b",
+                "x[width=10]###c# d## and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -91,7 +91,10 @@ impl LevelContext {
     /// A span the built-in backend renders with **no markup of its own** — an
     /// unquoted span that ends up carrying neither a role nor an id, whose
     /// rendering is its body and nothing else — is transparent, so its
-    /// children see whatever the span itself sees.
+    /// children see whatever the span itself sees. That is right whenever the
+    /// span is all its level holds; [`child_contexts`](Self::child_contexts)
+    /// is the same answer sharpened by what stands *beside* it, for the two
+    /// steps that can take it.
     pub(super) fn inside_styled(styled: &Styled<'_>, enclosing: Self) -> Self {
         match styled_boundaries(styled) {
             Some((before, after)) => Self {
@@ -103,23 +106,129 @@ impl LevelContext {
         }
     }
 
+    /// The context each node in `nodes` presents to its own children, one
+    /// entry per node, given the context the level itself sits in.
+    ///
+    /// A [`Ref`](InlineNode::Ref) always presents
+    /// [`INSIDE_REF`](Self::INSIDE_REF) and a [`Styled`] span whatever
+    /// [`inside_styled`](Self::inside_styled) says; every other node kind has
+    /// no children to match, and its entry — the enclosing context, unchanged
+    /// — is never read.
+    ///
+    /// # A transparent span reads its siblings
+    ///
+    /// A **transparent** span wraps its children in nothing, so what they read
+    /// is not the enclosing construct's markup but whatever stands *beside the
+    /// span itself* in the string pipeline's own flat haystack. Inheriting the
+    /// enclosing context — what [`inside_styled`](Self::inside_styled) does on
+    /// its own — is right only while the span is all its level holds; the
+    /// moment a sibling precedes it, the haystack shows what that sibling
+    /// rendered (`*x [width=10]#doc@example.org#*` presents the space `x `
+    /// ends with, where the enclosing `<strong>`'s own `>` is one of the bare
+    /// e-mail pattern's mismatch characters).
+    ///
+    /// The level's own **match string** already spells out what every node
+    /// kind presents — a text run's bytes, a [`CharRef`]'s entity, and, for an
+    /// opaque node, the [`SPAN_PLACEHOLDER`] wrapped in whatever
+    /// [`styled_sibling_boundaries`] can say — so the character beside the
+    /// span's own [`Piece`] is read straight out of it rather than recomputed
+    /// per node kind, and the two cannot drift. Building that match string is
+    /// worth it only when such a span is there, so it is built on demand:
+    /// every other level answers from [`styled_boundaries`] alone, exactly as
+    /// before.
+    ///
+    /// # Only the opening character
+    ///
+    /// A sibling supplies the **opening** character alone, for the reason
+    /// [`shift`](Self::shift) gives one level in and then some. A pattern's
+    /// *boundary* class reads one character and — where it consumes one, as a
+    /// constrained quote's `(^|[^\w&;:}])` does — the replacer writes it back,
+    /// which [`unshift`](Self::unshift)'s own clip reproduces by leaving the
+    /// character with the sibling that owns it. A *delimiter* or a greedy body
+    /// class swallows it instead, and what the replacer swallows it **deletes**
+    /// — a character another level's node owns, which this level's rebuild
+    /// cannot delete. So the closing half is dropped rather than
+    /// half-supplied, leaving a construct whose own closing delimiter fell
+    /// beside the span (`x[width=10]##d #c###`) exactly as divergent as it
+    /// already was, never newly wrong.
+    ///
+    /// The same reasoning keeps the
+    /// [`character replacements`](super::char_replacements) step off this
+    /// entirely: its one boundary-reading rule is the spaced em dash, whose
+    /// replacement *consumes* the spaces it matches on both sides, so even an
+    /// opening character a sibling owns would be deleted here and written
+    /// twice there. That step goes on inheriting through
+    /// [`inside_styled`](Self::inside_styled), and
+    /// `a_replacement_beside_a_transparent_span_is_a_documented_divergence`
+    /// keeps its shape.
+    pub(super) fn child_contexts(nodes: &[InlineNode<'_>], enclosing: Self) -> Vec<Self> {
+        let mut has_transparent = false;
+
+        let mut contexts: Vec<Self> = nodes
+            .iter()
+            .map(|node| match node {
+                InlineNode::Styled(styled) => {
+                    has_transparent |= styled_boundaries(styled).is_none();
+                    Self::inside_styled(styled, enclosing)
+                }
+
+                InlineNode::Ref(_) => Self::INSIDE_REF,
+
+                _ => enclosing,
+            })
+            .collect();
+
+        if !has_transparent {
+            return contexts;
+        }
+
+        let (s, pieces) = build_match_string(nodes);
+
+        // `build_match_string` contributes exactly one [`Piece`] per node, in
+        // order, so the three sequences line up and no lookup is needed.
+        for ((context, piece), node) in contexts.iter_mut().zip(&pieces).zip(nodes) {
+            if matches!(node, InlineNode::Styled(styled) if styled_boundaries(styled).is_none()) {
+                context.before = preceding_character(&s, piece).or(context.before);
+            }
+        }
+
+        contexts
+    }
+
     /// The haystack a pattern should be matched against for a level whose own
     /// match string is `s`, together with the byte length of the prefix
     /// [`unshift`](Self::unshift) removes again.
     ///
     /// At the top level this borrows `s` untouched, so the overwhelmingly
     /// common case allocates nothing.
+    ///
+    /// The two halves are applied independently, because a level can have an
+    /// opening character without a closing one: an enclosing construct always
+    /// presents both of its own or neither, but a **transparent** span's
+    /// opening character comes from a *sibling*
+    /// ([`child_contexts`](Self::child_contexts)) while its closing one stays
+    /// the enclosing construct's — so `x[width=10]###c# d##` at the content's
+    /// own top level carries the `x` its sibling ends with and still anchors
+    /// `$` where the content itself ends. The reverse never arises, which is
+    /// what lets the opening character gate the wrap.
     pub(super) fn haystack<'a>(&self, s: &'a str) -> (Cow<'a, str>, usize) {
-        let (Some(before), Some(after)) = (self.before, self.after) else {
+        let Some(before) = self.before else {
             return (Cow::Borrowed(s), 0);
         };
 
-        let mut hay = String::with_capacity(s.len() + before.len_utf8() + after.len_utf8());
+        let prefix = before.len_utf8();
+
+        let mut hay =
+            String::with_capacity(s.len() + prefix + self.after.map_or(0, char::len_utf8));
+
         hay.push(before);
         hay.push_str(s);
-        hay.push(after);
 
-        (Cow::Owned(hay), before.len_utf8())
+        if let Some(after) = self.after {
+            hay.push(after);
+        }
+
+        (Cow::Owned(hay), prefix)
     }
 
     /// [`haystack`](Self::haystack)'s counterpart for a step that maps no
@@ -281,6 +390,41 @@ fn styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
     }
 }
 
+/// The character a level's own match string `s` holds immediately before
+/// `piece`, or `None` where this module cannot say what the string pipeline
+/// holds there — because the piece is the first thing the level holds, or
+/// because what precedes it is an unclassified opaque node.
+///
+/// This is how a **transparent** span's children learn what precedes the span
+/// (see [`LevelContext::child_contexts`]): the match string is the one place
+/// every node kind's presented bytes are already spelled out, so reading the
+/// character out of it cannot drift from what a pattern matching at this level
+/// would read there.
+///
+/// # A bare placeholder is not an answer
+///
+/// [`SPAN_PLACEHOLDER`] is what [`build_match_string`] writes for a node whose
+/// rendering this module cannot describe — everything
+/// [`styled_sibling_boundaries`] declines to classify. Reporting it here would
+/// *manufacture* a character where the level previously read its own start
+/// anchor, which is a different answer rather than a better one: the string
+/// pipeline holds a tag's `>` beside a rendered span, and `>` is a boundary
+/// character the auto-link's own prefix group accepts exactly as `^` does.
+/// So an unclassified neighbour reports nothing and the span goes on
+/// inheriting, leaving that shape exactly as it already was — the same line
+/// [`styled_sibling_boundaries`] draws, for the same reason.
+fn preceding_character(s: &str, piece: &Piece) -> Option<char> {
+    // A piece's bounds are byte offsets this module itself pushed into `s`, so
+    // the lookup always lands on a character boundary within it; the crate
+    // forbids `unwrap`, so that is spelled `unwrap_or_default` rather than as a
+    // branch no input reaches.
+    s.get(..piece.s_start)
+        .unwrap_or_default()
+        .chars()
+        .next_back()
+        .filter(|ch| *ch != SPAN_PLACEHOLDER)
+}
+
 /// [`styled_boundaries`] for a span whose rendering shape is not decided by
 /// its variant alone: renders it through the built-in backend around a probe
 /// body and reads the characters that land beside it.
@@ -355,9 +499,10 @@ pub(super) fn apply_quotes<'src>(
 ///
 /// `ctx` is the boundary context this level sits in (see [`LevelContext`]);
 /// a span's own children are matched in the context that span's rendering
-/// presents, which is what keeps a sub matching *inside* an earlier sub's span
-/// reading the same characters the string pipeline's flat haystack holds
-/// there.
+/// presents — or, for a span that renders no markup of its own, the one its
+/// **siblings** present ([`LevelContext::child_contexts`]) — which is what
+/// keeps a sub matching *inside* an earlier sub's span reading the same
+/// characters the string pipeline's flat haystack holds there.
 fn apply_quote_sub<'src>(
     sub: &QuoteSub,
     nodes: Vec<InlineNode<'src>>,
@@ -368,11 +513,13 @@ fn apply_quote_sub<'src>(
     // Recurse into the spans produced by earlier subs *before* matching at this
     // level. A span this sub itself creates below is therefore never revisited
     // by the same sub, matching the string pipeline (a sub runs once).
+    let contexts = LevelContext::child_contexts(&nodes, ctx);
+
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
-        .map(|node| match node {
+        .zip(contexts)
+        .map(|(node, inner)| match node {
             InlineNode::Styled(mut styled) => {
-                let inner = LevelContext::inside_styled(&styled, ctx);
                 styled.children = apply_quote_sub(sub, styled.children, root, parser, inner);
                 InlineNode::Styled(styled)
             }
@@ -1477,13 +1624,14 @@ mod tests {
         }
 
         // An unquoted span carrying neither a role nor an id renders to its
-        // body and nothing else, so it presents no boundary of its own and its
-        // children inherit whatever it sees.
+        // body and nothing else, so it presents no boundary of its own — and,
+        // when it is all its level holds, its children fall back to whatever
+        // the span itself sees on both sides.
         let bare = span(StyleVariant::Unquoted);
         assert_eq!(styled_boundaries(&bare), None);
         assert_eq!(
-            LevelContext::inside_styled(&bare, LevelContext::INSIDE_REF),
-            LevelContext::INSIDE_REF
+            LevelContext::child_contexts(&[InlineNode::Styled(bare)], LevelContext::INSIDE_REF),
+            vec![LevelContext::INSIDE_REF]
         );
 
         // One carrying an id renders a `<span …>`, like every other tag. (The
@@ -1609,6 +1757,113 @@ mod tests {
     }
 
     #[test]
+    fn child_contexts_read_a_transparent_spans_siblings() {
+        use super::LevelContext;
+        use crate::inlines::Styled;
+
+        const TAG: LevelContext = LevelContext::INSIDE_REF;
+
+        fn styled(variant: StyleVariant) -> InlineNode<'static> {
+            InlineNode::Styled(Styled {
+                variant,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: Vec::new(),
+                attrs: None,
+                children: Vec::new(),
+                location: Span::new("x"),
+            })
+        }
+
+        fn text(value: &'static str) -> InlineNode<'static> {
+            InlineNode::Text {
+                value: CowStr::from(value),
+                location: Span::new(value),
+            }
+        }
+
+        // A span that renders markup of its own answers from that markup and
+        // never reads a sibling: `>`/`<` are what its children see whatever
+        // precedes the span. A node with no children of its own carries the
+        // enclosing context, which nothing reads.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[text("a "), styled(StyleVariant::Strong)],
+                LevelContext::ROOT
+            ),
+            vec![LevelContext::ROOT, TAG]
+        );
+
+        // A transparent span takes the last character of what precedes it,
+        // while the closing half stays the enclosing context's.
+        assert_eq!(
+            LevelContext::child_contexts(&[text("a "), styled(StyleVariant::Unquoted)], TAG),
+            vec![
+                TAG,
+                LevelContext {
+                    before: Some(' '),
+                    after: Some('<'),
+                }
+            ]
+        );
+
+        // With nothing before it, both halves fall back to the enclosing
+        // context — the answer inheriting alone always gave.
+        assert_eq!(
+            LevelContext::child_contexts(&[styled(StyleVariant::Unquoted), text(" a")], TAG),
+            vec![TAG, TAG]
+        );
+
+        // At the content's own top level that fallback is `^`, and a sibling
+        // supplies an opening character without a closing one.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[text("ab"), styled(StyleVariant::Unquoted)],
+                LevelContext::ROOT
+            ),
+            vec![
+                LevelContext::ROOT,
+                LevelContext {
+                    before: Some('b'),
+                    after: None,
+                }
+            ]
+        );
+
+        // An entity-rendered span beside it presents the `;` its own
+        // `&#8221;` ends in.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[
+                    styled(StyleVariant::DoubleQuote),
+                    styled(StyleVariant::Unquoted)
+                ],
+                LevelContext::ROOT
+            ),
+            vec![
+                LevelContext {
+                    before: Some(';'),
+                    after: Some('&'),
+                },
+                LevelContext {
+                    before: Some(';'),
+                    after: None,
+                }
+            ]
+        );
+
+        // A tag-rendered one contributes the bare placeholder, which says
+        // *nothing* rather than a character: the span goes on inheriting.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
+                LevelContext::ROOT
+            ),
+            vec![TAG, LevelContext::ROOT]
+        );
+    }
+
+    #[test]
     fn a_sub_inside_a_span_reads_that_spans_own_boundary_characters() {
         // The nesting cases the enclosing span's rendering decides, each
         // pinned against the string pipeline's own flat haystack.
@@ -1708,6 +1963,95 @@ mod tests {
     }
 
     #[test]
+    fn a_sub_inside_a_transparent_span_reads_that_spans_own_siblings() {
+        // The half both tests above name: a **transparent** span — an
+        // unquoted span whose attribute list resolves to neither a role nor an
+        // id — renders to its body and nothing else, so what its children read
+        // is not the enclosing construct's markup but whatever stands *beside
+        // the span itself*. Only one sub can reach this at all: the
+        // constrained `#mark#` is the last boundary-reading sub in the list,
+        // so the span it looks across must have been built by the
+        // unconstrained `##mark##` one place ahead of it.
+        //
+        // `x[width=10]###c# d##` is the shape that names it. The string
+        // pipeline's haystack after the unconstrained sub is `x#c# d`, where
+        // the `#` is preceded by a word character and the constrained sub's
+        // own `(^|[^\w&;:}])` rejects it; the level alone showed `^`, and
+        // wrapped it.
+        for source in [
+            // A word character beside the span, which both pipelines now
+            // reject.
+            "x[width=10]###c# d##",
+            "*x[width=10]###c# d##*",
+            // The same sibling one character further out: a space, which both
+            // pipelines accept.
+            "x [width=10]###c# d##",
+            "*x [width=10]###c# d##*",
+            // No sibling at all, where the span really is all its level holds
+            // and the enclosing context is the right answer — `^` at the
+            // content's own top level, and the enclosing `<strong>`'s own `>`
+            // inside one.
+            "[width=10]###c# d##",
+            "*[width=10]###c# d##*",
+            // A tag-rendered span beside it contributes the bare placeholder,
+            // which reads as its `>` does to this boundary class (both are
+            // non-word and in none of `&;:}`).
+            "*x*[width=10]###c# d##",
+            // A construct away from the span's own edge, where the character
+            // before it is the level's own text in both pipelines.
+            "x[width=10]##d #c# e##",
+            // And a sibling *after* the span, which supplies nothing: the
+            // closing half is deliberately not carried (see
+            // [`LevelContext::child_contexts`]).
+            "[width=10]###c# d##x",
+            "[width=10]###c# d## x",
+        ] {
+            assert_eq!(
+                golden_quotes(source),
+                fold_html(
+                    &build_through_quotes(Span::new(source)),
+                    &HtmlSubstitutionRenderer {}
+                ),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_sub_closing_on_a_transparent_spans_sibling_is_a_documented_divergence() {
+        // The closing half [`LevelContext::child_contexts`] deliberately does
+        // not carry. A boundary class reads one character and, where it
+        // consumes one, the replacer writes it back — which
+        // [`LevelContext::unshift`]'s clip reproduces by leaving the character
+        // with the sibling that owns it. A *delimiter* swallows it instead,
+        // and what the replacer swallows it deletes: here the constrained
+        // `#mark#` sub's own closing `#` is the sibling, so a level given it
+        // would build a span and still emit the `#` a level out.
+        //
+        // Supplying it would make this shape differently wrong rather than
+        // right; closing it means letting one level's rebuild consume a node
+        // another level owns.
+        let source = "x[width=10]##d #c###";
+
+        let folded = fold_html(
+            &build_through_quotes(Span::new(source)),
+            &HtmlSubstitutionRenderer {},
+        );
+
+        assert_ne!(
+            golden_quotes(source),
+            folded,
+            "expected the documented divergence to still reproduce"
+        );
+
+        // The string pipeline's haystack is `xd #c#`, all of it one flat
+        // string, so the sub wraps `c`; the tree holds `d #c` inside the span
+        // and the closing `#` beside it, and leaves both literal.
+        assert_eq!(golden_quotes(source), "xd <mark>c</mark>");
+        assert_eq!(folded, "xd #c#");
+    }
+
+    #[test]
     fn a_sub_beside_a_masked_passthrough_wrapper_keeps_the_bare_placeholder() {
         // The half [`styled_sibling_boundaries`] deliberately does not
         // answer. The passthrough-extraction pass builds a [`Styled`] wrapper
@@ -1804,6 +2148,8 @@ mod tests {
             "She said \"`hello`\"`code` and meant it.\n",
             "\n",
             "Then '`this`'`that` and \"`one`\"'`two`' in a row.\n",
+            "\n",
+            "And x[width=10]###c# d## beside x [width=10]###c# d## here.\n",
         ));
 
         let mut folded_blocks = 0;
@@ -1823,9 +2169,9 @@ mod tests {
             folded_blocks += 1;
         }
 
-        // The two paragraphs; the section that contains them holds no inline
+        // The three paragraphs; the section that contains them holds no inline
         // content of its own and is skipped.
-        assert_eq!(folded_blocks, 2, "expected both paragraphs to be checked");
+        assert_eq!(folded_blocks, 3, "expected every paragraph to be checked");
     }
 
     #[test]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -932,6 +932,14 @@ fn shapes_match_across_combined_constructs() {
          or just write to doc@example.org.",
     );
 
+    // The same families reached through a **transparent** span, which renders
+    // to its body and nothing else — so what a construct inside it reads is
+    // whatever stands beside the span.
+    assert_shapes(
+        "Mail *write to [width=10]#doc@example.org# now* or \
+         x [width=10]#doc@example.org# here.",
+    );
+
     // A bare address whose local part carries an escaped special: the builder
     // recovers its shown text as structured children (the `&` staying its own
     // `CharRef`), which is the shape the recorder reaches from the opposite


### PR DESCRIPTION
The three increments before this one answer what an enclosing construct presents to the level inside it (#1215), what the macros step's own families read there (#1216), and what a rendered span presents to a sibling (#1217). All three name the same remaining shape, and this is it.

## The shape

A **transparent** span — an unquoted span whose attribute list resolves to neither a role nor an id — renders to its body and nothing else. `LevelContext::inside_styled` therefore hands its children whatever the span itself sees. That is right while the span is all its level holds, and wrong the moment a **sibling** precedes it: the string pipeline, having no levels, shows what that sibling rendered where the inherited context still shows the enclosing construct's markup.

`*x [width=10]#doc@example.org#*` is the fixture that named it. The string pipeline reads the space `x ` ends with and links the address; the tree read the `>` that ends `<strong>` — one of the bare e-mail pattern's three mismatch characters — and left it literal.

## The mechanism

A new `LevelContext::child_contexts` answers a whole level at once, one context per node, so the three recursions that had each spelled out `inside_styled` and `INSIDE_REF` now zip a vector instead. A transparent span's own half is derived from the level's **match string** — the one place every node kind's presented bytes are already spelled out (a text run's, a `CharRef`'s entity, and the `SPAN_PLACEHOLDER` wrapped in whatever #1217 can say) — so the character is *read* rather than recomputed per node kind, and the two cannot drift. Each side falls back to the enclosing context where the level ends, which is exactly where the span really is the first thing its level holds.

Building that match string is worth it only when such a span is present, so it is built on demand: every other level answers from `styled_boundaries` alone and allocates nothing new.

## Two limits, both the previous increments' own rules

**Only the opening character**, for the reason `LevelContext::shift` gives one level in and then some. A *boundary* class reads one character and, where it consumes one, the replacer writes it back — which `unshift`'s clip reproduces by leaving the character with the sibling that owns it. A *delimiter* swallows it instead, and what the replacer swallows it **deletes**, which a level's rebuild cannot do to a node another level owns. `x[width=10]##d #c###`, whose closing `#` is the sibling, keeps its own divergence test.

**A bare placeholder reports nothing** rather than a character. It is what `build_match_string` writes for a node this module cannot describe, so reporting it would manufacture an answer where the level previously read its own `^` — and `^` is what the auto-link's prefix group accepts there anyway, so `*x*[width=10]#https://example.org#` would have gone from parity to divergence. An unclassified neighbour leaves the span inheriting, the same line `styled_sibling_boundaries` draws for the same reason.

`haystack` gains the one generalization this needs: the two halves applied independently, since a sibling can supply an opening character to a level whose closing one is still the content's own end.

## Which steps take it

The **character-replacements** step is deliberately excluded. Its one boundary-reading rule is the spaced em dash, whose replacement *consumes* the spaces it matches on both sides rather than writing them back — so even an opening character a sibling owns would be emitted here *and* left there. That step goes on inheriting, and `a_replacement_beside_a_transparent_span_is_a_documented_divergence` keeps its shape, its note now carrying the sharper reason (not "a strictly larger walk" but "one level's rebuild would have to consume a node another level owns").

The two steps that can take it do:

- the **macros** step's bare e-mail and auto-link families (`*x [width=10]#doc@example.org#*` — the divergence test #1216 left behind becomes a parity corpus exactly as its own note asked);
- the **quotes** step's constrained `#mark#`, the only boundary-reading sub that can run after a transparent span exists, since the span it looks across must have been built by the unconstrained `##mark##` one place ahead of it (`x[width=10]###c# d##`).

## Tests

Each family's construct gains a differential corpus written against a transparent span's edge with a word character, a space, an entity-rendered span and a tag-rendered one beside it; the same constructs with no sibling at all (where the enclosing context is still the answer); the same at the content's own top level; and a sibling *after* the span (which supplies nothing). Alongside them: a unit test of `child_contexts` itself, a structural assertion that the address builds a real link, and divergence tests for the two shapes this deliberately does not close.

Fixtures are added to the whole-pipeline broad sweep and combined-constructs corpus, to the group-parity corpus (what a sibling renders comes from its own rendering, which no effective order changes), and to the structural recorder cross-check; whole-document tests drive both shapes end to end through the real parse path.

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the genuine divergence set **unchanged** at 41 entries — no golden source writes a construct inside a transparent span, so like #1217 this is an unclaimed form rather than a wrong answer for content already under test — and, as every increment requires, **no new divergence appeared**.

As with every prep piece before it, nothing further is wired in.

## What still defers

The **tag-rendered** half, which waits on a way to carry `masked_locations`' identity into `build_match_string` (it now shows up in two places — what a rendered span presents to a sibling, and what an unclassified neighbour presents to a transparent span); the **closing** character both the macros step and this increment decline to half-supply; a **transparent** span read *as* a sibling, which presents its own body's last character where the placeholder says nothing; and the character-replacements step's consume-across-levels case above.

## Preflight

`cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, and `cargo +nightly doc --no-deps --document-private-items` are all clean. Coverage on a diff basis: `char_replacements.rs`, `macros/mod.rs`, and `quotes.rs` keep their exact missed-region and missed-line counts; `macros/links.rs` gains one of each, the `other => panic!(…)` fallback arm of a new test assertion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbJ1nMDX63H1YG8PBHvXz6)_