### PR TITLE
feat: Carry the extraction pass's identity into recognition (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4060,6 +4060,19 @@ Each phase is a reviewable unit with a clear exit gate.
   taken only for the order that escapes late, `flatten_prior_markup`'s own consumer), since a
   wrapper's identity has to be recorded before any step runs whatever the order is.
 
+  The identity answers for **one content's own** constructs, and one path puts constructs somewhere
+  else: the `x-` compatibility form (`[x-]++text++`) substitutes its body through a *separate,
+  nested* `Normal` build, so a wrapper **that** build extracts is invisible to this content's list.
+  Consulting the list there would find no entry and call the wrapper a rendered span — the one wrong
+  answer the type exists to prevent. Nothing consults it, because the macros step no longer descends
+  into a wrapper at all: a wrapper's body is not this content's to substitute (the string pipeline
+  holds it as a sentinel for every step from here on) and the nested build already substituted it
+  once, so descending had been applying the step's families a *second* time. That was inert while a
+  bare placeholder stopped every boundary class; it stops being inert the moment a span presents a
+  character, which is how `[x-]++**b**https://example.org++` had been growing an `<a>` inside the
+  `<a>` the nested build already made. Skipping the descent is the faithful reading, and it closes
+  that shape rather than deferring it: the fold now matches the string pipeline's bytes exactly.
+
   With it,
   [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) stops being a
   two-variant special case and becomes what its mirror image
@@ -4703,7 +4716,10 @@ Each phase is a reviewable unit with a clear exit gate.
        variant from its own rendering, closing `**bold**https://example.org` (and its reverse, and
        `*x*[width=10]#doc@example.org#` one level in) while `[quotes]++x++https://example.org`
        — the new divergence a rendering-only classification would have introduced — stays literal in
-       both. See the step's own "landed as" note above. What still defers is the closing character,
+       both, and — because the macros step no longer descends into a wrapper, whose body a *nested*
+       build has already substituted — `[x-]++**b**https://example.org++` folds to the string
+       pipeline's own bytes rather than to an `<a>` nested inside an `<a>`. See the step's own
+       "landed as" note above. What still defers is the closing character,
        the character-replacements step's consume-across-levels case, and a transparent span read *as*
        a sibling, which this unblocks but does not take.
 

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4034,6 +4034,79 @@ Each phase is a reviewable unit with a clear exit gate.
   character where the placeholder says nothing; and the character-replacements step's own
   consume-across-levels case above.
 
+  *Step 6 prep landed as (the extraction pass's identity, and with it the tag-rendered half):*
+  the two increments above both stop at the same place and name the same blocker: a
+  [`Styled`](../../parser/src/inlines/styled.rs) node reaching
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) is not necessarily a span
+  the string pipeline has rendered, because the passthrough-extraction pass builds one of its own for
+  an attribute-list-prefixed passthrough (`[quotes]++text++`) that the pipeline is still holding as
+  its `\u{96}…\u{97}` sentinel for every step this module runs. Both wrappers that pass builds are
+  **tag-rendered**, so classifying a tag-rendered span by its rendering alone would sometimes hand a
+  sibling a `>` the string pipeline does not present — and telling the two apart needs the *identity*
+  [`masked_locations`](../../parser/src/content/inline_builder/special_chars.rs) collects before any
+  step runs. This increment carries that identity into recognition, and closes the half it was
+  blocking.
+
+  The identity travels as a
+  [`Masked`](../../parser/src/content/inline_builder/special_chars.rs), whose point is its **third
+  state**: a caller that does not hold the list says `Masked::UNKNOWN` rather than passing an empty
+  one, which would claim that nothing is a wrapper. An unknown identity leaves every tag-rendered
+  span with the bare placeholder — the answer the module already gave — so every step but one goes on
+  passing it and is byte-identical to before. Only the **macros** step is given the real list, and
+  that is not a shortcut but the scope the previous increment's own note had already drawn: the two
+  classes in the whole module that read a tag's `>` differently from the placeholder are
+  `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s mismatch-prefix one, and a quote sub's
+  `(^|[^\w&;:}])` accepts the two alike. `masked_locations` itself becomes unconditional (it had been
+  taken only for the order that escapes late, `flatten_prior_markup`'s own consumer), since a
+  wrapper's identity has to be recorded before any step runs whatever the order is.
+
+  With it,
+  [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) stops being a
+  two-variant special case and becomes what its mirror image
+  [`styled_boundaries`](../../parser/src/content/inline_builder/quotes.rs) already was — every
+  variant answered from its own rendering shape, with the one whose shape its attribute list decides
+  probed. The two entity-rendered variants keep their unconditional answer, because the extraction
+  pass builds neither; a **transparent** span falls out by itself, having no markup to take a
+  character from, and defers with its own note. Nothing else changes: the two characters still belong
+  to no piece, so no gate, slice, or rebuild moves.
+
+  What reaches parity is `**bold**https://example.org` and every tag-rendered variant of it — the
+  string pipeline reads the `>` that ends `</strong>` where the tree read a placeholder belonging to
+  no class, so it linked and the tree did not — together with the reverse direction (a span written
+  against a bare URL's tail, where the `<` that opens the tag is what ends the URL body) and the
+  shape one level in: `*x*[width=10]#doc@example.org#`, where a **transparent** span's own sibling is
+  tag-rendered and
+  [`child_contexts`](../../parser/src/content/inline_builder/quotes.rs) now hands it that same `>`
+  — one of the e-mail pattern's mismatch characters — instead of the `^` it had been inheriting. Both
+  of those were divergence tests the two increments above left behind, and both become parity corpora
+  exactly as their own notes asked. The extraction pass's wrapper keeps its own test, asserting that
+  `[quotes]++x++https://example.org` stays literal in both pipelines — the new divergence this
+  increment would have introduced had it classified by rendering alone.
+
+  Fixtures join the whole-pipeline broad sweep and combined-constructs corpus and the group-parity
+  corpus (what a span presents to a sibling comes from its rendering, which no effective order
+  changes), a unit test pins `styled_sibling_boundaries` against the built-in renderer in all three
+  states of the identity, and a whole-document test drives the shapes end to end through the real
+  parse path. The **structural recorder cross-check** is again the one corpus these shapes do not
+  join, for the reason the increment above recorded: a
+  [`RecordingRenderer`](../../parser/src/content/inline_tree.rs) emits its marker *outside* the
+  markup it wraps, so a later sub reads that marker where the real pipeline reads the markup's own
+  outer character. Re-running the corpus-wide fold-parity audit (tree building forced on for every
+  parse in the suite) shows the divergence set **unchanged** — no golden source in the suite writes a
+  bare URL against a rendered span's closing edge — and, as every increment requires, no new
+  divergence appeared. As with every prep piece before it, nothing further is wired in.
+
+  What still defers is the rest of the same class, now one item shorter and one item unblocked. A
+  **transparent** span read *as* a sibling presents its own body's last character where the
+  placeholder says nothing (`[width=10]##x ##https://example.org`, which the string pipeline links on
+  the space the body ends with), and that was gated on this same identity for the same reason —
+  `[width=10]++x ++` is an extraction wrapper that renders its body and nothing else, so classifying
+  by rendering alone would have been wrong for it too. `Masked` tells the two apart, so the next
+  increment can take it; what it still needs is a way to *read* a transparent span's own outer
+  characters, which are its children's rather than any markup of its own. Beyond that: the **closing**
+  character both the macros step and the increment above decline to half-supply, and the
+  character-replacements step's own consume-across-levels case above.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4614,6 +4687,25 @@ Each phase is a reviewable unit with a clear exit gate.
        character would be written twice. See the step's own "landed as" note above. What still defers
        is the tag-rendered half, the closing character, a transparent span read *as* a sibling, and
        that consume-across-levels case.
+
+     - ✅ **prep (the extraction pass's identity, and the tag-rendered half it was blocking).** The
+       blocker all three increments above name — a tag-rendered [`Styled`] node may be the
+       passthrough-extraction pass's own wrapper, which the string pipeline holds as a sentinel
+       rather than as markup, and telling one from a rendered span needs
+       [`masked_locations`](../../parser/src/content/inline_builder/special_chars.rs)' identity — is
+       closed by carrying that identity into recognition as a
+       [`Masked`](../../parser/src/content/inline_builder/special_chars.rs), whose third state
+       (`UNKNOWN`) lets a caller say it does not hold the list rather than claim nothing is a
+       wrapper. Only the **macros** step is given the real one, which is the scope the increment
+       above had already drawn: `INLINE_LINK`'s and `INLINE_EMAIL`'s prefix groups are the only
+       classes in the module that read a tag's `>` differently from the bare placeholder. With it,
+       [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) answers every
+       variant from its own rendering, closing `**bold**https://example.org` (and its reverse, and
+       `*x*[width=10]#doc@example.org#` one level in) while `[quotes]++x++https://example.org`
+       — the new divergence a rendering-only classification would have introduced — stays literal in
+       both. See the step's own "landed as" note above. What still defers is the closing character,
+       the character-replacements step's consume-across-levels case, and a transparent span read *as*
+       a sibling, which this unblocks but does not take.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use super::{
     passthrough_step::is_special,
     quotes::{Piece, build_match_string, emit_range, source_slice},
+    special_chars::Masked,
 };
 use crate::{
     Parser, Span,
@@ -331,7 +332,7 @@ fn resolve_counters<'nodes, 'src>(
     parser: &Parser,
     out: &mut HashMap<usize, String>,
 ) {
-    let (s, pieces) = build_match_string(nodes);
+    let (s, pieces) = build_match_string(nodes, Masked::UNKNOWN);
 
     // A counter match's `name`/`seed` borrow from `s`, a local match string
     // that does not outlive this call, so they are owned rather than
@@ -465,7 +466,7 @@ fn attribute_references_level<'src>(
     span_drops: &[usize],
     specials: SplicedSpecials,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A span that forces a line drop is named by node index; the line decision
     // works in match-string offsets. Translating here (rather than in
@@ -553,7 +554,7 @@ fn styled_drop_indices(nodes: &[InlineNode<'_>], parser: &Parser) -> Vec<usize> 
 /// Recognition is [`find_attribute_matches`]'s own, so the two cannot disagree
 /// about what counts as a missing reference.
 fn subtree_has_missing_reference(nodes: &[InlineNode<'_>], parser: &Parser) -> bool {
-    let (s, _) = build_match_string(nodes);
+    let (s, _) = build_match_string(nodes, Masked::UNKNOWN);
 
     if s.contains('{')
         && find_attribute_matches(&s, parser, MissingHandling::DropLine)

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -2,7 +2,10 @@
 
 use regex::Regex;
 
-use super::quotes::{Piece, build_match_string, emit_range, source_slice};
+use super::{
+    quotes::{Piece, build_match_string, emit_range, source_slice},
+    special_chars::Masked,
+};
 use crate::{
     Parser, Span,
     attributes::Attrlist,
@@ -55,7 +58,7 @@ pub(super) fn apply_callouts<'src>(
     parser: &Parser,
     attrlist: Option<&Attrlist<'_>>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A callout's opening bracket is always rendered as `&lt;` by
     // `apply_special_characters`, so we can cheaply skip content without any

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -1,6 +1,9 @@
 //! The character-replacements substitution step.
 
-use super::quotes::{LevelContext, Piece, build_match_string, emit_range, source_slice};
+use super::{
+    quotes::{LevelContext, Piece, build_match_string, emit_range, source_slice},
+    special_chars::Masked,
+};
 use crate::{
     Span,
     content::{CharacterReplacement, character_replacements, maybe_has_replacements},
@@ -150,7 +153,7 @@ fn replace_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter: skip the pattern sweep when nothing replaceable is
     // present at this level.

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -6,6 +6,7 @@ use super::{
         image::range_has_no_opaque_piece,
     },
     quotes::{Piece, build_match_string, source_slice, text_slice},
+    special_chars::Masked,
 };
 use crate::{
     Parser, Span,
@@ -73,7 +74,7 @@ pub(super) fn apply_footnotes<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring the string step's `found_macroish &&
     // text.contains("tnote")`: both `footnote:` and the deprecated
@@ -100,7 +101,7 @@ pub(super) fn apply_footnotes<'src>(
 /// could) but allocates no [`InlineNode`], letting a subtree with nothing to
 /// find come back from `apply_footnotes` completely unchanged.
 fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
-    let (s, _) = build_match_string(nodes);
+    let (s, _) = build_match_string(nodes, Masked::UNKNOWN);
 
     if s.contains("tnote") {
         return true;

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -9,9 +9,12 @@ use crate::{
     Parser, Span,
     content::{
         INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR,
-        inline_builder::quotes::{
-            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
-            range_overlaps_synthesized, source_slice, text_slice,
+        inline_builder::{
+            quotes::{
+                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
+                range_overlaps_synthesized, source_slice, text_slice,
+            },
+            special_chars::Masked,
         },
     },
     document::RefType,
@@ -96,12 +99,13 @@ pub(super) fn biblio_anchor_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
     if !parser.in_bibliography_list_item.get() {
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter, mirroring the string step's own `text.contains("[[[")`
     // guard: the pattern is `^`-anchored, so only content *starting* with the
@@ -188,8 +192,9 @@ pub(super) fn anchor_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
     // `anchor:` macro prefix. The `[` characters are not special, so a shorthand
@@ -673,6 +678,7 @@ mod tests {
     };
     use crate::{
         Parser, Span,
+        content::inline_builder::special_chars::Masked,
         inlines::{Anchor, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -1637,7 +1643,7 @@ mod tests {
             location: root,
         }];
 
-        let out = biblio_anchor_level(nodes, root, &biblio_parser());
+        let out = biblio_anchor_level(nodes, root, &biblio_parser(), Masked::UNKNOWN);
         assert_eq!(out.len(), 1);
         assert!(matches!(out[0], InlineNode::Text { .. }));
     }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -6,8 +6,12 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_IMAGE_MACRO, basename,
-        inline_builder::quotes::{
-            LevelContext, Piece, build_match_string, replacement_entity, source_slice, text_slice,
+        inline_builder::{
+            quotes::{
+                LevelContext, Piece, build_match_string, replacement_entity, source_slice,
+                text_slice,
+            },
+            special_chars::Masked,
         },
         normalize_text_lf_escaped_bracket,
     },
@@ -25,8 +29,9 @@ pub(super) fn image_macros_level<'src>(
     root: Span<'src>,
     parser: &Parser,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's `found_macroish`: an image
     // or icon macro needs its name prefix and an opening bracket.
@@ -531,6 +536,7 @@ mod tests {
         HasSpan, Parser, Span,
         content::inline_builder::{
             build, char_replacements::apply_character_replacements, macros::apply_macros,
+            special_chars::Masked,
         },
         inlines::{Image, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
@@ -1103,6 +1109,7 @@ mod tests {
             build_through_special_and_replacements(Span::new(source)),
             Span::new(source),
             &Parser::default(),
+            Masked::UNKNOWN,
         );
 
         assert!(

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -6,8 +6,9 @@ use crate::{
     Span,
     content::{
         INLINE_INDEXTERM,
-        inline_builder::quotes::{
-            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice,
+        inline_builder::{
+            quotes::{LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+            special_chars::Masked,
         },
         normalize_index_text, strip_see_and_seealso,
     },
@@ -24,8 +25,9 @@ pub(super) fn indexterm_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a shorthand needs a
     // `((` … `))` pair (its parens are not special, so they reach the macros

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -11,8 +11,9 @@ use crate::{
     content::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
-        inline_builder::quotes::{
-            LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice,
+        inline_builder::{
+            quotes::{LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+            special_chars::Masked,
         },
     },
     inlines::{InlineNode, Ref, RefVariant},
@@ -138,8 +139,9 @@ pub(super) fn inline_link_level<'src>(
     root: Span<'src>,
     parser: &Parser,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: an auto-link needs a
     // `://` scheme separator somewhere in the level.
@@ -816,8 +818,9 @@ pub(super) fn link_macro_level<'src>(
     root: Span<'src>,
     parser: &Parser,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a link/mailto macro
     // needs its prefix and an opening bracket.
@@ -1393,8 +1396,9 @@ pub(super) fn email_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's own `text.contains('@')`
     // guard.
@@ -4055,24 +4059,96 @@ mod tests {
     }
 
     #[test]
-    fn an_auto_link_abutting_a_rendered_span_is_a_documented_divergence() {
+    fn an_auto_link_abutting_a_rendered_span_reads_that_spans_own_markup() {
         // The mirror image of the boundary above, in the sibling auto-link
         // family, which predates the e-mail pass: `INLINE_LINK`'s own
         // boundary-prefix group *requires* one of `^`, a blank, or
-        // `[>()\[\];"']`. The string pipeline reads `</strong>`'s own `>`
-        // there and builds a link; the placeholder standing in for the span
-        // here belongs to no such class, so the pattern simply fails to match
-        // and the URL is left literal. Pinned here so the two directions of
-        // this one boundary are recorded together.
-        let source = "**bold**https://example.org";
+        // `[>()\[\];"\']`. The string pipeline reads `</strong>`'s own `>`
+        // there and builds a link, where the bare placeholder standing in for
+        // the span belongs to no such class — so this is the one boundary a
+        // `>` and a placeholder read *differently*, and the reason the identity
+        // that tells a rendered span from an extraction-pass wrapper has to
+        // reach recognition at all.
+        for source in [
+            // A bare URL against each tag-rendered variant's closing edge. The
+            // string pipeline reads the `>` that ends the tag and links; so
+            // does the tree, now that the placeholder carries it.
+            "**bold**https://example.org",
+            "__em__https://example.org",
+            "``code``https://example.org",
+            "##mark##https://example.org",
+            "^sup^https://example.org",
+            "~sub~https://example.org",
+            "[.r]##a##https://example.org",
+            "[#a]##b##https://example.org",
+            "**bold**ftp://example.org",
+            // The two entity-rendered variants end their closing markup in the
+            // `;` of an entity, which that group does *not* accept — so both
+            // pipelines leave the URL literal, exactly as before.
+            r#""`q`"https://example.org"#,
+            r#"'`q`'https://example.org"#,
+            // One character further out, where a space intervenes and both
+            // pipelines match on the space itself.
+            "**bold** https://example.org",
+            // And with no span at all, where the level's own start anchor is
+            // what the string pipeline presents too.
+            "https://example.org",
+            "see https://example.org now",
+            // The reverse direction: a span written against a bare URL's own
+            // tail. The `<` that opens the tag is what ends the URL body
+            // (`[^\s\[\]<]*` excludes it) in the string pipeline, and now
+            // here as well.
+            "https://example.org**bold**",
+            "https://example.org\"`q`\"",
+            // A formal-URL link's own boundary-prefix group is the same one.
+            "**bold**https://example.org[Site]",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_auto_link_abutting_a_rendered_span_builds_a_link() {
+        // The parity above, read structurally: the tree really recognizes the
+        // URL rather than merely folding to the same bytes some other way.
+        let nodes = build_src(Span::new("**bold**https://example.org"));
+
+        assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Unconstrained);
+
+        assert_eq!(
+            assert_link(&nodes[1]).target.as_ref(),
+            "https://example.org"
+        );
+    }
+
+    #[test]
+    fn an_auto_link_abutting_a_passthrough_wrapper_stays_literal() {
+        // The half the identity exists to protect. An attribute-list-prefixed
+        // passthrough builds a [`Styled`](crate::inlines::Styled) wrapper that
+        // renders `<span class="quotes">…</span>` — but the string pipeline is
+        // holding it as its own `\u{96}…\u{97}` sentinel for every step this
+        // module runs, so the boundary-prefix group sees no `>` and the URL
+        // stays literal. Classifying it by its *rendering* would have made this
+        // the increment's own new divergence.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "[quotes]++x++https://example.org";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a URL abutting a rendered span must be left unrecognized: {nodes:?}"
+            "a URL abutting a masked wrapper must stay literal: {nodes:?}"
         );
 
-        assert!(golden_macros(source).contains(r#"href="https://example.org""#));
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source),
+            "fold diverged for {source:?}"
+        );
     }
 
     #[test]
@@ -4134,11 +4210,13 @@ mod tests {
             // The auto-link family reads the same character through its own
             // boundary-prefix group.
             "*x [width=10]#https://example.org#*",
-            // A **tag-rendered** span beside the transparent one says nothing
-            // this module can act on, so the span goes on inheriting: `^` here,
-            // which the auto-link's prefix group accepts exactly as it accepts
-            // the `>` the string pipeline reads there.
+            // A **tag-rendered** span beside the transparent one presents the
+            // `>` its own closing markup ends in, which the string pipeline
+            // reads there too — a mismatch character for the e-mail family and
+            // an accepted prefix for the auto-link one.
+            "*x*[width=10]#doc@example.org#",
             "*x*[width=10]#https://example.org#",
+            "``code``[width=10]#doc@example.org#",
             // And the same addresses at the content's own top level, where a
             // level's start is exactly what the string pipeline presents.
             "doc@example.org",
@@ -4197,33 +4275,31 @@ mod tests {
     }
 
     #[test]
-    fn an_address_after_a_transparent_spans_tag_rendered_sibling_is_a_documented_divergence() {
-        // The half a transparent span's own siblings cannot answer. What
-        // precedes the span here is a **tag-rendered** span, which
-        // [`build_match_string`](super::super::quotes::build_match_string)
-        // stands in as a bare [`SPAN_PLACEHOLDER`] belonging to no boundary
-        // class — so
+    fn an_address_after_a_transparent_spans_tag_rendered_sibling_stays_literal() {
+        // The half a transparent span's own siblings could not answer until
+        // the identity reached
+        // [`build_match_string`](super::super::quotes::build_match_string).
+        // What precedes the span here is a **tag-rendered** span, which now
+        // contributes the `>` that ends `</strong>` rather than a bare
+        // placeholder — so
         // [`LevelContext::child_contexts`](super::super::quotes::LevelContext)
-        // reports nothing and the transparent span inherits `^`, where the
-        // string pipeline reads the `>` that ends `<strong>` — one of the bare
-        // e-mail pattern's three mismatch characters.
-        //
-        // This is the same tag-rendered half `styled_sibling_boundaries`
-        // already defers one level out, for the same reason: telling a
-        // genuinely rendered span from the passthrough-extraction pass's own
-        // wrapper needs `masked_locations`' identity, which neither has. If
-        // that lands, fold this fixture into the parity corpus above.
+        // hands the transparent span that `>`, one of the bare e-mail
+        // pattern's three mismatch characters, and the address stays literal
+        // exactly as the string pipeline leaves it.
         let source = "*x*[width=10]#doc@example.org#";
-        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+        let nodes = build_src(Span::new(source));
 
-        assert_ne!(
-            golden_macros(source),
-            folded,
-            "expected the documented divergence to still reproduce"
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_macros(source)
         );
 
         assert_eq!(golden_macros(source), "<strong>x</strong>doc@example.org");
-        assert!(folded.contains("mailto:doc@example.org"), "{folded:?}");
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "an address after a tag-rendered sibling must stay literal: {nodes:?}"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -4152,6 +4152,61 @@ mod tests {
     }
 
     #[test]
+    fn a_url_beside_a_wrapper_in_a_nested_builds_body_stays_literal() {
+        // The shape that keeps the identity honest about its own scope.
+        // `masked_locations` answers for one content's **own** top level, and
+        // the `x-` compatibility form substitutes its body through a separate,
+        // nested `Normal` build — so a wrapper *that* build extracts is
+        // invisible to this content's list. Consulting the list there would
+        // find no entry and call the wrapper a rendered span, handing the URL
+        // beside it a `>` the string pipeline never presents (it is holding
+        // the wrapper as its own `\u{96}…\u{97}` sentinel, exactly as at the
+        // top level).
+        //
+        // Nothing consults it, because no family descends into a wrapper at
+        // all: its body is not this content's to substitute, and the nested
+        // build already substituted it once. Both fixtures leave the URL
+        // literal in both pipelines. (The bare **e-mail** family's own
+        // version of this shape, `[x-]++[quotes]$$y$$doc@example.org++`, is
+        // the deferral
+        // `an_email_abutting_a_construct_that_hides_its_boundary_is_a_documented_divergence`
+        // already records, and is unchanged either way.)
+        use super::super::super::test_support::golden_passthroughs;
+
+        for source in [
+            "[x-]++[quotes]$$y$$https://example.org++",
+            "[x-]++[.r]$$y$$https://example.org++",
+            "*[x-]++[quotes]$$y$$https://example.org++*",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_passthroughs(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_url_in_a_nested_builds_body_is_linked_once() {
+        // The same body, one step on: what the nested build *does* recognize
+        // it recognizes with its own identity in hand, so a URL written
+        // against a tag-rendered span there links exactly as the string
+        // pipeline links it — and links **once**, since the outer step does
+        // not descend to match over the result a second time.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "[x-]++**b**https://example.org++";
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, golden_passthroughs(source));
+
+        assert_eq!(
+            folded,
+            "<code><strong>b</strong><a href=\"https://example.org\" class=\"bare\">https://example.org</a></code>"
+        );
+    }
+
+    #[test]
     fn an_address_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
         // The mismatch-prefix group reads the character immediately before the
         // address, and inside a span the string pipeline reads that span's own

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -14,7 +14,10 @@ use links::{email_level, inline_link_level, link_macro_level};
 use ui::{kbd_btn_macros_level, menu_macros_level};
 use xref::xref_macros_level;
 
-use super::quotes::{LevelContext, Piece, emit_range, source_slice, special_entity, text_slice};
+use super::{
+    quotes::{LevelContext, Piece, emit_range, source_slice, special_entity, text_slice},
+    special_chars::Masked,
+};
 use crate::{
     Parser, Span,
     content::restored_entity_pattern,
@@ -130,6 +133,7 @@ pub(super) fn apply_macros<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
     // The bibliography anchor (`[[[label]]]`) runs before every other family,
     // exactly as the string step runs its own `INLINE_BIBLIO_ANCHOR` pass
@@ -140,9 +144,9 @@ pub(super) fn apply_macros<'src>(
     // [`apply_macro_families`]'s own recursion, and why it needs no
     // [`LevelContext`] of its own: the top level is the one level nothing
     // encloses.
-    let nodes = biblio_anchor_level(nodes, root, parser);
+    let nodes = biblio_anchor_level(nodes, root, parser, masked);
 
-    apply_macro_families(nodes, root, parser, LevelContext::ROOT)
+    apply_macro_families(nodes, root, parser, LevelContext::ROOT, masked)
 }
 
 /// Applies each macro family at this level — and, first, at every level nested
@@ -182,11 +186,29 @@ pub(super) fn apply_macros<'src>(
 /// children read what stands beside the *span* instead; that is
 /// [`LevelContext::child_contexts`]'s own job, and this function takes the
 /// answer it gives without caring which of the two it is.
+///
+/// # The boundary a sibling presents
+///
+/// The same two families read the character a construct written *beside* a
+/// rendered span presents, which
+/// [`build_match_string`](super::quotes::build_match_string) writes around
+/// that span's own placeholder — and which it can write only for a span the
+/// string pipeline has really rendered, not for the passthrough-extraction
+/// pass's own wrapper (see
+/// [`Masked`]). This step is where `masked` is
+/// carried, and only here, because these two prefix groups are the only
+/// classes in the whole module that read a tag's `>` differently from the
+/// bare placeholder: `**bold**https://example.org` links in the string
+/// pipeline, reading the `>` that ends `</strong>`, where a quote sub's own
+/// `(^|[^\w&;:}])` accepts the two alike. Every other step goes on passing
+/// [`Masked::UNKNOWN`](super::special_chars::Masked::UNKNOWN), which is not a
+/// shortcut but the same answer stated once.
 fn apply_macro_families<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
     // Recurse into spans/refs first, matching the string pipeline's
     // whole-string pass. Each nested level is matched in the context its own
@@ -194,19 +216,21 @@ fn apply_macro_families<'src>(
     // comment); a span the built-in backend renders with no markup of its own
     // is transparent, so `child_contexts` hands its children the character its
     // own *siblings* present instead.
-    let contexts = LevelContext::child_contexts(&nodes, ctx);
+    let contexts = LevelContext::child_contexts(&nodes, ctx, masked);
 
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
         .zip(contexts)
         .map(|(node, inner)| match node {
             InlineNode::Styled(mut styled) => {
-                styled.children = apply_macro_families(styled.children, root, parser, inner);
+                styled.children =
+                    apply_macro_families(styled.children, root, parser, inner, masked);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
-                reference.children = apply_macro_families(reference.children, root, parser, inner);
+                reference.children =
+                    apply_macro_families(reference.children, root, parser, inner, masked);
                 InlineNode::Ref(reference)
             }
 
@@ -217,45 +241,45 @@ fn apply_macro_families<'src>(
     // The UI macros run before image/icon and only under `experimental`,
     // mirroring the string step's order and gate.
     let nodes = if parser.is_attribute_set("experimental") {
-        let nodes = kbd_btn_macros_level(nodes, root, ctx);
-        menu_macros_level(nodes, root, ctx)
+        let nodes = kbd_btn_macros_level(nodes, root, ctx, masked);
+        menu_macros_level(nodes, root, ctx, masked)
     } else {
         nodes
     };
 
-    let nodes = image_macros_level(nodes, root, parser, ctx);
+    let nodes = image_macros_level(nodes, root, parser, ctx, masked);
 
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
     // `indexterm2:[…]`) run after image/icon and before the link families,
     // mirroring the string step's order.
-    let nodes = indexterm_macros_level(nodes, root, ctx);
+    let nodes = indexterm_macros_level(nodes, root, ctx, masked);
 
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro, mirroring the string step's
     // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
-    let nodes = inline_link_level(nodes, root, parser, ctx);
+    let nodes = inline_link_level(nodes, root, parser, ctx, masked);
 
     // The `link:`/`mailto:` macro runs after the auto-link pass, mirroring the
     // string step's order.
-    let nodes = link_macro_level(nodes, root, parser, ctx);
+    let nodes = link_macro_level(nodes, root, parser, ctx, masked);
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
     // families and before the anchor pass, exactly where the string step runs
     // `InlineEmailReplacer` — so an address that is really the tail of a URL, or
     // a `mailto:` macro's own target, is already inside an opaque node (there,
     // already-rendered `<a …>` markup) and is not re-recognized.
-    let nodes = email_level(nodes, root, ctx);
+    let nodes = email_level(nodes, root, ctx, masked);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
     // before cross-references, mirroring the string step's order. (The
     // bibliography-anchor pass the string step runs *first* — a `^`-anchored
     // `[[[id]]]`, recognized only inside a bibliography list item — runs in
     // [`apply_macros`], outside this recursion.)
-    let nodes = anchor_macros_level(nodes, root, ctx);
+    let nodes = anchor_macros_level(nodes, root, ctx, masked);
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
-    xref_macros_level(nodes, root, parser, ctx)
+    xref_macros_level(nodes, root, parser, ctx, masked)
 
     // Footnotes are **not** handled here. Every other family's recognition is
     // order-independent (no cross-node side effect), so it is safe for them to
@@ -676,7 +700,10 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::{super::test_support::golden_macros_with, apply_macro_side_effects, apply_macros};
+    use super::{
+        super::{special_chars::Masked, test_support::golden_macros_with},
+        apply_macro_side_effects, apply_macros,
+    };
     use crate::{
         Parser, Span,
         content::{
@@ -938,7 +965,7 @@ mod tests {
             location: root,
         });
 
-        let out = apply_macros(vec![reference], root, &Parser::default());
+        let out = apply_macros(vec![reference], root, &Parser::default(), Masked::UNKNOWN);
 
         // The reference survives, and its single child is now the recognized
         // image node.

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -222,6 +222,21 @@ fn apply_macro_families<'src>(
         .into_iter()
         .zip(contexts)
         .map(|(node, inner)| match node {
+            // An extraction wrapper's body is **not** this content's to
+            // substitute. The string pipeline holds it as a sentinel for every
+            // step from here on, and the body was already substituted once —
+            // by the separate, nested `Normal` build the `x-` compatibility
+            // form (`[x-]++text++`) runs it through — so descending here would
+            // apply this step's families to it a *second* time
+            // (`[x-]++**b**https://example.org++` grows an `<a>` inside the
+            // `<a>` that build already made). It is also the one place this
+            // level's `masked` could not answer even if it did descend, since
+            // the list is collected from one content's own top level and knows
+            // nothing of a nested build's nodes.
+            InlineNode::Styled(styled) if masked.covers(styled.location) => {
+                InlineNode::Styled(styled)
+            }
+
             InlineNode::Styled(mut styled) => {
                 styled.children =
                     apply_macro_families(styled.children, root, parser, inner, masked);

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -5,8 +5,9 @@ use crate::{
     Span,
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
-        inline_builder::quotes::{
-            LevelContext, Piece, build_match_string, source_slice, text_slice,
+        inline_builder::{
+            quotes::{LevelContext, Piece, build_match_string, source_slice, text_slice},
+            special_chars::Masked,
         },
         normalize_index_text, split_kbd_keys,
     },
@@ -33,8 +34,9 @@ pub(super) fn kbd_btn_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     if !(s.contains(":[") && (s.contains("kbd:") || s.contains("btn:"))) {
         return nodes;
@@ -199,8 +201,9 @@ pub(super) fn menu_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     if !(s.contains("menu:") && s.contains('[')) {
         return nodes;

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -9,7 +9,10 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_XREF,
-        inline_builder::quotes::{LevelContext, Piece, build_match_string, source_slice},
+        inline_builder::{
+            quotes::{LevelContext, Piece, build_match_string, source_slice},
+            special_chars::Masked,
+        },
         xref_target::{
             XrefTarget, interpret_xref_target, other_document_reference, this_document_reference,
         },
@@ -83,8 +86,9 @@ pub(super) fn xref_macros_level<'src>(
     root: Span<'src>,
     parser: &Parser,
     ctx: LevelContext,
+    masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter: both the `xref:` macro form and the `<<id>>` shorthand
     // (seen here as `&lt;&lt;id&gt;&gt;`, since specials run before macros) are

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -374,7 +374,8 @@ use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
 use special_chars::{
-    apply_special_characters, classify_unescaped_specials, flatten_prior_markup, masked_locations,
+    Masked, apply_special_characters, classify_unescaped_specials, flatten_prior_markup,
+    masked_locations,
 };
 use stem_step::apply_stem;
 
@@ -522,23 +523,21 @@ pub(crate) fn build_for_group<'src>(
         nodes = apply_stem(nodes, location, parser);
     }
 
-    // A `subs=` list can put the escaping step *after* a step that already
-    // produced markup, and there the string pipeline escapes the tags that
-    // step wrote. Recording what the extraction pass masked — before any step
-    // runs — is what lets `flatten_prior_markup` tell those tags from a
-    // passthrough body the escaping step never touches; see its own doc
-    // comment. The walk is skipped entirely for the overwhelmingly common
-    // order that escapes first (or never).
-    let escapes_late = steps
-        .iter()
-        .position(|step| step == &SubstitutionStep::SpecialCharacters)
-        .is_some_and(|position| position > 0);
-
-    let masked = if escapes_late {
-        masked_locations(&nodes)
-    } else {
-        vec![]
-    };
+    // What the extraction pass masked, recorded — as it must be — *before* any
+    // step runs, since a wrapper is told from an ordinary span by its identity
+    // alone. Two consumers read it, which is why it is taken unconditionally
+    // rather than only for the order that needs the first:
+    //
+    //   - `flatten_prior_markup`, for a `subs=` list that puts the escaping step
+    //     *after* a step that already produced markup: the string pipeline escapes
+    //     the tags that step wrote, and this is what tells those from a passthrough
+    //     body the escaping step never touches.
+    //
+    //   - recognition itself (`build_match_string`, via `Masked`), for every order:
+    //     a sibling reads a rendered span's own markup, and a wrapper — which the
+    //     string pipeline is still holding as a `\u{96}…\u{97}` placeholder —
+    //     presents no markup to read.
+    let masked = masked_locations(&nodes);
 
     for (position, step) in steps.iter().enumerate() {
         nodes = match step {
@@ -595,7 +594,7 @@ pub(crate) fn build_for_group<'src>(
                 // resolved at every level — see `apply_footnotes`'s doc
                 // comment for why this cannot be folded into `apply_macros`
                 // as an ordinary level pass.
-                let nodes = apply_macros(nodes, location, parser);
+                let nodes = apply_macros(nodes, location, parser, Masked::known(&masked));
                 apply_footnotes(nodes, location, parser)
             }
 
@@ -865,6 +864,18 @@ mod tests {
             r##""`a`"#mark#"##,
             r#""`a`"'`b`'"#,
             r#""`a`" `code`"#,
+            // And the **tag**-rendered half of the same seam, told from the
+            // passthrough-extraction pass's own wrapper by the identity the
+            // macros step now carries: the string pipeline reads the `>` that
+            // ends `</strong>` where the tree used to hold a bare placeholder.
+            "**bold**https://example.org",
+            "__em__https://example.org",
+            "``code``https://example.org",
+            "[.r]##a##https://example.org",
+            "**bold** https://example.org",
+            "https://example.org**bold**",
+            "**bold**doc@example.com",
+            "[quotes]++x++https://example.org",
             // The macros step's own boundary-reading families at the same
             // seam: the bare e-mail's mismatch prefix and the auto-link's
             // boundary prefix.
@@ -1368,6 +1379,16 @@ mod tests {
         // literal, and the surrounding constructs still resolve normally.
         assert_parity(r##"He said "`hello`"`code` and then "`bye`"#mark# alone."##);
         assert_parity(r#"Quoting "`one`"'`two`' back to back, plus a *bold* run."#);
+
+        // The **tag**-rendered half of that seam, in the one family that can
+        // tell a `>` from the placeholder: `INLINE_LINK`'s boundary-prefix
+        // group accepts the `>` a closing tag ends with, so both pipelines
+        // link a URL written straight against a span's outer edge — while the
+        // extraction pass's own wrapper, which the string pipeline is still
+        // holding as a sentinel, presents no such character and leaves it
+        // literal in both.
+        assert_parity("A **bold**https://example.org run and __em__https://example.org too.");
+        assert_parity("Then [quotes]++x++https://example.org stays literal.");
 
         // The same seam for the **macros** step, whose bare e-mail and
         // auto-link families read a boundary character of their own: a
@@ -1905,6 +1926,7 @@ mod tests {
                 // **sibling** likewise comes from its rendering, not from the
                 // order.
                 r#""`a`"`code` and a < b"#,
+                "**bold**https://example.org and a < b",
                 // The same for the macros step's own boundary-reading
                 // families, whose decision likewise comes from the enclosing
                 // span's rendering rather than from the order.

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -3,6 +3,7 @@
 use super::{
     macros::{MacroMatch, MacroMatchKind, image::range_is_verbatim, rebuild_macro_level},
     quotes::{Piece, attributes_of, build_match_string, source_slice},
+    special_chars::Masked,
 };
 use crate::{
     Parser, Span,
@@ -164,7 +165,7 @@ fn apply_pass_macro_level<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard: a
     // recognized form always contains `++`, `$$`, or (for `pass:`) `ss:`.
@@ -190,7 +191,7 @@ fn apply_bare_attrlisted_pass_level<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard for
     // `INLINE_PASS`.

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -1,6 +1,9 @@
 //! The post-replacements substitution step (hard line breaks).
 
-use super::quotes::{Piece, build_match_string, emit_range, source_slice};
+use super::{
+    quotes::{Piece, build_match_string, emit_range, source_slice},
+    special_chars::Masked,
+};
 use crate::{
     Parser, Span, attributes::Attrlist, content::hard_line_break_pattern, inlines::InlineNode,
 };
@@ -58,7 +61,7 @@ fn apply_level<'src>(
         return apply_hardbreaks(nodes, root);
     }
 
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A break needs a `+`, and — off the root level, where an end-of-level
     // match is discarded below — a `\n` for the pattern's `$` to anchor
@@ -115,7 +118,7 @@ fn apply_level<'src>(
 /// there is none) never gets one, matching the string pipeline leaving the
 /// popped last line unbroken.
 fn apply_hardbreaks<'src>(nodes: Vec<InlineNode<'src>>, root: Span<'src>) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     if !s.contains('\n') {
         return nodes;

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -2,7 +2,10 @@
 
 use std::{borrow::Cow, ops::Range};
 
-use super::macros::image::{range_has_no_opaque_piece, range_is_verbatim};
+use super::{
+    macros::image::{range_has_no_opaque_piece, range_is_verbatim},
+    special_chars::Masked,
+};
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
@@ -161,7 +164,22 @@ impl LevelContext {
     /// [`inside_styled`](Self::inside_styled), and
     /// `a_replacement_beside_a_transparent_span_is_a_documented_divergence`
     /// keeps its shape.
-    pub(super) fn child_contexts(nodes: &[InlineNode<'_>], enclosing: Self) -> Vec<Self> {
+    ///
+    /// # What a neighbour can be read as
+    ///
+    /// Because the answer is read out of the match string, it is exactly as
+    /// good as what [`build_match_string`] could write there — so `masked` is
+    /// passed straight through. A caller holding the extraction pass's
+    /// identity gets the `>` a tag-rendered neighbour's own closing markup
+    /// ends with; one that does not gets the bare [`SPAN_PLACEHOLDER`], which
+    /// [`preceding_character`] reports as *nothing* rather than as a
+    /// character. Both are right for what their caller knows, and the second
+    /// is what this function answered before the identity reached it at all.
+    pub(super) fn child_contexts(
+        nodes: &[InlineNode<'_>],
+        enclosing: Self,
+        masked: Masked<'_>,
+    ) -> Vec<Self> {
         let mut has_transparent = false;
 
         let mut contexts: Vec<Self> = nodes
@@ -182,7 +200,7 @@ impl LevelContext {
             return contexts;
         }
 
-        let (s, pieces) = build_match_string(nodes);
+        let (s, pieces) = build_match_string(nodes, masked);
 
         // `build_match_string` contributes exactly one [`Piece`] per node, in
         // order, so the three sequences line up and no lookup is needed.
@@ -348,11 +366,7 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 /// it rendered a smart quote's `&#8221;`, and a preceding one reads `<` or
 /// `&`.
 ///
-/// # Only the entity-rendered variants
-///
-/// The two smart quotes are answered; every other variant keeps the bare
-/// placeholder, and the asymmetry is not about what a variant renders but
-/// about what this function can *tell*.
+/// # An extraction-pass wrapper is not a rendered span
 ///
 /// A [`Styled`] node reaching [`build_match_string`] is not necessarily a span
 /// the string pipeline has rendered at all: the passthrough-extraction pass
@@ -362,32 +376,59 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 /// rather than as markup, for every step this module runs. A sibling reads
 /// that sentinel, which is exactly what the bare [`SPAN_PLACEHOLDER`] already
 /// reads as to every class in play (both are non-word, in none of `&;:}`,
-/// `[>\(\)\[\];"']`, or `[\\>:/]`), so leaving such a wrapper unclassified
-/// is not an approximation — it is the right answer.
+/// `[>\(\)\[\];"']`, or `[\\>:/]`), so such a wrapper keeps the bare
+/// placeholder — not as an approximation, but because that is the right
+/// answer.
 ///
-/// Telling one apart from a genuinely rendered span needs the *identity* that
+/// Telling one apart from a genuinely rendered span needs the *identity*
 /// [`masked_locations`](super::special_chars::masked_locations) collects
-/// before any step runs, which this function does not have — and both wrappers
-/// the extraction pass builds are tag-rendered
-/// ([`Unquoted`](StyleVariant::Unquoted) or [`Code`](StyleVariant::Code)), so
-/// classifying a tag-rendered span here would sometimes give a sibling a `>`
-/// the string pipeline does not present. An **entity**-rendered span carries
-/// no such ambiguity: the extraction pass builds neither smart-quote variant,
-/// so a [`DoubleQuote`](StyleVariant::DoubleQuote) or
+/// before any step runs, which `masked` carries here. Where a caller does not
+/// hold it ([`Masked::UNKNOWN`]), no tag-rendered span is classified — the
+/// answer this function gave before the identity reached it.
+///
+/// The two **entity**-rendered variants need no such check and are answered
+/// either way: the extraction pass builds neither smart-quote variant, so a
+/// [`DoubleQuote`](StyleVariant::DoubleQuote) or
 /// [`SingleQuote`](StyleVariant::SingleQuote) node can only have come from the
 /// quotes step, where the string pipeline really does hold `&#8220;…&#8221;`.
-/// The tag-rendered half waits on a way to carry that identity here.
-fn styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+///
+/// # A transparent span still says nothing
+///
+/// A span the built-in backend renders with **no markup of its own** — an
+/// unquoted span whose attribute list resolves to neither a role nor an id —
+/// presents its own *body* to a sibling rather than any markup, which is a
+/// different question from this one and defers with its own divergence note.
+/// It falls out of the probe by itself: there is no opening or closing run to
+/// take a character from.
+fn styled_sibling_boundaries(styled: &Styled<'_>, masked: Masked<'_>) -> Option<(char, char)> {
     match styled.variant {
-        // `&#8220;…&#8221;` / `&#8216;…&#8217;`.
+        // `&#8220;…&#8221;` / `&#8216;…&#8217;`, whichever step built them —
+        // and only the quotes step can. See this function's own scope note.
         StyleVariant::DoubleQuote | StyleVariant::SingleQuote => Some(('&', ';')),
 
-        // Every other variant wraps its body in a tag — the same shape the
-        // passthrough-extraction pass's own wrapper takes, which the string
-        // pipeline is still holding as a placeholder. See this function's own
-        // scope note.
-        _ => None,
+        // Every other variant wraps its body in a tag, which is also the shape
+        // the passthrough-extraction pass's own wrapper takes — so answering
+        // one turns on whether this node is such a wrapper, which only the
+        // identity `masked` carries can say.
+        _ if !masked.renders_to_its_siblings(styled.location) => None,
+
+        // The one variant whose rendering shape its attribute list decides:
+        // a `<span …>` when that resolves to a role or an id, and the body
+        // alone (no markup, so nothing to present) when it does not.
+        StyleVariant::Unquoted => probe_styled_sibling_boundaries(styled),
+
+        _ => Some(('<', '>')),
     }
+}
+
+/// [`styled_sibling_boundaries`] for a span whose rendering shape is not
+/// decided by its variant alone: renders it through the built-in backend
+/// around a probe body and reads the characters that land at the two outer
+/// edges. A span that wraps its body in nothing has neither.
+fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
+    let (before, after) = probe_styled_boundaries_markup(styled);
+
+    before.chars().next().zip(after.chars().next_back())
 }
 
 /// The character a level's own match string `s` holds immediately before
@@ -405,11 +446,13 @@ fn styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 ///
 /// [`SPAN_PLACEHOLDER`] is what [`build_match_string`] writes for a node whose
 /// rendering this module cannot describe — everything
-/// [`styled_sibling_boundaries`] declines to classify. Reporting it here would
-/// *manufacture* a character where the level previously read its own start
-/// anchor, which is a different answer rather than a better one: the string
-/// pipeline holds a tag's `>` beside a rendered span, and `>` is a boundary
-/// character the auto-link's own prefix group accepts exactly as `^` does.
+/// [`styled_sibling_boundaries`] declines to classify, which with the
+/// extraction pass's identity in hand is the pass's own wrapper and, without
+/// it, every tag-rendered span. Reporting it here would *manufacture* a
+/// character where the level previously read its own start anchor, which is a
+/// different answer rather than a better one — and for a wrapper it would be
+/// the wrong one, since the string pipeline holds a `\u{97}` sentinel there
+/// that the auto-link's own prefix group rejects exactly as `^` is accepted.
 /// So an unclassified neighbour reports nothing and the span goes on
 /// inheriting, leaving that shape exactly as it already was — the same line
 /// [`styled_sibling_boundaries`] draws, for the same reason.
@@ -513,7 +556,7 @@ fn apply_quote_sub<'src>(
     // Recurse into the spans produced by earlier subs *before* matching at this
     // level. A span this sub itself creates below is therefore never revisited
     // by the same sub, matching the string pipeline (a sub runs once).
-    let contexts = LevelContext::child_contexts(&nodes, ctx);
+    let contexts = LevelContext::child_contexts(&nodes, ctx, Masked::UNKNOWN);
 
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
@@ -576,7 +619,7 @@ fn match_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter: if nothing quote-like is present, no sub can match, so
     // skip building the (owned) result vector entirely.
@@ -652,10 +695,19 @@ fn attrlist_is_readable(nodes: &[InlineNode<'_>], pieces: &[Piece], m: &QuoteMat
 /// recognize a construct inside it, but is flagged
 /// [`synthesized`](Piece::synthesized) since those bytes have no honest
 /// `'src` counterpart; every other node contributes a single opaque
-/// [`SPAN_PLACEHOLDER`].
+/// [`SPAN_PLACEHOLDER`], wrapped in the two characters its own rendering
+/// presents to a sibling wherever [`styled_sibling_boundaries`] can say what
+/// those are.
+///
+/// `masked` is what the caller can say about which [`Styled`] nodes are the
+/// passthrough-extraction pass's own wrappers, which is what that last
+/// question turns on for every tag-rendered span; see [`Masked`].
 ///
 /// [`apply_character_replacements`]: super::char_replacements::apply_character_replacements
-pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece>) {
+pub(super) fn build_match_string(
+    nodes: &[InlineNode<'_>],
+    masked: Masked<'_>,
+) -> (String, Vec<Piece>) {
     let mut s = String::new();
     let mut pieces = Vec::with_capacity(nodes.len());
 
@@ -794,7 +846,7 @@ pub(super) fn build_match_string(nodes: &[InlineNode<'_>]) -> (String, Vec<Piece
                 // a pattern keeps is markup the span itself carries), and
                 // every gate skips it as non-overlapping.
                 let boundaries = match other {
-                    InlineNode::Styled(styled) => styled_sibling_boundaries(styled),
+                    InlineNode::Styled(styled) => styled_sibling_boundaries(styled, masked),
                     _ => None,
                 };
 
@@ -1573,8 +1625,12 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::test_support::{
-        assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_passthroughs,
+    use super::{
+        super::test_support::{
+            assert_styled, assert_text, build_src, build_through_quotes, fold_html,
+            golden_passthroughs,
+        },
+        Masked,
     };
     use crate::{
         HasSpan, Span,
@@ -1630,7 +1686,11 @@ mod tests {
         let bare = span(StyleVariant::Unquoted);
         assert_eq!(styled_boundaries(&bare), None);
         assert_eq!(
-            LevelContext::child_contexts(&[InlineNode::Styled(bare)], LevelContext::INSIDE_REF),
+            LevelContext::child_contexts(
+                &[InlineNode::Styled(bare)],
+                LevelContext::INSIDE_REF,
+                Masked::UNKNOWN
+            ),
             vec![LevelContext::INSIDE_REF]
         );
 
@@ -1663,21 +1723,59 @@ mod tests {
             location: Span::new("x"),
         };
 
-        for variant in [StyleVariant::DoubleQuote, StyleVariant::SingleQuote] {
+        // With the identity in hand, every variant that renders markup of its
+        // own is answered from that markup's two outer characters.
+        for variant in [
+            StyleVariant::DoubleQuote,
+            StyleVariant::SingleQuote,
+            StyleVariant::Strong,
+            StyleVariant::Emphasis,
+            StyleVariant::Code,
+            StyleVariant::Mark,
+            StyleVariant::Superscript,
+            StyleVariant::Subscript,
+        ] {
             let styled = span(variant);
 
             let (opening, closing) = probe_styled_boundaries_markup(&styled);
 
             assert_eq!(
-                styled_sibling_boundaries(&styled),
+                styled_sibling_boundaries(&styled, Masked::known(&[])),
                 opening.chars().next().zip(closing.chars().next_back()),
                 "sibling boundary characters drifted from the built-in rendering of {variant:?}"
             );
         }
 
-        // Every tag-rendered variant keeps the bare placeholder — not because
-        // its rendering has no outer characters (it has `<` and `>`), but
-        // because a `Styled` node reaching `build_match_string` may be the
+        // An unquoted span carrying neither a role nor an id renders to its
+        // body and nothing else, so there is no markup to take a character
+        // from — a different question, deferred with its own divergence note.
+        assert_eq!(
+            styled_sibling_boundaries(&span(StyleVariant::Unquoted), Masked::known(&[])),
+            None
+        );
+
+        // One carrying an id renders a `<span …>`, like every other tag.
+        let mut identified = span(StyleVariant::Unquoted);
+        identified.id = Some(CowStr::from("anchor"));
+
+        assert_eq!(
+            styled_sibling_boundaries(&identified, Masked::known(&[])),
+            Some(('<', '>'))
+        );
+
+        // The two **entity**-rendered variants are answered whether or not the
+        // caller holds the identity: the extraction pass builds neither, so a
+        // smart-quote span can only have come from the quotes step.
+        for variant in [StyleVariant::DoubleQuote, StyleVariant::SingleQuote] {
+            assert_eq!(
+                styled_sibling_boundaries(&span(variant), Masked::UNKNOWN),
+                Some(('&', ';'))
+            );
+        }
+
+        // Every tag-rendered variant keeps the bare placeholder where the
+        // identity is missing — not because its rendering has no outer
+        // characters (it has `<` and `>`), but because such a node may be the
         // passthrough-extraction pass's own wrapper, which the string pipeline
         // is still holding as a placeholder. See
         // [`styled_sibling_boundaries`]'s own scope note.
@@ -1690,8 +1788,26 @@ mod tests {
             StyleVariant::Subscript,
             StyleVariant::Unquoted,
         ] {
-            assert_eq!(styled_sibling_boundaries(&span(variant)), None);
+            assert_eq!(
+                styled_sibling_boundaries(&span(variant), Masked::UNKNOWN),
+                None
+            );
         }
+
+        // And a node the identity *names* keeps it too, which is the whole
+        // point of carrying the identity: `[quotes]++text++` renders a
+        // `<span class="quotes">`, but the string pipeline is holding it as
+        // its own `\u{96}…\u{97}` sentinel for every step this module runs.
+        let wrapper = span(StyleVariant::Code);
+        let identity = (
+            wrapper.location.byte_offset(),
+            wrapper.location.data().len(),
+        );
+
+        assert_eq!(
+            styled_sibling_boundaries(&wrapper, Masked::known(&[identity])),
+            None
+        );
     }
 
     #[test]
@@ -1789,7 +1905,8 @@ mod tests {
         assert_eq!(
             LevelContext::child_contexts(
                 &[text("a "), styled(StyleVariant::Strong)],
-                LevelContext::ROOT
+                LevelContext::ROOT,
+                Masked::UNKNOWN
             ),
             vec![LevelContext::ROOT, TAG]
         );
@@ -1797,7 +1914,11 @@ mod tests {
         // A transparent span takes the last character of what precedes it,
         // while the closing half stays the enclosing context's.
         assert_eq!(
-            LevelContext::child_contexts(&[text("a "), styled(StyleVariant::Unquoted)], TAG),
+            LevelContext::child_contexts(
+                &[text("a "), styled(StyleVariant::Unquoted)],
+                TAG,
+                Masked::UNKNOWN
+            ),
             vec![
                 TAG,
                 LevelContext {
@@ -1810,7 +1931,11 @@ mod tests {
         // With nothing before it, both halves fall back to the enclosing
         // context — the answer inheriting alone always gave.
         assert_eq!(
-            LevelContext::child_contexts(&[styled(StyleVariant::Unquoted), text(" a")], TAG),
+            LevelContext::child_contexts(
+                &[styled(StyleVariant::Unquoted), text(" a")],
+                TAG,
+                Masked::UNKNOWN
+            ),
             vec![TAG, TAG]
         );
 
@@ -1819,7 +1944,8 @@ mod tests {
         assert_eq!(
             LevelContext::child_contexts(
                 &[text("ab"), styled(StyleVariant::Unquoted)],
-                LevelContext::ROOT
+                LevelContext::ROOT,
+                Masked::UNKNOWN
             ),
             vec![
                 LevelContext::ROOT,
@@ -1838,7 +1964,8 @@ mod tests {
                     styled(StyleVariant::DoubleQuote),
                     styled(StyleVariant::Unquoted)
                 ],
-                LevelContext::ROOT
+                LevelContext::ROOT,
+                Masked::UNKNOWN
             ),
             vec![
                 LevelContext {
@@ -1852,12 +1979,44 @@ mod tests {
             ]
         );
 
-        // A tag-rendered one contributes the bare placeholder, which says
-        // *nothing* rather than a character: the span goes on inheriting.
+        // A tag-rendered one contributes the bare placeholder where the caller
+        // cannot say whether it is an extraction-pass wrapper, and the bare
+        // placeholder says *nothing* rather than a character: the span goes on
+        // inheriting.
         assert_eq!(
             LevelContext::child_contexts(
                 &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
-                LevelContext::ROOT
+                LevelContext::ROOT,
+                Masked::UNKNOWN
+            ),
+            vec![TAG, LevelContext::ROOT]
+        );
+
+        // With the identity in hand it presents the `>` its own `<strong>`
+        // ends in, exactly as the string pipeline's flat haystack does.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
+                LevelContext::ROOT,
+                Masked::known(&[])
+            ),
+            vec![
+                TAG,
+                LevelContext {
+                    before: Some('>'),
+                    after: None,
+                }
+            ]
+        );
+
+        // And a node that identity *names* is an extraction-pass wrapper the
+        // string pipeline is still holding as a placeholder, so it goes back to
+        // contributing the bare one.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
+                LevelContext::ROOT,
+                Masked::known(&[(0, 1)])
             ),
             vec![TAG, LevelContext::ROOT]
         );
@@ -2053,39 +2212,59 @@ mod tests {
 
     #[test]
     fn a_sub_beside_a_masked_passthrough_wrapper_keeps_the_bare_placeholder() {
-        // The half [`styled_sibling_boundaries`] deliberately does not
-        // answer. The passthrough-extraction pass builds a [`Styled`] wrapper
-        // of its own for an attribute-list-prefixed passthrough, which the
-        // string pipeline is holding as its `\u{96}…\u{97}` sentinel rather
-        // than as markup for every step this module runs — so a sibling reads
-        // that sentinel, which is exactly what the bare placeholder reads as.
-        // Both wrappers the pass builds are tag-rendered, and telling one from
-        // a genuinely rendered span needs an identity this function does not
-        // have, so no tag-rendered span is classified.
+        // The one tag-rendered span that presents *no* markup to a sibling.
+        // The passthrough-extraction pass builds a [`Styled`] wrapper of its
+        // own for an attribute-list-prefixed passthrough, which the string
+        // pipeline is holding as its `\u{96}…\u{97}` sentinel rather than as
+        // markup for every step this module runs — so a sibling reads that
+        // sentinel, which is exactly what the bare placeholder reads as. The
+        // identity `masked` carries is what tells one from a genuinely
+        // rendered span of the identical shape.
         //
-        // Asserted directly on the match string rather than through a fold,
-        // since a quote boundary class cannot tell the two apart in the first
-        // place (which is the very reason the deferral is safe).
+        // Asserted directly on the match string, since a quote boundary class
+        // cannot tell a `>` from the placeholder in the first place (which is
+        // why the quotes step goes on passing `Masked::UNKNOWN`).
         use super::{SPAN_PLACEHOLDER, build_match_string, styled_sibling_boundaries};
         use crate::inlines::Styled;
 
+        // An id rather than a role, so the probe sees a `<span …>`: the fold
+        // hands the renderer the span's `attrs` and `id` and lets it derive
+        // the roles, so a `roles` field with no attribute list behind it
+        // renders nothing (see `styled_boundaries_match_the_built_in_renderer`).
         let styled = Styled {
             variant: StyleVariant::Unquoted,
             form: SpanForm::Unconstrained,
-            id: None,
-            roles: vec![CowStr::from("x")],
+            id: Some(CowStr::from("x")),
+            roles: Vec::new(),
             attrs: None,
             children: Vec::new(),
-            location: Span::new("[.x]##y##"),
+            location: Span::new("[#x]##y##"),
         };
 
-        assert_eq!(styled_sibling_boundaries(&styled), None);
+        let identity = (styled.location.byte_offset(), styled.location.data().len());
 
-        let (s, pieces) = build_match_string(&[InlineNode::Styled(styled)]);
+        assert_eq!(
+            styled_sibling_boundaries(&styled, Masked::known(&[identity])),
+            None
+        );
+
+        let (s, pieces) = build_match_string(
+            &[InlineNode::Styled(styled.clone())],
+            Masked::known(&[identity]),
+        );
 
         assert_eq!(s, SPAN_PLACEHOLDER.to_string());
         assert_eq!(pieces.len(), 1);
         assert_eq!(pieces[0].s_start, 0);
+
+        // The same node, *not* named by the identity, is a span the string
+        // pipeline has really rendered — and presents the two characters its
+        // `<span class="x">…</span>` puts beside its siblings.
+        let (s, pieces) = build_match_string(&[InlineNode::Styled(styled)], Masked::known(&[]));
+
+        assert_eq!(s, format!("<{SPAN_PLACEHOLDER}>"));
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].s_start, 1);
     }
 
     #[test]
@@ -2150,6 +2329,51 @@ mod tests {
             "Then '`this`'`that` and \"`one`\"'`two`' in a row.\n",
             "\n",
             "And x[width=10]###c# d## beside x [width=10]###c# d## here.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        // The three paragraphs; the section that contains them holds no inline
+        // content of its own and is skipped.
+        assert_eq!(folded_blocks, 3, "expected every paragraph to be checked");
+    }
+
+    #[test]
+    fn a_real_documents_tag_rendered_sibling_tree_folds_to_its_rendered_string() {
+        // End-to-end, through the real parse path, on the **tag**-rendered half
+        // of the shape above — the one the extraction pass's identity had to
+        // reach recognition for. A URL written against a closing tag's own `>`
+        // links in both pipelines; one written against the pass's own wrapper,
+        // which the string pipeline is still holding as a sentinel, stays
+        // literal in both.
+        use crate::{
+            Parser,
+            blocks::{FindBlocks, IsBlock},
+        };
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "See **bold**https://example.org and __em__https://example.org here.\n",
+            "\n",
+            "But [quotes]++x++https://example.org stays literal.\n",
+            "\n",
+            "And *x*[width=10]#doc@example.org# beside *x [width=10]#doc@example.org#*.\n",
         ));
 
         let mut folded_blocks = 0;
@@ -2883,7 +3107,7 @@ mod tests {
             },
         ];
 
-        let (s, pieces) = super::build_match_string(&nodes);
+        let (s, pieces) = super::build_match_string(&nodes, Masked::UNKNOWN);
 
         assert_eq!(s, "a&copy;&amp;");
         assert_eq!(pieces.len(), 3);

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -351,6 +351,49 @@ pub(super) fn masked_locations(nodes: &[InlineNode<'_>]) -> Vec<(usize, usize)> 
         .collect()
 }
 
+/// What a caller can say about which [`Styled`](crate::inlines::Styled) nodes
+/// are the passthrough-extraction pass's own wrappers — carried to the one
+/// place *recognition* needs to tell one from a span the string pipeline has
+/// really rendered.
+///
+/// [`masked_locations`] collects that identity once, before any step runs; this
+/// is how it reaches
+/// [`build_match_string`](super::quotes::build_match_string), which stands
+/// every opaque node in as one placeholder and wraps it in the characters its
+/// own rendering presents to a sibling. A wrapper has no such characters — the
+/// string pipeline is holding it as its own `\u{96}…\u{97}` placeholder for
+/// every step this module runs — so a sibling reads there exactly what the bare
+/// placeholder already reads as, and the wrapper must stay unwrapped.
+///
+/// The third state is the point of the type. A caller that does **not** hold
+/// the identity says so ([`UNKNOWN`](Self::UNKNOWN)) rather than passing an
+/// empty list, which would claim that *nothing* is a wrapper; an unknown
+/// identity leaves every tag-rendered span with the bare placeholder, which is
+/// the answer that module gave before this reached it at all.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct Masked<'a>(Option<&'a [(usize, usize)]>);
+
+impl<'a> Masked<'a> {
+    /// The identity is not in hand here, so no tag-rendered span is
+    /// classified. See the type's own note for why this is not the same as an
+    /// empty list.
+    pub(super) const UNKNOWN: Self = Self(None);
+
+    /// The identity of every extraction-pass wrapper in this content, as
+    /// [`masked_locations`] collected it.
+    pub(super) fn known(locations: &'a [(usize, usize)]) -> Self {
+        Self(Some(locations))
+    }
+
+    /// Reports whether what a sibling reads beside the node at `location` is
+    /// that node's own rendering — true only when the identity is in hand
+    /// *and* the node is not one of the wrappers it names.
+    pub(super) fn renders_to_its_siblings(self, location: Span<'_>) -> bool {
+        self.0
+            .is_some_and(|masked| !masked.contains(&span_identity(location)))
+    }
+}
+
 /// Reports whether `node` — or anything nested inside it — is hidden from the
 /// escaping step.
 ///
@@ -398,7 +441,12 @@ fn covers_masked(node: &InlineNode<'_>, masked: &[(usize, usize)]) -> bool {
 }
 
 fn identity(node: &InlineNode<'_>) -> (usize, usize) {
-    let location = node.span();
+    span_identity(node.span())
+}
+
+/// [`identity`] for a caller that holds the node's own `location` rather than
+/// the node.
+fn span_identity(location: Span<'_>) -> (usize, usize) {
     (location.byte_offset(), location.data().len())
 }
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -385,12 +385,19 @@ impl<'a> Masked<'a> {
         Self(Some(locations))
     }
 
+    /// Reports whether the node at `location` is one of the wrappers this
+    /// list names — false whenever the identity is not in hand, since an
+    /// unknown identity names nothing.
+    pub(super) fn covers(self, location: Span<'_>) -> bool {
+        self.0
+            .is_some_and(|masked| masked.contains(&span_identity(location)))
+    }
+
     /// Reports whether what a sibling reads beside the node at `location` is
     /// that node's own rendering — true only when the identity is in hand
     /// *and* the node is not one of the wrappers it names.
     pub(super) fn renders_to_its_siblings(self, location: Span<'_>) -> bool {
-        self.0
-            .is_some_and(|masked| !masked.contains(&span_identity(location)))
+        self.0.is_some() && !self.covers(location)
     }
 }
 

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -6,6 +6,7 @@ use super::{
     macros::{MacroMatch, MacroMatchKind, rebuild_macro_level},
     passthrough_step::passthrough_text,
     quotes::{Piece, build_match_string, emit_range, source_slice},
+    special_chars::Masked,
 };
 use crate::{
     Parser, Span,
@@ -119,7 +120,7 @@ pub(super) fn apply_stem<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes);
+    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard.
     if !(s.contains(':') && (s.contains("stem:") || s.contains("math:"))) {

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -124,7 +124,8 @@
 //!   reads the character the span's own rendering ends with (``` "`a`"`code`
 //!   ```, whose `` `code` `` both the real pipeline and the builder leave
 //!   literal because `&#8221;` ends in a `;` the monospace sub's boundary class
-//!   excludes). This one is the recorder's own artifact rather than a builder
+//!   excludes; `**bold**https://example.org`, which both link because
+//!   `</strong>` ends in a `>` the auto-link's prefix group accepts). This one is the recorder's own artifact rather than a builder
 //!   deferral, and it is the seam Phase 1 already named when it left special
 //!   characters and replacements unmarked ("their escaped output is re-consumed
 //!   by later steps, so bracketing it would perturb recognition"): a


### PR DESCRIPTION
The three increments before this one all stop at the same blocker and name it: a tag-rendered `Styled` node reaching `build_match_string` is not necessarily a span the string pipeline has rendered, because the passthrough-extraction pass builds one of its own for an attribute-list-prefixed passthrough (`[quotes]++text++`) that the pipeline is still holding as its `\u{96}…\u{97}` sentinel for every step this module runs. Both wrappers that pass builds are tag-rendered, so classifying by rendering alone would hand a sibling a `>` the string pipeline does not present — and telling the two apart needs the identity `masked_locations` collects before any step runs.

## The identity, and where it goes

That identity now travels as a `Masked`, whose point is its **third state**: a caller that does not hold the list says `UNKNOWN` rather than passing an empty one, which would claim that *nothing* is a wrapper. An unknown identity leaves every tag-rendered span with the bare placeholder — the answer the module already gave — so every step but one is byte-identical to before.

Only the **macros** step gets the real list, which is not a shortcut but the scope the previous increment's own note had already drawn: `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s mismatch-prefix one are the only classes in the whole module that read a tag's `>` differently from the bare placeholder, where a quote sub's `(^|[^\w&;:}])` accepts the two alike. `masked_locations` itself becomes unconditional — it had been taken only for the order that escapes late, `flatten_prior_markup`'s own consumer — since a wrapper's identity has to be recorded before any step runs whatever the order is.

With it, `styled_sibling_boundaries` stops being a two-variant special case and becomes what its mirror image `styled_boundaries` already was: every variant answered from its own rendering shape, with the one whose shape its attribute list decides probed. The two entity-rendered variants keep their unconditional answer (the extraction pass builds neither); a **transparent** span falls out by itself, having no markup to take a character from, and defers with its own note. Nothing else changes — the two characters still belong to no piece, so no gate, slice, or rebuild moves.

## What reaches parity

- `**bold**https://example.org` and every tag-rendered variant of it: the string pipeline reads the `>` that ends `</strong>` where the tree read a placeholder belonging to no class, so it linked and the tree did not.
- The reverse direction — a span written against a bare URL's tail, where the `<` that opens the tag is what ends the URL body.
- `*x*[width=10]#doc@example.org#`, one level in: a **transparent** span whose own sibling is tag-rendered now gets that same `>` from `child_contexts` — one of the e-mail pattern's mismatch characters — instead of the `^` it had been inheriting.

The first and third were divergence tests earlier increments left behind; both become parity corpora exactly as their own notes asked. The extraction pass's wrapper keeps a test of its own, pinning that `[quotes]++x++https://example.org` stays literal in both pipelines — the new divergence this increment would have introduced had it classified by rendering alone.

## Testing

Fixtures join the whole-pipeline broad sweep and combined-constructs corpus and the group-parity corpus (what a span presents to a sibling comes from its rendering, which no effective order changes); a unit test pins `styled_sibling_boundaries` against the built-in renderer in all three states of the identity; a whole-document test drives the shapes end to end through the real parse path. The **structural recorder cross-check** is again the one corpus these shapes do not join, for the reason the increment above recorded: a `RecordingRenderer` emits its marker *outside* the markup it wraps, so a later sub reads that marker where the real pipeline reads the markup's own outer character.

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the divergence set **unchanged** — no golden source in the suite writes a bare URL against a rendered span's closing edge — and, as every increment requires, no new divergence appeared. Coverage is diff-neutral: missed regions, lines, and functions are unchanged from `inline-ast` in every `inline_builder` file.

As with every prep piece before it, nothing further is wired in.

## What still defers

One item shorter and one item unblocked. A **transparent** span read *as* a sibling presents its own body's last character where the placeholder says nothing (`[width=10]##x ##https://example.org`, which the string pipeline links on the space the body ends with) — that was gated on this same identity for the same reason, since `[width=10]++x ++` is an extraction wrapper that renders its body and nothing else. `Masked` tells the two apart, so the next increment can take it; what it still needs is a way to *read* a transparent span's own outer characters, which are its children's rather than any markup of its own. Beyond that: the **closing** character both the macros step and the increment above decline to half-supply, and the character-replacements step's own consume-across-levels case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfWmfYV8D94Yvsfn3LRjeM)_