### PR TITLE
feat: Restore a masked passthrough into a link macro's target (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4188,6 +4188,61 @@ Each phase is a reviewable unit with a clear exit gate.
   that: the **closing** character both the macros step and the sibling increments decline to
   half-supply, and the character-replacements step's own consume-across-levels case.
 
+  *Step 6 prep landed as (a `link:`/`mailto:` target crossing a **passthrough**):* with the
+  boundary-character seam settled — its three remaining deferrals all of the keep-forever,
+  markup-perturbed kind — re-running the corpus-wide fold-parity audit and classifying what remains
+  by *source* found the largest golden-exercised class to be something no note had named: a masked
+  passthrough in a `link:`/`mailto:` macro's **target**, the documented idioms
+  `link:++https://example.org/now_this__link_works.html++[]` (formatting characters kept literal)
+  and `link:pass:[My Documents/report.pdf][Get Report]` (a space, which the target class itself
+  rejects) — five real fixtures across the asciidoc-lang corpus. The string replacer swallows the
+  `\u{96}`*n*`\u{97}` sentinel into the target (its `[^\s\[\]]+` class admits it exactly as it
+  admits the tree's placeholder, so the two recognize the same extent), and
+  [`Passthroughs::restore_to`](../../parser/src/content/passthroughs.rs) then splices the extracted
+  body's substituted text over every sentinel in the rendered string. A
+  [`Raw`](../../parser/src/inlines/inline_node.rs) node's `value` **is** that substituted text,
+  known at build time — which is what separates a masked passthrough from a rendered span, whose
+  markup exists only at fold time — so a fourth gate,
+  [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs), admits it for a
+  value the caller *restores*, and
+  [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs)
+  substitutes the value for the placeholder, finishing the computed target into exactly the
+  restored string's bytes. Every *decision* the replacer makes stays on the bytes as matched — the
+  `URI_SNIFF` strip under `hide-uri-scheme` sniffs the masked target, so a scheme hidden inside the
+  passthrough keeps its scheme in the shown text, as the golden does — and the shown text itself is
+  structural: a bare macro's `emit_range` carries the `Raw` node whole, folding to the restored
+  bytes with no re-escaping.
+
+  One reading is deliberately **not** faithful: the dangerous-scheme check runs over the *restored*
+  target, where the string replacer checks its own masked haystack — through which
+  `link:++javascript:alert(1)++[]` passes, the restore then completing a live `javascript:` link in
+  the golden output. The tree defers it instead, a security divergence test pinning the safe
+  reading over byte parity. The staged
+  [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs) similarly
+  registers the node's honest restored target where the string pipeline registers the sentinel
+  bytes verbatim (its restore rewrites only the rendered string, never the catalog) — a wart the
+  cutover deliberately will not reproduce, pinned by its own test rather than by a golden-catalog
+  comparison.
+
+  What reaches parity is the five golden fixtures and the class around them: both idioms bare and
+  labeled, a passthrough covering part of the target (`link:https://++example.org/a++[]`,
+  `link:a++b c++d[T]`), the `mailto:` spellings (with and without a subject/body attrlist), an
+  attribute list on a text beside a restored target, the triple-plus form, escapes, and the macro
+  inside a rendered span. Fixtures join a new differential corpus, a `hide-uri-scheme` pair pins
+  the masked strip in both directions, structural tests pin the restored target and the
+  `Raw`-child text, and a whole-document test drives the shapes end to end through the real parse
+  path. Re-running the corpus-wide audit shows **no new divergence and five closed** — the first
+  increment since the audit map closed to shrink the golden set. The other families keep the
+  boundary, each newly pinned with the reason it cannot make the same move yet: the
+  cross-reference family *must* keep it (a deferred xref's target is read **before** restore can
+  reach it, and the golden output for `xref:++id++[]` leaks the raw sentinel into its own `href` —
+  the tree's literal reading is the well-formed one), the image family computes several
+  masked-arithmetic values off the same bytes (`default_alt`'s basename/`_`/`-` rewrites run over
+  the sentinel, so `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"`), and the auto-link family
+  reads boundary-prefix and trailing-strip arithmetic off them; each is a later increment by the
+  same restore-the-value, decide-over-the-masked-bytes move, where its own goldens call for it.
+  Coverage stays diff-neutral. As with every prep piece before it, nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -4810,6 +4865,24 @@ Each phase is a reviewable unit with a clear exit gate.
        what precedes the span. See the step's own "landed as" note above. What still defers is a
        body class wanting more than one character (`https://example.org[width=10]##x##`), the
        closing character, and the character-replacements step's consume-across-levels case.
+
+     - ✅ **prep (a `link:`/`mailto:` target crossing a passthrough).** The largest
+       golden-exercised class the audit's remainder held — five asciidoc-lang fixtures spelling
+       the two documented idioms, `link:++…++[]` and `link:pass:[…][…]` — is closed by a fourth
+       gate: [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs)
+       admits a masked passthrough's [`Raw`](../../parser/src/inlines/inline_node.rs) piece for a
+       value the caller **restores**, since the node's `value` is the very substituted body
+       `Passthroughs::restore_to` splices over the string pipeline's sentinel, and
+       [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs)
+       finishes the computed target into the restored string's own bytes — every decision (the
+       `URI_SNIFF` strip) still made over the bytes as matched, and a bare macro's shown text
+       carried structurally as the `Raw` node itself. A smuggled dangerous scheme
+       (`link:++javascript:…++[]`) defers with a security divergence test — the string replacer's
+       masked check misses it and emits a live link — and the staged side effect registers the
+       honest restored target where the string pipeline registers sentinel bytes. The xref family
+       (a deferred target read before restore, whose golden leaks the sentinel), the image family
+       (masked `default_alt` arithmetic), and the auto-link family (boundary/strip arithmetic)
+       keep the boundary, each pinned. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -233,28 +233,87 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
             continue;
         }
 
-        // The atomic pieces `build_match_string` gives real bytes to are the
-        // three `CharRef` leaves — an escaped special, a restored entity, and
-        // a typographic replacement the built-in backend has a rendering for;
-        // everything else it stands in as one placeholder. The
-        // `replacement_entity` test mirrors that arm's own guard, so a
-        // hand-built node carrying a value no rule produces stays opaque here
-        // exactly as it does there.
-        let recoverable = match nodes.get(piece.node_index) {
-            Some(InlineNode::CharRef {
-                value: CharRef::Special(_) | CharRef::Entity(_),
-                ..
-            }) => true,
+        if !atomic_piece_is_recoverable(nodes, piece) {
+            return false;
+        }
+    }
 
-            Some(InlineNode::CharRef {
-                value: CharRef::Replacement(value),
-                ..
-            }) => replacement_entity(value).is_some(),
+    true
+}
 
-            _ => false,
-        };
+/// Tells whether one [`atomic`](Piece::atomic) piece is a leaf
+/// [`build_match_string`] gives real bytes to — the classification
+/// [`range_has_no_opaque_piece`] applies per overlapping piece (see its own
+/// doc comment for why exactly these three [`CharRef`] leaves qualify).
+fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool {
+    // The atomic pieces `build_match_string` gives real bytes to are the
+    // three `CharRef` leaves — an escaped special, a restored entity, and
+    // a typographic replacement the built-in backend has a rendering for;
+    // everything else it stands in as one placeholder. The
+    // `replacement_entity` test mirrors that arm's own guard, so a
+    // hand-built node carrying a value no rule produces stays opaque here
+    // exactly as it does there.
+    match nodes.get(piece.node_index) {
+        Some(InlineNode::CharRef {
+            value: CharRef::Special(_) | CharRef::Entity(_),
+            ..
+        }) => true,
 
-        if !recoverable {
+        Some(InlineNode::CharRef {
+            value: CharRef::Replacement(value),
+            ..
+        }) => replacement_entity(value).is_some(),
+
+        _ => false,
+    }
+}
+
+/// [`range_has_no_opaque_piece`], further admitting a masked **passthrough**
+/// — a [`Raw`](InlineNode::Raw) piece — for a value the caller *restores*
+/// rather than reads: the placeholder's bytes are not the string pipeline's
+/// (its haystack holds the `\u{96}`*n*`\u{97}` sentinel there), but the
+/// passthrough's own substituted body **is** known at build time — it is the
+/// `Raw` node's `value`, the very text
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
+/// the sentinel after the steps run — so a computed value that substitutes it
+/// for the placeholder (see [`restore_masked_passthroughs`](super::links))
+/// finishes with exactly the restored string's bytes.
+///
+/// That makes this gate right only for a value whose *recognition* treats the
+/// masked span as one swallowed token and whose *use* happens after restore —
+/// today the `link:`/`mailto:` macro family's **target**, whose
+/// `[^\s\[\]]+` body class swallows the sentinel and the placeholder alike,
+/// and whose bytes reach the output (the `href`, and a bare macro's shown
+/// text) only in the restored rendered string. A family that *matches over*
+/// the masked bytes with a class the two spellings answer differently, or
+/// reads them into a value the string pipeline uses **before** restore (a
+/// deferred cross-reference's target, captured into its placeholder template
+/// with the sentinel still in it — see
+/// `a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`),
+/// keeps [`range_has_no_opaque_piece`].
+pub(in crate::content::inline_builder) fn range_is_restorable(
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+    range: &std::ops::Range<usize>,
+) -> bool {
+    for piece in pieces {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the range.
+        if p_end <= range.start || p_start >= range.end {
+            continue;
+        }
+
+        if !piece.atomic {
+            continue;
+        }
+
+        if matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })) {
+            continue;
+        }
+
+        if !atomic_piece_is_recoverable(nodes, piece) {
             return false;
         }
     }
@@ -1119,6 +1178,38 @@ mod tests {
 
         // The string pipeline, by contrast, *does* build an image here.
         assert!(golden_macros(source).contains("<img"));
+    }
+
+    #[test]
+    fn an_image_target_over_a_passthrough_is_a_documented_divergence() {
+        // The image family keeps the opaque-piece gate over a masked
+        // passthrough. Its builder computes more than one value off the
+        // masked bytes — the target feeds `src`, the `default_alt`
+        // derivation (whose basename/extension/`_`/`-` rewrites the string
+        // pipeline applies to the sentinel bytes, so `image:++a_b-c.jpg++[]`
+        // keeps `alt="a_b-c.jpg"` where the verbatim spelling shows `a b c`),
+        // and the registered asset — so the lift needs the
+        // masked-arithmetic-then-restore treatment applied per value, an
+        // increment of its own. The string pipeline swallows the sentinel
+        // into the target and restores it in the rendered `src`.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "image:++sunset.jpg++[Alt]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+            "an image target over a passthrough must stay literal: {nodes:?}"
+        );
+
+        let golden = golden_passthroughs(source);
+
+        assert!(
+            golden.contains("src=\"sunset.jpg\""),
+            "expected the documented divergence to still reproduce: {golden:?}"
+        );
+
+        assert_ne!(golden, fold_html(&nodes, &HtmlSubstitutionRenderer {}));
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2,7 +2,10 @@
 
 use super::{
     MacroMatch, MacroMatchKind, escaped_value_children,
-    image::{range_has_no_opaque_piece, range_is_verbatim, range_is_verbatim_or_synthesized},
+    image::{
+        range_has_no_opaque_piece, range_is_restorable, range_is_verbatim,
+        range_is_verbatim_or_synthesized,
+    },
     macro_text_children, rebuild_macro_level,
 };
 use crate::{
@@ -892,19 +895,24 @@ fn find_link_macro_matches<'src>(
         // The gate covers the bytes the node *reads*, not the whole match. The
         // one value this family computes off the match string is its **target**
         // (group 3; group 2 is the empty-target alternative, which has no bytes
-        // to gate), so only that range needs a match string whose bytes are the
-        // string replacer's own. The bracketed **display text** reads nothing:
-        // it becomes structured children through `macro_text_children`, whose
-        // `emit_range` path carries an opaque piece's own node, so it is
-        // admitted — see [`link_macro_level`]'s own rendered-span note. The
-        // `link:`/`mailto:` marker and the brackets need no gate of their own:
-        // those bytes are literal, and no atomic piece — a placeholder, or an
-        // entity delimited by `&` and `;` — can supply them. (The marker keeps
-        // its own stricter, verbatim gate below, for `link_form`'s sake; a text
-        // carrying an attribute list keeps this same gate inside
-        // `text_attrlist`, since its display text comes back from a *parse*.)
+        // to gate), so only that range needs a match string whose bytes the
+        // builder can finish into the string replacer's own — which for this
+        // family includes a masked **passthrough**, restored into the computed
+        // target exactly as `Passthroughs::restore_to` rewrites the emitted
+        // `href` (see [`range_is_restorable`] and
+        // [`restore_masked_passthroughs`]). The bracketed **display text**
+        // reads nothing: it becomes structured children through
+        // `macro_text_children`, whose `emit_range` path carries an opaque
+        // piece's own node, so it is admitted — see [`link_macro_level`]'s own
+        // rendered-span note. The `link:`/`mailto:` marker and the brackets
+        // need no gate of their own: those bytes are literal, and no atomic
+        // piece — a placeholder, or an entity delimited by `&` and `;` — can
+        // supply them. (The marker keeps its own stricter, verbatim gate
+        // below, for `link_form`'s sake; a text carrying an attribute list
+        // keeps the opaque-piece gate inside `text_attrlist`, since its
+        // display text comes back from a *parse*.)
         if let Some(target) = caps.get(3)
-            && !range_has_no_opaque_piece(nodes, pieces, &(target.start()..target.end()))
+            && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
             continue;
         }
@@ -942,6 +950,73 @@ fn find_link_macro_matches<'src>(
     }
 
     matches
+}
+
+/// Substitutes each masked **passthrough**'s own substituted body for its
+/// placeholder in `masked` — the match-string bytes at `range`, which is the
+/// same span in the level's match-string coordinates — returning `None` when
+/// the range holds no passthrough (so a caller keeps the bytes it already
+/// has).
+///
+/// This is [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own
+/// rewrite, applied to a *computed value* instead of the rendered string: the
+/// string pipeline's replacer reads the `\u{96}`*n*`\u{97}` sentinel into the
+/// value (a `link:` macro's target, and with it the emitted `href` and a bare
+/// macro's shown text), and the restore pass then splices the extracted
+/// body's substituted text over every sentinel in the rendered string. A
+/// [`Raw`](InlineNode::Raw) node's `value` **is** that substituted text
+/// (`build_passthrough_node` runs the body's own subs at build time), so
+/// substituting it for the placeholder here finishes the value into exactly
+/// the restored string's bytes. Every other byte is kept as matched, which is
+/// what restore does too — it rewrites the sentinels and nothing else.
+pub(super) fn restore_masked_passthroughs(
+    masked: &str,
+    range: &std::ops::Range<usize>,
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+) -> Option<String> {
+    let mut out = String::new();
+
+    // In match-string coordinates; `masked` is indexed relative to
+    // `range.start`.
+    let mut cursor = range.start;
+
+    for piece in pieces {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the range.
+        if p_end <= range.start || p_start >= range.end {
+            continue;
+        }
+
+        let Some(InlineNode::Raw { value, .. }) = nodes.get(piece.node_index) else {
+            continue;
+        };
+
+        // A `Raw` piece is one placeholder character, atomic and never
+        // sliced, so an overlapping one lies wholly inside the range and
+        // `p_start`/`p_end` are safe bounds.
+        out.push_str(
+            masked
+                .get(cursor.saturating_sub(range.start)..p_start.saturating_sub(range.start))
+                .unwrap_or_default(),
+        );
+        out.push_str(value.as_ref());
+        cursor = p_end;
+    }
+
+    if cursor == range.start {
+        return None;
+    }
+
+    out.push_str(
+        masked
+            .get(cursor.saturating_sub(range.start)..)
+            .unwrap_or_default(),
+    );
+
+    Some(out)
 }
 
 /// Builds one [`Ref`](InlineNode::Ref) link node from a recognized
@@ -996,16 +1071,37 @@ pub(super) fn build_link_node<'src>(
     let is_mailto = caps.get(1).is_some();
     let target_str = caps.get(3).map_or("", |m| m.as_str());
 
+    // A target crossing a masked **passthrough** finishes into the restored
+    // bytes — the `Raw` node's value substituted for its placeholder, the same
+    // rewrite `Passthroughs::restore_to` performs on the emitted `href` — and
+    // only the node's computed values take them. Every *decision* the string
+    // replacer makes over the bytes as matched (the `URI_SNIFF` strip below)
+    // stays on `target_str`, whose placeholder the sentinel-holding haystack
+    // answers the same way.
+    let restored = caps.get(3).and_then(|m| {
+        restore_masked_passthroughs(m.as_str(), &(m.start()..m.end()), nodes, pieces)
+    });
+
+    let restored_target_str = restored.as_deref().unwrap_or(target_str);
+
     let mut target = if is_mailto {
-        format!("mailto:{target_str}")
+        format!("mailto:{restored_target_str}")
     } else {
-        target_str.to_string()
+        restored_target_str.to_string()
     };
 
     // A `link:` target whose scheme could execute script is neutralized by the
     // string step (left literal); mirror that by deferring — the node would
     // otherwise render a live, dangerous link. `mailto:` carries its own safe
     // scheme and is exempt.
+    //
+    // The check reads the *restored* target, which for a scheme smuggled
+    // inside a passthrough (`link:++javascript:...++[]`) is deliberately
+    // **stricter** than the string pipeline: its replacer checks the masked
+    // haystack, where the sentinel hides the scheme, so it emits a live
+    // dangerous link the restore then completes. That is the one place this
+    // increment chooses the safe reading over byte parity — see
+    // `a_dangerous_scheme_inside_a_passthrough_is_a_documented_divergence`.
     if !is_mailto && has_dangerous_scheme(&target) {
         return None;
     }
@@ -1121,10 +1217,18 @@ pub(super) fn build_link_node<'src>(
                 // target. A strip that would leave nothing falls back to the
                 // whole target, mirroring the string replacer's own
                 // `if lt.is_empty()` guard.
+                //
+                // Sniffed over the bytes as *matched* (`target_str`, not the
+                // restored `target`): the string replacer sniffs its own
+                // haystack, where a scheme inside a passthrough is hidden
+                // behind the sentinel — so `link:++https://x++[]` shows its
+                // scheme even under `hide-uri-scheme`, and the strip offset,
+                // being a match of literal ASCII the placeholder cannot take
+                // part in, indexes the restored bytes identically.
                 URI_SNIFF
-                    .find(&target)
+                    .find(target_str)
                     .map(|m| m.end())
-                    .filter(|end| *end < target.len())
+                    .filter(|end| *end < target_str.len())
                     .unwrap_or(0)
             } else {
                 0
@@ -1871,6 +1975,226 @@ mod tests {
                 "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_link_macro_target_over_a_passthrough() {
+        // The differential corpus for a `link:`/`mailto:` target crossing a
+        // masked **passthrough** — the string pipeline swallows the
+        // `\u{96}`*n*`\u{97}` sentinel into the target (its class admits it as
+        // it admits the placeholder) and the restore pass then splices the
+        // extracted body over every sentinel in the rendered string, so the
+        // tree's computed target substitutes the `Raw` node's value for its
+        // placeholder the same way (see [`restore_masked_passthroughs`]).
+        // These are the documented idioms: `++…++` to keep a target's
+        // formatting characters literal, and `pass:[…]` to admit characters
+        // the target class itself rejects (a space).
+        use super::super::super::test_support::golden_passthroughs;
+
+        let fixtures = [
+            // The double-plus idiom, bare and labeled — the asciidoc-lang
+            // "now_this__link_works" fixture's own shape.
+            "link:++https://example.org/now_this__link_works.html++[]",
+            "link:++https://example.org/a__b__c.html++[the docs]",
+            // A `pass:[…]` target carrying a space — a byte the target class
+            // itself excludes, which only the sentinel lets through.
+            "link:pass:[My Documents/report.pdf][Get Report]",
+            // A `pass:c[…]` target, and an attribute list on the (empty)
+            // display text beside it.
+            "link:pass:c[https://example.org/no such file.adoc][role=include]",
+            // A passthrough covering only part of the target, at either edge.
+            "link:https://++example.org/a++[]",
+            "link:a++b c++d[T]",
+            // `mailto:`, bare and labeled, and with a subject/body attrlist
+            // in the text beside the restored target.
+            "mailto:++a@example.org++[]",
+            "mailto:++a@example.org++[Write us]",
+            "mailto:++a@example.org++[Subject line,Hello]",
+            // A labeled text with markup, and the macro inside a rendered
+            // span.
+            "link:++https://example.org/x++[the *docs*]",
+            "*a link:++https://example.org/x++[] b*",
+            // An attribute list on a labeled text beside a restored target.
+            "link:++x y++[T,role=hl]",
+            // A triple-plus passthrough (no substitutions on the body).
+            "link:+++a_b+++[T]",
+            // Escaped: the backslash drops and the rest stays literal — the
+            // passthrough's own restore still applies, in both pipelines.
+            "\\link:++https://example.org/x++[]",
+            // Two in one flow.
+            "link:++a b++[A] then link:pass:[c d][C]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hide_uri_scheme_reads_the_target_as_matched_over_a_passthrough() {
+        // The `URI_SNIFF` strip runs over the bytes as *matched*, exactly as
+        // the string replacer sniffs its own sentinel-holding haystack: a
+        // scheme hidden inside the passthrough is invisible to the strip (the
+        // shown text keeps it), while a verbatim scheme prefix ahead of the
+        // passthrough is stripped — and the offset, a match of literal ASCII
+        // the placeholder cannot take part in, indexes the restored bytes
+        // identically.
+        use super::super::super::test_support::golden_passthroughs_with;
+        use crate::parser::ModificationContext;
+
+        let parser = Parser::default().with_intrinsic_attribute_bool(
+            "hide-uri-scheme",
+            true,
+            ModificationContext::Anywhere,
+        );
+
+        let fixtures = [
+            // Scheme inside the passthrough: no strip, full URL shown.
+            "link:++https://example.org/a++[]",
+            // Scheme verbatim ahead of it: stripped, suffix shown.
+            "link:https://++example.org/a++[]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = crate::content::inline_builder::fold_html(
+                &build(Span::new(fixture), &parser, None),
+                &renderer,
+                &parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_passthroughs_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_link_macro_target_over_a_passthrough_is_recognized() {
+        use super::super::super::test_support::assert_raw;
+
+        // Bare: the target is the restored bytes, and the shown text is the
+        // `Raw` node itself, carried structurally (it folds to the same
+        // restored bytes without re-escaping).
+        let nodes = build_src(Span::new("link:++https://example.org/a__b++[]"));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "https://example.org/a__b");
+        assert_eq!(reference.roles, [CowStr::from("bare")]);
+        assert_eq!(reference.children.len(), 1);
+        assert_raw(&reference.children[0], "https://example.org/a__b");
+
+        // Labeled: the display text is its own slice, untouched by the
+        // restore.
+        let nodes = build_src(Span::new("link:pass:[My Documents/report.pdf][Get Report]"));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "My Documents/report.pdf");
+        assert_eq!(link_text_of(reference), "Get Report");
+        assert!(reference.roles.is_empty());
+    }
+
+    #[test]
+    fn a_dangerous_scheme_inside_a_passthrough_is_a_documented_divergence() {
+        // The one place this increment chooses the safe reading over byte
+        // parity. The string replacer's dangerous-scheme check reads its own
+        // masked haystack, where the sentinel hides the scheme — so
+        // `link:++javascript:...++[]` passes its check and the restore then
+        // completes a live `javascript:` link in the golden output. The
+        // builder checks the *restored* target instead and defers, leaving
+        // the text literal (the passthrough's own restore still applies to
+        // it), exactly as both pipelines treat the unmasked
+        // `link:javascript:...[x]` spelling.
+        use super::super::super::test_support::golden_passthroughs;
+
+        for source in [
+            "link:++javascript:alert(1)++[]",
+            "link:++javascript:alert(1)++[Click]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a dangerous restored scheme must stay literal: {nodes:?}"
+            );
+
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+            assert!(
+                !folded.contains("<a "),
+                "the fold must not emit a live link: {folded:?}"
+            );
+
+            // The string pipeline, by contrast, emits one.
+            let golden = golden_passthroughs(source);
+
+            assert!(
+                golden.contains("href=\"javascript:"),
+                "expected the documented divergence to still reproduce: {golden:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_url_over_a_passthrough_is_a_documented_divergence() {
+        // The auto-link / formal-URL family keeps the opaque-piece gate over
+        // a masked passthrough: its values are read straight off the match
+        // string (a boundary prefix, the scheme, the trailing-punctuation
+        // arithmetic), so admitting the placeholder there would need the
+        // restore-then-recompute treatment the `link:`/`mailto:` family's
+        // single computed target takes — a later increment's own call. The
+        // string pipeline swallows the sentinel into the URL and restores it.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "see https://example.++org++/x now";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "a bare URL over a passthrough must stay literal: {nodes:?}"
+        );
+
+        let golden = golden_passthroughs(source);
+
+        assert!(
+            golden.contains("<a href=\"https://example.org/x\""),
+            "expected the documented divergence to still reproduce: {golden:?}"
+        );
+
+        assert_ne!(golden, fold_html(&nodes, &HtmlSubstitutionRenderer {}));
+    }
+
+    #[test]
+    fn registers_the_restored_target_for_a_link_macro_over_a_passthrough() {
+        // The staged side effect registers the node's own target — the
+        // *restored* bytes. The string pipeline registers the sentinel it
+        // matched (`"\u{96}0\u{97}"` verbatim, since its restore pass rewrites
+        // only the rendered string, never the catalog), which no consumer can
+        // read anything from; the cutover deliberately adopts the tree's
+        // honest answer rather than reproducing that wart, so this pins the
+        // policy with no golden-catalog comparison.
+        let source =
+            "link:++https://example.org/a__b++[] and link:pass:[My Documents/report.pdf][R]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(
+            parser.catalog().links(),
+            ["https://example.org/a__b", "My Documents/report.pdf"]
+        );
     }
 
     #[test]
@@ -4474,6 +4798,50 @@ mod tests {
         );
 
         assert_eq!(folded, "https://example.orgx");
+    }
+
+    #[test]
+    fn a_real_documents_passthrough_link_targets_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shapes that named
+        // this increment: a `link:`/`mailto:` target wrapped in (or crossing)
+        // a passthrough must finish into the restored bytes the rendered
+        // string carries, so a tree that kept it literal — or restored it
+        // differently — would regress the moment `rendered_html()` becomes a
+        // fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "This URL has repeating underscores ",
+            "link:++https://example.org/now_this__link_works.html++[].\n",
+            "\n",
+            "See link:pass:[My Documents/report.pdf][Get Report] or ",
+            "mailto:++a@example.org++[] today.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1694,6 +1694,55 @@ mod tests {
     }
 
     #[test]
+    fn a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence() {
+        // The cross-reference family keeps the opaque-piece gate over a
+        // masked passthrough — unlike the `link:`/`mailto:` family, which
+        // restores one into its target — because a deferred cross-reference's
+        // target is used *before* the restore pass can reach it: the string
+        // pipeline captures it into the deferred segment while the haystack
+        // still holds the `\u{96}`*n*`\u{97}` sentinel, and the restore pass
+        // rewrites only the rendered string, so the sentinel bytes leak into
+        // the golden output's own `href` and fallback text. The tree defers
+        // instead and folds the restored literal — the well-formed reading
+        // against the string pipeline's leaked one.
+        use crate::content::Passthroughs;
+
+        let source = "xref:++someid++[]";
+
+        let parser = Parser::default();
+        let mut content = Content::from(Span::new(source));
+        let passthroughs = Passthroughs::extract_from(&mut content, &parser);
+
+        SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
+        SubstitutionStep::Quotes.apply(&mut content, &parser, None);
+        SubstitutionStep::CharacterReplacements.apply(&mut content, &parser, None);
+        SubstitutionStep::Macros.apply(&mut content, &parser, None);
+        SubstitutionStep::PostReplacement.apply(&mut content, &parser, None);
+
+        passthroughs.restore_to(&mut content, &parser);
+        content.finalize_deferred(&HtmlSubstitutionRenderer {});
+
+        let golden = content.rendered_str().to_string();
+
+        assert!(
+            golden.contains('\u{96}'),
+            "expected the string pipeline's sentinel leak to still reproduce: {golden:?}"
+        );
+
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+            "an xref target over a passthrough must stay literal: {nodes:?}"
+        );
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            "xref:someid[]"
+        );
+    }
+
+    #[test]
     fn an_xref_attribute_list_text_populates_window_role_and_xrefstyle() {
         // An `xref:` text carrying an `=` splits into an attribute list: the
         // first positional attribute becomes the display text, and the


### PR DESCRIPTION
## What this closes

Re-running the corpus-wide fold-parity audit (tree building forced on for every parse in the suite) and classifying the remaining divergences by *source* showed the largest golden-exercised class to be one no landed-as note had named: a masked **passthrough** in a `link:`/`mailto:` macro's **target** — the documented idioms `link:++https://example.org/now_this__link_works.html++[]` (formatting characters kept literal) and `link:pass:[My Documents/report.pdf][Get Report]` (a space, which the target class itself rejects). Five real golden fixtures across the asciidoc-lang corpus (`macros/complex_urls.rs`, `pass/pass_macro.rs`, `macros/link_macro.rs`, `directives/include_uri.rs`) exercised it and diverged.

## How

The string replacer swallows the `\u{96}`*n*`\u{97}` sentinel into the target — its `[^\s\[\]]+` class admits it exactly as it admits the tree's placeholder, so the two pipelines recognize the same extent — and `Passthroughs::restore_to` then splices the extracted body's substituted text over every sentinel in the rendered string. A `Raw` node's `value` **is** that substituted text, known at build time (which is what separates a masked passthrough from a rendered span, whose markup exists only at fold time). So:

- a fourth gate, `range_is_restorable` (`macros/image.rs`, beside its three siblings), admits a `Raw` piece for a value the caller *restores*;
- `restore_masked_passthroughs` (`macros/links.rs`) substitutes the node's value for its placeholder, finishing the computed target into exactly the restored string's bytes;
- every *decision* the replacer makes stays on the bytes as matched — the `URI_SNIFF` strip under `hide-uri-scheme` sniffs the masked target, so a scheme hidden inside the passthrough keeps its scheme in the shown text, as the golden does;
- a bare macro's shown text is structural: `emit_range` carries the `Raw` node whole, folding to the restored bytes with no re-escaping.

## Two deliberate non-reproductions

- **Security:** the dangerous-scheme check reads the *restored* target. The string replacer checks its masked haystack, through which `link:++javascript:alert(1)++[]` passes — the restore then completes a live `javascript:` link in the golden output. The tree defers it instead (its own divergence test pins the safe reading over byte parity).
- **Catalog:** the staged `apply_link_side_effects` registers the honest restored target. The string pipeline registers the raw sentinel bytes verbatim (`"\u{96}0\u{97}"` — its restore rewrites only the rendered string, never the catalog), a wart the cutover deliberately will not reproduce; pinned by its own test rather than a golden-catalog comparison.

## Kept boundaries, each newly pinned

- **xref** must keep it: a deferred cross-reference's target is read *before* restore can reach it, and the golden output for `xref:++id++[]` leaks the raw sentinel into its own `href` — the tree's literal reading is the well-formed one.
- **image**: several masked-arithmetic values ride on the same bytes (`default_alt`'s basename/`_`/`-` rewrites run over the sentinel, so `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"`).
- **auto-link / formal URL**: boundary-prefix and trailing-strip arithmetic read the match bytes.

Each is a later increment by the same restore-the-value, decide-over-the-masked-bytes move, where its own goldens call for it.

## Verification

- New differential corpus (15 fixtures via `golden_passthroughs`), a `hide-uri-scheme` pair pinning the masked strip in both directions, structural tests for the restored target and `Raw`-child text, and a whole-document test through the real parse path with the tree flag on.
- **Corpus-wide fold-parity audit: no new divergence; five closed** (the five golden fixtures above) — the first increment since the audit map closed to shrink the golden set.
- Preflight: nightly `fmt --check`, `clippy --all-targets`, `cargo test --workspace` (5310 passed), nightly `doc --no-deps --document-private-items` all clean; coverage diff-neutral (missed-region/-line counts unchanged in all three touched files).
- Design doc: new "Step 6 prep landed as" narrative + checklist entry.

As with every prep piece before it, nothing further is wired in: `rendered_html()` remains the string pipeline's own string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGxWAFFWycrKjh7vGDayGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGxWAFFWycrKjh7vGDayGw)_