### PR TITLE
feat: Restore a masked passthrough inside an image's parsed bracket (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4445,6 +4445,88 @@ Each phase is a reviewable unit with a clear exit gate.
   target (whose golden leaks the raw sentinel into its own `href`), and the well-formed readings
   these four increments pinned.
 
+  *Step 6 prep landed as (a masked passthrough inside an image's **parsed bracket** — the bracket
+  half's first family):* the four increments above closed the restore-the-value class for every
+  family that *computes* a target off the match string. What each of them deferred, in the same
+  words, was the **bracket half**: restoring inside a value that comes back from a **parse**, where
+  "the string pipeline's own parse swallows the sentinel into a value that only restores after the
+  split". This takes the first of that half's four captures, the `image:`/`icon:` bracket, by
+  reproducing exactly that order.
+
+  The order is the whole point, and it is what a restore-then-parse cannot reproduce.
+  [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs) reads the `\u{96}`*n*`\u{97}`
+  sentinel as one opaque run carrying none of the `,`/`=`/`"` bytes the split reads, so
+  `image:x.png[++a,b++]` is **one** positional whose value is `a,b` — restoring first would divide
+  it into two. So the bracket is put into that same shape before the parse and restored after it:
+  [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) rewrites each masked
+  piece in the bracket's match-string bytes to an index-keyed token (normalizing two spellings into
+  one — [`widen_masked_passthroughs`](../../parser/src/content/inline_builder/macros/image.rs) has
+  already widened a `Raw` piece for *recognition*, but numbered per level), and a new
+  [`Attrlist::into_owned_restoring`](../../parser/src/attributes/attrlist.rs) — the restoring
+  sibling of the [`into_owned`](../../parser/src/attributes/attrlist.rs) the first attribute-list
+  increment added — splices each body into the parsed values on the way out. Restoration is
+  index-keyed, as [`Passthroughs::restore_to`](../../parser/src/content/passthroughs.rs) is, so a
+  token the split discarded does not shift the ones that survive.
+
+  One thing had to be *shifted* rather than recomputed. An
+  [`ElementAttribute`](../../parser/src/attributes/element_attribute.rs)'s
+  `shorthand_item_indices` are byte offsets into its own `value`, and a restore that lengthens the
+  value ahead of them would leave them pointing mid-word — so
+  [`into_owned_restoring`](../../parser/src/attributes/element_attribute.rs) moves each offset past
+  every substitution that ends at or before it. Shifting is the faithful move and re-deriving is
+  not: a token holds none of the `#`/`.`/`%` delimiters the shorthand scan keys off, so the items
+  the string pipeline found over its sentinel are the same items, only further along
+  (`image:x.png[++abc++.myrole]` keeps the `myrole` role while its `alt` becomes `abc.myrole`),
+  where a re-derivation would find a delimiter *inside* a restored body that the string pipeline
+  never sees. The no-token path keeps the plain `CowStr::into_owned` conversion, so nothing that
+  does not carry a token pays for this.
+
+  The family's gate simply becomes the one its target already uses —
+  [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs) with
+  [`Restorable::Passthrough`](../../parser/src/content/inline_builder/macros/image.rs) — in place
+  of [`range_has_no_opaque_piece`](../../parser/src/content/inline_builder/macros/image.rs), so
+  target and bracket now admit exactly the same kinds. Recognition needed no widening for the
+  bracket: `INLINE_IMAGE_MACRO`'s bracket class swallows either spelling. `alt`, `width`, and
+  `height` are read off the attribute list, so they follow with no code of their own.
+
+  A masked **STEM** expression is deliberately still deferred here, for the reason the target's own
+  increment gave and one more site: the bracket has a `web_path`-bound value of its own — an
+  interactive SVG's `fallback=`, run through `image_src` — and every rendered STEM body carries a
+  backslash `web_path` would posixify on a Windows-separator resolver. Keeping both halves of this
+  family on `Restorable::Passthrough` keeps its `src` identical on every platform, and leaves the
+  family's STEM story exactly one item rather than two.
+
+  What reaches parity is the whole bracket vocabulary over a passthrough: the plain and partial
+  alt, several tokens in one bracket, the split invariant in all three spellings (a body carrying a
+  `,`, an `=`, or sitting inside a quoted value), named values (`title=`, `role=`), the positional
+  width/height slots, both shorthand items after a token, a restored `&` (which
+  `encode_attribute_value` passes through in both pipelines), the `pass:[…]` and triple-plus
+  spellings, an attribute reference hidden inside the body (which neither pipeline expands, both
+  parsing the masked text), target and bracket both masked, the icon form, and the whole set inside
+  a rendered span, twice in one flow, and escaped. Re-running the corpus-wide fold-parity audit
+  shows the divergence set strictly **shrank** — a real golden source is gone
+  (`image:pause.png[title=Pause pass:p[{abc +\ndef}] Resume]`) and no new divergence appeared.
+  Coverage stays diff-neutral, and as with every prep piece before it, nothing further is wired in.
+
+  Three shapes are left where they were, each pinned. As in the target's own increment, one of them
+  runs the **safe** way rather than the byte-parity way: the renderer's dangerous-scheme check reads
+  the `link=` attribute, which now carries the *restored* bytes, so
+  `image:x.png[Alt,link=++javascript:alert(1)++]` renders without its anchor where the string
+  pipeline checked the sentinel its own parse put there, passed it, and let the restore complete a
+  live link. A restored `"` is escaped by the fold's
+  `encode_attribute_value` where the string pipeline encoded its quote-free sentinel and spliced
+  the raw quote into the finished `alt="…"`, closing the attribute — the tree's is the well-formed
+  reading, and the same one the two link families' restores already take for a target. And an
+  author's own sentinel-shaped bytes survive the tree's restore where the string pipeline's
+  `replace_all` over the *finished* string rewrites them too — its own wart, and the reading the
+  sibling target test already pins.
+
+  What still defers of the bracket half is its other three captures — the `link:`/`mailto:` and
+  auto-link families' attribute-list display texts, which keep the opaque-piece gate inside
+  [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs) — plus the image
+  family's STEM target and bracket, and the keeps: the cross-reference family's pre-restore target,
+  and the well-formed readings these five increments pinned.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5144,6 +5226,27 @@ Each phase is a reviewable unit with a clear exit gate.
        pinned by a literal-stays test and a both-separators fold test. The attribute-list display
        texts keep the opaque-piece gate. See the step's own "landed as" note above. The bracket
        half and the image family's own STEM target are what remain of the class.
+
+     - ✅ **prep (a masked passthrough inside an image's parsed bracket).** The first of the
+       **bracket half**'s four captures — the half every restore-the-value increment above deferred
+       in the same words, where the value comes back from a *parse* rather than being computed off
+       the match string. Reproducing the string pipeline means reproducing its *order*:
+       [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs) reads the sentinel as one
+       opaque run carrying none of the `,`/`=`/`"` bytes the split reads, so
+       [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) puts the
+       bracket into that shape before the parse and a new
+       [`Attrlist::into_owned_restoring`](../../parser/src/attributes/attrlist.rs) splices each
+       body into the parsed values after it — index-keyed, so a discarded token shifts nothing.
+       An [`ElementAttribute`](../../parser/src/attributes/element_attribute.rs)'s shorthand
+       offsets are *shifted* past each substitution rather than re-derived, since a token holds
+       none of the delimiters the scan keys off. The gate becomes the target's own
+       [`range_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs)/[`Restorable::Passthrough`](../../parser/src/content/inline_builder/macros/image.rs)
+       pair, so both halves of the family admit the same kinds; a masked **STEM** stays deferred
+       here too, the bracket having a `web_path`-bound value of its own (an interactive SVG's
+       `fallback=`). A restored `"` and an author's own sentinel-shaped bytes each defer with their
+       own test. See the step's own "landed as" note above. The bracket half's other three
+       captures — the three families' attribute-list display texts — and the image family's STEM
+       are what remain of the class.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -1,6 +1,9 @@
 use crate::{
     HasSpan, Parser, Span,
-    attributes::{ElementAttribute, element_attribute::ParseShorthand},
+    attributes::{
+        ElementAttribute,
+        element_attribute::{ParseShorthand, restore_into},
+    },
     content::{Content, SubstitutionStep},
     internal::{debug::DebugSliceReference, opaque_iter::opaque_slice_iter},
     span::MatchedItem,
@@ -72,6 +75,44 @@ impl<'src> Attrlist<'src> {
             anchor: self.anchor.map(CowStr::into_owned),
             source,
             source_text: Some(CowStr::from(self.source.data().to_string())),
+        }
+    }
+
+    /// [`into_owned`](Self::into_owned), first substituting each
+    /// `\u{96}`*n*`\u{97}` **token** in every parsed value — and in the
+    /// anchor and the retained
+    /// [`source_text`](Self::source_text) — with `bodies[n]`.
+    ///
+    /// This is how a caller restores a masked construct that its attribute
+    /// list text still holds. The restore has to happen **after** the parse,
+    /// not before it: the string pipeline parses its own haystack with the
+    /// passthrough sentinel still in place, so the body's own bytes never
+    /// reach the split that divides the list into entries, names, and values.
+    /// See [`ElementAttribute::into_owned_restoring`] for the per-attribute
+    /// half, including what it does to the shorthand offsets.
+    pub(crate) fn into_owned_restoring<'dst>(
+        self,
+        source: Span<'dst>,
+        bodies: &[&str],
+    ) -> Attrlist<'dst> {
+        Attrlist {
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(|attribute| attribute.into_owned_restoring(bodies))
+                .collect(),
+            // The anchor takes the plain conversion rather than a restoring
+            // one. An anchor is only ever set for the `[…]`-delimited whole
+            // -bracket form, and no restoring caller can present one: each
+            // parses a macro's bracket capture, whose own pattern ends the
+            // match at the first `]`, so `[x]` never arrives here intact.
+            anchor: self.anchor.map(CowStr::into_owned),
+            source,
+            source_text: Some(restore_into(
+                CowStr::from(self.source.data()),
+                bodies,
+                &mut [],
+            )),
         }
     }
 

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -82,6 +82,49 @@ impl<'src> ElementAttribute<'src> {
         }
     }
 
+    /// [`into_owned`](Self::into_owned), first substituting each
+    /// `\u{96}`*n*`\u{97}` **token** in this attribute's name and value with
+    /// `bodies[n]`.
+    ///
+    /// This is the *after the split* half of restoring a masked construct
+    /// inside a parsed attribute list. A caller that parses an attribute list
+    /// whose text still holds a masked passthrough cannot restore the body
+    /// first: the string pipeline's own
+    /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) reads the
+    /// sentinel — an opaque token carrying none of the `,`/`=`/`"` bytes the
+    /// split reads — so a body holding one of those characters must not
+    /// influence how the list divides (`image:x.png[++a,b++]` is one
+    /// positional whose value is `a,b`, not two). Restoring per *parsed value*
+    /// reproduces that, exactly as
+    /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices each
+    /// body over whatever sentinel reached the rendered string.
+    ///
+    /// [`shorthand_item_indices`](Self::shorthand_item_indices) are byte
+    /// offsets into `value`, so each is **shifted** past every substitution
+    /// that ends at or before it — a token is one opaque run holding none of
+    /// the `#`/`.`/`%` delimiters the shorthand scan keys off, so the items it
+    /// found stay the same items, only further along
+    /// (`image:x.png[++abc++.myrole]` keeps the `myrole` role while its value
+    /// becomes `abc.myrole`). Re-deriving them over the restored text would
+    /// instead find a delimiter *inside* a body, which the string pipeline
+    /// never sees.
+    ///
+    /// Substitution is **index-keyed**, as `restore_to` is, so a token whose
+    /// index the caller did not supply is left as written rather than
+    /// renumbering the ones that follow.
+    pub(crate) fn into_owned_restoring<'dst>(self, bodies: &[&str]) -> ElementAttribute<'dst> {
+        let mut shorthand_item_indices = self.shorthand_item_indices;
+
+        ElementAttribute {
+            name: self.name.map(|name| restore_into(name, bodies, &mut [])),
+            value: restore_into(self.value, bodies, &mut shorthand_item_indices),
+            shorthand_item_indices,
+            positional_index: self.positional_index,
+            value_is_quoted: self.value_is_quoted,
+            value_is_substituted: self.value_is_substituted,
+        }
+    }
+
     pub(crate) fn parse(
         source_text: &CowStr<'src>,
         start_index: usize,
@@ -703,6 +746,106 @@ fn parse_shorthand_items(source: &str, warnings: &mut Vec<WarningType>) -> Vec<u
 
 fn is_shorthand_delimiter(c: char) -> bool {
     c == '#' || c == '%' || c == '.'
+}
+
+/// Substitutes each `\u{96}`*n*`\u{97}` token in `text` with `bodies[n]`,
+/// shifting every offset in `indices` past the substitutions that end at or
+/// before it.
+///
+/// The token spelling is the string pipeline's own passthrough sentinel (see
+/// [`Passthroughs`](crate::content::Passthroughs)), which is what makes this
+/// the faithful restore: a caller hands over the very text
+/// `Attrlist::parse` would have seen there, and each body lands where
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices it.
+///
+/// A run that is not a well-formed token, or whose index `bodies` does not
+/// supply, is copied through verbatim — the same index-keyed leniency
+/// `restore_to` has, so an unsupplied index never renumbers the tokens after
+/// it. See [`ElementAttribute::into_owned_restoring`] for why the shift is
+/// right where a re-derivation would not be.
+/// [`restore_tokens`] over a [`CowStr`], keeping the plain
+/// [`into_owned`](CowStr::into_owned) conversion — and with it the inline
+/// representation a short string prefers — for the overwhelmingly common text
+/// that holds no token at all.
+pub(super) fn restore_into<'dst>(
+    text: CowStr<'_>,
+    bodies: &[&str],
+    indices: &mut [usize],
+) -> CowStr<'dst> {
+    if bodies.is_empty() || !text.contains('\u{96}') {
+        return text.into_owned();
+    }
+
+    CowStr::from(restore_tokens(text.as_ref(), bodies, indices))
+}
+
+fn restore_tokens(text: &str, bodies: &[&str], indices: &mut [usize]) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+
+    // `(offset just past a substituted token, cumulative delta)`, in the
+    // *original* text's coordinates and in increasing order.
+    let mut shifts: Vec<(usize, isize)> = vec![];
+    let mut delta: isize = 0;
+
+    while let Some(rel) = text.get(cursor..).and_then(|rest| rest.find('\u{96}')) {
+        let start = cursor.saturating_add(rel);
+        let digits_start = start.saturating_add('\u{96}'.len_utf8());
+
+        let digits = text
+            .get(digits_start..)
+            .map(|rest| {
+                let len = rest
+                    .find(|c: char| !c.is_ascii_digit())
+                    .unwrap_or(rest.len());
+
+                rest.get(..len).unwrap_or_default()
+            })
+            .unwrap_or_default();
+
+        let digits_end = digits_start.saturating_add(digits.len());
+        let end = digits_end.saturating_add('\u{97}'.len_utf8());
+
+        let body = if digits.is_empty() || text.get(digits_end..end) != Some("\u{97}") {
+            None
+        } else {
+            digits.parse::<usize>().ok().and_then(|n| bodies.get(n))
+        };
+
+        let Some(body) = body else {
+            // Not a token this caller supplied: copy the `\u{96}` through and
+            // resume scanning after it, so a later token in the same text is
+            // still found.
+            let next = start.saturating_add('\u{96}'.len_utf8());
+            out.push_str(text.get(cursor..next).unwrap_or_default());
+            cursor = next;
+            continue;
+        };
+
+        out.push_str(text.get(cursor..start).unwrap_or_default());
+        out.push_str(body);
+
+        delta = delta
+            .saturating_add(isize::try_from(body.len()).unwrap_or(isize::MAX))
+            .saturating_sub(isize::try_from(end.saturating_sub(start)).unwrap_or(isize::MAX));
+
+        shifts.push((end, delta));
+        cursor = end;
+    }
+
+    out.push_str(text.get(cursor..).unwrap_or_default());
+
+    for index in indices.iter_mut() {
+        // A token holds none of the `#`/`.`/`%` delimiters the shorthand scan
+        // keys off, so no offset ever falls *inside* one: each is either
+        // before every substitution or after some, and takes that one's
+        // cumulative delta.
+        if let Some((_, delta)) = shifts.iter().rev().find(|(end, _)| *end <= *index) {
+            *index = index.saturating_add_signed(*delta);
+        }
+    }
+
+    out
 }
 
 #[derive(Clone, Debug)]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -126,7 +126,7 @@ fn find_image_matches<'src>(
             .get(2)
             .map_or(full.end..full.end, |m| m.start()..m.end());
 
-        if !range_has_no_opaque_piece(nodes, pieces, &bracket) {
+        if !range_is_restorable(nodes, pieces, &bracket, Restorable::Passthrough) {
             continue;
         }
 
@@ -561,7 +561,7 @@ fn build_image_node<'src>(
         (m.as_str(), m.start()..m.end())
     });
 
-    let attrlist = bracket_attrlist(bracket_text, bracket_range, pieces, root, parser);
+    let attrlist = bracket_attrlist(bracket_text, bracket_range, nodes, pieces, root, parser);
 
     // The default alt text derives from the target's basename, with `_`/`-`
     // read as spaces — exactly the string replacer's `default_alt`, which
@@ -818,6 +818,7 @@ fn masked_default_alt(
 fn bracket_attrlist<'src>(
     bracket_text: &str,
     bracket_range: std::ops::Range<usize>,
+    nodes: &[InlineNode<'_>],
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
@@ -834,7 +835,108 @@ fn bracket_attrlist<'src>(
         return parse_attrlist(bracket, parser);
     }
 
-    parse_attrlist(Span::new(bracket_text), parser).into_owned(bracket)
+    let (tokened, bodies) = tokened_bracket(
+        bracket_text,
+        &bracket_range,
+        nodes,
+        pieces,
+        parser.renderer.as_ref(),
+    );
+
+    let bodies: Vec<&str> = bodies.iter().map(Cow::as_ref).collect();
+
+    parse_attrlist(Span::new(&tokened), parser).into_owned_restoring(bracket, &bodies)
+}
+
+/// Rewrites the bracket's own match-string bytes so each masked
+/// **passthrough** in it becomes an index-keyed `\u{96}`*n*`\u{97}` token,
+/// returning that text alongside the bodies those tokens restore to.
+///
+/// This is the *before the split* half of the bracket restore, and it exists
+/// so the text handed to [`Attrlist::parse`] is the same **shape** the string
+/// pipeline's own haystack has there. Two spellings have to be normalized into
+/// one: [`widen_masked_passthroughs`] has already rewritten a
+/// [`Raw`](InlineNode::Raw) piece to a sentinel-shaped token for this family's
+/// *recognition*, but its numbering is per level, and any other masked piece
+/// is still the bare one-character [`SPAN_PLACEHOLDER`](super::super::quotes).
+/// Renumbering every restorable piece from zero, per bracket, is what lets the
+/// restore be **index-keyed** on the way back out
+/// ([`Attrlist::into_owned_restoring`]) — the parse can drop a token
+/// (a blank slot, a value the split discards) without shifting the ones that
+/// survive, exactly as
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) is unshifted by
+/// a sentinel that never reached the rendered string.
+///
+/// Only the kinds [`Restorable::Passthrough`] names are tokened, which is the
+/// same set this family's own gate admits: a masked **STEM** expression is
+/// deferred here as it is in the target, and for the same reason — see
+/// [`Restorable`], and
+/// `an_image_bracket_over_a_stem_expression_is_a_documented_divergence`.
+fn tokened_bracket<'a>(
+    bracket_text: &str,
+    range: &std::ops::Range<usize>,
+    nodes: &'a [InlineNode<'_>],
+    pieces: &[Piece],
+    renderer: &dyn InlineSubstitutionRenderer,
+) -> (String, Vec<Cow<'a, str>>) {
+    let mut tokened = String::new();
+    let mut bodies: Vec<Cow<'a, str>> = Vec::new();
+
+    // In match-string coordinates; `bracket_text` is indexed relative to
+    // `range.start`.
+    let mut cursor = range.start;
+
+    for piece in pieces {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the range.
+        if p_end <= range.start || p_start >= range.end {
+            continue;
+        }
+
+        if !piece.atomic {
+            continue;
+        }
+
+        // The kinds gate and the body are one step: `restorable_body`
+        // answers `Some` for exactly the nodes `node_is_restorable` admits
+        // (pinned by `restorable_body_agrees_with_node_is_restorable`), so
+        // splitting them would leave a branch no input can take. A piece this
+        // skips is an atomic one the *gate* admitted for another reason — a
+        // `CharRef` leaf the match string gives real bytes to.
+        let Some(body) = nodes
+            .get(piece.node_index)
+            .filter(|node| node_is_restorable(node, Restorable::Passthrough))
+            .and_then(|node| restorable_body(node, renderer))
+        else {
+            continue;
+        };
+
+        // A masked piece is atomic and never sliced, so an overlapping one
+        // lies wholly inside the range and `p_start`/`p_end` are safe bounds.
+        tokened.push_str(
+            bracket_text
+                .get(cursor.saturating_sub(range.start)..p_start.saturating_sub(range.start))
+                .unwrap_or_default(),
+        );
+
+        tokened.push_str(&format!("\u{96}{n}\u{97}", n = bodies.len()));
+        bodies.push(body);
+        cursor = p_end;
+    }
+
+    if bodies.is_empty() {
+        return (bracket_text.to_string(), bodies);
+    }
+
+    tokened.push_str(
+        bracket_text
+            .get(cursor.saturating_sub(range.start)..)
+            .unwrap_or_default(),
+    );
+
+    (tokened, bodies)
 }
 
 /// Parses one inline attribute list, discarding the warnings — the shared
@@ -1715,32 +1817,260 @@ mod tests {
     }
 
     #[test]
-    fn an_image_bracket_over_a_passthrough_is_a_documented_divergence() {
-        // The **bracket** keeps the opaque-piece gate: it comes back from a
-        // *parse* (`bracket_attrlist` reads its bytes as content), and the
-        // string pipeline's own parse swallows the sentinel into a value
-        // that only restores after the split — a body carrying a `,` or `=`
-        // therefore stays one attribute there, which a restore-then-parse
-        // could not reproduce. Restoring inside each parsed value is a later
-        // increment's own call.
+    fn fold_matches_the_string_pipeline_for_an_image_bracket_over_a_passthrough() {
+        // The differential corpus for an `image:`/`icon:` **bracket**
+        // crossing a masked passthrough. The bracket comes back from a
+        // *parse*, so the restore is the one the string pipeline performs:
+        // `Attrlist::parse` reads the `\u{96}`*n*`\u{97}` sentinel as one
+        // opaque run — carrying none of the `,`/`=`/`"` bytes the split
+        // reads — and the restore pass splices each body over whatever
+        // sentinel reached the rendered string. `tokened_bracket` puts the
+        // match string into that same shape and
+        // `Attrlist::into_owned_restoring` performs the after-the-split
+        // half.
         use super::super::super::test_support::golden_passthroughs;
 
-        let source = "image:sunset.jpg[++Alt text++]";
+        let fixtures = [
+            // The plain alt, whole and partial, and a body whose own
+            // formatting characters stay literal inside the passthrough.
+            "image:sunset.jpg[++Alt text++]",
+            "image:x.png[a ++b_c__d++ e]",
+            "image:x.png[++a++ and ++b++]",
+            // The split invariant: a `,` or an `=` inside the body must not
+            // divide the list, because the string pipeline's own parse never
+            // sees it. These are the fixtures a restore-*then*-parse fails.
+            "image:x.png[++a,b++]",
+            "image:x.png[++a=b++]",
+            r#"image:x.png["++q,r++"]"#,
+            // Named values, and the positional width/height slots.
+            "image:x.png[title=++t_t__t++]",
+            "image:x.png[Sunset,role=++hl++]",
+            "image:x.png[alt,++100++,50]",
+            "image:x.png[++a++,++200++]",
+            // Shorthand: the `#id`/`.role` the scan finds sit *after* a
+            // token, so their offsets have to shift with the restore while
+            // the items themselves stay the ones the string pipeline found.
+            "image:x.png[++abc++#myid]",
+            "image:x.png[++abc++.myrole]",
+            "image:x.png[++a b++.myrole#myid]",
+            // A restored `&` passes through `encode_attribute_value`
+            // untouched in both pipelines (only `"` is encoded — see the
+            // quote divergence below).
+            "image:x.png[++A & B++]",
+            // A non-restorable atomic piece — a restored entity, which the
+            // match string gives real bytes to — beside a masked one in the
+            // same bracket: the gate admits both, and only the masked piece
+            // is tokened.
+            "image:x.png[Tom &amp; Jerry ++and co++]",
+            // The other passthrough spellings.
+            "image:x.png[pass:[a,b]]",
+            "image:x.png[+++a_b+++]",
+            // An attribute reference hidden inside the body: neither
+            // pipeline expands it, since both parse the masked text.
+            "image:x.png[++{name}++]",
+            // Target and bracket both over passthroughs.
+            "image:++s.png++[++alt++]",
+            // The icon form, whose alt comes from the same bracket.
+            "icon:home[++Home++]",
+            // Inside a rendered span, two in one flow, and escaped.
+            "*a image:x.png[++alt++] b*",
+            "image:x.png[++A++] then image:y.png[++B,C++]",
+            "\\image:x.png[++alt++]",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_bracket_over_a_passthrough_is_recognized() {
+        // The parsed values carry the *restored* bytes, owned off the
+        // temporary the parse read and tagged with the bracket's own coarse
+        // span (design §4.4), exactly as every other non-verbatim bracket is.
+        let source = "image:x.png[++Alt text++,++100++,50]";
         let nodes = build_src(Span::new(source));
 
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.target.as_ref(), "x.png");
+        assert_eq!(image.alt.as_deref(), Some("Alt text"));
+        assert_eq!(image.width.as_deref(), Some("100"));
+        assert_eq!(image.height.as_deref(), Some("50"));
+
+        // A body carrying the split's own delimiters stays inside one value.
+        let nodes = build_src(Span::new("image:x.png[++a,b=c++]"));
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.alt.as_deref(), Some("a,b=c"));
+
+        // The shorthand items keep pointing at the same characters after the
+        // restore lengthens the value ahead of them.
+        let nodes = build_src(Span::new("image:x.png[++abc++.myrole#myid]"));
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.alt.as_deref(), Some("abc.myrole#myid"));
+
+        let attrlist = image.attrs.as_ref().unwrap();
+
+        assert_eq!(attrlist.id(), Some("myid"));
+        assert_eq!(attrlist.roles(), vec!["myrole"]);
+    }
+
+    #[test]
+    fn a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched() {
+        // The bracket restore is one left-to-right pass, like
+        // `Passthroughs::restore_to`'s own: a body that itself contains the
+        // bytes of a *later* token must not have that token spliced into it,
+        // and a token index the bracket never issued is left as written
+        // rather than renumbering the ones after it.
+        let source = "image:x.png[++x\u{96}1\u{97}y++ ++b++]";
+        let nodes = build_src(Span::new(source));
+
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.alt.as_deref(), Some("x\u{96}1\u{97}y b"));
+
+        // The leniency the index-keyed restore rests on, in both spellings a
+        // bracket can present: a run that is not a well-formed token (no
+        // digits) and one whose index the bracket never issued are each left
+        // exactly as the author wrote them, rather than renumbering — or
+        // consuming — the real tokens around them.
+        let nodes = build_src(Span::new(
+            "image:x.png[++a++ \u{96}x\u{97} \u{96}9\u{97} ++b++]",
+        ));
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(
+            image.alt.as_deref(),
+            Some("a \u{96}x\u{97} \u{96}9\u{97} b")
+        );
+
+        // The string pipeline reads this one differently, and the difference
+        // is its own wart rather than something to reproduce: `restore_to`
+        // is a `replace_all` over the *finished* rendered string, so it also
+        // rewrites the sentinel-shaped bytes the author wrote — splicing
+        // passthrough 1's body into the middle of passthrough 0's. The tree
+        // restores per token, into the value each token actually stands in,
+        // so an author's own bytes survive. Its sibling
+        // `a_restored_body_carrying_sentinel_shaped_bytes_is_not_re_matched`
+        // pins the same reading for a target.
+        use super::super::super::test_support::golden_passthroughs;
+
         assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-            "an image bracket over a passthrough must stay literal: {nodes:?}"
+            golden_passthroughs(source).contains(r#"alt="xby b""#),
+            "expected the documented divergence to still reproduce"
+        );
+    }
+
+    #[test]
+    fn a_dangerous_link_inside_a_bracket_passthrough_is_a_documented_divergence() {
+        // The bracket's own version of
+        // `a_dangerous_target_inside_a_passthrough_is_a_documented_divergence`,
+        // and the same safe reading. The renderer's dangerous-scheme check
+        // reads the `link=` attribute, which now carries the *restored*
+        // bytes; the string pipeline's renderer checks the sentinel its own
+        // parse put there, so a smuggled `javascript:` passes and its restore
+        // pass then completes a live anchor around the image.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "image:x.png[Alt,link=++javascript:alert(1)++]";
+        let nodes = build_src(Span::new(source));
+
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(
+            image
+                .attrs
+                .as_ref()
+                .unwrap()
+                .named_attribute("link")
+                .unwrap()
+                .value(),
+            "javascript:alert(1)"
         );
 
         let golden = golden_passthroughs(source);
 
         assert!(
-            golden.contains("alt=\"Alt text\""),
+            golden.contains("href=\"javascript:"),
             "expected the documented divergence to still reproduce: {golden:?}"
         );
 
-        assert_ne!(golden, fold_html(&nodes, &HtmlSubstitutionRenderer {}));
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+        assert!(
+            !folded.contains("href="),
+            "the fold must not emit the live link: {folded:?}"
+        );
+    }
+
+    #[test]
+    fn a_quote_restored_into_an_image_bracket_is_a_documented_divergence() {
+        // The one shape the bracket restore does not reach byte-for-byte,
+        // and the same well-formed reading the two link families' own
+        // restores take for a `"` in a target. The string pipeline encodes
+        // its quote-free *sentinel* into `alt="…"` and the restore pass then
+        // splices the raw `"` into the finished attribute, closing it; the
+        // tree holds the restored bytes as the node's own `alt`, so the
+        // fold's `encode_attribute_value` escapes the quote and the
+        // attribute stays well formed.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = r#"image:x.png[++a"b++]"#;
+        let nodes = build_src(Span::new(source));
+
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.alt.as_deref(), Some(r#"a"b"#));
+
+        let golden = golden_passthroughs(source);
+
+        assert!(
+            golden.contains(r#"alt="a"b""#),
+            "expected the documented divergence to still reproduce: {golden:?}"
+        );
+
+        assert!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}).contains(r#"alt="a&quot;b""#),
+            "the fold must emit the encoded quote"
+        );
+    }
+
+    #[test]
+    fn an_image_bracket_over_a_stem_expression_is_a_documented_divergence() {
+        // The bracket admits exactly the kinds the *target* does
+        // ([`Restorable::Passthrough`]), and defers a masked STEM expression
+        // for the same reason the target does — see
+        // `an_image_target_over_a_stem_expression_is_a_documented_divergence`.
+        // The bracket has a `web_path`-bound value of its own: an
+        // interactive SVG's `fallback=` is run through `image_src`, so a
+        // restored body carrying a backslash — which *every* rendered STEM
+        // body does — would posixify on a Windows-separator resolver where
+        // the string pipeline's own `web_path` saw only the backslash-free
+        // sentinel.
+        use super::super::super::test_support::golden_passthroughs;
+
+        for source in ["image:x.png[stem:[y]]", "icon:home[stem:[y]]"] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
+                "an image bracket over a STEM expression must stay literal: {nodes:?}"
+            );
+        }
+
+        // The string pipeline builds one, restoring the rendered expression
+        // into the `alt` after its own parse split the list.
+        let golden = golden_passthroughs("image:x.png[stem:[y]]");
+
+        assert!(
+            golden.contains(r#"alt="\$y\$""#),
+            "expected the documented divergence to still reproduce: {golden:?}"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -1369,6 +1369,16 @@ mod tests {
         assert_parity("Visit https://example.org[a +[literal]+ label] now.");
         assert_parity("Visit https://example.org[a +++<b>x</b>+++ label] today.");
 
+        // The image family's **bracket** over a masked passthrough — the
+        // restore that happens *inside* a parsed attribute-list value, run
+        // here through the whole assembled pipeline. The two fixtures that
+        // matter are a body carrying the split's own delimiters (which must
+        // stay one value, as it does where the string pipeline's parse reads
+        // its sentinel) and one sitting ahead of a shorthand item (whose
+        // offsets shift with the restore).
+        assert_parity("See image:chart.png[++a, b = c++] and image:x.png[++A & B++].");
+        assert_parity("An image:y.png[++abc++.myrole] beside *bold* text.");
+
         // A construct written against an enclosing span's own edge, where the
         // string pipeline's haystack holds that span's rendered markup and a
         // level matched in isolation holds its own start or end — the quotes


### PR DESCRIPTION
The four restore-the-value increments before this one closed the class for every family that *computes* a target off the match string. Each deferred the same remainder in the same words: the **bracket half**, restoring inside a value that comes back from a *parse*. This takes the first of that half's four captures, the `image:`/`icon:` bracket.

## The order is the point

`Attrlist::parse` reads the `\u{96}`*n*`\u{97}` sentinel as one opaque run carrying none of the `,`/`=`/`"` bytes the split reads, so `image:x.png[++a,b++]` is **one** positional whose value is `a,b`. Restoring before the parse would divide it in two — which is exactly why every earlier increment held this back.

So the bracket is put into that same shape before the parse and restored after it:

- `tokened_bracket` rewrites each masked piece in the bracket's match-string bytes to an index-keyed token, normalizing two spellings into one (`widen_masked_passthroughs` has already widened a `Raw` piece for *recognition*, but numbered per level).
- A new `Attrlist::into_owned_restoring` — the restoring sibling of the `into_owned` the first attribute-list increment added — splices each body into the parsed values on the way out, index-keyed as `Passthroughs::restore_to` is, so a token the split discarded does not shift the ones that survive.

## Shifted, not recomputed

An `ElementAttribute`'s `shorthand_item_indices` are byte offsets into its own `value`, so `into_owned_restoring` moves each past every substitution that ends at or before it. Shifting is the faithful move and re-deriving is not: a token holds none of the `#`/`.`/`%` delimiters the shorthand scan keys off, so the items the string pipeline found over its sentinel are the same items, only further along — `image:x.png[++abc++.myrole]` keeps the `myrole` role while its `alt` becomes `abc.myrole`, where a re-derivation would find a delimiter *inside* a restored body. The no-token path keeps the plain `CowStr::into_owned`, so nothing that carries no token pays for this.

## Gate

The family's gate simply becomes the one its target already uses — `range_is_restorable` with `Restorable::Passthrough` — in place of `range_has_no_opaque_piece`, so target and bracket now admit exactly the same kinds. Recognition needed no widening (`INLINE_IMAGE_MACRO`'s bracket class swallows either spelling), and `alt`/`width`/`height` are read off the attribute list, so they follow with no code of their own.

A masked **STEM** stays deferred here too, for the target's own reason plus one more site: the bracket has a `web_path`-bound value of its own — an interactive SVG's `fallback=` — and every rendered STEM body carries a backslash `web_path` would posixify on a Windows-separator resolver. Keeping both halves of this family on `Restorable::Passthrough` keeps its `src` identical on every platform.

## What reaches parity

The whole bracket vocabulary over a passthrough: plain and partial alt, several tokens in one bracket, the split invariant in all three spellings (a body carrying a `,`, an `=`, or inside a quoted value), named values (`title=`, `role=`), the positional width/height slots, both shorthand items after a token, a restored `&`, the `pass:[…]` and triple-plus spellings, an attribute reference hidden inside the body, target and bracket both masked, the icon form, and the whole set inside a rendered span, twice in one flow, and escaped.

## Deliberately left where they were, each pinned

- A dangerous scheme smuggled into `link=` — the check now reads the *restored* bytes, so the tree renders without the anchor where the string pipeline passed its sentinel and let the restore complete a live link. The safe reading, as in the target's own increment.
- A restored `"` — escaped by the fold's `encode_attribute_value` where the string pipeline spliced the raw quote into a finished `alt="…"`, closing the attribute. The well-formed reading, as both link families' restores already take.
- An author's own sentinel-shaped bytes — the tree restores per token, so they survive; the string pipeline's `replace_all` over the *finished* string rewrites them too.

## Verification

- Preflight clean: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5338 passing), `cargo +nightly doc --no-deps --document-private-items`.
- **Corpus-wide fold-parity audit**: the divergence set strictly **shrank** — one real golden source is gone (`image:pause.png[title=Pause pass:p[{abc +\ndef}] Resume]`) and **no new divergence appeared**.
- **Coverage is diff-neutral**: missed-region/missed-line counts unchanged against `origin/inline-ast` for every changed file (`attrlist.rs` 0/0, `element_attribute.rs` 1/0, `image.rs` 4/1, `inline_builder/mod.rs` 0/0).

As with every prep piece before it, nothing further is wired in.

## What remains of the class

The bracket half's other three captures — the `link:`/`mailto:` and auto-link families' attribute-list display texts, which keep the opaque-piece gate inside `text_attrlist` — plus the image family's STEM target and bracket, and the keeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JauX7HHaZnfL63vQzaxn79)_