### PR TITLE
feat: Read a transparent span's own body where a sibling reads it (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4120,6 +4120,74 @@ Each phase is a reviewable unit with a clear exit gate.
   character both the macros step and the increment above decline to half-supply, and the
   character-replacements step's own consume-across-levels case above.
 
+  *Step 6 prep landed as (a **transparent** span read as a sibling):* the increment above closed the
+  tag-rendered half of what a span presents to its siblings and named what it left: a span rendering
+  to its **body and nothing else** presents no markup for
+  [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) to take a
+  character from, so [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) went
+  on standing it in as one bare placeholder — where the string pipeline, having no levels, holds
+  that body itself. `[width=10]##x ##https://example.org` links there on the space the body ends
+  with, and the tree read a placeholder belonging to no boundary class.
+
+  A transparent span's two outer characters are its **children's**, so
+  [`transparent_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) reads them
+  out of the children's own match string rather than recomputing them per node kind — the same move
+  [`child_contexts`](../../parser/src/content/inline_builder/quotes.rs) made one increment ago for
+  the same reason: the match string is the one place every node kind's presented bytes are already
+  spelled out (a text run's, a `CharRef`'s entity, a nested span's own placeholder wrapped in
+  whatever this module can say there), so the two cannot drift, and a transparent span nested inside
+  another answers from *its* children with no second mechanism. The pair becomes two independent
+  `Option`s, because a body can begin with something this module cannot describe and still end in
+  something it can; every markup-rendering variant goes on answering both or neither, and a
+  [`SPAN_PLACEHOLDER`](../../parser/src/content/inline_builder/quotes.rs) at either edge reports
+  *nothing* rather than manufacturing a character — the line `preceding_character` already draws.
+
+  The **identity** is what makes this safe, and it is why this increment had to wait for the one
+  above: `[width=10]++x ++` is an extraction wrapper that renders its body and nothing else too, and
+  what the string pipeline holds there is its own `\u{96}…\u{97}` sentinel, not the body — so
+  classifying a transparent span by its rendering alone would have handed the URL beside it a space
+  the pipeline never presents. A transparent span takes exactly the same `masked` guard every
+  tag-rendered one takes, which also keeps the scope the previous increments drew: only the
+  **macros** step holds the real list, so only its two boundary-reading families see any of this and
+  every other step is byte-identical to before. `child_contexts` gains the one adjustment this
+  forces — the character a transparent span presents to its *neighbour* now sits between them, so
+  the lookup steps back over it to reach what the span's own children read, which is what precedes
+  the **span**.
+
+  What reaches parity is that shape and its mirror image: `[width=10]##x ##https://example.org` and
+  `[width=10]##x ##doc@example.org` (and the same one level in, inside a `*strong*` span, and with a
+  sibling of its own before the span), whatever node kind carries the body's last character — a text
+  run after a tag-rendered child, a restored entity, a typographic replacement, an escaped special —
+  together with `https://example.org[width=10]## x##`, where the body's **first** character is what
+  ends a bare URL written against the span's opening edge, and the negative half, where a body
+  ending in a word character or in one of the e-mail pattern's own mismatch characters leaves the
+  construct literal in both. The extraction pass's wrapper keeps its own test, pinning that
+  `[width=10]++x ++https://example.org` stays literal in both pipelines — the new divergence a
+  rendering-only classification would have introduced.
+
+  Fixtures join the whole-pipeline broad sweep and combined-constructs corpus and the group-parity
+  corpus (what a span presents to a sibling comes from its own rendering, which no effective order
+  changes), unit tests pin `styled_sibling_boundaries` against the built-in renderer in all three
+  states of the identity and the match string's own wrap directly, another pins that a transparent
+  span's children still read what precedes the span, and a whole-document test drives both shapes
+  end to end through the real parse path. The **structural recorder cross-check** is again the one
+  corpus these shapes do not join, and for the same reason as the two increments above seen from the
+  other side: a [`RecordingRenderer`](../../parser/src/content/inline_tree.rs) emits its marker
+  *outside* the span it wraps, so it stands between a transparent span's body and the construct
+  beside it and the recorder reads the marker where the real pipeline reads the space. Re-running
+  the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the
+  divergence set **unchanged** — no golden source writes a construct beside a transparent span —
+  and, as every increment requires, no new divergence appeared. Coverage stays diff-neutral. As with
+  every prep piece before it, nothing further is wired in.
+
+  What still defers is the rest of the same class, now one item shorter. A bare URL whose **body
+  class** wants more than one character still cannot swallow a transparent span's whole body the way
+  the string pipeline's flat haystack lets it (`https://example.org[width=10]##x##`, which the
+  pipeline links as `https://example.orgx`): the character the span presents is right, and a match
+  crossing the span is not this level's to build, so that keeps its own divergence test. Beyond
+  that: the **closing** character both the macros step and the sibling increments decline to
+  half-supply, and the character-replacements step's own consume-across-levels case.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4722,6 +4790,26 @@ Each phase is a reviewable unit with a clear exit gate.
        "landed as" note above. What still defers is the closing character,
        the character-replacements step's consume-across-levels case, and a transparent span read *as*
        a sibling, which this unblocks but does not take.
+
+     - ✅ **prep (the same boundary, for a transparent span read *as* a sibling).** The half the
+       increment above unblocked but did not take: a span rendering to its **body and nothing else**
+       presents no markup, so
+       [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) stood it in as a
+       bare placeholder where the string pipeline holds that body — and
+       `[width=10]##x ##https://example.org` links there on the space the body ends with. A
+       transparent span's outer characters are its children's, so
+       [`transparent_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs) reads
+       them out of the children's own **match string**, the same place
+       [`child_contexts`](../../parser/src/content/inline_builder/quotes.rs) reads a level's
+       siblings from, and the pair becomes two independent halves since a body's two ends are
+       described separately. The
+       [`Masked`](../../parser/src/content/inline_builder/special_chars.rs) guard is what makes it
+       safe — `[width=10]++x ++` is an extraction wrapper that renders its body and nothing else too
+       — and keeps the scope at the **macros** step alone; `child_contexts` steps back over the
+       character a transparent span now presents to its neighbour, so its own children go on reading
+       what precedes the span. See the step's own "landed as" note above. What still defers is a
+       body class wanting more than one character (`https://example.org[width=10]##x##`), the
+       closing character, and the character-replacements step's consume-across-levels case.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -4102,6 +4102,35 @@ mod tests {
             "https://example.org\"`q`\"",
             // A formal-URL link's own boundary-prefix group is the same one.
             "**bold**https://example.org[Site]",
+            // A **transparent** span read *as* a sibling: rendering to its
+            // body and nothing else, what it presents is that body — so the
+            // string pipeline's flat haystack holds the space `x ` ends with
+            // where the tree stood one placeholder, and both link.
+            "[width=10]##x ##https://example.org",
+            "*[width=10]##x ##https://example.org*",
+            "x [width=10]##y ##https://example.org",
+            "[width=10]## ##https://example.org",
+            "[width=10]##x ##https://example.org[Docs]",
+            // The body's own last character, whatever node kind carries it: a
+            // text run after a tag-rendered child, a restored entity, a
+            // typographic replacement, an escaped special.
+            "[width=10]##*b* ##https://example.org",
+            "[width=10]##**b**##https://example.org",
+            "[width=10]##&copy; ##https://example.org",
+            "[width=10]##(C) ##https://example.org",
+            "[width=10]##a&##https://example.org",
+            // A body ending in a word character is no accepted prefix in
+            // either pipeline, so the URL stays literal in both.
+            "[width=10]##x##https://example.org",
+            "[width=10]##x-##https://example.org",
+            // The reverse direction: the body's *first* character is what ends
+            // a bare URL written against the span's own opening edge.
+            "https://example.org[width=10]## x##",
+            "https://example.org [width=10]##x##",
+            // And one transparent span inside another, where the inner span's
+            // own body is what the outer one presents.
+            "[width=10]##[width=10]##y ##z##https://example.org",
+            "[width=10]##[width=10]##y ##https://example.org##",
         ] {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
@@ -4272,6 +4301,18 @@ mod tests {
             "*x*[width=10]#doc@example.org#",
             "*x*[width=10]#https://example.org#",
             "``code``[width=10]#doc@example.org#",
+            // A transparent span read *as* a sibling presents its own body,
+            // where every other variant presents its markup: the space `x `
+            // ends with is what the string pipeline's flat haystack holds
+            // beside the address, and neither pipeline reads a mismatch
+            // character there.
+            "[width=10]##x ##doc@example.org",
+            "*x [width=10]##y ##doc@example.org*",
+            "[width=10]##x>##doc@example.org",
+            // A body ending in one of the pattern's own three mismatch
+            // characters suppresses the address in both.
+            "[width=10]##x/##doc@example.org",
+            "[width=10]##x:##doc@example.org",
             // And the same addresses at the content's own top level, where a
             // level's start is exactly what the string pipeline presents.
             "doc@example.org",
@@ -4355,6 +4396,126 @@ mod tests {
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
             "an address after a tag-rendered sibling must stay literal: {nodes:?}"
         );
+    }
+
+    #[test]
+    fn a_url_after_a_transparent_span_builds_a_link() {
+        // The parity above, read structurally, for the shape that named this
+        // increment: a span rendering to its body and nothing else presents
+        // that **body** to a sibling — the space `x ` ends with, which is one
+        // of the boundary-prefix group's own accepted characters — where
+        // [`build_match_string`](super::super::quotes::build_match_string)
+        // used to stand the whole span in as one placeholder belonging to no
+        // class at all.
+        let source = "[width=10]##x ##https://example.org";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(
+            golden_macros(source),
+            fold_html(&nodes, &HtmlSubstitutionRenderer {})
+        );
+
+        assert_eq!(
+            assert_link(&nodes[1]).target.as_ref(),
+            "https://example.org"
+        );
+    }
+
+    #[test]
+    fn a_url_after_a_transparent_passthrough_wrapper_stays_literal() {
+        // The half the identity protects here, exactly as it protects the
+        // tag-rendered one. `[width=10]++x ++` renders its body and nothing
+        // else too — but it is the passthrough-extraction pass's own wrapper,
+        // and the string pipeline is holding it as its `\u{96}…\u{97}`
+        // sentinel for every step this module runs, so the space inside it is
+        // not what the boundary-prefix group reads there and the URL stays
+        // literal. Classifying a transparent span by its *body* alone would
+        // have made this the increment's own new divergence.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "[width=10]++x ++https://example.org";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a URL beside a transparent wrapper must stay literal: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source),
+            "fold diverged for {source:?}"
+        );
+    }
+
+    #[test]
+    fn a_bare_url_swallowing_a_transparent_spans_body_is_a_documented_divergence() {
+        // What the *opening* half cannot reach. A bare URL's body class
+        // (`[^\s\[\]<]*`) consumes greedily rather than reading one
+        // character, so where the string pipeline's flat haystack lets it
+        // swallow the whole body of the span beside it — building a target out
+        // of both — a level holding that span as one opaque piece can only
+        // reject the match: a URL crossing a span is not this level's to
+        // build. The character the span presents is right; what defers is a
+        // class that wants more than one of them.
+        let source = "https://example.org[width=10]##x##";
+
+        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+        assert_ne!(
+            golden_macros(source),
+            folded,
+            "expected the documented divergence to still reproduce"
+        );
+
+        assert_eq!(
+            golden_macros(source),
+            "<a href=\"https://example.orgx\" class=\"bare\">https://example.orgx</a>"
+        );
+
+        assert_eq!(folded, "https://example.orgx");
+    }
+
+    #[test]
+    fn a_real_documents_transparent_span_siblings_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shapes that named
+        // this increment: a URL or an address written beside a transparent
+        // span must read that span's own body — linking where it ends in a
+        // space and staying literal where it ends in a word character — so a
+        // tree that decided either the other way would regress the moment
+        // `rendered_html()` becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "See [width=10]##x ##https://example.org and [width=10]##y##https://example.org here.\n",
+            "\n",
+            "Mail [width=10]##x ##doc@example.org or *a [width=10]##b ##doc@example.org* today.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -192,10 +192,12 @@ pub(super) fn apply_macros<'src>(
 /// The same two families read the character a construct written *beside* a
 /// rendered span presents, which
 /// [`build_match_string`](super::quotes::build_match_string) writes around
-/// that span's own placeholder — and which it can write only for a span the
-/// string pipeline has really rendered, not for the passthrough-extraction
-/// pass's own wrapper (see
-/// [`Masked`]). This step is where `masked` is
+/// that span's own placeholder — the two outer characters of its markup, or,
+/// for a span rendering to its **body** and nothing else, that body's own two
+/// outer characters. Either one it can write only for a span the string
+/// pipeline has really rendered, not for the passthrough-extraction pass's own
+/// wrapper (see [`Masked`]), whose body the pipeline is holding inside its own
+/// sentinel whatever that body renders as. This step is where `masked` is
 /// carried, and only here, because these two prefix groups are the only
 /// classes in the whole module that read a tag's `>` differently from the
 /// bare placeholder: `**bold**https://example.org` links in the string

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -898,6 +898,16 @@ mod tests {
             "x[width=10]###c# d##",
             "x [width=10]###c# d##",
             "*x[width=10]###c# d##*",
+            // And the same transparent span read *as* a sibling, where what
+            // it presents is its own body rather than any markup: the space
+            // `x ` ends with, which the string pipeline's flat haystack holds
+            // beside the construct.
+            "[width=10]##x ##https://example.org",
+            "[width=10]##x ##doc@example.org",
+            "[width=10]##x##https://example.org",
+            "https://example.org[width=10]## x##",
+            "*[width=10]##x ##https://example.org*",
+            "[width=10]++x ++https://example.org",
             "   ",
             "a\nb\nc",
         ];
@@ -1409,6 +1419,17 @@ mod tests {
             "Mail *write to [width=10]#doc@example.org# now* or x [width=10]#doc@example.org# here.",
         );
         assert_parity("Beside x[width=10]###c# d## and x [width=10]###c# d## in one line.");
+
+        // And the same span read *as* a sibling: a construct written beside
+        // one reads the span's own body, so an address or a URL links where
+        // that body ends in a space and stays literal where it ends in a word
+        // character.
+        assert_parity(
+            "See [width=10]##x ##https://example.org and [width=10]##y##https://example.org here.",
+        );
+        assert_parity(
+            "Mail [width=10]##x ##doc@example.org or *a [width=10]##b ##doc@example.org* now.",
+        );
     }
 
     /// [`build_from_value`] against the real pipeline, seeded from a
@@ -1938,6 +1959,10 @@ mod tests {
                 // either.
                 "*x [width=10]#doc@example.org#* and a < b",
                 "x[width=10]###c# d## and a < b",
+                // And the same span read *as* a sibling, whose own body is
+                // what it presents — again its rendering, not the order.
+                "[width=10]##x ##https://example.org and a < b",
+                "[width=10]##x ##doc@example.org and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -171,10 +171,12 @@ impl LevelContext {
     /// good as what [`build_match_string`] could write there — so `masked` is
     /// passed straight through. A caller holding the extraction pass's
     /// identity gets the `>` a tag-rendered neighbour's own closing markup
-    /// ends with; one that does not gets the bare [`SPAN_PLACEHOLDER`], which
-    /// [`preceding_character`] reports as *nothing* rather than as a
-    /// character. Both are right for what their caller knows, and the second
-    /// is what this function answered before the identity reached it at all.
+    /// ends with, or the last character of a **transparent** neighbour's own
+    /// body ([`transparent_sibling_boundaries`]); one that does not gets the
+    /// bare [`SPAN_PLACEHOLDER`], which [`preceding_character`] reports as
+    /// *nothing* rather than as a character. Both are right for what their
+    /// caller knows, and the second is what this function answered before the
+    /// identity reached it at all.
     pub(super) fn child_contexts(
         nodes: &[InlineNode<'_>],
         enclosing: Self,
@@ -205,9 +207,26 @@ impl LevelContext {
         // `build_match_string` contributes exactly one [`Piece`] per node, in
         // order, so the three sequences line up and no lookup is needed.
         for ((context, piece), node) in contexts.iter_mut().zip(&pieces).zip(nodes) {
-            if matches!(node, InlineNode::Styled(styled) if styled_boundaries(styled).is_none()) {
-                context.before = preceding_character(&s, piece).or(context.before);
+            let InlineNode::Styled(styled) = node else {
+                continue;
+            };
+
+            if styled_boundaries(styled).is_some() {
+                continue;
             }
+
+            // Read from before the span's **own** opening character. A
+            // transparent span presents its body's first character to whatever
+            // precedes it ([`transparent_sibling_boundaries`]), and that
+            // character sits between the neighbour and this piece — so the
+            // lookup steps back over it to reach what the span's *children*
+            // read, which is what precedes the span itself.
+            let own = styled_sibling_boundaries(styled, masked)
+                .0
+                .map_or(0, char::len_utf8);
+
+            context.before =
+                preceding_character(&s, piece.s_start.saturating_sub(own)).or(context.before);
         }
 
         contexts
@@ -392,33 +411,92 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 /// [`SingleQuote`](StyleVariant::SingleQuote) node can only have come from the
 /// quotes step, where the string pipeline really does hold `&#8220;…&#8221;`.
 ///
-/// # A transparent span still says nothing
+/// # A transparent span presents its own body
 ///
 /// A span the built-in backend renders with **no markup of its own** — an
 /// unquoted span whose attribute list resolves to neither a role nor an id —
-/// presents its own *body* to a sibling rather than any markup, which is a
-/// different question from this one and defers with its own divergence note.
-/// It falls out of the probe by itself: there is no opening or closing run to
-/// take a character from.
-fn styled_sibling_boundaries(styled: &Styled<'_>, masked: Masked<'_>) -> Option<(char, char)> {
+/// wraps its body in nothing, so what a sibling reads there is that *body*:
+/// the string pipeline's flat haystack holds `x ` where
+/// `[width=10]##x ##https://example.org` stands one opaque placeholder, and
+/// links on the space the body ends with.
+/// [`transparent_sibling_boundaries`] answers that pair from the span's own
+/// children, and the identity gates it for exactly the reason it gates a tag:
+/// `[width=10]++x ++` is an extraction wrapper that renders its body and
+/// nothing else, and what the string pipeline holds *there* is the sentinel a
+/// bare placeholder already reads as.
+///
+/// # Two halves, answered independently
+///
+/// The pair is two [`Option`]s rather than one option of a pair, because a
+/// transparent span's halves are read from opposite ends of its body and
+/// either can be a character this module cannot describe while the other is
+/// not. Every markup-rendering variant goes on answering both or neither.
+fn styled_sibling_boundaries(
+    styled: &Styled<'_>,
+    masked: Masked<'_>,
+) -> (Option<char>, Option<char>) {
     match styled.variant {
         // `&#8220;…&#8221;` / `&#8216;…&#8217;`, whichever step built them —
         // and only the quotes step can. See this function's own scope note.
-        StyleVariant::DoubleQuote | StyleVariant::SingleQuote => Some(('&', ';')),
+        StyleVariant::DoubleQuote | StyleVariant::SingleQuote => (Some('&'), Some(';')),
 
         // Every other variant wraps its body in a tag, which is also the shape
         // the passthrough-extraction pass's own wrapper takes — so answering
         // one turns on whether this node is such a wrapper, which only the
-        // identity `masked` carries can say.
-        _ if !masked.renders_to_its_siblings(styled.location) => None,
+        // identity `masked` carries can say. A wrapper that renders its body
+        // and nothing else is covered by the same guard, for the same reason.
+        _ if !masked.renders_to_its_siblings(styled.location) => (None, None),
 
         // The one variant whose rendering shape its attribute list decides:
         // a `<span …>` when that resolves to a role or an id, and the body
-        // alone (no markup, so nothing to present) when it does not.
-        StyleVariant::Unquoted => probe_styled_sibling_boundaries(styled),
+        // alone when it does not — which presents the body's own two outer
+        // characters.
+        StyleVariant::Unquoted => match probe_styled_sibling_boundaries(styled) {
+            Some((before, after)) => (Some(before), Some(after)),
 
-        _ => Some(('<', '>')),
+            None => transparent_sibling_boundaries(&styled.children, masked),
+        },
+
+        _ => (Some('<'), Some('>')),
     }
+}
+
+/// [`styled_sibling_boundaries`] for a **transparent** span — one whose
+/// rendering is its body and nothing else — whose two outer characters are its
+/// children's rather than any markup of its own.
+///
+/// Those characters are already spelled out in the children's own **match
+/// string**, which is the one place every node kind's presented bytes are
+/// written down (a text run's, a [`CharRef`]'s entity, and a nested opaque
+/// node's placeholder wrapped in whatever this function's own caller can say)
+/// — the same reason [`LevelContext::child_contexts`] reads a level's siblings
+/// out of it rather than recomputing them per node kind, and the reason the two
+/// cannot drift. The recursion terminates on the tree: a transparent span
+/// nested inside this one answers from *its* children.
+///
+/// A [`SPAN_PLACEHOLDER`] at either edge reports **nothing** rather than a
+/// character, the line [`preceding_character`] draws for the same reason: it is
+/// what [`build_match_string`] writes for a node this module cannot describe,
+/// so reporting it would manufacture an answer rather than sharpen one.
+fn transparent_sibling_boundaries(
+    children: &[InlineNode<'_>],
+    masked: Masked<'_>,
+) -> (Option<char>, Option<char>) {
+    let (s, _) = build_match_string(children, masked);
+
+    let mut chars = s.chars();
+
+    let before = chars.next().filter(|ch| *ch != SPAN_PLACEHOLDER);
+
+    // A one-character body presents that same character on both sides: `next`
+    // has already consumed it, so the closing half falls back to what the
+    // opening one read.
+    let after = chars
+        .next_back()
+        .filter(|ch| *ch != SPAN_PLACEHOLDER)
+        .or(before);
+
+    (before, after)
 }
 
 /// [`styled_sibling_boundaries`] for a span whose rendering shape is not
@@ -431,10 +509,10 @@ fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> 
     before.chars().next().zip(after.chars().next_back())
 }
 
-/// The character a level's own match string `s` holds immediately before
-/// `piece`, or `None` where this module cannot say what the string pipeline
-/// holds there — because the piece is the first thing the level holds, or
-/// because what precedes it is an unclassified opaque node.
+/// The character a level's own match string `s` holds immediately before byte
+/// offset `at`, or `None` where this module cannot say what the string pipeline
+/// holds there — because nothing precedes that offset, or because what does is
+/// an unclassified opaque node.
 ///
 /// This is how a **transparent** span's children learn what precedes the span
 /// (see [`LevelContext::child_contexts`]): the match string is the one place
@@ -447,8 +525,9 @@ fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> 
 /// [`SPAN_PLACEHOLDER`] is what [`build_match_string`] writes for a node whose
 /// rendering this module cannot describe — everything
 /// [`styled_sibling_boundaries`] declines to classify, which with the
-/// extraction pass's identity in hand is the pass's own wrapper and, without
-/// it, every tag-rendered span. Reporting it here would *manufacture* a
+/// extraction pass's identity in hand is the pass's own wrapper (tag-rendered
+/// or transparent alike) and, without it, every span but the two
+/// entity-rendered ones. Reporting it here would *manufacture* a
 /// character where the level previously read its own start anchor, which is a
 /// different answer rather than a better one — and for a wrapper it would be
 /// the wrong one, since the string pipeline holds a `\u{97}` sentinel there
@@ -456,12 +535,12 @@ fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> 
 /// So an unclassified neighbour reports nothing and the span goes on
 /// inheriting, leaving that shape exactly as it already was — the same line
 /// [`styled_sibling_boundaries`] draws, for the same reason.
-fn preceding_character(s: &str, piece: &Piece) -> Option<char> {
-    // A piece's bounds are byte offsets this module itself pushed into `s`, so
-    // the lookup always lands on a character boundary within it; the crate
+fn preceding_character(s: &str, at: usize) -> Option<char> {
+    // Every offset a caller passes is one this module itself pushed into `s`,
+    // so the lookup always lands on a character boundary within it; the crate
     // forbids `unwrap`, so that is spelled `unwrap_or_default` rather than as a
     // branch no input reaches.
-    s.get(..piece.s_start)
+    s.get(..at)
         .unwrap_or_default()
         .chars()
         .next_back()
@@ -697,7 +776,8 @@ fn attrlist_is_readable(nodes: &[InlineNode<'_>], pieces: &[Piece], m: &QuoteMat
 /// `'src` counterpart; every other node contributes a single opaque
 /// [`SPAN_PLACEHOLDER`], wrapped in the two characters its own rendering
 /// presents to a sibling wherever [`styled_sibling_boundaries`] can say what
-/// those are.
+/// those are — which for a span rendering to its body and nothing else is that
+/// **body**'s own two outer characters, since it wraps them in no markup.
 ///
 /// `masked` is what the caller can say about which [`Styled`] nodes are the
 /// passthrough-extraction pass's own wrappers, which is what that last
@@ -845,12 +925,12 @@ pub(super) fn build_match_string(
                 // overlapping it (which is right, since a boundary character
                 // a pattern keeps is markup the span itself carries), and
                 // every gate skips it as non-overlapping.
-                let boundaries = match other {
+                let (before, after) = match other {
                     InlineNode::Styled(styled) => styled_sibling_boundaries(styled, masked),
-                    _ => None,
+                    _ => (None, None),
                 };
 
-                if let Some((before, _)) = boundaries {
+                if let Some(before) = before {
                     s.push(before);
                 }
 
@@ -871,7 +951,7 @@ pub(super) fn build_match_string(
                     synthesized: false,
                 });
 
-                if let Some((_, after)) = boundaries {
+                if let Some(after) = after {
                     s.push(after);
                 }
             }
@@ -1741,17 +1821,56 @@ mod tests {
 
             assert_eq!(
                 styled_sibling_boundaries(&styled, Masked::known(&[])),
-                opening.chars().next().zip(closing.chars().next_back()),
+                (opening.chars().next(), closing.chars().next_back()),
                 "sibling boundary characters drifted from the built-in rendering of {variant:?}"
             );
         }
 
         // An unquoted span carrying neither a role nor an id renders to its
-        // body and nothing else, so there is no markup to take a character
-        // from — a different question, deferred with its own divergence note.
+        // body and nothing else, so what a sibling reads is that body: its
+        // first and last characters, read out of the children's own match
+        // string. With no children there is nothing to read.
         assert_eq!(
             styled_sibling_boundaries(&span(StyleVariant::Unquoted), Masked::known(&[])),
-            None
+            (None, None)
+        );
+
+        let mut transparent = span(StyleVariant::Unquoted);
+        transparent.children = vec![InlineNode::Text {
+            value: CowStr::from("ab "),
+            location: Span::new("ab "),
+        }];
+
+        assert_eq!(
+            styled_sibling_boundaries(&transparent, Masked::known(&[])),
+            (Some('a'), Some(' '))
+        );
+
+        // A one-character body is the same character on both sides, and one
+        // this module cannot describe — a nested span with no identity to
+        // classify it by — is no character at all.
+        transparent.children = vec![InlineNode::Text {
+            value: CowStr::from("a"),
+            location: Span::new("a"),
+        }];
+
+        assert_eq!(
+            styled_sibling_boundaries(&transparent, Masked::known(&[])),
+            (Some('a'), Some('a'))
+        );
+
+        transparent.children = vec![InlineNode::Styled(span(StyleVariant::Strong))];
+
+        assert_eq!(
+            styled_sibling_boundaries(&transparent, Masked::UNKNOWN),
+            (None, None)
+        );
+
+        // The same body, with the identity in hand: the nested span's own
+        // `<strong>…</strong>` is what the string pipeline holds at both edges.
+        assert_eq!(
+            styled_sibling_boundaries(&transparent, Masked::known(&[])),
+            (Some('<'), Some('>'))
         );
 
         // One carrying an id renders a `<span …>`, like every other tag.
@@ -1760,7 +1879,7 @@ mod tests {
 
         assert_eq!(
             styled_sibling_boundaries(&identified, Masked::known(&[])),
-            Some(('<', '>'))
+            (Some('<'), Some('>'))
         );
 
         // The two **entity**-rendered variants are answered whether or not the
@@ -1769,7 +1888,7 @@ mod tests {
         for variant in [StyleVariant::DoubleQuote, StyleVariant::SingleQuote] {
             assert_eq!(
                 styled_sibling_boundaries(&span(variant), Masked::UNKNOWN),
-                Some(('&', ';'))
+                (Some('&'), Some(';'))
             );
         }
 
@@ -1777,8 +1896,9 @@ mod tests {
         // identity is missing — not because its rendering has no outer
         // characters (it has `<` and `>`), but because such a node may be the
         // passthrough-extraction pass's own wrapper, which the string pipeline
-        // is still holding as a placeholder. See
-        // [`styled_sibling_boundaries`]'s own scope note.
+        // is still holding as a placeholder. A **transparent** span takes the
+        // same guard: `[width=10]++x ++` is a wrapper that renders its body and
+        // nothing else. See [`styled_sibling_boundaries`]'s own scope note.
         for variant in [
             StyleVariant::Strong,
             StyleVariant::Emphasis,
@@ -1790,7 +1910,7 @@ mod tests {
         ] {
             assert_eq!(
                 styled_sibling_boundaries(&span(variant), Masked::UNKNOWN),
-                None
+                (None, None)
             );
         }
 
@@ -1806,7 +1926,7 @@ mod tests {
 
         assert_eq!(
             styled_sibling_boundaries(&wrapper, Masked::known(&[identity])),
-            None
+            (None, None)
         );
     }
 
@@ -2019,6 +2139,56 @@ mod tests {
                 Masked::known(&[(0, 1)])
             ),
             vec![TAG, LevelContext::ROOT]
+        );
+
+        // A **transparent** span presents no markup either, but it does
+        // present its own *body*: the second span here reads the space the
+        // first one's body ends with, which is what the string pipeline's flat
+        // haystack holds between the two.
+        fn transparent(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
+            InlineNode::Styled(Styled {
+                variant: StyleVariant::Unquoted,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: Vec::new(),
+                attrs: None,
+                children,
+                location: Span::new("x"),
+            })
+        }
+
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[transparent(vec![text("y ")]), transparent(vec![text("z")])],
+                LevelContext::ROOT,
+                Masked::known(&[])
+            ),
+            vec![
+                LevelContext::ROOT,
+                LevelContext {
+                    before: Some(' '),
+                    after: None,
+                }
+            ]
+        );
+
+        // The character a transparent span presents to its *neighbour* is not
+        // the one its own children read: what they read is whatever precedes
+        // the span, so the lookup steps back over the body's own first
+        // character rather than reporting it.
+        assert_eq!(
+            LevelContext::child_contexts(
+                &[text("a "), transparent(vec![text("bc")])],
+                LevelContext::ROOT,
+                Masked::known(&[])
+            ),
+            vec![
+                LevelContext::ROOT,
+                LevelContext {
+                    before: Some(' '),
+                    after: None,
+                }
+            ]
         );
     }
 
@@ -2245,7 +2415,7 @@ mod tests {
 
         assert_eq!(
             styled_sibling_boundaries(&styled, Masked::known(&[identity])),
-            None
+            (None, None)
         );
 
         let (s, pieces) = build_match_string(
@@ -2265,6 +2435,73 @@ mod tests {
         assert_eq!(s, format!("<{SPAN_PLACEHOLDER}>"));
         assert_eq!(pieces.len(), 1);
         assert_eq!(pieces[0].s_start, 1);
+    }
+
+    #[test]
+    fn a_transparent_spans_placeholder_carries_its_own_body() {
+        // A span that renders to its body and nothing else presents *that
+        // body* to a sibling, where every other variant presents its markup —
+        // so the placeholder standing in for it carries the body's own two
+        // outer characters, read out of the children's own match string.
+        //
+        // Asserted directly on the match string for the reason the wrapper
+        // test above is: the class that reads these characters is the macros
+        // step's, and it is the only step holding the identity that gates
+        // them.
+        use super::{SPAN_PLACEHOLDER, build_match_string};
+        use crate::inlines::Styled;
+
+        let styled = |children| Styled {
+            variant: StyleVariant::Unquoted,
+            form: SpanForm::Unconstrained,
+            id: None,
+            roles: Vec::new(),
+            attrs: None,
+            children,
+            location: Span::new("[width=10]##x ##"),
+        };
+
+        let text = |value: &'static str| InlineNode::Text {
+            value: CowStr::from(value),
+            location: Span::new(value),
+        };
+
+        let body = || vec![text("x ")];
+
+        // With the identity in hand, the body's first and last characters land
+        // on either side of the placeholder — and the piece still covers the
+        // placeholder alone, so the two belong to no node and no range a
+        // caller slices moves.
+        let (s, pieces) =
+            build_match_string(&[InlineNode::Styled(styled(body()))], Masked::known(&[]));
+
+        assert_eq!(s, format!("x{SPAN_PLACEHOLDER} "));
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].s_start, 1);
+
+        // Without it — every step but `macros` — the span this module cannot
+        // rule out being an extraction wrapper keeps the bare placeholder,
+        // byte for byte what it carried before.
+        let (s, pieces) =
+            build_match_string(&[InlineNode::Styled(styled(body()))], Masked::UNKNOWN);
+
+        assert_eq!(s, SPAN_PLACEHOLDER.to_string());
+        assert_eq!(pieces[0].s_start, 0);
+
+        // And a node the identity *names* is such a wrapper — `[width=10]++x ++`
+        // renders its body and nothing else too, and the string pipeline is
+        // holding its `\u{96}…\u{97}` sentinel there, which is exactly what a
+        // bare placeholder reads as.
+        let wrapper = styled(body());
+
+        let identity = (
+            wrapper.location.byte_offset(),
+            wrapper.location.data().len(),
+        );
+
+        let (s, _) = build_match_string(&[InlineNode::Styled(wrapper)], Masked::known(&[identity]));
+
+        assert_eq!(s, SPAN_PLACEHOLDER.to_string());
     }
 
     #[test]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -133,7 +133,12 @@
 //!   later sub matching over the recorded string reads that marker — which
 //!   belongs to no boundary class — where the real pipeline reads the markup's
 //!   own last character. The recorder therefore builds a span the real pipeline
-//!   never rendered. Recognition **inside** a span is unaffected (the marker
+//!   never rendered. A **transparent** span — one rendering to its body and
+//!   nothing else, whose own body is therefore what a sibling reads
+//!   (`[width=10]##x ##https://example.org`) — is the same artifact seen from
+//!   the other side: the marker stands between that body and the construct
+//!   beside it, so the recorder reads the marker where the real pipeline reads
+//!   the space. Recognition **inside** a span is unaffected (the marker
 //!   sits outside the tag or entity pair, so the interior reads the same `>` or
 //!   `;` either way), which is why the sweep's own boundary fixtures one level
 //!   *in* are cross-checked here normally; the sibling shapes are pinned


### PR DESCRIPTION
The increment before this one ([#1220](https://github.com/asciidoc-rs/asciidoc-parser/pull/1220)) closed the tag-rendered half of what a span presents to its siblings and named what it left behind: a span rendering to its **body and nothing else** has no markup for `styled_sibling_boundaries` to take a character from, so `build_match_string` went on standing it in as one bare placeholder — where the string pipeline, having no levels, holds that body itself. `[width=10]##x ##https://example.org` links there on the space the body ends with, and the tree read a placeholder belonging to no boundary class.

## What changed

A transparent span's two outer characters are its **children's**, so `transparent_sibling_boundaries` reads them out of the children's own **match string** rather than recomputing them per node kind — the same move `child_contexts` made one increment ago, and for the same reason: the match string is the one place every node kind's presented bytes are already spelled out (a text run's, a `CharRef`'s entity, a nested span's own placeholder wrapped in whatever this module can say there), so the two cannot drift, and a transparent span nested inside another answers from *its* children with no second mechanism.

The pair becomes two independent `Option`s, because a body can begin with something this module cannot describe and still end in something it can; every markup-rendering variant goes on answering both or neither, and a `SPAN_PLACEHOLDER` at either edge reports *nothing* rather than manufacturing a character — the line `preceding_character` already draws.

The **identity** is what makes this safe, and why it had to wait for the increment above: `[width=10]++x ++` is an extraction wrapper that renders its body and nothing else too, and what the string pipeline holds there is its own `\u{96}…\u{97}` sentinel, not the body — so classifying a transparent span by its rendering alone would have handed the URL beside it a space the pipeline never presents. A transparent span takes exactly the same `masked` guard every tag-rendered one takes, which keeps the scope the previous increments drew: only the **macros** step holds the real list, so only its two boundary-reading families see any of this and every other step is byte-identical to before.

`child_contexts` gains the one adjustment this forces — the character a transparent span presents to its *neighbour* now sits between them, so the lookup steps back over it to reach what the span's own children read, which is what precedes the **span**.

## What reaches parity

- `[width=10]##x ##https://example.org` and `[width=10]##x ##doc@example.org`, the same one level in (inside a `*strong*` span) and with a sibling of their own before the span.
- Whatever node kind carries the body's last character: a text run after a tag-rendered child, a restored entity, a typographic replacement, an escaped special.
- The mirror direction: `https://example.org[width=10]## x##`, where the body's **first** character is what ends a bare URL written against the span's opening edge.
- The negative half, where a body ending in a word character or in one of the e-mail pattern's own mismatch characters leaves the construct literal in both pipelines.
- `[width=10]++x ++https://example.org` — the extraction pass's transparent wrapper — keeps its own test, staying literal in both: the new divergence a rendering-only classification would have introduced.

## Testing

- Fixtures join the whole-pipeline broad sweep, the combined-constructs corpus, and the group-parity corpus (what a span presents to a sibling comes from its own rendering, which no effective order changes).
- Unit tests pin `styled_sibling_boundaries` against the built-in renderer in all three states of the identity, the match string's own wrap directly, and that a transparent span's children still read what precedes the span.
- A whole-document test drives both shapes end to end through the real parse path.
- The **structural recorder cross-check** is again the one corpus these shapes do not join, for the reason the two increments above recorded, seen from the other side: a `RecordingRenderer` emits its marker *outside* the span it wraps, so it stands between a transparent span's body and the construct beside it.
- The corpus-wide fold-parity audit (tree building forced on for every parse in the suite) shows the divergence set **unchanged**, with no new divergence. Coverage stays diff-neutral (missed-region and missed-line counts unchanged in every touched file).
- Preflight: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, and `cargo +nightly doc --no-deps --document-private-items` all clean.

## What still defers

A bare URL whose **body class** wants more than one character still cannot swallow a transparent span's whole body the way the string pipeline's flat haystack lets it (`https://example.org[width=10]##x##`, which the pipeline links as `https://example.orgx`) — the character the span presents is right, and a match crossing the span is not this level's to build, so that keeps its own divergence test. Beyond that: the **closing** character both the macros step and the sibling increments decline to half-supply, and the character-replacements step's own consume-across-levels case.

As with every prep piece before it, nothing further is wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSquYT3LGbGMpEC3xFrHwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSquYT3LGbGMpEC3xFrHwB)_