### PR TITLE
feat: Restore a masked STEM expression into a computed target (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4369,6 +4369,21 @@ Each phase is a reviewable unit with a clear exit gate.
   [`Raw`](../../parser/src/inlines/inline_node.rs) node's `value` by name, and a masked STEM builds a
   [`Stem`](../../parser/src/inlines/stem.rs) node instead.
 
+  One family is deliberately **left out**: `image:`/`icon:`. Its target is the only one re-processed
+  by [`web_path`](../../parser/src/parser/path_resolver.rs) at fold time, and `web_path`
+  *posixifies the platform separator* — so a restored body carrying a backslash comes out rewritten
+  on a Windows-separator resolver. The string pipeline never meets this, because its `web_path` runs
+  over the backslash-free **sentinel** and the restore splices the body into the finished `src`
+  afterwards. For a passthrough that is an exotic body — the increment above pinned exactly one such
+  case, a restored *space* the fold percent-encodes. For STEM it is **every** body: a rendered
+  expression always carries a backslash (`\$…\$`, `\(…\)`), so `image:stem:[x].png[]` would render
+  `src="/$x/$.png"` on Windows against the golden's `src="\$x\$.png"`. Deferring keeps this family's
+  `src` identical on every platform, where restoring would make it differ by one; the two link
+  families, whose targets reach the `href` as computed, take the restore. That split is what
+  [`Restorable`](../../parser/src/content/inline_builder/macros/image.rs) names at the gate, and two
+  tests pin it — one that the image family stays literal, one that its fold is byte-identical under
+  either separator, so the difference is visible on a Posix runner instead of only on Windows CI.
+
   The fix is a **pair of shared helpers** rather than a widened `matches!` at each site:
   [`node_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) is the cheap
   discriminant the two gates use (so a range about to be *rejected* costs no rendering), and
@@ -4380,15 +4395,17 @@ Each phase is a reviewable unit with a clear exit gate.
   `render_quoted_substitution` call, over the already-substituted `value` with no attribute list or
   id, that `PassthroughRestoreReplacer` makes for a STEM entry. Reusing that one function is what
   keeps the restore and the fold from drifting, and a unit test pins the two helpers to the same set.
-  With the pair in place, all four sites the passthrough increments built —
-  [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs),
-  [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs),
-  and the image family's [`widen_masked_passthroughs`](../../parser/src/content/inline_builder/macros/image.rs)
-  and [`masked_default_alt`](../../parser/src/content/inline_builder/macros/image.rs) — extend to
-  both masked kinds at once, and all three families follow. Recognition needed no new widening beyond
-  the one the image family already had (its two-character-minimum target class cannot match a bare
-  placeholder), and every pre-restore decision keeps reading the bytes as matched, which a
-  placeholder answers as the sentinel does.
+  With the pair in place, the two sites the link families use —
+  [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) (which now takes
+  the kinds its caller admits) and
+  [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs) — extend
+  to both masked kinds at once, and both link families follow. The image family's own two pieces,
+  [`widen_masked_passthroughs`](../../parser/src/content/inline_builder/macros/image.rs) and
+  [`masked_default_alt`](../../parser/src/content/inline_builder/macros/image.rs), are untouched:
+  that family is unchanged by this increment. Recognition needed no widening at all here — both link
+  families' target classes swallow the one-character placeholder as they swallow the sentinel — and
+  every pre-restore decision keeps reading the bytes as matched, which a placeholder answers as the
+  sentinel does.
 
   One difference from the passthrough class is worth recording, because it runs the *safe* way: a
   STEM body cannot smuggle a dangerous scheme. `link:++javascript:…++[]` defers with a security
@@ -4402,30 +4419,31 @@ Each phase is a reviewable unit with a clear exit gate.
   time instead — the two agree whenever the fold uses the parser's renderer, which is the seam §3.3.1
   defines and the only one `Content` uses.
 
-  What reaches parity is every spelling all three families have: the `link:`/`mailto:` macro (bare
+  What reaches parity is every spelling the two link families have: the `link:`/`mailto:` macro (bare
   and labeled, the expression at either edge, in the middle, and twice in one target), auto-links,
-  formal-URL links and the two angle-bracketed forms, and `image:`/`icon:` — including a target that
-  *is* the expression (`image:stem:[x][]`), the `default_alt` arithmetic around one
-  (`image:a_bstem:[x]c_d.png[]`, where an `_` inside the expression hides from the replace and one
-  outside it does not), all three notations, an explicit substitution list (`stem:c,q[…]`), the
-  `hide-uri-scheme` strip, the trailing-punctuation strip in both directions, a display text beside a
-  restored target, a STEM beside a passthrough in either order, and the whole set inside a rendered
-  span, escaped, and end to end through the real parse path. Re-running the corpus-wide audit shows
-  the divergence set **unchanged** — no golden source writes a STEM expression inside a computed
-  target — and no new divergence appeared. Coverage stays diff-neutral, and as with every prep piece
-  before it, nothing further is wired in.
+  formal-URL links and the two angle-bracketed forms — with all three notations, an explicit
+  substitution list (`stem:c,q[…]`), the `hide-uri-scheme` strip, the trailing-punctuation strip in
+  both directions, a display text beside a restored target, a STEM beside a passthrough in either
+  order, both path separators, and the whole set inside a rendered span, escaped, and end to end
+  through the real parse path. Re-running the corpus-wide audit shows the divergence set
+  **unchanged** — no golden source writes a STEM expression inside a computed target — and no new
+  divergence appeared. Coverage stays diff-neutral, and as with every prep piece before it, nothing
+  further is wired in.
 
-  Two shapes are deliberately left where they were, each pinned by its own test, and they are the
-  same two the passthrough increments left: an **image's bracket** and an **attribute-list display
-  text** over a STEM expression each keep the opaque-piece gate, because both come back from a
-  *parse* and a placeholder inside a parsed value has no node to map back to.
+  Beyond the image family just described, one more shape is left where it was: an **attribute-list
+  display text** over a STEM expression keeps the opaque-piece gate, as its passthrough sibling does,
+  because it comes back from a *parse* and a placeholder inside a parsed value has no node to map
+  back to.
 
-  With this the restore-the-value class is closed for **both** masked kinds in every family that
-  computes a target. What still defers is the **bracket half** — restoring inside each *parsed*
-  attribute-list value (an image's bracket, the three families' attribute-list display texts), where
-  the string pipeline's own parse swallows the sentinel into a value that only restores after the
-  split — and the keeps: the cross-reference family's pre-restore target (whose golden leaks the raw
-  sentinel into its own `href`), and the well-formed readings these four increments pinned.
+  With this the restore-the-value class is closed for both masked kinds in the two families whose
+  computed target reaches the output as computed. What still defers is the **bracket half** —
+  restoring inside each *parsed* attribute-list value (an image's bracket, the three families'
+  attribute-list display texts), where the string pipeline's own parse swallows the sentinel into a
+  value that only restores after the split — the **image family's STEM target**, whose fold-time
+  `web_path` is the blocker just described (closing it means keeping this family's restore out of
+  `web_path`'s way, not widening a gate), and the keeps: the cross-reference family's pre-restore
+  target (whose golden leaks the raw sentinel into its own `href`), and the well-formed readings
+  these four increments pinned.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -5112,16 +5130,20 @@ Each phase is a reviewable unit with a clear exit gate.
        [`node_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) (the cheap
        gate discriminant) and
        [`restorable_body`](../../parser/src/content/inline_builder/macros/image.rs) (the bytes),
-       which together carry all four sites the passthrough increments built. The invariant is that
-       a restored body is exactly what the *fold* of that node emits, so a `Stem`'s comes from
+       which together carry the two sites the link families use. The invariant is that a restored
+       body is exactly what the *fold* of that node emits, so a `Stem`'s comes from
        [`fold_stem`](../../parser/src/content/inline_builder/fold.rs) itself — the same
        `render_quoted_substitution` call `PassthroughRestoreReplacer` makes — and the two
        directions cannot drift. Unlike its passthrough sibling this one needs no security
        divergence: a STEM body is restored *wrapped* in its notation's delimiters, so it cannot
-       smuggle a live scheme. The image bracket and the attribute-list display texts keep the
-       opaque-piece gate, each with its own test. See the step's own "landed as" note above. With
-       this the restore-the-value class is closed for both masked kinds; the bracket half is what
-       remains of it.
+       smuggle a live scheme. The **`image:`/`icon:` family is deliberately left out** and its
+       family code untouched: its target alone is re-processed by `web_path` at fold time, which
+       posixifies the platform separator, and *every* rendered STEM body carries a backslash — so
+       restoring there would make the `src` differ by platform. That split is what
+       [`Restorable`](../../parser/src/content/inline_builder/macros/image.rs) names at the gate,
+       pinned by a literal-stays test and a both-separators fold test. The attribute-list display
+       texts keep the opaque-piece gate. See the step's own "landed as" note above. The bracket
+       half and the image family's own STEM target are what remain of the class.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4359,6 +4359,74 @@ Each phase is a reviewable unit with a clear exit gate.
   leaks the raw sentinel into its own `href`), and the four well-formed readings these three
   increments pinned.
 
+  *Step 6 prep landed as (a masked **STEM** expression in a computed target):* the lift the three
+  restore-the-value increments above each deferred to "the STEM step's own increment, across all
+  three families at once", made in one place rather than three. A STEM expression is an *implicit*
+  passthrough — [`Passthroughs::extract_from`](../../parser/src/content/passthroughs.rs) masks it in
+  the very same pass, before any substitution step runs — so it stands in the string pipeline's
+  haystack as the same `\u{96}`*n*`\u{97}` sentinel and in this module's match string as the same
+  one-character placeholder. What kept it out was only that the restore machinery reached into a
+  [`Raw`](../../parser/src/inlines/inline_node.rs) node's `value` by name, and a masked STEM builds a
+  [`Stem`](../../parser/src/inlines/stem.rs) node instead.
+
+  The fix is a **pair of shared helpers** rather than a widened `matches!` at each site:
+  [`node_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) is the cheap
+  discriminant the two gates use (so a range about to be *rejected* costs no rendering), and
+  [`restorable_body`](../../parser/src/content/inline_builder/macros/image.rs) produces the bytes the
+  two restores splice. The invariant they rest on is that a restored body is **exactly what the fold
+  of that node emits**: a `Raw` leaf's is its `value`, which the fold emits verbatim (so it is
+  borrowed, not rendered); a `Stem` leaf's is
+  [`fold_stem`](../../parser/src/content/inline_builder/fold.rs)'s own output — the same
+  `render_quoted_substitution` call, over the already-substituted `value` with no attribute list or
+  id, that `PassthroughRestoreReplacer` makes for a STEM entry. Reusing that one function is what
+  keeps the restore and the fold from drifting, and a unit test pins the two helpers to the same set.
+  With the pair in place, all four sites the passthrough increments built —
+  [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs),
+  [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs),
+  and the image family's [`widen_masked_passthroughs`](../../parser/src/content/inline_builder/macros/image.rs)
+  and [`masked_default_alt`](../../parser/src/content/inline_builder/macros/image.rs) — extend to
+  both masked kinds at once, and all three families follow. Recognition needed no new widening beyond
+  the one the image family already had (its two-character-minimum target class cannot match a bare
+  placeholder), and every pre-restore decision keeps reading the bytes as matched, which a
+  placeholder answers as the sentinel does.
+
+  One difference from the passthrough class is worth recording, because it runs the *safe* way: a
+  STEM body cannot smuggle a dangerous scheme. `link:++javascript:…++[]` defers with a security
+  divergence test because a passthrough's body is restored **bare**, so the string replacer's masked
+  check misses a live scheme; a STEM body is restored **wrapped** in its notation's delimiters
+  (`\$javascript:alert(1)\$`), which is not a scheme in either pipeline — so
+  `link:stem:[javascript:alert(1)][]` and an image `link=self` over a STEM target both reach plain
+  parity, with no divergence to pin. The `renderer` these restores use is the **parser's**, mirroring
+  `restore_to`'s own: a computed target freezes its STEM bytes at build time exactly as the string
+  pipeline freezes them into its `href`, where a `Stem` node standing in the flow is rendered at fold
+  time instead — the two agree whenever the fold uses the parser's renderer, which is the seam §3.3.1
+  defines and the only one `Content` uses.
+
+  What reaches parity is every spelling all three families have: the `link:`/`mailto:` macro (bare
+  and labeled, the expression at either edge, in the middle, and twice in one target), auto-links,
+  formal-URL links and the two angle-bracketed forms, and `image:`/`icon:` — including a target that
+  *is* the expression (`image:stem:[x][]`), the `default_alt` arithmetic around one
+  (`image:a_bstem:[x]c_d.png[]`, where an `_` inside the expression hides from the replace and one
+  outside it does not), all three notations, an explicit substitution list (`stem:c,q[…]`), the
+  `hide-uri-scheme` strip, the trailing-punctuation strip in both directions, a display text beside a
+  restored target, a STEM beside a passthrough in either order, and the whole set inside a rendered
+  span, escaped, and end to end through the real parse path. Re-running the corpus-wide audit shows
+  the divergence set **unchanged** — no golden source writes a STEM expression inside a computed
+  target — and no new divergence appeared. Coverage stays diff-neutral, and as with every prep piece
+  before it, nothing further is wired in.
+
+  Two shapes are deliberately left where they were, each pinned by its own test, and they are the
+  same two the passthrough increments left: an **image's bracket** and an **attribute-list display
+  text** over a STEM expression each keep the opaque-piece gate, because both come back from a
+  *parse* and a placeholder inside a parsed value has no node to map back to.
+
+  With this the restore-the-value class is closed for **both** masked kinds in every family that
+  computes a target. What still defers is the **bracket half** — restoring inside each *parsed*
+  attribute-list value (an image's bracket, the three families' attribute-list display texts), where
+  the string pipeline's own parse swallows the sentinel into a value that only restores after the
+  split — and the keeps: the cross-reference family's pre-restore target (whose golden leaks the raw
+  sentinel into its own `href`), and the well-formed readings these four increments pinned.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5035,6 +5103,25 @@ Each phase is a reviewable unit with a clear exit gate.
        honest restored target. See the step's own "landed as" note above. With this the class is
        closed for every family that computes a target; the bracket half — restoring inside each
        *parsed* attribute-list value — is what remains of it.
+
+     - ✅ **prep (a masked STEM expression in a computed target).** The lift the three increments
+       above each deferred to "the STEM step's own increment, across all three families at once".
+       A masked STEM is the *other* node kind the one extraction pass produces — an implicit
+       passthrough, standing in both haystacks as the same sentinel and the same placeholder — so
+       the whole class extends to it through a pair of shared helpers,
+       [`node_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) (the cheap
+       gate discriminant) and
+       [`restorable_body`](../../parser/src/content/inline_builder/macros/image.rs) (the bytes),
+       which together carry all four sites the passthrough increments built. The invariant is that
+       a restored body is exactly what the *fold* of that node emits, so a `Stem`'s comes from
+       [`fold_stem`](../../parser/src/content/inline_builder/fold.rs) itself — the same
+       `render_quoted_substitution` call `PassthroughRestoreReplacer` makes — and the two
+       directions cannot drift. Unlike its passthrough sibling this one needs no security
+       divergence: a STEM body is restored *wrapped* in its notation's delimiters, so it cannot
+       smuggle a live scheme. The image bracket and the attribute-list display texts keep the
+       opaque-piece gate, each with its own test. See the step's own "landed as" note above. With
+       this the restore-the-value class is closed for both masked kinds; the bracket half is what
+       remains of it.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -571,7 +571,17 @@ fn fold_callout(
 /// the body — no further processing is needed, mirroring how a STEM
 /// passthrough is restored with no attribute list or id (`INLINE_STEM_MACRO`
 /// captures neither).
-fn fold_stem(stem: &Stem<'_>, renderer: &dyn InlineSubstitutionRenderer, out: &mut String) {
+///
+/// Shared with the macro families, whose *restore* of a masked STEM
+/// expression into a computed target must emit exactly the bytes this fold
+/// does — see
+/// [`restorable_body`](super::macros::image::restorable_body) — so the two
+/// directions cannot drift.
+pub(in crate::content::inline_builder) fn fold_stem(
+    stem: &Stem<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    out: &mut String,
+) {
     let type_ = match stem.notation {
         StemNotation::AsciiMath => QuoteType::AsciiMath,
         StemNotation::LatexMath => QuoteType::LatexMath,

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -131,7 +131,12 @@ fn find_image_matches<'src>(
         }
 
         if let Some(target) = caps.get(1)
-            && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
+            && !range_is_restorable(
+                nodes,
+                pieces,
+                &(target.start()..target.end()),
+                Restorable::Passthrough,
+            )
         {
             continue;
         }
@@ -299,13 +304,11 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
     }
 }
 
-/// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a
-/// passthrough's [`Raw`](InlineNode::Raw) or a STEM expression's
-/// [`Stem`](InlineNode::Stem), the exact pair [`restorable_body`] names — for
-/// a value the caller *restores* rather than reads: the placeholder's bytes
-/// are not the string pipeline's (its haystack holds the
-/// `\u{96}`*n*`\u{97}` sentinel there), but the masked construct's own
-/// rendered body **is** known at build time — it is what
+/// [`range_has_no_opaque_piece`], further admitting a **masked** piece — one
+/// of the kinds `kinds` names — for a value the caller *restores* rather than
+/// reads: the placeholder's bytes are not the string pipeline's (its haystack
+/// holds the `\u{96}`*n*`\u{97}` sentinel there), but the masked construct's
+/// own rendered body **is** known at build time — it is what
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
 /// the sentinel after the steps run — so a computed value that substitutes it
 /// for the placeholder (see [`restore_masked_passthroughs`](super::links))
@@ -336,6 +339,7 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
     range: &std::ops::Range<usize>,
+    kinds: Restorable,
 ) -> bool {
     for piece in pieces {
         let p_start = piece.s_start;
@@ -350,7 +354,10 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
             continue;
         }
 
-        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
+        if nodes
+            .get(piece.node_index)
+            .is_some_and(|node| node_is_restorable(node, kinds))
+        {
             continue;
         }
 
@@ -362,9 +369,36 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
     true
 }
 
-/// Reports whether `node` is one a computed value can **restore**: a masked
-/// passthrough ([`Raw`](InlineNode::Raw)) or a masked STEM expression
-/// ([`Stem`](InlineNode::Stem)).
+/// Which masked kinds a caller is able to **restore**, and so which ones
+/// [`range_is_restorable`] admits for it.
+///
+/// The two kinds differ in one way that matters to a caller whose value the
+/// **fold** re-processes: a STEM expression's rendered body always carries a
+/// backslash (`\$…\$`, `\(…\)`), and the `image:`/`icon:` family's target
+/// is run through
+/// [`PathResolver::web_path`](crate::parser::PathResolver::web_path) at fold
+/// time — which *posixifies* the platform separator, rewriting `\` to `/` on
+/// a Windows-separator resolver. The string pipeline never has that problem:
+/// its `web_path` sees the backslash-free **sentinel**, and the restore pass
+/// splices the STEM bytes into the finished `src` afterwards. So the image
+/// family defers a masked STEM entirely rather than produce a `src` that
+/// differs by platform; the link families, whose targets reach the `href`
+/// with no such re-processing, take both kinds. See
+/// `an_image_target_over_a_stem_expression_is_a_documented_divergence`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::content::inline_builder) enum Restorable {
+    /// A masked passthrough's [`Raw`](InlineNode::Raw) body only — for the
+    /// `image:`/`icon:` family, whose target the fold re-processes.
+    Passthrough,
+
+    /// Either masked kind — for the two link families.
+    PassthroughOrStem,
+}
+
+/// Reports whether `node` is one a computed value can **restore**, given the
+/// kinds its caller admits: a masked passthrough ([`Raw`](InlineNode::Raw))
+/// always, and a masked STEM expression ([`Stem`](InlineNode::Stem)) when
+/// `kinds` is [`Restorable::PassthroughOrStem`].
 ///
 /// These are exactly the two node kinds the *same* extraction pass
 /// ([`Passthroughs::extract_from`](crate::content::Passthroughs)) masks before
@@ -377,11 +411,19 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
 /// run.
 ///
 /// This is the cheap discriminant half of [`restorable_body`], which produces
-/// those bytes: the two return `true`/`Some` for the same set, pinned by
-/// `restorable_body_and_node_is_restorable_agree`. A gate uses this one so a
-/// range it is about to *reject* costs no rendering.
-pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'_>) -> bool {
-    matches!(node, InlineNode::Raw { .. } | InlineNode::Stem(_))
+/// those bytes: under [`Restorable::PassthroughOrStem`] the two return
+/// `true`/`Some` for the same set, pinned by
+/// `restorable_body_agrees_with_node_is_restorable`. A gate uses this one so
+/// a range it is about to *reject* costs no rendering.
+pub(in crate::content::inline_builder) fn node_is_restorable(
+    node: &InlineNode<'_>,
+    kinds: Restorable,
+) -> bool {
+    match node {
+        InlineNode::Raw { .. } => true,
+        InlineNode::Stem(_) => kinds == Restorable::PassthroughOrStem,
+        _ => false,
+    }
 }
 
 /// The bytes a [`node_is_restorable`] node restores to — the very text
@@ -488,13 +530,14 @@ fn build_image_node<'src>(
         // where the match string holds an entity — so it falls back to the
         // match string's own bytes, which is what `text_slice` declines to
         // recover and precisely what the string replacer reads as `caps[1]`.
-        // A target crossing a **masked** construct — a passthrough or a STEM
-        // expression — finishes into the restored bytes: the node's own
-        // rendered body ([`restorable_body`]) substituted for its
+        // A target crossing a masked **passthrough** finishes into the
+        // restored bytes — the `Raw` node's value substituted for its
         // placeholder, the same rewrite `Passthroughs::restore_to` performs
         // on the rendered `src` — while the `default_alt` *arithmetic* below
         // stays on the bytes as matched, where the string replacer's own
-        // runs (see [`masked_default_alt`]).
+        // runs (see [`masked_default_alt`]). A masked **STEM** expression is
+        // deferred by this family's gate before it reaches here (see
+        // [`Restorable`]).
         Some(m) => {
             match restore_masked_passthroughs(
                 m.as_str(),
@@ -522,17 +565,11 @@ fn build_image_node<'src>(
 
     // The default alt text derives from the target's basename, with `_`/`-`
     // read as spaces — exactly the string replacer's `default_alt`, which
-    // runs over the *masked* bytes (its haystack holds the extraction pass's
-    // sentinel), with each masked body restored into whatever survives the
-    // arithmetic.
+    // runs over the *masked* bytes (its haystack holds the passthrough
+    // sentinel), with the passthrough bodies restored into whatever survives
+    // the arithmetic.
     let default_alt = caps.get(1).map_or_else(String::new, |m| {
-        masked_default_alt(
-            m.as_str(),
-            &(m.start()..m.end()),
-            nodes,
-            pieces,
-            parser.renderer.as_ref(),
-        )
+        masked_default_alt(m.as_str(), &(m.start()..m.end()), nodes, pieces)
     });
 
     // Pre-extract the resolved alt/width/height into owned values, ending the
@@ -574,24 +611,28 @@ fn build_image_node<'src>(
     })
 }
 
-/// Rewrites this level's match string so each **masked** construct's
-/// placeholder — a passthrough's or a STEM expression's, the pair
-/// [`node_is_restorable`] names — becomes a sentinel-shaped token,
-/// `\u{96}`*n*`\u{97}`, the very bytes the string pipeline's own haystack
-/// holds there, moving the pieces into the rewritten string's coordinates
-/// (each masked piece keeps its node, wider; every other piece keeps its
-/// bytes).
+/// Rewrites this level's match string so each masked **passthrough**'s
+/// placeholder becomes a sentinel-shaped token — `\u{96}`*n*`\u{97}`, the
+/// very bytes the string pipeline's own haystack holds there — moving the
+/// pieces into the rewritten string's coordinates (each
+/// [`Raw`](InlineNode::Raw) piece keeps its node, wider; every other piece
+/// keeps its bytes).
 ///
 /// This family alone needs the widening because [`INLINE_IMAGE_MACRO`]'s
 /// target class is the one in this module that requires **two** characters
 /// (`[^:\s\[\n][^\[\n]*?[^\s\[\n]`): a target written wholly inside a
-/// passthrough (`image:++sunset.jpg++[]`) or a STEM expression
-/// (`image:stem:[x][]`) is a single placeholder character, which that class
-/// cannot match — where the string replacer's three-byte sentinel matches it
-/// exactly. Widening the placeholder to the sentinel's own shape makes
-/// recognition agree byte-for-byte with the string step without touching the
-/// shared pattern. (The `link:`/`mailto:` family's one-or-more target class
-/// never faced this, so its increment left the placeholder bare.)
+/// passthrough (`image:++sunset.jpg++[]`) is a single placeholder character,
+/// which that class cannot match — where the string replacer's three-byte
+/// sentinel matches it exactly. Widening the placeholder to the sentinel's
+/// own shape makes recognition agree byte-for-byte with the string step
+/// without touching the shared pattern. (The `link:`/`mailto:` family's
+/// one-or-more target class never faced this, so its increment left the
+/// placeholder bare.)
+///
+/// A masked **STEM** expression is deliberately *not* widened here: this
+/// family defers it entirely (see [`range_is_restorable`]'s `kinds`
+/// parameter and [`Restorable::Passthrough`]), so widening it would only
+/// grow a match this level's gate then rejects.
 ///
 /// The token's bytes never reach an output node: an unmatched token sits in
 /// a gap [`rebuild_macro_level`] re-emits from the piece's own *node*, a
@@ -609,7 +650,7 @@ fn widen_masked_passthroughs(
 ) -> (String, Vec<Piece>) {
     if !pieces
         .iter()
-        .any(|piece| nodes.get(piece.node_index).is_some_and(node_is_restorable))
+        .any(|piece| matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })))
     {
         return (s, pieces);
     }
@@ -630,7 +671,7 @@ fn widen_masked_passthroughs(
 
         let s_start = out.len();
 
-        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
+        if matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })) {
             out.push_str(&format!("\u{96}{n}\u{97}"));
             n += 1;
         } else {
@@ -653,31 +694,28 @@ fn widen_masked_passthroughs(
 
 /// The string replacer's `default_alt` derivation —
 /// `basename(&target.replace(['_', '-'], " "))` — performed over the
-/// **masked** bytes, with each masked construct's body ([`restorable_body`]:
-/// a passthrough's or a STEM expression's) restored into whatever survives
-/// the arithmetic.
+/// **masked** bytes, with each masked passthrough's body restored into
+/// whatever survives the arithmetic.
 ///
 /// The string pipeline computes `default_alt` from its own haystack, where a
-/// masked construct is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
+/// masked passthrough is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
 /// carrying none of the bytes the arithmetic acts on (no `_`/`-` for the
 /// replace, no `/` or `.` for [`basename`]'s stem cut), so the derivation
 /// treats it as one indivisible character and the restore pass then splices
 /// the extracted body over whatever sentinel reaches the rendered `alt` —
 /// which is how `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"` where the
 /// verbatim spelling shows `a b c`, its underscores hidden from the replace
-/// inside the sentinel, and how `image:a_bstem:[x]c.png[]` keeps the STEM
-/// expression's rendered bytes intact inside an otherwise
-/// underscore-replaced `alt`. This reproduces that byte-for-byte: each
-/// overlapping [`restorable`](node_is_restorable) piece's placeholder becomes
-/// the same sentinel-shaped token, the arithmetic runs, and each *surviving*
-/// token is restored with its own node's body — index-keyed, as
+/// inside the sentinel. This reproduces that byte-for-byte: each overlapping
+/// [`Raw`](InlineNode::Raw) piece's placeholder becomes the same
+/// sentinel-shaped token, the arithmetic runs, and each *surviving* token is
+/// restored with its own node's value — index-keyed, as
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) is, so a token
 /// the basename cut dropped (a passthrough wholly inside a directory prefix
 /// or an extension) does not shift the ones that survive. A token survives
 /// whole or is dropped whole: both of the cut points [`basename`] reads (the
 /// last `/`, the last `.`) are bytes no token contains.
 ///
-/// A range holding no masked construct takes the plain derivation over the
+/// A range holding no masked passthrough takes the plain derivation over the
 /// match-string bytes — exactly what this family computed before the restore
 /// existed, since `masked` here is the same `caps[1]` the string replacer
 /// reads.
@@ -686,10 +724,9 @@ fn masked_default_alt(
     range: &std::ops::Range<usize>,
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
-    renderer: &dyn InlineSubstitutionRenderer,
 ) -> String {
     let mut tokened = String::new();
-    let mut values: Vec<Cow<'_, str>> = Vec::new();
+    let mut values: Vec<&str> = Vec::new();
 
     // In match-string coordinates; `masked` is indexed relative to
     // `range.start`.
@@ -704,14 +741,11 @@ fn masked_default_alt(
             continue;
         }
 
-        let Some(value) = nodes
-            .get(piece.node_index)
-            .and_then(|node| restorable_body(node, renderer))
-        else {
+        let Some(InlineNode::Raw { value, .. }) = nodes.get(piece.node_index) else {
             continue;
         };
 
-        // A masked piece is one placeholder character, atomic and never
+        // A `Raw` piece is one placeholder character, atomic and never
         // sliced, so an overlapping one lies wholly inside the range and
         // `p_start`/`p_end` are safe bounds.
         tokened.push_str(
@@ -720,7 +754,7 @@ fn masked_default_alt(
                 .unwrap_or_default(),
         );
         tokened.push_str(&format!("\u{96}{n}\u{97}", n = values.len()));
-        values.push(value);
+        values.push(value.as_ref());
         cursor = p_end;
     }
 
@@ -917,7 +951,7 @@ mod tests {
             assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_macros,
             golden_macros_with,
         },
-        node_is_restorable, restorable_body,
+        Restorable, node_is_restorable, restorable_body,
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -926,7 +960,7 @@ mod tests {
             special_chars::Masked,
         },
         inlines::{CharRef, Image, InlineNode, SpanForm, StyleVariant},
-        parser::HtmlSubstitutionRenderer,
+        parser::{DefaultPathResolver, HtmlSubstitutionRenderer},
         strings::CowStr,
     };
 
@@ -1778,141 +1812,79 @@ mod tests {
     }
 
     #[test]
-    fn fold_matches_the_string_pipeline_for_an_image_target_over_a_stem_expression() {
-        // The differential corpus for an `image:`/`icon:` target crossing a
-        // masked **STEM** expression — the same restore-the-value move the
-        // passthrough corpus above pins, over the other node kind the one
-        // extraction pass masks. A STEM entry stands in the string
-        // pipeline's haystack as the same `\u{96}`*n*`\u{97}` sentinel a
-        // passthrough does, and its restore splices the *rendered*
-        // expression (`render_quoted_substitution`, which the tree spells as
-        // `fold_stem` — see [`restorable_body`]), so target, `default_alt`
-        // arithmetic, and `src` all finish into identical bytes.
+    fn an_image_target_over_a_stem_expression_is_a_documented_divergence() {
+        // This family defers a masked **STEM** expression in the target,
+        // where the two link families restore it (see
+        // [`Restorable`]). The reason is the fold-time
+        // [`web_path`](crate::parser::PathResolver::web_path) seam this
+        // family alone sits behind, and it is the same one the passthrough
+        // increment already pinned for a restored *space*: the string
+        // pipeline runs `web_path` over its own **sentinel** and splices the
+        // extracted body into the finished `src` afterwards, so bytes
+        // `web_path` would rewrite never reach it — while a tree that
+        // restores at build time hands those bytes straight to `web_path`.
+        //
+        // For a passthrough that is an exotic body. For STEM it is *every*
+        // body: a rendered expression always carries a backslash (`\$…\$`,
+        // `\(…\)`), and `web_path` posixifies the platform separator — so on
+        // a Windows-separator resolver `image:stem:[x].png[]` would render
+        // `src="/$x/$.png"` against the golden's `src="\$x\$.png"`. Deferring
+        // keeps this family's `src` identical on every platform; restoring
+        // would make it differ by one.
         use super::super::super::test_support::golden_passthroughs;
 
-        let fixtures = [
-            // A target wholly inside the expression — the shape that needs
-            // the placeholder widened, since one character cannot match this
-            // family's two-character-minimum class.
+        for source in [
             "image:stem:[x][]",
-            "icon:stem:[x][]",
-            // The expression as one piece of a longer target, at either edge
-            // and in the middle, and two in one target.
             "image:stem:[x].png[]",
-            "image:dir/stem:[x].png[]",
-            "image:a_bstem:[x]c.png[]",
-            "image:stem:[a]stem:[b].png[]",
-            // The `default_alt` arithmetic runs over the masked bytes in both
-            // pipelines: an `_`/`-` *inside* the expression hides from the
-            // replace, one outside it does not, and the basename cut keys off
-            // bytes no token contains.
-            "image:a_bstem:[x]c_d.png[]",
-            "image:stem:[x]_y.png[]",
-            "image:dir_a/stem:[x].png[]",
-            "image:stem:[a_b].png[]",
-            // An explicit alt beside a restored target, and the other
-            // notations and the explicit substitution list the family admits.
-            "image:stem:[x].png[Alt]",
-            "image:latexmath:[\\alpha].png[]",
-            "image:asciimath:[a/b].png[]",
-            "image:stem:c,q[x*y*z].png[]",
-            // `link=self` reads the restored target in both pipelines — a
-            // STEM body cannot smuggle a dangerous scheme past it, since its
-            // rendered form is wrapped rather than spliced bare (see
-            // `a_dangerous_target_inside_a_passthrough_is_a_documented_divergence`,
-            // which this family's passthrough sibling *does* defer).
-            "image:stem:[x].png[link=self]",
-            "image:stem:[javascript:alert(1)].png[link=self]",
-            // Inside a rendered span, escaped, and beside a passthrough.
-            "*image:stem:[x].png[]*",
-            "\\image:stem:[x].png[]",
-            "image:stem:[a]/++b++.png[]",
-            "image:++a++/stem:[b].png[]",
-        ];
+            "icon:stem:[x][]",
+        ] {
+            let nodes = build_src(Span::new(source));
 
-        let renderer = HtmlSubstitutionRenderer {};
-
-        for fixture in fixtures {
-            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
-
-            assert_eq!(
-                folded,
-                golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+                "an image target over a STEM expression must stay literal: {nodes:?}"
             );
         }
-    }
 
-    #[test]
-    fn an_image_target_over_a_stem_expression_is_recognized() {
-        // The target is the restored bytes — the expression's *rendered*
-        // form, not its source spelling — and the default alt is the masked
-        // derivation with the surviving token restored, so an `_` inside the
-        // expression hides from the replace exactly as one inside a
-        // passthrough does.
-        let nodes = build_src(Span::new("image:a_bstem:[x_y]c.png[]"));
-
-        let image = assert_image(&nodes[0]);
-        assert!(!image.is_icon);
-        assert_eq!(image.target.as_ref(), "a_b\\$x_y\\$c.png");
-        assert_eq!(image.alt.as_deref(), Some("a b\\$x_y\\$c"));
-
-        // A target that *is* the expression: one placeholder character, which
-        // only the widened token lets this family's class match at all.
-        let nodes = build_src(Span::new("image:stem:[x][]"));
-
-        let image = assert_image(&nodes[0]);
-        assert_eq!(image.target.as_ref(), "\\$x\\$");
-        assert_eq!(image.alt.as_deref(), Some("\\$x\\$"));
-    }
-
-    #[test]
-    fn an_image_bracket_over_a_stem_expression_is_a_documented_divergence() {
-        // The **bracket** keeps the opaque-piece gate for a STEM expression
-        // exactly as it does for a passthrough
-        // (`an_image_bracket_over_a_passthrough_is_a_documented_divergence`):
-        // it comes back from a *parse*, and the string pipeline's own
-        // `Attrlist::parse` swallows the sentinel into a value that only
-        // restores after the split, which a placeholder with no node to map
-        // back to cannot reproduce. This is the "bracket half" the restore
-        // class still defers, for both masked kinds alike.
-        use super::super::super::test_support::golden_passthroughs;
-
-        let source = "image:x.png[stem:[a]]";
-        let nodes = build_src(Span::new(source));
+        // The string pipeline does build one, restoring the rendered
+        // expression into the `src` after its own `web_path` ran.
+        let golden = golden_passthroughs("image:stem:[x].png[]");
 
         assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-            "a bracket over a STEM expression must stay literal: {nodes:?}"
-        );
-
-        let golden = golden_passthroughs(source);
-
-        assert!(
-            golden.contains("alt=\"\\$a\\$\""),
+            golden.contains("src=\"\\$x\\$.png\""),
             "expected the documented divergence to still reproduce: {golden:?}"
         );
     }
 
     #[test]
-    fn registers_the_restored_target_for_an_image_over_a_stem_expression() {
-        // As for a passthrough target, the staged side effect registers the
-        // node's own — *restored* — target, where the string pipeline
-        // registers the sentinel it matched.
-        let source = "image:stem:[x].png[] and image:a_bstem:[y]c.png[]";
-        let parser = Parser::default().with_catalog_assets(true);
-        let nodes = build_with(Span::new(source), &parser);
+    fn an_image_target_over_a_stem_expression_is_platform_independent() {
+        // The reason the divergence above is a *deferral* rather than an
+        // accepted difference: with a Windows-separator path resolver, a
+        // restored STEM body would have its backslashes posixified into the
+        // `src`. Left literal, this family's output is identical under either
+        // separator — which is what this pins, since CI runs all three
+        // platforms and a restored target would only fail on one.
+        let source = "image:stem:[x].png[]";
 
-        apply_image_side_effects(&nodes, &parser, Span::new(source));
+        let posix = Parser::default().with_path_resolver(DefaultPathResolver {
+            file_separator: '/',
+        });
 
-        let targets: Vec<_> = parser
-            .catalog()
-            .images()
-            .iter()
-            .map(|i| i.target.clone())
-            .collect();
+        let windows = Parser::default().with_path_resolver(DefaultPathResolver {
+            file_separator: '\\',
+        });
 
-        assert_eq!(targets, ["\\$x\\$.png", "a_b\\$y\\$c.png"]);
+        let renderer = HtmlSubstitutionRenderer {};
+
+        let fold_with = |parser: &Parser| {
+            crate::content::inline_builder::fold_html(
+                &build_with(Span::new(source), parser),
+                &renderer,
+                parser,
+            )
+        };
+
+        assert_eq!(fold_with(&posix), fold_with(&windows));
     }
 
     #[test]
@@ -1938,12 +1910,20 @@ mod tests {
         ];
 
         for node in &restorable {
-            assert!(node_is_restorable(node), "expected restorable: {node:?}");
+            assert!(
+                node_is_restorable(node, Restorable::PassthroughOrStem),
+                "expected restorable: {node:?}"
+            );
             assert!(
                 restorable_body(node, &renderer).is_some(),
                 "expected a body: {node:?}"
             );
         }
+
+        // Under `Passthrough` the STEM half is withheld, which is the image
+        // family's deferral — the `Raw` half is admitted either way.
+        assert!(node_is_restorable(&restorable[0], Restorable::Passthrough));
+        assert!(!node_is_restorable(&restorable[1], Restorable::Passthrough));
 
         let opaque = [
             InlineNode::Text {
@@ -1958,52 +1938,15 @@ mod tests {
         ];
 
         for node in &opaque {
-            assert!(!node_is_restorable(node), "expected opaque: {node:?}");
+            assert!(
+                !node_is_restorable(node, Restorable::PassthroughOrStem),
+                "expected opaque: {node:?}"
+            );
             assert!(
                 restorable_body(node, &renderer).is_none(),
                 "expected no body: {node:?}"
             );
         }
-    }
-
-    #[test]
-    fn a_real_documents_stem_image_targets_fold_to_their_rendered_strings() {
-        // End-to-end, through the real parse path: an `image:`/`icon:` target
-        // crossing a STEM expression must finish into the restored bytes the
-        // rendered string carries — the `src` and the masked-derived default
-        // alt alike.
-        use crate::blocks::{FindBlocks, IsBlock};
-
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
-            "== A heading\n",
-            "\n",
-            "A plot: image:stem:[x_i].png[] under a rendered name.\n",
-            "\n",
-            "See image:chart_stem:[a/b].png[Chart] or icon:stem:[y][] today.\n",
-        ));
-
-        let mut folded_blocks = 0;
-
-        for block in doc.descendant_blocks() {
-            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
-            else {
-                continue;
-            };
-
-            assert_eq!(
-                crate::content::inline_builder::fold_html(
-                    inlines,
-                    &HtmlSubstitutionRenderer {},
-                    &Parser::default()
-                ),
-                rendered,
-                "fold diverged from the rendered string for {inlines:?}"
-            );
-
-            folded_blocks += 1;
-        }
-
-        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1,5 +1,7 @@
 //! Image and icon macro recognition (`image:target[…]`, `icon:target[…]`).
 
+use std::borrow::Cow;
+
 use super::{MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level};
 use crate::{
     Parser, Span,
@@ -7,6 +9,7 @@ use crate::{
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
+            fold::fold_stem,
             quotes::{
                 LevelContext, Piece, build_match_string, replacement_entity, source_slice,
                 text_slice,
@@ -16,7 +19,9 @@ use crate::{
         normalize_text_lf_escaped_bracket,
     },
     inlines::{CharRef, Image, InlineNode},
-    parser::{has_dangerous_scheme, has_dangerous_self_href, is_uri_ish},
+    parser::{
+        InlineSubstitutionRenderer, has_dangerous_scheme, has_dangerous_self_href, is_uri_ish,
+    },
     strings::CowStr,
     warnings::WarningType,
 };
@@ -294,12 +299,13 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
     }
 }
 
-/// [`range_has_no_opaque_piece`], further admitting a masked **passthrough**
-/// — a [`Raw`](InlineNode::Raw) piece — for a value the caller *restores*
-/// rather than reads: the placeholder's bytes are not the string pipeline's
-/// (its haystack holds the `\u{96}`*n*`\u{97}` sentinel there), but the
-/// passthrough's own substituted body **is** known at build time — it is the
-/// `Raw` node's `value`, the very text
+/// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a
+/// passthrough's [`Raw`](InlineNode::Raw) or a STEM expression's
+/// [`Stem`](InlineNode::Stem), the exact pair [`restorable_body`] names — for
+/// a value the caller *restores* rather than reads: the placeholder's bytes
+/// are not the string pipeline's (its haystack holds the
+/// `\u{96}`*n*`\u{97}` sentinel there), but the masked construct's own
+/// rendered body **is** known at build time — it is what
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
 /// the sentinel after the steps run — so a computed value that substitutes it
 /// for the placeholder (see [`restore_masked_passthroughs`](super::links))
@@ -344,7 +350,7 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
             continue;
         }
 
-        if matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })) {
+        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
             continue;
         }
 
@@ -354,6 +360,69 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
     }
 
     true
+}
+
+/// Reports whether `node` is one a computed value can **restore**: a masked
+/// passthrough ([`Raw`](InlineNode::Raw)) or a masked STEM expression
+/// ([`Stem`](InlineNode::Stem)).
+///
+/// These are exactly the two node kinds the *same* extraction pass
+/// ([`Passthroughs::extract_from`](crate::content::Passthroughs)) masks before
+/// any substitution step runs — STEM being an implicit passthrough, as
+/// [`Stem::value`](crate::inlines::Stem) documents — so each stands in the
+/// string pipeline's haystack as one `\u{96}`*n*`\u{97}` sentinel and in this
+/// module's match string as one [`SPAN_PLACEHOLDER`](super::super::quotes)
+/// character, and each has a body known at build time that
+/// `Passthroughs::restore_to` splices over that sentinel once the steps have
+/// run.
+///
+/// This is the cheap discriminant half of [`restorable_body`], which produces
+/// those bytes: the two return `true`/`Some` for the same set, pinned by
+/// `restorable_body_and_node_is_restorable_agree`. A gate uses this one so a
+/// range it is about to *reject* costs no rendering.
+pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'_>) -> bool {
+    matches!(node, InlineNode::Raw { .. } | InlineNode::Stem(_))
+}
+
+/// The bytes a [`node_is_restorable`] node restores to — the very text
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
+/// the string pipeline's own sentinel — or `None` for any other node.
+///
+/// The invariant both callers rest on is that this returns **exactly what the
+/// fold of that node emits**, so a value finished with these bytes reads the
+/// same as the surrounding tree:
+///
+/// - a [`Raw`](InlineNode::Raw) leaf's body is its `value`, which the fold also
+///   emits verbatim, so it is borrowed rather than rendered;
+/// - a [`Stem`](InlineNode::Stem) leaf's body is [`fold_stem`]'s own output —
+///   `render_quoted_substitution` over the already-substituted `value`, with no
+///   attribute list or id — which is the same call `PassthroughRestoreReplacer`
+///   makes for a STEM entry. Sharing that one function is what keeps the
+///   restore and the fold from drifting.
+///
+/// `renderer` is the **parser's** renderer, mirroring `restore_to`'s own
+/// (`Passthroughs::restore_to` renders a STEM entry through `parser.renderer`
+/// before splicing it into the rendered string). A computed target therefore
+/// freezes its STEM bytes at build time, exactly as the string pipeline
+/// freezes them into its `href`, where a `Stem` node standing in the flow is
+/// rendered at fold time instead; the two agree whenever the fold uses the
+/// parser's renderer, which is the seam design §3.3.1 defines and the only
+/// one `Content` uses.
+pub(in crate::content::inline_builder) fn restorable_body<'a>(
+    node: &'a InlineNode<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+) -> Option<Cow<'a, str>> {
+    match node {
+        InlineNode::Raw { value, .. } => Some(Cow::Borrowed(value.as_ref())),
+
+        InlineNode::Stem(stem) => {
+            let mut out = String::new();
+            fold_stem(stem, renderer, &mut out);
+            Some(Cow::Owned(out))
+        }
+
+        _ => None,
+    }
 }
 
 /// Builds one [`Image`](InlineNode::Image) node from a recognized image/icon
@@ -419,14 +488,21 @@ fn build_image_node<'src>(
         // where the match string holds an entity — so it falls back to the
         // match string's own bytes, which is what `text_slice` declines to
         // recover and precisely what the string replacer reads as `caps[1]`.
-        // A target crossing a masked **passthrough** finishes into the
-        // restored bytes — the `Raw` node's value substituted for its
+        // A target crossing a **masked** construct — a passthrough or a STEM
+        // expression — finishes into the restored bytes: the node's own
+        // rendered body ([`restorable_body`]) substituted for its
         // placeholder, the same rewrite `Passthroughs::restore_to` performs
         // on the rendered `src` — while the `default_alt` *arithmetic* below
         // stays on the bytes as matched, where the string replacer's own
         // runs (see [`masked_default_alt`]).
         Some(m) => {
-            match restore_masked_passthroughs(m.as_str(), &(m.start()..m.end()), nodes, pieces) {
+            match restore_masked_passthroughs(
+                m.as_str(),
+                &(m.start()..m.end()),
+                nodes,
+                pieces,
+                parser.renderer.as_ref(),
+            ) {
                 Some(restored) => CowStr::from(restored),
                 None => text_slice(nodes, pieces, m.start()..m.end())
                     .unwrap_or_else(|| CowStr::from(m.as_str().to_string())),
@@ -446,11 +522,17 @@ fn build_image_node<'src>(
 
     // The default alt text derives from the target's basename, with `_`/`-`
     // read as spaces — exactly the string replacer's `default_alt`, which
-    // runs over the *masked* bytes (its haystack holds the passthrough
-    // sentinel), with the passthrough bodies restored into whatever survives
-    // the arithmetic.
+    // runs over the *masked* bytes (its haystack holds the extraction pass's
+    // sentinel), with each masked body restored into whatever survives the
+    // arithmetic.
     let default_alt = caps.get(1).map_or_else(String::new, |m| {
-        masked_default_alt(m.as_str(), &(m.start()..m.end()), nodes, pieces)
+        masked_default_alt(
+            m.as_str(),
+            &(m.start()..m.end()),
+            nodes,
+            pieces,
+            parser.renderer.as_ref(),
+        )
     });
 
     // Pre-extract the resolved alt/width/height into owned values, ending the
@@ -492,23 +574,24 @@ fn build_image_node<'src>(
     })
 }
 
-/// Rewrites this level's match string so each masked **passthrough**'s
-/// placeholder becomes a sentinel-shaped token — `\u{96}`*n*`\u{97}`, the
-/// very bytes the string pipeline's own haystack holds there — moving the
-/// pieces into the rewritten string's coordinates (each
-/// [`Raw`](InlineNode::Raw) piece keeps its node, wider; every other piece
-/// keeps its bytes).
+/// Rewrites this level's match string so each **masked** construct's
+/// placeholder — a passthrough's or a STEM expression's, the pair
+/// [`node_is_restorable`] names — becomes a sentinel-shaped token,
+/// `\u{96}`*n*`\u{97}`, the very bytes the string pipeline's own haystack
+/// holds there, moving the pieces into the rewritten string's coordinates
+/// (each masked piece keeps its node, wider; every other piece keeps its
+/// bytes).
 ///
 /// This family alone needs the widening because [`INLINE_IMAGE_MACRO`]'s
 /// target class is the one in this module that requires **two** characters
 /// (`[^:\s\[\n][^\[\n]*?[^\s\[\n]`): a target written wholly inside a
-/// passthrough (`image:++sunset.jpg++[]`) is a single placeholder character,
-/// which that class cannot match — where the string replacer's three-byte
-/// sentinel matches it exactly. Widening the placeholder to the sentinel's
-/// own shape makes recognition agree byte-for-byte with the string step
-/// without touching the shared pattern. (The `link:`/`mailto:` family's
-/// one-or-more target class never faced this, so its increment left the
-/// placeholder bare.)
+/// passthrough (`image:++sunset.jpg++[]`) or a STEM expression
+/// (`image:stem:[x][]`) is a single placeholder character, which that class
+/// cannot match — where the string replacer's three-byte sentinel matches it
+/// exactly. Widening the placeholder to the sentinel's own shape makes
+/// recognition agree byte-for-byte with the string step without touching the
+/// shared pattern. (The `link:`/`mailto:` family's one-or-more target class
+/// never faced this, so its increment left the placeholder bare.)
 ///
 /// The token's bytes never reach an output node: an unmatched token sits in
 /// a gap [`rebuild_macro_level`] re-emits from the piece's own *node*, a
@@ -526,7 +609,7 @@ fn widen_masked_passthroughs(
 ) -> (String, Vec<Piece>) {
     if !pieces
         .iter()
-        .any(|piece| matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })))
+        .any(|piece| nodes.get(piece.node_index).is_some_and(node_is_restorable))
     {
         return (s, pieces);
     }
@@ -547,7 +630,7 @@ fn widen_masked_passthroughs(
 
         let s_start = out.len();
 
-        if matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })) {
+        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
             out.push_str(&format!("\u{96}{n}\u{97}"));
             n += 1;
         } else {
@@ -570,28 +653,31 @@ fn widen_masked_passthroughs(
 
 /// The string replacer's `default_alt` derivation —
 /// `basename(&target.replace(['_', '-'], " "))` — performed over the
-/// **masked** bytes, with each masked passthrough's body restored into
-/// whatever survives the arithmetic.
+/// **masked** bytes, with each masked construct's body ([`restorable_body`]:
+/// a passthrough's or a STEM expression's) restored into whatever survives
+/// the arithmetic.
 ///
 /// The string pipeline computes `default_alt` from its own haystack, where a
-/// masked passthrough is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
+/// masked construct is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
 /// carrying none of the bytes the arithmetic acts on (no `_`/`-` for the
 /// replace, no `/` or `.` for [`basename`]'s stem cut), so the derivation
 /// treats it as one indivisible character and the restore pass then splices
 /// the extracted body over whatever sentinel reaches the rendered `alt` —
 /// which is how `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"` where the
 /// verbatim spelling shows `a b c`, its underscores hidden from the replace
-/// inside the sentinel. This reproduces that byte-for-byte: each overlapping
-/// [`Raw`](InlineNode::Raw) piece's placeholder becomes the same
-/// sentinel-shaped token, the arithmetic runs, and each *surviving* token is
-/// restored with its own node's value — index-keyed, as
+/// inside the sentinel, and how `image:a_bstem:[x]c.png[]` keeps the STEM
+/// expression's rendered bytes intact inside an otherwise
+/// underscore-replaced `alt`. This reproduces that byte-for-byte: each
+/// overlapping [`restorable`](node_is_restorable) piece's placeholder becomes
+/// the same sentinel-shaped token, the arithmetic runs, and each *surviving*
+/// token is restored with its own node's body — index-keyed, as
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) is, so a token
 /// the basename cut dropped (a passthrough wholly inside a directory prefix
 /// or an extension) does not shift the ones that survive. A token survives
 /// whole or is dropped whole: both of the cut points [`basename`] reads (the
 /// last `/`, the last `.`) are bytes no token contains.
 ///
-/// A range holding no masked passthrough takes the plain derivation over the
+/// A range holding no masked construct takes the plain derivation over the
 /// match-string bytes — exactly what this family computed before the restore
 /// existed, since `masked` here is the same `caps[1]` the string replacer
 /// reads.
@@ -600,9 +686,10 @@ fn masked_default_alt(
     range: &std::ops::Range<usize>,
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
+    renderer: &dyn InlineSubstitutionRenderer,
 ) -> String {
     let mut tokened = String::new();
-    let mut values: Vec<&str> = Vec::new();
+    let mut values: Vec<Cow<'_, str>> = Vec::new();
 
     // In match-string coordinates; `masked` is indexed relative to
     // `range.start`.
@@ -617,11 +704,14 @@ fn masked_default_alt(
             continue;
         }
 
-        let Some(InlineNode::Raw { value, .. }) = nodes.get(piece.node_index) else {
+        let Some(value) = nodes
+            .get(piece.node_index)
+            .and_then(|node| restorable_body(node, renderer))
+        else {
             continue;
         };
 
-        // A `Raw` piece is one placeholder character, atomic and never
+        // A masked piece is one placeholder character, atomic and never
         // sliced, so an overlapping one lies wholly inside the range and
         // `p_start`/`p_end` are safe bounds.
         tokened.push_str(
@@ -630,7 +720,7 @@ fn masked_default_alt(
                 .unwrap_or_default(),
         );
         tokened.push_str(&format!("\u{96}{n}\u{97}", n = values.len()));
-        values.push(value.as_ref());
+        values.push(value);
         cursor = p_end;
     }
 
@@ -822,9 +912,12 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::super::test_support::{
-        assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_macros,
-        golden_macros_with,
+    use super::{
+        super::super::test_support::{
+            assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_macros,
+            golden_macros_with,
+        },
+        node_is_restorable, restorable_body,
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -832,7 +925,7 @@ mod tests {
             build, char_replacements::apply_character_replacements, macros::apply_macros,
             special_chars::Masked,
         },
-        inlines::{Image, InlineNode, SpanForm, StyleVariant},
+        inlines::{CharRef, Image, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
@@ -1658,6 +1751,235 @@ mod tests {
             "A sunset: image:++sunset_beach.jpg++[] under a masked name.\n",
             "\n",
             "See image:pass:[chart,v2.png][Chart] or icon:++a_b++[] today.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_an_image_target_over_a_stem_expression() {
+        // The differential corpus for an `image:`/`icon:` target crossing a
+        // masked **STEM** expression — the same restore-the-value move the
+        // passthrough corpus above pins, over the other node kind the one
+        // extraction pass masks. A STEM entry stands in the string
+        // pipeline's haystack as the same `\u{96}`*n*`\u{97}` sentinel a
+        // passthrough does, and its restore splices the *rendered*
+        // expression (`render_quoted_substitution`, which the tree spells as
+        // `fold_stem` — see [`restorable_body`]), so target, `default_alt`
+        // arithmetic, and `src` all finish into identical bytes.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let fixtures = [
+            // A target wholly inside the expression — the shape that needs
+            // the placeholder widened, since one character cannot match this
+            // family's two-character-minimum class.
+            "image:stem:[x][]",
+            "icon:stem:[x][]",
+            // The expression as one piece of a longer target, at either edge
+            // and in the middle, and two in one target.
+            "image:stem:[x].png[]",
+            "image:dir/stem:[x].png[]",
+            "image:a_bstem:[x]c.png[]",
+            "image:stem:[a]stem:[b].png[]",
+            // The `default_alt` arithmetic runs over the masked bytes in both
+            // pipelines: an `_`/`-` *inside* the expression hides from the
+            // replace, one outside it does not, and the basename cut keys off
+            // bytes no token contains.
+            "image:a_bstem:[x]c_d.png[]",
+            "image:stem:[x]_y.png[]",
+            "image:dir_a/stem:[x].png[]",
+            "image:stem:[a_b].png[]",
+            // An explicit alt beside a restored target, and the other
+            // notations and the explicit substitution list the family admits.
+            "image:stem:[x].png[Alt]",
+            "image:latexmath:[\\alpha].png[]",
+            "image:asciimath:[a/b].png[]",
+            "image:stem:c,q[x*y*z].png[]",
+            // `link=self` reads the restored target in both pipelines — a
+            // STEM body cannot smuggle a dangerous scheme past it, since its
+            // rendered form is wrapped rather than spliced bare (see
+            // `a_dangerous_target_inside_a_passthrough_is_a_documented_divergence`,
+            // which this family's passthrough sibling *does* defer).
+            "image:stem:[x].png[link=self]",
+            "image:stem:[javascript:alert(1)].png[link=self]",
+            // Inside a rendered span, escaped, and beside a passthrough.
+            "*image:stem:[x].png[]*",
+            "\\image:stem:[x].png[]",
+            "image:stem:[a]/++b++.png[]",
+            "image:++a++/stem:[b].png[]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_target_over_a_stem_expression_is_recognized() {
+        // The target is the restored bytes — the expression's *rendered*
+        // form, not its source spelling — and the default alt is the masked
+        // derivation with the surviving token restored, so an `_` inside the
+        // expression hides from the replace exactly as one inside a
+        // passthrough does.
+        let nodes = build_src(Span::new("image:a_bstem:[x_y]c.png[]"));
+
+        let image = assert_image(&nodes[0]);
+        assert!(!image.is_icon);
+        assert_eq!(image.target.as_ref(), "a_b\\$x_y\\$c.png");
+        assert_eq!(image.alt.as_deref(), Some("a b\\$x_y\\$c"));
+
+        // A target that *is* the expression: one placeholder character, which
+        // only the widened token lets this family's class match at all.
+        let nodes = build_src(Span::new("image:stem:[x][]"));
+
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.target.as_ref(), "\\$x\\$");
+        assert_eq!(image.alt.as_deref(), Some("\\$x\\$"));
+    }
+
+    #[test]
+    fn an_image_bracket_over_a_stem_expression_is_a_documented_divergence() {
+        // The **bracket** keeps the opaque-piece gate for a STEM expression
+        // exactly as it does for a passthrough
+        // (`an_image_bracket_over_a_passthrough_is_a_documented_divergence`):
+        // it comes back from a *parse*, and the string pipeline's own
+        // `Attrlist::parse` swallows the sentinel into a value that only
+        // restores after the split, which a placeholder with no node to map
+        // back to cannot reproduce. This is the "bracket half" the restore
+        // class still defers, for both masked kinds alike.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "image:x.png[stem:[a]]";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+            "a bracket over a STEM expression must stay literal: {nodes:?}"
+        );
+
+        let golden = golden_passthroughs(source);
+
+        assert!(
+            golden.contains("alt=\"\\$a\\$\""),
+            "expected the documented divergence to still reproduce: {golden:?}"
+        );
+    }
+
+    #[test]
+    fn registers_the_restored_target_for_an_image_over_a_stem_expression() {
+        // As for a passthrough target, the staged side effect registers the
+        // node's own — *restored* — target, where the string pipeline
+        // registers the sentinel it matched.
+        let source = "image:stem:[x].png[] and image:a_bstem:[y]c.png[]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_image_side_effects(&nodes, &parser, Span::new(source));
+
+        let targets: Vec<_> = parser
+            .catalog()
+            .images()
+            .iter()
+            .map(|i| i.target.clone())
+            .collect();
+
+        assert_eq!(targets, ["\\$x\\$.png", "a_b\\$y\\$c.png"]);
+    }
+
+    #[test]
+    fn restorable_body_agrees_with_node_is_restorable() {
+        // The cheap discriminant and the body producer must name the same set
+        // — a gate that admits a piece whose body cannot be produced would
+        // leave the placeholder in a computed value, and one that rejects a
+        // piece whose body *can* be would keep a construct needlessly
+        // literal. Pinned over one node of every kind the two decide between.
+        let renderer = HtmlSubstitutionRenderer {};
+        let root = Span::new("x");
+
+        let restorable = [
+            InlineNode::Raw {
+                value: CowStr::from("raw"),
+                location: root,
+            },
+            InlineNode::Stem(crate::inlines::Stem {
+                notation: crate::inlines::StemNotation::AsciiMath,
+                value: CowStr::from("x"),
+                location: root,
+            }),
+        ];
+
+        for node in &restorable {
+            assert!(node_is_restorable(node), "expected restorable: {node:?}");
+            assert!(
+                restorable_body(node, &renderer).is_some(),
+                "expected a body: {node:?}"
+            );
+        }
+
+        let opaque = [
+            InlineNode::Text {
+                value: CowStr::from("t"),
+                location: root,
+            },
+            InlineNode::CharRef {
+                value: CharRef::Special('<'),
+                location: root,
+            },
+            InlineNode::LineBreak { location: root },
+        ];
+
+        for node in &opaque {
+            assert!(!node_is_restorable(node), "expected opaque: {node:?}");
+            assert!(
+                restorable_body(node, &renderer).is_none(),
+                "expected no body: {node:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_real_documents_stem_image_targets_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path: an `image:`/`icon:` target
+        // crossing a STEM expression must finish into the restored bytes the
+        // rendered string carries — the `src` and the masked-derived default
+        // alt alike.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "A plot: image:stem:[x_i].png[] under a rendered name.\n",
+            "\n",
+            "See image:chart_stem:[a/b].png[Chart] or icon:stem:[y][] today.\n",
         ));
 
         let mut folded_blocks = 0;

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3,7 +3,7 @@
 use super::{
     MacroMatch, MacroMatchKind, escaped_value_children,
     image::{
-        range_has_no_opaque_piece, range_is_restorable, range_is_verbatim,
+        Restorable, range_has_no_opaque_piece, range_is_restorable, range_is_verbatim,
         range_is_verbatim_or_synthesized, restorable_body,
     },
     macro_text_children, rebuild_macro_level,
@@ -139,12 +139,15 @@ use crate::{
 /// A **masked** construct — a passthrough's [`Raw`](InlineNode::Raw) piece or
 /// a STEM expression's [`Stem`](InlineNode::Stem) one, the pair
 /// [`restorable_body`] names — is admitted in the target, this being the
-/// third and last family to take [`range_is_restorable`]: the string replacer
-/// swallows the `\u{96}`*n*`\u{97}` sentinel into its own target (both target
-/// classes admit it exactly as they admit the tree's placeholder, and the bare
-/// branch's trailing-character class admits the last byte of either spelling,
-/// so the two recognize the same extent — this family needs no widening of
-/// its own, unlike the `image:`/`icon:` one), and
+/// third and last family to take [`range_is_restorable`]. (Both kinds, unlike
+/// the `image:`/`icon:` family, which admits only the passthrough: this
+/// family's target reaches the `href` as computed, where that one's is
+/// re-processed by `web_path` at fold time — see [`Restorable`].) the string
+/// replacer swallows the `\u{96}`*n*`\u{97}` sentinel into its own target (both
+/// target classes admit it exactly as they admit the tree's placeholder, and
+/// the bare branch's trailing-character class admits the last byte of either
+/// spelling, so the two recognize the same extent — this family needs no
+/// widening of its own, unlike the `image:`/`icon:` one), and
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) then splices
 /// the extracted body's substituted text over every sentinel in the rendered
 /// string. A `Raw` node's `value` **is** that text, known at build time, so
@@ -379,7 +382,12 @@ fn build_inline_link_node<'src>(
     // ASCII no single-character piece can supply.
     let computed_end = n.attrlist().map_or(full.end, |m| m.start());
 
-    if !range_is_restorable(nodes, pieces, &(full.start..computed_end)) {
+    if !range_is_restorable(
+        nodes,
+        pieces,
+        &(full.start..computed_end),
+        Restorable::PassthroughOrStem,
+    ) {
         return None;
     }
 
@@ -747,7 +755,7 @@ fn build_angle_link_node<'src>(
 
     let interior = scheme_m.start()..angle_url.end();
 
-    if !range_is_restorable(nodes, pieces, &interior) {
+    if !range_is_restorable(nodes, pieces, &interior, Restorable::PassthroughOrStem) {
         return None;
     }
 
@@ -1022,7 +1030,12 @@ fn find_link_macro_matches<'src>(
         // keeps the opaque-piece gate inside `text_attrlist`, since its
         // display text comes back from a *parse*.)
         if let Some(target) = caps.get(3)
-            && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
+            && !range_is_restorable(
+                nodes,
+                pieces,
+                &(target.start()..target.end()),
+                Restorable::PassthroughOrStem,
+            )
         {
             continue;
         }
@@ -1932,7 +1945,7 @@ mod tests {
         HasSpan, Parser, Span,
         content::inline_builder::build,
         inlines::{CharRef, InlineNode, SpanForm, StyleVariant},
-        parser::HtmlSubstitutionRenderer,
+        parser::{DefaultPathResolver, HtmlSubstitutionRenderer},
         strings::CowStr,
     };
 
@@ -2331,6 +2344,53 @@ mod tests {
                 golden_passthroughs(fixture),
                 "fold diverged from the string pipeline for {fixture:?}"
             );
+        }
+    }
+
+    #[test]
+    fn a_stem_target_folds_identically_under_either_path_separator() {
+        // The regression guard for the seam that made the `image:`/`icon:`
+        // family defer STEM entirely (see
+        // `an_image_target_over_a_stem_expression_is_a_documented_divergence`):
+        // a rendered STEM body always carries a backslash, and
+        // [`web_path`](crate::parser::PathResolver::web_path) posixifies the
+        // platform separator. These two families never route a target through
+        // `web_path` — it reaches the `href` as computed — so a restored STEM
+        // target must be byte-identical under either separator, and must
+        // match the string pipeline under both.
+        //
+        // Without this, the difference is invisible on a Posix runner and
+        // only surfaces on Windows CI.
+        use super::super::super::test_support::golden_passthroughs_with;
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        let fixtures = [
+            "link:https://example.org/stem:[x][]",
+            "link:https://example.org/latexmath:[\\alpha][docs]",
+            "https://example.org/stem:[x]",
+            "<https://example.org/stem:[x]>",
+            "mailto:stem:[x]@example.org[Mail]",
+        ];
+
+        for separator in ['/', '\\'] {
+            let parser = Parser::default().with_path_resolver(DefaultPathResolver {
+                file_separator: separator,
+            });
+
+            for fixture in fixtures {
+                let folded = crate::content::inline_builder::fold_html(
+                    &build_with(Span::new(fixture), &parser),
+                    &renderer,
+                    &parser,
+                );
+
+                assert_eq!(
+                    folded,
+                    golden_passthroughs_with(fixture, &parser),
+                    "fold diverged for {fixture:?} with separator {separator:?}"
+                );
+            }
         }
     }
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -4,7 +4,7 @@ use super::{
     MacroMatch, MacroMatchKind, escaped_value_children,
     image::{
         range_has_no_opaque_piece, range_is_restorable, range_is_verbatim,
-        range_is_verbatim_or_synthesized,
+        range_is_verbatim_or_synthesized, restorable_body,
     },
     macro_text_children, rebuild_macro_level,
 };
@@ -20,7 +20,7 @@ use crate::{
         },
     },
     inlines::{InlineNode, Ref, RefVariant},
-    parser::has_dangerous_scheme,
+    parser::{InlineSubstitutionRenderer, has_dangerous_scheme},
     strings::CowStr,
 };
 
@@ -52,8 +52,9 @@ use crate::{
 ///   [`Styled`](crate::inlines::Styled) span, or any other construct
 ///   [`build_match_string`] stands in as one [`SPAN_PLACEHOLDER`]. A
 ///   **bracketed display text** crossing one is admitted (see below), and so is
-///   a masked **passthrough** anywhere in the target, whose own body the
-///   computed value is finished into (see "A passthrough in the target" below).
+///   a **masked** construct — a passthrough or a STEM expression — anywhere in
+///   the target, whose own body the computed value is finished into (see "A
+///   masked construct in the target" below).
 /// - A **bare URL whose stripped trailing punctuation is not its own**: the
 ///   strip keys off the target's final character (`;` or `:`, plus an adjacent
 ///   `)`), and a bare URL ending in an escaped special has an entity there
@@ -133,13 +134,14 @@ use crate::{
 ///   fires on the markup's own `=`, and the parse then keeps only what precedes
 ///   that comma.
 ///
-/// # A passthrough in the target
+/// # A masked construct in the target
 ///
-/// A masked **passthrough** — a [`Raw`](InlineNode::Raw) piece — is admitted
-/// in the target, the third and last family to take
-/// [`range_is_restorable`]: the string replacer swallows the
-/// `\u{96}`*n*`\u{97}` sentinel into its own target (both target classes
-/// admit it exactly as they admit the tree's placeholder, and the bare
+/// A **masked** construct — a passthrough's [`Raw`](InlineNode::Raw) piece or
+/// a STEM expression's [`Stem`](InlineNode::Stem) one, the pair
+/// [`restorable_body`] names — is admitted in the target, this being the
+/// third and last family to take [`range_is_restorable`]: the string replacer
+/// swallows the `\u{96}`*n*`\u{97}` sentinel into its own target (both target
+/// classes admit it exactly as they admit the tree's placeholder, and the bare
 /// branch's trailing-character class admits the last byte of either spelling,
 /// so the two recognize the same extent — this family needs no widening of
 /// its own, unlike the `image:`/`icon:` one), and
@@ -363,8 +365,9 @@ fn build_inline_link_node<'src>(
     // An expanded attribute value and an escaped special are admitted
     // throughout, since every value read here comes off the match string —
     // whose bytes are, for both, exactly the ones the string replacer's own
-    // haystack carries there. So is a masked **passthrough**, whose bytes the
-    // string replacer's own haystack does *not* carry: the target finishes
+    // haystack carries there. So is a **masked** construct — a passthrough or
+    // a STEM expression — whose bytes the string replacer's own haystack does
+    // *not* carry: the target finishes
     // into the restored ones below (see [`range_is_restorable`] and
     // [`restore_masked_passthroughs`]), while every decision made here —
     // the quoted-prefix rejection, the trailing-punctuation strip, the
@@ -463,15 +466,15 @@ fn build_inline_link_node<'src>(
         }
     }
 
-    // A target crossing a masked **passthrough** finishes into the restored
-    // bytes — the `Raw` node's value substituted for its placeholder, the
-    // same rewrite `Passthroughs::restore_to` performs on the emitted `href`
-    // — and only the node's values take them. Every *decision* the string
-    // replacer makes over the bytes as matched is already behind us (the
-    // quoted-prefix rejection and the trailing-punctuation strip above), each
-    // reading a placeholder exactly as the sentinel-holding haystack reads
-    // its own sentinel: neither spelling is a quote, and neither ends in the
-    // `;` or `:` the strip keys off.
+    // A target crossing a **masked** construct finishes into the restored
+    // bytes — the node's own rendered body ([`restorable_body`]) substituted
+    // for its placeholder, the same rewrite `Passthroughs::restore_to`
+    // performs on the emitted `href` — and only the node's values take them. Every
+    // *decision* the string replacer makes over the bytes as matched is already
+    // behind us (the quoted-prefix rejection and the trailing-punctuation strip
+    // above), each reading a placeholder exactly as the sentinel-holding
+    // haystack reads its own sentinel: neither spelling is a quote, and neither
+    // ends in the `;` or `:` the strip keys off.
     //
     // `target` is the match string's own bytes from the scheme through the
     // URL — one contiguous run, less whatever the strip truncated — so its
@@ -481,6 +484,7 @@ fn build_inline_link_node<'src>(
         &(scheme_m.start()..scheme_m.start() + target.len()),
         nodes,
         pieces,
+        parser.renderer.as_ref(),
     );
 
     let target = restored.unwrap_or(target);
@@ -574,9 +578,10 @@ fn build_inline_link_node<'src>(
         // `Text` would have the fold escape it a second time (design §3.4).
         // There is no `\]` unescape here — this text comes from the URL groups,
         // whose own character classes never admit a bracket. A URL crossing a
-        // masked **passthrough** takes that same structured path, carrying the
-        // [`Raw`](InlineNode::Raw) node itself — which folds to the very bytes
-        // the restore splices into the string pipeline's own shown text.
+        // **masked** construct takes that same structured path, carrying the
+        // [`Raw`](InlineNode::Raw) or [`Stem`](InlineNode::Stem) node itself —
+        // which folds to the very bytes the restore splices into the string
+        // pipeline's own shown text.
         //
         // The scheme-hiding offset indexes the match string even when
         // `target` is the restored value, because [`URI_SNIFF`] is
@@ -752,14 +757,20 @@ fn build_angle_link_node<'src>(
         url = angle_url.as_str()
     );
 
-    // As in the general path: a masked **passthrough** in the interior
+    // As in the general path: a **masked** construct in the interior
     // finishes into the restored bytes, which are what the string pipeline's
     // own `href` and shown text carry once `Passthroughs::restore_to` runs.
     // This form makes no decision off the bytes as matched at all — it has
     // neither a quoted-prefix rejection nor a trailing-punctuation strip —
     // and the interior *is* the target's own range, so the restore covers it
     // whole.
-    let restored = restore_masked_passthroughs(&masked_target, &interior, nodes, pieces);
+    let restored = restore_masked_passthroughs(
+        &masked_target,
+        &interior,
+        nodes,
+        pieces,
+        parser.renderer.as_ref(),
+    );
 
     let target = restored.unwrap_or(masked_target);
 
@@ -995,7 +1006,8 @@ fn find_link_macro_matches<'src>(
         // (group 3; group 2 is the empty-target alternative, which has no bytes
         // to gate), so only that range needs a match string whose bytes the
         // builder can finish into the string replacer's own — which for this
-        // family includes a masked **passthrough**, restored into the computed
+        // family includes a **masked** construct (a passthrough or a STEM
+        // expression), restored into the computed
         // target exactly as `Passthroughs::restore_to` rewrites the emitted
         // `href` (see [`range_is_restorable`] and
         // [`restore_masked_passthroughs`]). The bracketed **display text**
@@ -1050,28 +1062,34 @@ fn find_link_macro_matches<'src>(
     matches
 }
 
-/// Substitutes each masked **passthrough**'s own substituted body for its
+/// Substitutes each **masked** construct's own rendered body for its
 /// placeholder in `masked` — the match-string bytes at `range`, which is the
 /// same span in the level's match-string coordinates — returning `None` when
-/// the range holds no passthrough (so a caller keeps the bytes it already
-/// has).
+/// the range holds no masked construct (so a caller keeps the bytes it
+/// already has).
 ///
 /// This is [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own
 /// rewrite, applied to a *computed value* instead of the rendered string: the
 /// string pipeline's replacer reads the `\u{96}`*n*`\u{97}` sentinel into the
 /// value (a `link:` macro's target, and with it the emitted `href` and a bare
 /// macro's shown text), and the restore pass then splices the extracted
-/// body's substituted text over every sentinel in the rendered string. A
-/// [`Raw`](InlineNode::Raw) node's `value` **is** that substituted text
-/// (`build_passthrough_node` runs the body's own subs at build time), so
-/// substituting it for the placeholder here finishes the value into exactly
-/// the restored string's bytes. Every other byte is kept as matched, which is
-/// what restore does too — it rewrites the sentinels and nothing else.
+/// body's text over every sentinel in the rendered string.
+/// [`restorable_body`] is the build-time counterpart of that splice, for both
+/// kinds the one extraction pass masks: a
+/// [`Raw`](InlineNode::Raw) node's `value` **is** the substituted text
+/// (`build_passthrough_node` runs the body's own subs at build time), and a
+/// [`Stem`](InlineNode::Stem) node's is its fold — the same
+/// `render_quoted_substitution` call `PassthroughRestoreReplacer` makes for a
+/// STEM entry — so substituting either for the placeholder here finishes the
+/// value into exactly the restored string's bytes. Every other byte is kept
+/// as matched, which is what restore does too — it rewrites the sentinels and
+/// nothing else.
 pub(super) fn restore_masked_passthroughs(
     masked: &str,
     range: &std::ops::Range<usize>,
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
+    renderer: &dyn InlineSubstitutionRenderer,
 ) -> Option<String> {
     let mut out = String::new();
 
@@ -1088,11 +1106,14 @@ pub(super) fn restore_masked_passthroughs(
             continue;
         }
 
-        let Some(InlineNode::Raw { value, .. }) = nodes.get(piece.node_index) else {
+        let Some(value) = nodes
+            .get(piece.node_index)
+            .and_then(|node| restorable_body(node, renderer))
+        else {
             continue;
         };
 
-        // A `Raw` piece is one placeholder character, atomic and never
+        // A masked piece is one placeholder character, atomic and never
         // sliced, so an overlapping one lies wholly inside the range and
         // `p_start`/`p_end` are safe bounds.
         out.push_str(
@@ -1169,15 +1190,22 @@ pub(super) fn build_link_node<'src>(
     let is_mailto = caps.get(1).is_some();
     let target_str = caps.get(3).map_or("", |m| m.as_str());
 
-    // A target crossing a masked **passthrough** finishes into the restored
-    // bytes — the `Raw` node's value substituted for its placeholder, the same
-    // rewrite `Passthroughs::restore_to` performs on the emitted `href` — and
-    // only the node's computed values take them. Every *decision* the string
-    // replacer makes over the bytes as matched (the `URI_SNIFF` strip below)
-    // stays on `target_str`, whose placeholder the sentinel-holding haystack
-    // answers the same way.
+    // A target crossing a **masked** construct — a passthrough or a STEM
+    // expression — finishes into the restored bytes: the node's own rendered
+    // body substituted for its placeholder, the same rewrite
+    // `Passthroughs::restore_to` performs on the emitted `href`, and only the
+    // node's computed values take them. Every *decision* the string replacer
+    // makes over the bytes as matched (the `URI_SNIFF` strip below) stays on
+    // `target_str`, whose placeholder the sentinel-holding haystack answers
+    // the same way.
     let restored = caps.get(3).and_then(|m| {
-        restore_masked_passthroughs(m.as_str(), &(m.start()..m.end()), nodes, pieces)
+        restore_masked_passthroughs(
+            m.as_str(),
+            &(m.start()..m.end()),
+            nodes,
+            pieces,
+            parser.renderer.as_ref(),
+        )
     });
 
     let restored_target_str = restored.as_deref().unwrap_or(target_str);
@@ -2245,6 +2273,129 @@ mod tests {
     }
 
     #[test]
+    fn fold_matches_the_string_pipeline_for_a_link_macro_target_over_a_stem_expression() {
+        // The differential corpus for a `link:`/`mailto:` target crossing a
+        // masked **STEM** expression — the same restore-the-value move this
+        // family's passthrough corpus above pins, over the other node kind
+        // the one extraction pass masks. `INLINE_LINK_MACRO`'s `[^\s\[\]]+`
+        // target class swallows the sentinel and the placeholder alike, so
+        // recognition agrees with no widening, and the `URI_SNIFF` strip
+        // still runs over the bytes as matched.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let fixtures = [
+            // A bare macro (the target is also the shown text) and a labeled
+            // one, with the expression at either edge and in the middle.
+            "link:https://example.org/stem:[x + y][]",
+            "link:https://example.org/stem:[x][the docs]",
+            "link:stem:[a].example.org/x[]",
+            "link:https://example.org/stem:[a]stem:[b][]",
+            // The `mailto:` spelling, whose target the node prefixes.
+            "mailto:stem:[x]@example.org[Mail]",
+            // A display text beside a restored target: markup, a `^` window
+            // suffix, and a text that is itself a passthrough.
+            "link:https://example.org/stem:[x][Text with *bold*]",
+            "link:https://example.org/stem:[x][T^]",
+            "link:https://example.org/stem:[x][++b++]",
+            // The other notations and the explicit substitution list.
+            "link:https://example.org/latexmath:[\\sqrt{2}][]",
+            "link:https://example.org/asciimath:[a/b][]",
+            "link:https://example.org/stem:c,q[x*y*z][]",
+            // A `javascript:` scheme written *inside* an expression cannot
+            // smuggle a live link past either pipeline the way one inside a
+            // passthrough can (`a_dangerous_scheme_inside_a_passthrough_is_a_
+            // documented_divergence`): a STEM body is restored **wrapped** in
+            // its notation's delimiters, never spliced in bare, so the
+            // restored target is not a dangerous scheme in the first place.
+            "link:stem:[javascript:alert(1)][Click]",
+            "link:javascriptstem:[:alert(1)][Click]",
+            // Beside a passthrough, inside a rendered span, and two in one
+            // flow. (An *escaped* `\\link:…[…]` is left out deliberately: it
+            // diverges already, with or without a masked target — the string
+            // step emits `\\` followed by a rendered link — which is this
+            // family's own pre-existing escape behavior, not something a
+            // restored target reaches. The auto-link and image corpora, whose
+            // families do honor the escape, keep their escaped fixtures.)
+            "link:https://example.org/stem:[a]/++b++[]",
+            "*a link:https://example.org/stem:[x][t] b*",
+            "link:https://example.org/stem:[a][p] and link:https://example.org/stem:[b][q]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn registers_the_restored_target_for_a_link_over_a_stem_expression() {
+        // As for a passthrough target, the staged side effect registers the
+        // node's own — *restored* — target, for both the macro family and the
+        // auto-link one, where the string pipeline registers the sentinel it
+        // matched. The two come back in **family pass order**, not source
+        // order (see
+        // `registers_interleaved_forms_in_family_pass_order_not_source_order`),
+        // so the auto-link precedes the macro written before it.
+        let source = "link:https://example.org/stem:[x][] and https://example.org/stem:[y]";
+        let parser = Parser::default().with_catalog_assets(true);
+        let nodes = build_with(Span::new(source), &parser);
+
+        apply_link_side_effects(&nodes, &parser);
+
+        assert_eq!(
+            parser.catalog().links(),
+            ["https://example.org/\\$y\\$", "https://example.org/\\$x\\$"]
+        );
+    }
+
+    #[test]
+    fn a_real_documents_stem_link_targets_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path: a `link:`/`mailto:`,
+        // auto-link, formal-URL, or angle-bracketed target crossing a STEM
+        // expression must finish into the restored bytes the rendered string
+        // carries — the `href` and a bare link's shown text alike.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "Read link:https://example.org/stem:[x_i][the paper] today.\n",
+            "\n",
+            "See https://example.org/stem:[a/b] or <https://example.org/latexmath:[\\alpha]>.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
+    }
+
+    #[test]
     fn registers_the_restored_target_for_a_link_macro_over_a_passthrough() {
         // The staged side effect registers the node's own target — the
         // *restored* bytes. The string pipeline registers the sentinel it
@@ -3021,32 +3172,124 @@ mod tests {
     }
 
     #[test]
-    fn a_stem_expression_in_an_auto_link_target_is_a_documented_divergence() {
-        // The gate admits a masked **passthrough** and nothing else opaque —
-        // a rendered span keeps its own boundary
-        // (`a_formal_url_target_over_a_rendered_span_is_a_documented_divergence`),
-        // and so does a **STEM** expression, which the same extraction pass
-        // masks but which builds a [`Stem`](InlineNode::Stem) node rather
-        // than a [`Raw`](InlineNode::Raw) one: its rendered value is known at
-        // build time too, so a restore *could* reach it, but that is the STEM
-        // step's own increment to make across all three families at once —
-        // the `link:`/`mailto:` family left the identical shape
-        // (`link:https://example.org/stem:[x + y][]`) literal. The string
-        // pipeline swallows the sentinel into the URL and restores it.
+    fn fold_matches_the_string_pipeline_for_an_auto_link_target_over_a_stem_expression() {
+        // The differential corpus for an auto-link / formal-URL target
+        // crossing a masked **STEM** expression. The gate now admits both
+        // node kinds the one extraction pass masks — a passthrough's
+        // [`Raw`](InlineNode::Raw) and a STEM expression's
+        // [`Stem`](InlineNode::Stem) — because each has a body known at build
+        // time ([`restorable_body`]); a rendered span, whose bytes exist only
+        // at fold time, still keeps its own boundary
+        // (`a_formal_url_target_over_a_rendered_span_is_a_documented_divergence`).
+        //
+        // Recognition needs no widening here for the same reason the
+        // passthrough increment found: [`INLINE_LINK`]'s three URL classes
+        // admit the sentinel and the one-character placeholder alike, and
+        // both pre-restore decisions — rejecting a quoted URL, stripping a
+        // bare one's trailing punctuation — read a placeholder exactly as the
+        // sentinel-holding haystack reads its own sentinel.
         use super::super::super::test_support::golden_passthroughs;
 
-        let source = "https://example.org/stem:[x + y]";
+        let fixtures = [
+            // The expression as one piece of a target, at either edge and in
+            // the middle, and two in one target.
+            "https://example.org/stem:[x + y]",
+            "https://stem:[a].example.org/x",
+            "https://example.org/stem:[a]stem:[b]",
+            "https://example.org/stem:[x]#frag",
+            // The trailing-punctuation strip keys off the target's final
+            // character in both pipelines — a placeholder is no more a `;`
+            // or a `.` than the sentinel is.
+            "https://example.org/stem:[x],",
+            "(https://example.org/stem:[x])",
+            "See https://example.org/stem:[x]. Then.",
+            "see https://example.org/stem:[x]; now",
+            // The angle-bracketed spellings: `<url>`, whose delimiters the
+            // node consumes, and the bracketed one that keeps its `&lt;`.
+            "<https://example.org/stem:[x]>",
+            "<https://example.org/stem:[x][Docs]",
+            // A display text beside a restored target: markup carried
+            // structurally, an attribute list parsed from the verbatim
+            // bracket, a `^` window suffix, and a text that is a passthrough.
+            "https://example.org/stem:[x][the docs]",
+            "https://example.org/stem:[x][Text with *bold*]",
+            "https://example.org/stem:[x][T,role=hl]",
+            "https://example.org/stem:[x][T^]",
+            "https://example.org/stem:[x][++b++]",
+            // The other notations, the explicit substitution list, and the
+            // other schemes the pattern admits.
+            "https://example.org/latexmath:[\\sqrt{2}]",
+            "https://example.org/asciimath:[a/b]",
+            "https://example.org/stem:c,q[x*y*z]",
+            "ftp://example.org/stem:[x]",
+            // Beside a passthrough, in either order — the two masked kinds
+            // restore through the same index-free left-to-right walk.
+            "https://example.org/stem:[a]/++b++",
+            "https://example.org/++a++/stem:[b]",
+            // Inside a rendered span, escaped, and two in one flow.
+            "*a https://example.org/stem:[x] b*",
+            "\\https://example.org/stem:[x]",
+            "a stem:[x] and https://example.org/stem:[y] and stem:[z]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_auto_link_target_over_a_stem_expression_is_recognized() {
+        // The computed target is the restored bytes — the expression's
+        // *rendered* form, which is what the string pipeline's `href`
+        // carries once `Passthroughs::restore_to` runs — while the bare
+        // link's shown text keeps the [`Stem`](InlineNode::Stem) node itself
+        // as a child, so the fold emits those same bytes without re-escaping
+        // them (design §3.4), exactly as a bare macro's `Raw` child does.
+        let nodes = build_src(Span::new("https://example.org/stem:[x + y]"));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "https://example.org/\\$x + y\\$");
+
+        assert!(
+            reference
+                .children
+                .iter()
+                .any(|c| matches!(c, InlineNode::Stem(_))),
+            "the shown text should carry the Stem node itself: {:?}",
+            reference.children
+        );
+    }
+
+    #[test]
+    fn an_auto_link_attribute_list_text_over_a_stem_expression_is_a_documented_divergence() {
+        // A display text that also carries an attribute list comes back from
+        // a *parse*, so it keeps the opaque-piece gate inside [`text_attrlist`]
+        // for a STEM expression exactly as it does for a passthrough
+        // (`an_auto_link_attribute_list_text_over_a_passthrough_is_a_documented_divergence`):
+        // a placeholder inside a parsed value has no node to map back to.
+        // This is the "bracket half" the restore class still defers.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "https://example.org/x[stem:[a],role=hl]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a target crossing a STEM expression must stay literal: {nodes:?}"
+            "an attribute-list text over a STEM expression must stay literal: {nodes:?}"
         );
 
         let golden = golden_passthroughs(source);
 
         assert!(
-            golden.contains("<a href="),
+            golden.contains("class=\"hl\""),
             "expected the documented divergence to still reproduce: {golden:?}"
         );
     }


### PR DESCRIPTION
The lift the three restore-the-value increments (#1222, #1223, #1224) each deferred to "the STEM step's own increment, across all three families at once" — made in one place rather than three, for the **two link families**. The `image:`/`icon:` family turns out to have a blocker of its own and is deliberately left out; see below.

## The problem

A STEM expression is an *implicit* passthrough: `Passthroughs::extract_from` masks it in the very same pass, before any substitution step runs. So it stands in the string pipeline's haystack as the same `\u{96}`*n*`\u{97}` sentinel, and in this module's match string as the same one-character placeholder, that a passthrough does.

What kept it out of the restore class was only that the machinery reached into a `Raw` node's `value` **by name**, while a masked STEM builds a `Stem` node.

## The change

A **pair of shared helpers** rather than a widened `matches!` at each site:

- `node_is_restorable(node, kinds)` — the cheap discriminant the gates use, so a range about to be *rejected* costs no rendering.
- `restorable_body(node, renderer)` — the bytes the restores splice.

The invariant they rest on is that a restored body is **exactly what the fold of that node emits**:

- a `Raw` leaf's body is its `value`, which the fold emits verbatim (so it is borrowed, not rendered);
- a `Stem` leaf's body is `fold_stem`'s own output — the same `render_quoted_substitution` call, over the already-substituted `value` with no attribute list or id, that `PassthroughRestoreReplacer` makes for a STEM entry.

Reusing that one function is what keeps the restore and the fold from drifting; a unit test pins the two helpers to the same set.

`range_is_restorable` now takes the kinds its caller admits (`Restorable`), and `restore_masked_passthroughs` handles both. Recognition needs no widening — both link families' target classes swallow the one-character placeholder as they swallow the sentinel — and every pre-restore decision keeps reading the bytes as matched.

## Why `image:`/`icon:` is left out

Its target is the only one re-processed by `PathResolver::web_path` at fold time, and `web_path` **posixifies the platform separator** (`\` → `/` on a Windows-separator resolver). The string pipeline never meets this: its `web_path` runs over the backslash-free *sentinel*, and the restore splices the body into the finished `src` afterwards.

For a passthrough that is an exotic body — the earlier increment pinned exactly one such case, a restored *space* the fold percent-encodes. For STEM it is **every** body: a rendered expression always carries a backslash (`\$…\$`, `\(…\)`), so `image:stem:[x].png[]` rendered `src="/$x/$.png"` on Windows against the golden's `src="\$x\$.png"`.

Deferring keeps this family's `src` identical on every platform, where restoring would make it differ by one. Its own code (`widen_masked_passthroughs`, `masked_default_alt`) is **untouched** by this increment.

Two tests pin the deferral, both of which fail if the image gate is widened again: one that the target stays literal, one that its fold is byte-identical under either separator. A third does the same for the two link families — folding each restored STEM target under both separators and comparing to the golden — so this class of difference shows up on a Posix runner instead of only on Windows CI.

## One way this runs *safer* than the passthrough class

A STEM body cannot smuggle a dangerous scheme. `link:++javascript:…++[]` defers with a security divergence test because a passthrough's body is restored **bare**, so the string replacer's masked check misses a live scheme. A STEM body is restored **wrapped** in its notation's delimiters (`\$javascript:alert(1)\$`), which is not a scheme in either pipeline — so `link:stem:[javascript:alert(1)][]` reaches plain parity, with no divergence to pin.

## What reaches parity

Every spelling the two link families have: the `link:`/`mailto:` macro (bare and labeled; the expression at either edge, in the middle, and twice in one target), auto-links, formal-URL links, and the two angle-bracketed forms — with all three notations, an explicit substitution list (`stem:c,q[…]`), the `hide-uri-scheme` strip, the trailing-punctuation strip in both directions, a display text beside a restored target, a STEM beside a passthrough in either order, **both path separators**, and the whole set inside a rendered span, escaped, and end to end through the real parse path.

## What still defers

- The **bracket half** — restoring inside each *parsed* attribute-list value (an image's bracket, the three families' attribute-list display texts), where the string pipeline's own parse swallows the sentinel into a value that only restores after the split.
- The **image family's STEM target**, blocked on the fold-time `web_path` seam above — closing it means keeping the restore out of `web_path`'s way, not widening a gate.
- The keeps: the cross-reference family's pre-restore target, and the well-formed readings these increments pinned.

## Verification

- `cargo test --workspace` — 5333 passed, 0 failed.
- **Corpus-wide fold-parity audit** (tree building forced on for every parse, run on this branch and on `origin/inline-ast`): divergence set **unchanged** — 0 new divergences.
- **Coverage** — diff-neutral: missed regions/lines identical to `origin/inline-ast` for every changed file (`fold.rs` 3/3, `image.rs` 4/1, `links.rs` 17/8; total 562/316 on both).
- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, and `cargo +nightly doc --no-deps --document-private-items` all clean.

As with every prep piece before it, nothing further is wired in.