### PR TITLE
feat: Restore a masked construct inside a link's display-text attribute list (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4527,6 +4527,91 @@ Each phase is a reviewable unit with a clear exit gate.
   family's STEM target and bracket, and the keeps: the cross-reference family's pre-restore target,
   and the well-formed readings these five increments pinned.
 
+  *Step 6 prep landed as (a masked construct inside a link's **display-text attribute list** — the
+  bracket half's other three captures):* the increment above took the bracket half's first family
+  and named the rest of it in one phrase — "the `link:`/`mailto:` and auto-link families'
+  attribute-list display texts". Those three captures are three call sites of a *single* function,
+  [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs), so one gate closes
+  all three: the `link:` macro's `=` list (roles / id / title / window), a `mailto:`'s `,` list
+  (its subject and body), and the auto-link / formal-URL family's own `=` list.
+
+  The *order* is the same one the image bracket found, and the machinery is now literally shared.
+  [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) becomes
+  `pub(in inline_builder)` and takes the
+  [`Restorable`](../../parser/src/content/inline_builder/macros/image.rs) kinds its caller admits,
+  so the two families cannot disagree about what a token may stand for: the image bracket keeps
+  `Passthrough` (its `web_path`-bound `fallback=`), while a display-text list passes
+  `PassthroughOrStem`, having no re-processing of its own — a `Stem` is admitted here on its first
+  bracket-half increment rather than waiting for one of its own. It returns
+  [`MaskedPiece`](../../parser/src/content/inline_builder/macros/image.rs) — the node *and* its
+  body, produced by the one `node_is_restorable`/`restorable_body` chain — because the two callers
+  need different halves of it, which is the whole novelty of this increment.
+
+  What is new is the **sink**. The image bracket's restore ends in a string: each body is spliced
+  into the parsed attribute *values*, which the fold then emits into `alt="…"`. A link's display
+  text ends in the node's **children**, and there the honest restore is the node itself.
+  [`restored_value_children`](../../parser/src/content/inline_builder/macros/links.rs) re-splits
+  the parsed positional on the very tokens
+  [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) placed —
+  index-keyed and left to right, as `Passthroughs::restore_to` is, so a token the split discarded
+  is simply not found and the ones after it splice by their own index — handing each run to
+  [`escaped_value_children`](../../parser/src/content/inline_builder/macros/mod.rs) and each token
+  to the masked node, cloned whole. That is exactly what a *sliced* display text has always done
+  with an opaque piece (`emit_range` clones the node), so the two paths now agree; splicing the
+  restored **bytes** instead would have the fold escape them a second time, turning
+  `link:x[++<b>a</b>++,role=hl]`'s golden `&lt;b&gt;` into `&amp;lt;b&amp;gt;`. The list's own
+  values still take the byte restore
+  ([`Attrlist::into_owned_restoring`](../../parser/src/attributes/attrlist.rs)), so `role=`,
+  `title=`, and `id=` reach the fold as the string pipeline's restore leaves them.
+
+  One shape defers, and it is the family's own analogue of the image bracket's `web_path`: a
+  `mailto:`'s **subject or body**. Those two positionals are read *before* the restore —
+  `encode_uri_component` folds them into the `href` — and the string pipeline percent-encodes its
+  own sentinel there (`?subject=%C2%960%C2%97`), which `Passthroughs::restore_to` then cannot find
+  in the finished attribute. Its golden *leaks* the encoded sentinel, so there is nothing to
+  reproduce: this is the cross-reference family's pre-restore boundary, kept for the same reason.
+  What is new is that it is drawn per **slot** rather than per family — `text_attrlist` takes the
+  positional numbers its caller reads early, and only a token that lands in one of them defers the
+  match — so `mailto:x@y.com[++Tom, Jr++ R,Subject]`, whose masked piece is in the display text
+  beside a plain subject, still reaches parity.
+
+  What reaches parity is the whole display-text vocabulary over both masked kinds: the text as one
+  piece of the list at either edge, several in one text, and the whole text; the split invariant in
+  both spellings (a body carrying the `,` or the `=` the split reads); a body inside a named value,
+  a quoted value, and both halves of one list at once; a token the split discards; the shorthand
+  items after a token (`link:x[++abc++#myid.myrole,role=hl]` keeps its `myid` and `myrole`); the
+  `^` window suffix and the `\]` unescape past a token; all three STEM notations and an explicit
+  substitution list; a body that is live markup, an attribute reference neither pipeline expands,
+  and the escaped and restored bytes the value already admitted around it; the `mailto:` and
+  auto-link spellings, the angle form that keeps its `&lt;`, a restored target beside a restored
+  text; and the whole set inside a rendered span, twice in one flow, in a footnote's extracted
+  text, and end to end through the real parse path. Re-running the corpus-wide fold-parity audit
+  shows the divergence set **unchanged** — no golden source writes an attribute list *and* a
+  masked construct in one display text — and no new divergence appeared. Coverage stays
+  diff-neutral, and
+  as with every prep piece before it, nothing further is wired in.
+
+  Three shapes are left where they were, each pinned, and one of them again runs the **safe** way
+  rather than the byte-parity way. A restored `"` in a `title=` is escaped by the fold's
+  `encode_attribute_value` where the string pipeline encoded its quote-free sentinel and spliced
+  the raw quote into the finished `title="…"` — the same well-formed reading the image bracket's
+  `alt` takes (the `id=` slot, emitted unescaped in both, stays byte-identical). A `window=` or
+  `opts=` is a value the renderer *decides* on rather than emits, and it now reads the restored
+  bytes where the string pipeline tested its own sentinel and found neither `_blank` nor
+  `nofollow`: `link:x[T,window=++_blank++]` gains the `rel="noopener"` hardening its golden
+  omits — the same class as the image family's `link=` dangerous-scheme check, and the same
+  direction. And
+  an author's own sentinel-shaped bytes survive this restore where the string pipeline's
+  `replace_all` over the *finished* string rewrites them too, the wart the image bracket's own
+  sibling test already pins.
+
+  With this the **bracket half is closed for the two link families**, and the restore-the-value
+  class as a whole is down to one family: the `image:`/`icon:` STEM target and its bracket's
+  `fallback=`, both blocked on the same fold-time `web_path` (closing them means keeping the
+  restore out of `web_path`'s way, not widening a gate). Beyond that only the keeps remain: the
+  cross-reference family's pre-restore target, a `mailto:`'s subject and body for the same
+  pre-restore reason, and the well-formed readings these six increments pinned.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5247,6 +5332,30 @@ Each phase is a reviewable unit with a clear exit gate.
        own test. See the step's own "landed as" note above. The bracket half's other three
        captures — the three families' attribute-list display texts — and the image family's STEM
        are what remain of the class.
+
+     - ✅ **prep (a masked construct inside a link's display-text attribute list).** The bracket
+       half's other three captures at once — the `link:` macro's `=` list, a `mailto:`'s `,` list,
+       and the auto-link / formal-URL family's `=` list — which are three call sites of one
+       function, [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs), so
+       one gate closes them all. It takes the image bracket's own order (token before the parse,
+       restore after it) through a
+       [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) now shared by
+       the two families, each passing the
+       [`Restorable`](../../parser/src/content/inline_builder/macros/image.rs) kinds its own gate
+       admits — `PassthroughOrStem` here, this family having no `web_path` of its own. What is new
+       is the **sink**: a display text becomes the node's *children*, so the restore is
+       structural — [`restored_value_children`](../../parser/src/content/inline_builder/macros/links.rs)
+       re-splits the parsed value on its own tokens and splices the masked **node** back in, where
+       splicing its bytes into a `Text` would have the fold escape live markup a second time. The
+       one shape that defers is a `mailto:`'s **subject or body**, whose `encode_uri_component`
+       runs before the restore and percent-encodes the string pipeline's own sentinel into an
+       `href` nothing then restores — the cross-reference family's pre-restore boundary, drawn per
+       *slot* so a masked display text beside a plain subject still lands. A restored `"` in the
+       fold-escaped `title`, a `window=`/`opts=` the renderer *decides* on rather than emits (the
+       safe reading, as the image family's own `link=` check is), and an author's own
+       sentinel-shaped bytes each keep their divergence with their own test. See the step's own
+       "landed as" note above. What remains of the class is the image family's STEM target and
+       bracket, and the keeps.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -328,7 +328,11 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
 /// spelling with no widening at all and whose two pre-restore decisions —
 /// rejecting a quoted URL, stripping a bare one's trailing punctuation — read
 /// a placeholder exactly as the string replacer's own sentinel reads
-/// (`links::build_inline_link_node`). A family that *matches
+/// (`links::build_inline_link_node`). It is right for a value that comes back
+/// from a **parse** too, once that parse is given the sentinel's own shape
+/// first — the `image:`/`icon:` bracket and the link families' display-text
+/// attribute list, each tokened by [`tokened_bracket`] and restored after the
+/// split. A family that *matches
 /// over* the masked bytes with a class the two spellings answer differently,
 /// or reads them into a value the string pipeline uses **before** restore (a
 /// deferred cross-reference's target, captured into its placeholder template
@@ -835,52 +839,81 @@ fn bracket_attrlist<'src>(
         return parse_attrlist(bracket, parser);
     }
 
-    let (tokened, bodies) = tokened_bracket(
+    let (tokened, masked) = tokened_bracket(
         bracket_text,
         &bracket_range,
         nodes,
         pieces,
         parser.renderer.as_ref(),
+        Restorable::Passthrough,
     );
 
-    let bodies: Vec<&str> = bodies.iter().map(Cow::as_ref).collect();
+    let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
 
     parse_attrlist(Span::new(&tokened), parser).into_owned_restoring(bracket, &bodies)
 }
 
-/// Rewrites the bracket's own match-string bytes so each masked
-/// **passthrough** in it becomes an index-keyed `\u{96}`*n*`\u{97}` token,
-/// returning that text alongside the bodies those tokens restore to.
+/// One masked piece a [`tokened_bracket`] token stands for: the node itself,
+/// and the bytes it restores to.
 ///
-/// This is the *before the split* half of the bracket restore, and it exists
+/// The two are produced together, by the one
+/// [`node_is_restorable`]/[`restorable_body`] chain, because a caller may need
+/// either: the `image:`/`icon:` family splices the **body** into the parsed
+/// attribute values ([`Attrlist::into_owned_restoring`]), while the link
+/// families' display text — which becomes a node's *children* rather than a
+/// string — splices the **node**, so the fold emits those same bytes without
+/// re-escaping them (design §3.4). Pairing them here rather than re-deriving
+/// one from the other is what keeps the two spellings of "what this token
+/// restores to" from drifting.
+pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
+    /// The masked node — a [`Raw`](InlineNode::Raw) passthrough or a
+    /// [`Stem`](InlineNode::Stem) expression — the token stands for.
+    pub(in crate::content::inline_builder) node: &'a InlineNode<'src>,
+
+    /// What the token restores to: exactly what the fold of
+    /// [`node`](Self::node) emits (see [`restorable_body`]).
+    pub(in crate::content::inline_builder) body: Cow<'a, str>,
+}
+
+/// Rewrites a macro **bracket**'s own match-string bytes so each masked piece
+/// in it becomes an index-keyed `\u{96}`*n*`\u{97}` token, returning that text
+/// alongside the [`MaskedPiece`]s those tokens stand for.
+///
+/// This is the *before the split* half of every bracket restore, and it exists
 /// so the text handed to [`Attrlist::parse`] is the same **shape** the string
 /// pipeline's own haystack has there. Two spellings have to be normalized into
 /// one: [`widen_masked_passthroughs`] has already rewritten a
-/// [`Raw`](InlineNode::Raw) piece to a sentinel-shaped token for this family's
-/// *recognition*, but its numbering is per level, and any other masked piece
-/// is still the bare one-character [`SPAN_PLACEHOLDER`](super::super::quotes).
-/// Renumbering every restorable piece from zero, per bracket, is what lets the
-/// restore be **index-keyed** on the way back out
-/// ([`Attrlist::into_owned_restoring`]) — the parse can drop a token
-/// (a blank slot, a value the split discards) without shifting the ones that
-/// survive, exactly as
+/// [`Raw`](InlineNode::Raw) piece to a sentinel-shaped token for the image
+/// family's *recognition*, but its numbering is per level, and any other
+/// masked piece is still the bare one-character
+/// [`SPAN_PLACEHOLDER`](super::super::quotes). Renumbering every restorable
+/// piece from zero, per bracket, is what lets the restore be **index-keyed**
+/// on the way back out ([`Attrlist::into_owned_restoring`]) — the parse can
+/// drop a token (a blank slot, a value the split discards) without shifting
+/// the ones that survive, exactly as
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) is unshifted by
 /// a sentinel that never reached the rendered string.
 ///
-/// Only the kinds [`Restorable::Passthrough`] names are tokened, which is the
-/// same set this family's own gate admits: a masked **STEM** expression is
-/// deferred here as it is in the target, and for the same reason — see
+/// Shared by the two families whose bracket comes back from a parse, each
+/// passing the `kinds` its own gate admits so the two cannot disagree about
+/// what a token may stand for: the `image:`/`icon:` bracket passes
+/// [`Restorable::Passthrough`] (a masked **STEM** is deferred there as it is
+/// in that family's target, and for the same `web_path` reason — see
 /// [`Restorable`], and
-/// `an_image_bracket_over_a_stem_expression_is_a_documented_divergence`.
-fn tokened_bracket<'a>(
+/// `an_image_bracket_over_a_stem_expression_is_a_documented_divergence`),
+/// while the link families' display-text list
+/// ([`text_attrlist`](super::links)) passes
+/// [`Restorable::PassthroughOrStem`], having no such re-processing of its own.
+pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
     bracket_text: &str,
     range: &std::ops::Range<usize>,
-    nodes: &'a [InlineNode<'_>],
+    nodes: &'a [InlineNode<'src>],
     pieces: &[Piece],
     renderer: &dyn InlineSubstitutionRenderer,
-) -> (String, Vec<Cow<'a, str>>) {
+    kinds: Restorable,
+) -> (String, Vec<MaskedPiece<'a, 'src>>) {
     let mut tokened = String::new();
-    let mut bodies: Vec<Cow<'a, str>> = Vec::new();
+    let mut masked_pieces: Vec<MaskedPiece<'a, 'src>> = Vec::new();
 
     // In match-string coordinates; `bracket_text` is indexed relative to
     // `range.start`.
@@ -905,10 +938,12 @@ fn tokened_bracket<'a>(
         // splitting them would leave a branch no input can take. A piece this
         // skips is an atomic one the *gate* admitted for another reason — a
         // `CharRef` leaf the match string gives real bytes to.
-        let Some(body) = nodes
+        let Some(masked) = nodes
             .get(piece.node_index)
-            .filter(|node| node_is_restorable(node, Restorable::Passthrough))
-            .and_then(|node| restorable_body(node, renderer))
+            .filter(|node| node_is_restorable(node, kinds))
+            .and_then(|node| {
+                restorable_body(node, renderer).map(|body| MaskedPiece { node, body })
+            })
         else {
             continue;
         };
@@ -921,13 +956,13 @@ fn tokened_bracket<'a>(
                 .unwrap_or_default(),
         );
 
-        tokened.push_str(&format!("\u{96}{n}\u{97}", n = bodies.len()));
-        bodies.push(body);
+        tokened.push_str(&format!("\u{96}{n}\u{97}", n = masked_pieces.len()));
+        masked_pieces.push(masked);
         cursor = p_end;
     }
 
-    if bodies.is_empty() {
-        return (bracket_text.to_string(), bodies);
+    if masked_pieces.is_empty() {
+        return (bracket_text.to_string(), masked_pieces);
     }
 
     tokened.push_str(
@@ -936,7 +971,7 @@ fn tokened_bracket<'a>(
             .unwrap_or_default(),
     );
 
-    (tokened, bodies)
+    (tokened, masked_pieces)
 }
 
 /// Parses one inline attribute list, discarding the warnings — the shared

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3,8 +3,8 @@
 use super::{
     MacroMatch, MacroMatchKind, escaped_value_children,
     image::{
-        Restorable, range_has_no_opaque_piece, range_is_restorable, range_is_verbatim,
-        range_is_verbatim_or_synthesized, restorable_body,
+        Restorable, range_is_restorable, range_is_verbatim, range_is_verbatim_or_synthesized,
+        restorable_body, tokened_bracket,
     },
     macro_text_children, rebuild_macro_level,
 };
@@ -79,8 +79,9 @@ use crate::{
 /// admitted too, in an attribute-list text as much as anywhere else
 /// (`https://example.org/?a=1&b=2`, `https://example.org[a < b]`,
 /// `<https://example.org/a&b>`) — the third family to take
-/// [`range_has_no_opaque_piece`], after the cross-reference and
-/// `link:`/`mailto:` macro families. The match string carries such a leaf's
+/// [`range_has_no_opaque_piece`](super::image::range_has_no_opaque_piece),
+/// after the cross-reference and `link:`/`mailto:` macro families. The match
+/// string carries such a leaf's
 /// canonical entity — the very bytes the string replacer's own escaped haystack
 /// holds there — so the target this pass computes off that string
 /// (`https://example.org/?a=1&amp;b=2`) *is* the one the replacer computed, and
@@ -92,13 +93,13 @@ use crate::{
 ///
 /// # A rendered span inside the display text
 ///
-/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, an
-/// already-recognized macro node of another family, a masked passthrough — is
-/// *not* recoverable: [`build_match_string`] stands it in as one
+/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, or an
+/// already-recognized macro node of another family — is *not* recoverable:
+/// [`build_match_string`] stands it in as one
 /// [`SPAN_PLACEHOLDER`] where the string pipeline's haystack holds its markup
-/// (or its own passthrough mask) inline, and that markup exists only at fold
-/// time. It is nonetheless admitted **inside the bracketed display text** of a
-/// formal URL link (`https://example.org[a *b* c]`, and the angle spelling
+/// inline, and that markup exists only at fold time. It is nonetheless admitted
+/// **inside the bracketed display text** of a formal URL link
+/// (`https://example.org[a *b* c]`, and the angle spelling
 /// `<https://example.org[a *b* c]` that keeps its `&lt;`), because that text is
 /// the one capture this family never reads as bytes: it becomes the node's
 /// children through [`macro_text_children`], whose
@@ -110,9 +111,13 @@ use crate::{
 /// and the `<url>` form's whole interior (see [`build_angle_link_node`]). An
 /// **attribute-list text** is computed too — its display text comes back from
 /// an [`Attrlist`] parse rather than from a range — so [`text_attrlist`] keeps
-/// the same gate there: a placeholder inside a *parsed* value has no node it
-/// can be mapped back to. This is the third family to take that lift, after
-/// the cross-reference one (`xref::find_xref_matches`) and the
+/// the same gate there for a *rendered* span, whose bytes exist only at fold
+/// time: a placeholder inside a parsed value has no node it can be mapped back
+/// to. A **masked** construct is the one such piece that does, its body being
+/// known at build time: [`text_attrlist`] tokens it through the parse and
+/// splices the node back into the children afterwards
+/// ([`restored_value_children`]). This is the third family to take that lift,
+/// after the cross-reference one (`xref::find_xref_matches`) and the
 /// `link:`/`mailto:` macro ([`find_link_macro_matches`]).
 ///
 /// What the admission cannot do is make the *recognition* agree in every case,
@@ -217,9 +222,9 @@ pub(super) fn inline_link_level<'src>(
 /// Finds every recognized auto-link / formal-URL / angle-bracketed link at this
 /// level, skipping a `link:` macro match and any form
 /// [`build_inline_link_node`] defers — including one whose *computed* bytes
-/// cross an opaque piece, whose gate lives inside that function (it needs the
-/// branch's own capture groups to know which sub-range the gate covers, and
-/// must run after the escape checks; see [`inline_link_level`]).
+/// cross a piece it cannot reproduce, whose gate lives inside that function (it
+/// needs the branch's own capture groups to know which sub-range the gate
+/// covers, and must run after the escape checks; see [`inline_link_level`]).
 fn find_inline_link_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -361,9 +366,10 @@ fn build_inline_link_node<'src>(
     // admitted — see [`inline_link_level`]'s own rendered-span note. Its
     // closing `]` needs no gate of its own: that byte is literal, and no atomic
     // piece — a placeholder, or an entity delimited by `&` and `;` — can supply
-    // it. (A text carrying an attribute list keeps this same gate inside
+    // it. (A text carrying an attribute list has its own gate inside
     // `text_attrlist`, since its display text comes back from a *parse*
-    // rather than from a range.)
+    // rather than from a range: a masked construct is tokened through that
+    // parse and restored after it, a rendered span still deferred.)
     //
     // An expanded attribute value and an escaped special are admitted
     // throughout, since every value read here comes off the match string —
@@ -520,6 +526,10 @@ fn build_inline_link_node<'src>(
     // the children's range stops one (ASCII) byte short of the bracket's end.
     let mut caret_stripped = false;
 
+    // The masked nodes that computed value still holds a token for, if any —
+    // spliced back into the children below (see [`restored_value_children`]).
+    let mut restores: Vec<InlineNode<'src>> = vec![];
+
     let link_text = if let Some(mut link_text) = link_text {
         link_text = link_text.replace("\\]", "]");
 
@@ -533,7 +543,7 @@ fn build_inline_link_node<'src>(
             #[allow(clippy::unwrap_used)]
             let range = text_location_range.clone().unwrap();
 
-            let parsed = text_attrlist(raw_text, range, nodes, pieces, root, parser)?;
+            let parsed = text_attrlist(raw_text, range, nodes, pieces, root, parser, &[])?;
 
             // Mirrors `InlineLinkReplacer`'s own guard: only adopt the parsed
             // result when a real named attribute actually split off from the
@@ -545,6 +555,7 @@ fn build_inline_link_node<'src>(
                 attrs = Some(parsed.attrs);
                 computed_text = true;
                 escaped_computed_text = parsed.escaped;
+                restores = parsed.restores;
             }
         }
 
@@ -618,8 +629,10 @@ fn build_inline_link_node<'src>(
             // special's canonical entity (and a restored entity's own bytes)
             // where a node holds logical text: rebuild design §3.4's
             // trichotomy from those bytes, exactly as the cross-reference
-            // family's own attribute-list value is rebuilt.
-            escaped_value_children(&link_text, text_location)
+            // family's own attribute-list value is rebuilt — and each masked
+            // construct the value still holds a token for as the node itself,
+            // whose fold emits the bytes `restore_to` splices there.
+            restored_value_children(&link_text, &restores, text_location)
         } else {
             // Parsed out of the source's own bytes, which are already logical
             // text carrying no entity to undo: one synthesized `Text`.
@@ -887,14 +900,14 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 ///
 /// # A rendered span inside the display text
 ///
-/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, an
-/// already-recognized macro node of another family, a masked passthrough — is
-/// *not* recoverable: [`build_match_string`] stands it in as one
+/// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, or an
+/// already-recognized macro node of another family — is *not* recoverable:
+/// [`build_match_string`] stands it in as one
 /// [`SPAN_PLACEHOLDER`] where the string pipeline's haystack holds its markup
-/// (or its own passthrough mask) inline, and that markup exists only at fold
-/// time. It is nonetheless admitted **inside the bracketed display text**,
-/// because that text is the one capture this family never reads as bytes: it
-/// becomes the node's children through [`macro_text_children`], whose
+/// inline, and that markup exists only at fold time. It is nonetheless admitted
+/// **inside the bracketed display text**, because that text is the one capture
+/// this family never reads as bytes: it becomes the node's children through
+/// [`macro_text_children`], whose
 /// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
 /// piece's own node whole into them — so the text is carried *structurally*,
 /// and the fold re-renders exactly the markup the string replacer captured
@@ -902,7 +915,9 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// off the match string. So does an **attribute-list text**, for the same
 /// reason: its display text comes back from an [`Attrlist`] parse rather than
 /// from a range, and a placeholder inside a *parsed* value has no node it can
-/// be mapped back to (see [`text_attrlist`]).
+/// be mapped back to — unless it stands for a **masked** construct, whose body
+/// is known at build time, which [`text_attrlist`] tokens through the parse and
+/// splices back into the children afterwards ([`restored_value_children`]).
 /// This is the second family to take that lift, after the cross-reference one
 /// (see `xref::find_xref_matches`).
 ///
@@ -964,8 +979,9 @@ pub(super) fn link_macro_level<'src>(
 
 /// Finds every recognized `link:`/`mailto:` macro at this level, skipping any
 /// match whose **target** crosses an **opaque** piece (see
-/// [`range_has_no_opaque_piece`]), whose own marker is not verbatim source, or
-/// that [`build_link_node`] defers (see [`link_macro_level`]).
+/// [`range_has_no_opaque_piece`](super::image::range_has_no_opaque_piece)),
+/// whose own marker is not verbatim source, or that [`build_link_node`] defers
+/// (see [`link_macro_level`]).
 ///
 /// The gate covers the bytes the node *reads*, not the whole match: the target
 /// is computed off the level's match string, while the bracketed display text
@@ -1027,8 +1043,9 @@ fn find_link_macro_matches<'src>(
         // piece — a placeholder, or an entity delimited by `&` and `;` — can
         // supply them. (The marker keeps its own stricter, verbatim gate
         // below, for `link_form`'s sake; a text carrying an attribute list
-        // keeps the opaque-piece gate inside `text_attrlist`, since its
-        // display text comes back from a *parse*.)
+        // has its own gate inside `text_attrlist`, since its display text
+        // comes back from a *parse*: a masked construct is tokened through
+        // that parse and restored after it, a rendered span still deferred.)
         if let Some(target) = caps.get(3)
             && !range_is_restorable(
                 nodes,
@@ -1155,8 +1172,9 @@ pub(super) fn restore_masked_passthroughs(
 /// `link:`/`mailto:` match, computing the target, display text, window, and
 /// roles exactly as the string replacer does so the fold reproduces the same
 /// bytes. Returns `None` for a form this increment defers (see
-/// [`link_macro_level`]): a rejected dangerous `link:` scheme, or a link text
-/// that carries an attribute list *and* crosses an opaque piece (see
+/// [`link_macro_level`]): a rejected dangerous `link:` scheme, a link text
+/// that carries an attribute list *and* crosses an opaque piece, or a
+/// `mailto:` whose subject or body carries a masked construct (see
 /// [`text_attrlist`]).
 ///
 /// The display text becomes the node's children, so the fold recovers
@@ -1182,7 +1200,9 @@ pub(super) fn restore_masked_passthroughs(
 ///   a parse of the level's **match string** yields already-escaped text
 ///   instead, so it is rebuilt through [`escaped_value_children`] — design
 ///   §3.4's trichotomy — exactly as the cross-reference family's own
-///   attribute-list value is.
+///   attribute-list value is, with each **masked** construct that value still
+///   holds a token for spliced back in as its own node
+///   ([`restored_value_children`]).
 ///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect — notably it does **not** `register_link` the target in the asset
@@ -1268,6 +1288,10 @@ pub(super) fn build_link_node<'src>(
     // the children's range stops one (ASCII) byte short of the bracket's end.
     let mut caret_stripped = false;
 
+    // The masked nodes that computed value still holds a token for, if any —
+    // spliced back into the children below (see [`restored_value_children`]).
+    let mut restores: Vec<InlineNode<'src>> = vec![];
+
     if !link_text.is_empty() {
         link_text = link_text.replace("\\]", "]");
 
@@ -1287,12 +1311,24 @@ pub(super) fn build_link_node<'src>(
                 #[allow(clippy::unwrap_used)]
                 let m = raw_text_m.unwrap();
 
-                let parsed =
-                    text_attrlist(raw_text, m.start()..m.end(), nodes, pieces, root, parser)?;
+                // A `mailto:`'s second and third positionals are read
+                // *before* the restore — `encode_uri_component` folds them
+                // into the `href` below — so a masked construct landing in
+                // one of them defers the whole match (see `text_attrlist`).
+                let parsed = text_attrlist(
+                    raw_text,
+                    m.start()..m.end(),
+                    nodes,
+                    pieces,
+                    root,
+                    parser,
+                    &[2, 3],
+                )?;
 
                 link_text = parsed.text;
                 computed_text = true;
                 escaped_computed_text = parsed.escaped;
+                restores = parsed.restores;
 
                 if let Some(target_attr) = parsed.attrs.nth_attribute(2) {
                     target = format!(
@@ -1314,11 +1350,20 @@ pub(super) fn build_link_node<'src>(
             #[allow(clippy::unwrap_used)]
             let m = raw_text_m.unwrap();
 
-            let parsed = text_attrlist(raw_text, m.start()..m.end(), nodes, pieces, root, parser)?;
+            let parsed = text_attrlist(
+                raw_text,
+                m.start()..m.end(),
+                nodes,
+                pieces,
+                root,
+                parser,
+                &[],
+            )?;
 
             link_text = parsed.text;
             computed_text = true;
             escaped_computed_text = parsed.escaped;
+            restores = parsed.restores;
             attrs = Some(parsed.attrs);
         }
 
@@ -1404,8 +1449,10 @@ pub(super) fn build_link_node<'src>(
             // special's canonical entity (and a restored entity's own bytes)
             // where a node holds logical text: rebuild design §3.4's
             // trichotomy from those bytes, exactly as the cross-reference
-            // family's own attribute-list value is rebuilt.
-            escaped_value_children(&link_text, text_location)
+            // family's own attribute-list value is rebuilt — and each masked
+            // construct the value still holds a token for as the node itself,
+            // whose fold emits the bytes `restore_to` splices there.
+            restored_value_children(&link_text, &restores, text_location)
         } else {
             // Parsed out of the source's own bytes, which are already logical
             // text carrying no entity to undo: one synthesized `Text`.
@@ -1472,6 +1519,21 @@ struct TextAttrlist<'src> {
     /// `false` means the `=` was incidental and the whole text is the sole
     /// positional value.
     adopted: bool,
+
+    /// The masked nodes [`text`](Self::text) still holds a
+    /// `\u{96}`*n*`\u{97}` token for, in token-index order — empty for a list
+    /// that crossed none.
+    ///
+    /// The list's *values* are restored on the way out of the parse
+    /// ([`Attrlist::into_owned_restoring`]), but the display text becomes the
+    /// node's **children**, where the honest reading is the node itself: a
+    /// [`Raw`](InlineNode::Raw) or [`Stem`](InlineNode::Stem) child folds to
+    /// the very bytes `Passthroughs::restore_to` splices into the string
+    /// pipeline's own display text, where the same bytes spliced into a
+    /// [`Text`](InlineNode::Text) would be escaped a second time (design
+    /// §3.4). The caller re-splits [`text`](Self::text) on these tokens in
+    /// [`restored_value_children`].
+    restores: Vec<InlineNode<'src>>,
 }
 
 /// Parses a link's bracketed **display text** as the [`Attrlist`]`<'src>` its
@@ -1506,13 +1568,40 @@ struct TextAttrlist<'src> {
 /// reference's backslash as a *gap* (`link:x[\{name},role=hl]`), so the
 /// enclosing slice carries a byte the replacer's own text does not.
 ///
-/// Returns `None` — the one shape still deferred — when the text crosses an
-/// **opaque** piece (a rendered span, an earlier-recognized macro node, a
-/// masked passthrough). That is not a bytes problem the match string can
-/// solve: [`build_match_string`] stands such a piece in as one
-/// [`SPAN_PLACEHOLDER`] where the string replacer's haystack holds its markup,
-/// and a placeholder inside a *parsed* value has no node it can be mapped back
-/// to (see [`link_macro_level`]'s own rendered-span note).
+/// A **masked** construct — a passthrough or a STEM expression — is admitted
+/// too, and restored the way the image family's own bracket is: the text is
+/// put into the string pipeline's own *shape* before the parse
+/// ([`tokened_bracket`], each masked piece rewritten to the
+/// `\u{96}`*n*`\u{97}` token whose shape the sentinel has), so the split sees
+/// one opaque run carrying none of the `,`/`=`/`"` bytes it reads, and each
+/// body is spliced into the parsed values after it
+/// ([`Attrlist::into_owned_restoring`]). What the *display text* keeps is the
+/// tokens themselves, so the caller can rebuild it as **children** that carry
+/// each masked node structurally (see [`TextAttrlist::restores`] and
+/// [`restored_value_children`]) rather than as bytes the fold would escape a
+/// second time.
+///
+/// `pre_restore` names the positional slots whose value the caller reads
+/// **before** that restore, and a token reaching one of them defers the whole
+/// match. There is exactly one such caller: a `mailto:`'s comma list, whose
+/// second and third positionals become the `?subject=`/`&amp;body=` query
+/// through [`encode_uri_component`]. The string pipeline percent-encodes its
+/// own sentinel there (`%C2%960%C2%97`), which
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) then cannot find
+/// in the finished `href` — so its golden *leaks* the encoded sentinel, and no
+/// restore here can reproduce that. This is the same boundary the
+/// cross-reference family's own pre-restore target keeps, drawn per slot
+/// rather than per family so that a masked piece in the display text beside a
+/// plain subject still restores.
+///
+/// Returns `None` — the one shape still deferred outright — when the text
+/// crosses an **opaque** piece (a rendered span, an earlier-recognized macro
+/// node). That is not a bytes problem the match string can solve:
+/// [`build_match_string`] stands such a piece in as one [`SPAN_PLACEHOLDER`]
+/// where the string replacer's haystack holds its markup, and — unlike a
+/// masked construct, whose body is known at build time — its bytes exist only
+/// at fold time, so there is nothing to token (see [`link_macro_level`]'s own
+/// rendered-span note).
 fn text_attrlist<'src>(
     raw_text: &str,
     text_range: std::ops::Range<usize>,
@@ -1520,14 +1609,15 @@ fn text_attrlist<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    pre_restore: &[usize],
 ) -> Option<TextAttrlist<'src>> {
-    if !range_has_no_opaque_piece(nodes, pieces, &text_range) {
+    if !range_is_restorable(nodes, pieces, &text_range, Restorable::PassthroughOrStem) {
         return None;
     }
 
     let normalized = raw_text.replace('\n', " ");
     let verbatim_range = text_range.clone();
-    let source = source_slice(pieces, text_range, root);
+    let source = source_slice(pieces, text_range.clone(), root);
 
     if range_is_verbatim(pieces, &verbatim_range) && source.data() == normalized {
         let (text, attrs) = extract_attributes_from_text(source, parser, None);
@@ -1537,17 +1627,101 @@ fn text_attrlist<'src>(
             text,
             attrs,
             escaped: false,
+            restores: vec![],
         });
     }
 
-    let (text, attrs) = extract_attributes_from_text(Span::new(&normalized), parser, None);
+    // A masked piece is atomic, so a range holding one never took the
+    // verbatim path above. Tokening leaves a range holding none byte-identical
+    // to `normalized`, so both paths below read the same string.
+    let (tokened, masked) = tokened_bracket(
+        &normalized,
+        &text_range,
+        nodes,
+        pieces,
+        parser.renderer.as_ref(),
+        Restorable::PassthroughOrStem,
+    );
+
+    let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
+
+    if masked.is_empty() {
+        return Some(TextAttrlist {
+            adopted: text != tokened,
+            text,
+            attrs: attrs.into_owned(source),
+            escaped: true,
+            restores: vec![],
+        });
+    }
+
+    // A value this caller reads before the restore cannot be reproduced from
+    // the restored bytes — see this function's own `pre_restore` note.
+    if pre_restore.iter().any(|n| {
+        attrs
+            .nth_attribute(*n)
+            .is_some_and(|attribute| attribute.value().contains('\u{96}'))
+    }) {
+        return None;
+    }
+
+    let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
+
+    let restores = masked.iter().map(|piece| piece.node.clone()).collect();
 
     Some(TextAttrlist {
-        adopted: text != normalized,
+        adopted: text != tokened,
         text,
-        attrs: attrs.into_owned(source),
+        attrs: attrs.into_owned_restoring(source, &bodies),
         escaped: true,
+        restores,
     })
+}
+
+/// Rebuilds a computed display text that still holds
+/// [`tokened_bracket`] tokens as the node's children: each token becomes the
+/// masked node itself, and the escaped bytes around it take
+/// [`escaped_value_children`]'s own trichotomy rebuild.
+///
+/// Splicing the node rather than its bytes is what keeps the fold honest. A
+/// [`Raw`](InlineNode::Raw) leaf's body is emitted verbatim and a
+/// [`Stem`](InlineNode::Stem) leaf's is rendered at fold time — which is
+/// exactly what `Passthroughs::restore_to` splices into the string pipeline's
+/// own display text — where those same bytes spliced into a
+/// [`Text`](InlineNode::Text) would be escaped a second time (design §3.4):
+/// `link:x[++<b>a</b>++,role=hl]` would show `&amp;lt;b&amp;gt;` against the
+/// golden's `&lt;b&gt;`.
+///
+/// The walk is index-keyed and left to right, like
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own: each
+/// token is sought only in the bytes after the previous one, and a token the
+/// parse dropped (a value the split discarded) is simply not found, leaving
+/// the ones after it to splice by their own index.
+fn restored_value_children<'src>(
+    text: &str,
+    restores: &[InlineNode<'src>],
+    location: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let mut children: Vec<InlineNode<'src>> = Vec::new();
+    let mut rest = text;
+
+    for (n, node) in restores.iter().enumerate() {
+        let token = format!("\u{96}{n}\u{97}");
+
+        if let Some(pos) = rest.find(&token) {
+            children.append(&mut escaped_value_children(
+                rest.get(..pos).unwrap_or_default(),
+                location,
+            ));
+
+            children.push(node.clone());
+            rest = rest.get(pos + token.len()..).unwrap_or_default();
+        }
+    }
+
+    children.append(&mut escaped_value_children(rest, location));
+
+    children
 }
 
 /// The bare e-mail auto-link pass at a level: matches [`INLINE_EMAIL`] over the
@@ -1621,7 +1795,8 @@ fn text_attrlist<'src>(
 /// the special folds back to its own entity instead of being escaped twice.
 ///
 /// Unlike its three predecessors, this family needs no
-/// [`range_has_no_opaque_piece`] gate to express that lift: an address
+/// [`range_has_no_opaque_piece`](super::image::range_has_no_opaque_piece)
+/// gate to express that lift: an address
 /// **cannot** cross an opaque piece in the first place. Every such piece is
 /// exactly one [`SPAN_PLACEHOLDER`] (U+E0F0, Unicode category `Co`), which
 /// none of the pattern's character classes admit — not the local part's
@@ -3329,58 +3504,319 @@ mod tests {
     }
 
     #[test]
-    fn an_auto_link_attribute_list_text_over_a_stem_expression_is_a_documented_divergence() {
-        // A display text that also carries an attribute list comes back from
-        // a *parse*, so it keeps the opaque-piece gate inside [`text_attrlist`]
-        // for a STEM expression exactly as it does for a passthrough
-        // (`an_auto_link_attribute_list_text_over_a_passthrough_is_a_documented_divergence`):
-        // a placeholder inside a parsed value has no node to map back to.
-        // This is the "bracket half" the restore class still defers.
+    fn an_attribute_list_display_text_over_a_masked_construct_is_recognized() {
+        // The display text is rebuilt as children that carry the masked node
+        // *itself* — a [`Raw`](InlineNode::Raw) for a passthrough, a
+        // [`Stem`](InlineNode::Stem) for an expression — rather than as bytes
+        // the fold would escape a second time, exactly as a *sliced* display
+        // text already carries an opaque piece's own node. The list's own
+        // values take the restored bytes instead
+        // ([`Attrlist::into_owned_restoring`]), which is what the fold reads
+        // for the `class`.
+        for (source, is_stem) in [
+            ("https://example.org/x[T ++a++,role=hl]", false),
+            ("https://example.org/x[T stem:[a],role=hl]", true),
+            ("link:https://example.org[T ++a++,role=hl]", false),
+            ("link:https://example.org[T stem:[a],role=hl]", true),
+        ] {
+            let nodes = build_src(Span::new(source));
+            let reference = assert_link(&nodes[0]);
+
+            let carried = reference.children.iter().any(|child| {
+                if is_stem {
+                    matches!(child, InlineNode::Stem(_))
+                } else {
+                    matches!(child, InlineNode::Raw { .. })
+                }
+            });
+
+            assert!(
+                carried,
+                "the display text should carry the masked node itself for {source:?}: {:?}",
+                reference.children
+            );
+
+            assert_eq!(
+                reference.attrs.as_ref().map(|attrs| attrs.roles().clone()),
+                Some(vec!["hl"]),
+                "the parsed list should still split its named attribute for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_for_a_display_text_attribute_list_over_a_masked_construct()
+    {
+        // The differential corpus for the **bracket half**'s remaining three
+        // captures: the display-text attribute lists of the `link:` macro
+        // (an `=`), of a `mailto:` (a `,`), and of the auto-link /
+        // formal-URL family (an `=`) — all three of which come back from the
+        // one [`text_attrlist`] parse.
+        //
+        // Reproducing the string pipeline means reproducing its *order*, as
+        // the image family's own bracket increment found: its
+        // [`Attrlist::parse`] reads the `\u{96}`n`\u{97}` sentinel as one
+        // opaque run carrying none of the `,`/`=`/`"` bytes the split reads,
+        // so the text is put into that same shape before the parse
+        // ([`tokened_bracket`]) and restored after it — into the parsed
+        // *values* as bytes, and into the display *text* as the masked node
+        // itself ([`restored_value_children`]).
         use super::super::super::test_support::golden_passthroughs;
 
-        let source = "https://example.org/x[stem:[a],role=hl]";
-        let nodes = build_src(Span::new(source));
+        let fixtures = [
+            // The text as one piece of the list, at either edge and in the
+            // middle, several in one text, and the whole text.
+            "link:https://example.org[++a b++,role=hl]",
+            "link:https://example.org[Text ++<b>x</b>++,role=hl]",
+            "link:https://example.org[++a++ and ++b++,role=hl]",
+            "link:https://example.org[++a++ ++b++ ++c++,role=hl]",
+            "link:https://example.org[++++,role=hl]",
+            // The split invariant: a body carrying the `,` or the `=` the
+            // split reads is one opaque run in both pipelines, so it never
+            // divides the list.
+            "link:https://example.org[++a,b++,role=hl]",
+            "link:https://example.org[++a=b++,role=hl]",
+            "link:https://example.org[++a,b++]",
+            // An `=` inside the body, with no real named attribute to split
+            // off: `extract_attributes_from_text` hands the whole tokened text
+            // back unparsed, exactly as it hands the string replacer its own
+            // sentinel-bearing one.
+            "link:https://example.org[++a=b++]",
+            // A body inside a *named* value, a quoted one, and both halves of
+            // one list at once.
+            "link:https://example.org[T,title=++a b++]",
+            "link:https://example.org[T,role=++hl++]",
+            "link:https://example.org[T,role=++a b++]",
+            "link:https://example.org[T,id=++x++]",
+            "link:https://example.org[T,title=\"a ++b++ c\"]",
+            "link:https://example.org[T ++a++,role=++hl++]",
+            "link:https://example.org[T,title=++a++,role=++b++]",
+            // A token the split discards — a value no positional or named
+            // slot keeps — leaves the ones that survive on their own indices.
+            "link:https://example.org[T,role=hl,++a++]",
+            "link:https://example.org[++a++,,role=hl]",
+            // The shorthand items after a token: their offsets are shifted
+            // past the restore rather than re-derived, so the `#`/`.`/`%` the
+            // string pipeline found over its own sentinel are the same ones.
+            "link:https://example.org[++abc++#myid.myrole,role=hl]",
+            "link:https://example.org[++a++%myopt,role=hl]",
+            // The `^` window suffix past a token, and the `\]` unescape.
+            "link:https://example.org[++a++^,role=hl]",
+            "link:https://example.org[++a++^]",
+            "link:https://example.org[T\\]x ++a++,role=hl]",
+            // A masked **STEM** expression, in all three notations and beside
+            // a passthrough: the display text carries the `Stem` node, whose
+            // fold emits the very bytes `restore_to` splices there.
+            "link:https://example.org[stem:[x],role=hl]",
+            "link:https://example.org[latexmath:[\\sqrt{2}],role=hl]",
+            "link:https://example.org[asciimath:[a/b],role=hl]",
+            "link:https://example.org[stem:c,q[x*y*z],role=hl]",
+            "link:https://example.org[T,title=stem:[x]]",
+            "link:https://example.org[stem:[a] and ++b++,role=hl]",
+            // The other passthrough spelling, an attribute reference hidden
+            // inside a body (which neither pipeline expands), and a body that
+            // is live markup — carried structurally so the fold does not
+            // escape it a second time.
+            "link:https://example.org[pass:[<i>x</i>],role=hl]",
+            "link:https://example.org[++{name}++,role=hl]",
+            "link:https://example.org[a ++<b>++ c,id=x,title=T]",
+            // Beside the escaped and restored bytes the same value already
+            // admitted, so the trichotomy rebuild still comes apart correctly
+            // around a token.
+            "link:https://example.org[a ++&++ b,role=hl]",
+            "link:https://example.org[a &amp; ++b++,role=hl]",
+            "link:https://example.org[a < b ++c++,role=hl]",
+            // A `mailto:`'s comma list, whose first positional restores while
+            // its subject stays plain (a masked subject defers — see
+            // `a_mailto_subject_over_a_masked_construct_is_deferred`).
+            "mailto:x@y.com[++Tom++ R,Subject]",
+            "mailto:x@y.com[++Tom, Jr++ R,Subject]",
+            "mailto:x@y.com[++T++]",
+            // The auto-link / formal-URL family's own list, the angle
+            // spelling that keeps its `&lt;`, and a restored target beside a
+            // restored text.
+            "https://example.org/x[++a++,role=hl]",
+            "https://example.org[++a++,role=hl]",
+            "https://example.org/x[stem:[a],role=hl]",
+            "https://example.org/x[++a++^,role=hl]",
+            "<https://example.org/x[++a++,role=hl]",
+            "https://example.org/++t++[++a++,role=hl]",
+            // Inside a rendered span, twice in one flow, and in a footnote's
+            // own extracted text.
+            "*a link:https://example.org[++x++,role=hl] b*",
+            "link:https://example.org[++a++,role=hl] and link:https://example.org[++b++,role=hl]",
+            "footnote:[link:https://example.org[++a++,role=hl]]",
+        ];
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list text over a STEM expression must stay literal: {nodes:?}"
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mailto_subject_over_a_masked_construct_is_deferred() {
+        // A `mailto:`'s second and third positionals are read **before** the
+        // restore: [`encode_uri_component`] folds them into the `href`, and
+        // the string pipeline encodes its own sentinel there
+        // (`%C2%960%C2%97`), which `Passthroughs::restore_to` then cannot
+        // find in the finished attribute — so its golden *leaks* the encoded
+        // sentinel and no restore here can reproduce it. Deferred with the
+        // whole match left literal, the same boundary the cross-reference
+        // family's own pre-restore target keeps, and drawn per *slot* so that
+        // the sibling fixtures above (a masked display text beside a plain
+        // subject) still restore.
+        use super::super::super::test_support::golden_passthroughs;
+
+        for source in [
+            "mailto:x@y.com[Text,++Sub++]",
+            "mailto:x@y.com[Tom,++Sub++ject]",
+            "mailto:x@y.com[Tom,Sub,Body ++b++]",
+            "mailto:x@y.com[Tom,stem:[a]]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a masked subject or body must stay literal for {source:?}: {nodes:?}"
+            );
+
+            let golden = golden_passthroughs(source);
+
+            assert!(
+                golden.contains("%C2%96"),
+                "expected the documented divergence to still reproduce: {golden:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_restored_quote_in_a_link_title_is_a_documented_divergence() {
+        // The tree's is the **well-formed** reading, and the same one the
+        // image family's own bracket already takes for its `alt`: the fold
+        // escapes the restored `"` through `encode_attribute_value`, where
+        // the string pipeline encoded its quote-free *sentinel* and then
+        // spliced the raw quote into the finished `title="…"`, closing the
+        // attribute early. (The `id` slot is emitted unescaped in both, so it
+        // stays byte-identical; only the encoded slots come apart.)
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "link:https://example.org[T,title=++a\"b++]";
+        let renderer = HtmlSubstitutionRenderer {};
+
+        assert_eq!(
+            fold_html(&build_src(Span::new(source)), &renderer),
+            r#"<a href="https://example.org" title="a&quot;b">T</a>"#
         );
 
-        let golden = golden_passthroughs(source);
-
-        assert!(
-            golden.contains("class=\"hl\""),
-            "expected the documented divergence to still reproduce: {golden:?}"
+        assert_eq!(
+            golden_passthroughs(source),
+            r#"<a href="https://example.org" title="a"b">T</a>"#
         );
     }
 
     #[test]
-    fn an_auto_link_attribute_list_text_over_a_passthrough_is_a_documented_divergence() {
-        // The **display text** carries an opaque piece structurally, but one
-        // that also carries an attribute list comes back from a *parse*, so
-        // it keeps the opaque-piece gate inside [`text_attrlist`] — where a
-        // masked passthrough is opaque like any other placeholder, since a
-        // parsed value has no node to map back to. Deferred with the whole
-        // match left literal, as its rendered-span sibling is
-        // (`a_formal_url_attribute_list_text_over_a_rendered_span_is_a_
-        // documented_divergence`), and independent of the target's own
-        // restore beside it.
+    fn a_restored_link_constraint_value_is_a_documented_divergence() {
+        // The other half of the same class the image family's `link=` check
+        // named, and it runs the **safe** way here too: `window=` and
+        // `opts=` are values the renderer makes a *decision* on rather than
+        // emits, and it now reads the restored bytes, where the string
+        // pipeline tested its own sentinel and found neither `_blank` nor
+        // `nofollow`. So the tree emits the `rel` hardening the golden omits.
         use super::super::super::test_support::golden_passthroughs;
 
-        let source = "https://example.org/x[++a++,role=hl]";
-        let nodes = build_src(Span::new(source));
+        let renderer = HtmlSubstitutionRenderer {};
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list text over a passthrough must stay literal: {nodes:?}"
+        for (source, folded, golden) in [
+            (
+                "link:https://example.org[T,window=++_blank++]",
+                r#"<a href="https://example.org" target="_blank" rel="noopener">T</a>"#,
+                r#"<a href="https://example.org" target="_blank">T</a>"#,
+            ),
+            (
+                "link:https://example.org[T,opts=++nofollow++]",
+                r#"<a href="https://example.org" rel="nofollow">T</a>"#,
+                r#"<a href="https://example.org">T</a>"#,
+            ),
+        ] {
+            assert_eq!(fold_html(&build_src(Span::new(source)), &renderer), folded);
+            assert_eq!(golden_passthroughs(source), golden);
+        }
+    }
+
+    #[test]
+    fn an_authors_own_sentinel_shaped_bytes_in_a_display_text_are_a_documented_divergence() {
+        // The wart the image family's own bracket already pins, reached from
+        // this side: the string pipeline restores by `replace_all` over the
+        // *finished* string, so an author's own `\u{96}`n`\u{97}` bytes are
+        // rewritten too (both copies become the body), while this restore
+        // splices at the token it placed. Neither reading is reachable by
+        // ordinary authoring — these are C1 control characters.
+        use super::super::super::test_support::golden_passthroughs;
+
+        let source = "link:https://example.org[\u{96}0\u{97}++a++,role=hl]";
+        let renderer = HtmlSubstitutionRenderer {};
+
+        assert_eq!(
+            fold_html(&build_src(Span::new(source)), &renderer),
+            "<a href=\"https://example.org\" class=\"hl\">a\u{96}0\u{97}</a>"
         );
 
-        let golden = golden_passthroughs(source);
-
-        assert!(
-            golden.contains("class=\"hl\""),
-            "expected the documented divergence to still reproduce: {golden:?}"
+        assert_eq!(
+            golden_passthroughs(source),
+            "<a href=\"https://example.org\" class=\"hl\">aa</a>"
         );
+    }
+
+    #[test]
+    fn a_real_documents_display_text_attribute_lists_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shapes that named
+        // this increment: a display text that carries both an attribute list
+        // and a masked construct must finish into the same bytes the rendered
+        // string carries, so a tree that kept it literal — or restored it
+        // into text the fold escapes again — would regress the moment
+        // `rendered_html()` becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "See link:https://example.org[++the <docs>++,role=hl] today.\n",
+            "\n",
+            "Or https://example.org/x[stem:[a + b],role=hl] instead.\n",
+            "\n",
+            "Write mailto:team@example.org[++Team, Inc++,Hello] now.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 3, "expected every paragraph to carry a tree");
     }
 
     #[test]


### PR DESCRIPTION
One increment on the `inline-ast` branch, against `inline-ast` (design §5.2, Phase 4 step 6 prep).

## What this takes

The previous increment (#1226) closed the **bracket half**'s first family — the `image:`/`icon:` bracket — and named the rest of it in one phrase: "the `link:`/`mailto:` and auto-link families' attribute-list display texts". Those three captures turn out to be three call sites of a *single* function, [`text_attrlist`](https://github.com/asciidoc-rs/asciidoc-parser/blob/claude/inline-ast-increment-kn4n8q/parser/src/content/inline_builder/macros/links.rs), so one gate closes all three:

* the `link:` macro's `=` list (roles / id / title / window),
* a `mailto:`'s `,` list (its subject and body),
* the auto-link / formal-URL family's own `=` list.

## How

The *order* is the one the image bracket found — token before the parse, restore after it — and the machinery is now literally shared. `tokened_bracket` becomes `pub(in inline_builder)` and takes the `Restorable` kinds its caller admits, so the two families cannot disagree about what a token may stand for: the image bracket keeps `Passthrough` (its `web_path`-bound `fallback=`), while a display-text list passes `PassthroughOrStem`, having no re-processing of its own. It returns a new `MaskedPiece` — the node *and* its body, from the one `node_is_restorable`/`restorable_body` chain — because the two callers need different halves of it.

That is the novelty here: **the sink**. The image bracket's restore ends in a string (bodies spliced into the parsed attribute values). A link's display text ends in the node's **children**, and there the honest restore is the node itself. `restored_value_children` re-splits the parsed positional on the very tokens `tokened_bracket` placed — index-keyed and left to right, as `Passthroughs::restore_to` is — handing each surrounding run to `escaped_value_children` and each token to the masked node, cloned whole. That is exactly what a *sliced* display text has always done with an opaque piece, so the two paths now agree; splicing the restored **bytes** instead would have the fold escape them a second time, turning `link:x[++<b>a</b>++,role=hl]`'s golden `&lt;b&gt;` into `&amp;lt;b&amp;gt;`. The list's own values still take the byte restore (`Attrlist::into_owned_restoring`), so `role=`, `title=`, and `id=` reach the fold as the string pipeline's restore leaves them.

## What defers

A `mailto:`'s **subject or body** — the family's analogue of the image bracket's `web_path`. Those two positionals are read *before* the restore (`encode_uri_component` folds them into the `href`), and the string pipeline percent-encodes its own sentinel there (`?subject=%C2%960%C2%97`), which `restore_to` then cannot find in the finished attribute. Its golden *leaks* the encoded sentinel, so there is nothing to reproduce — the cross-reference family's pre-restore boundary, kept for the same reason. What is new is that it is drawn per **slot** rather than per family, so `mailto:x@y.com[++Tom, Jr++ R,Subject]` still reaches parity.

Three shapes keep their divergence, each pinned by its own test, and one again runs the **safe** way rather than the byte-parity way:

* a restored `"` in a `title=` is escaped by the fold's `encode_attribute_value` where the string pipeline encoded its quote-free sentinel and spliced the raw quote into the finished `title="…"` — the well-formed reading the image bracket's `alt` already takes;
* a `window=`/`opts=` is a value the renderer *decides* on rather than emits, and it now reads the restored bytes, so `link:x[T,window=++_blank++]` gains the `rel="noopener"` hardening its golden omits — the same class and direction as the image family's `link=` dangerous-scheme check;
* an author's own sentinel-shaped bytes survive this restore where the string pipeline's `replace_all` over the *finished* string rewrites them too.

## Verification

* Differential corpus (§5.3) over the whole display-text vocabulary for both masked kinds: the text at either edge / several in one text / the whole text; the split invariant (a body carrying the `,` or the `=`); a body in a named value, a quoted value, and both halves of one list; a token the split discards; shorthand items after a token; the `^` suffix and `\]` unescape past a token; all three STEM notations and an explicit substitution list; live markup, an attribute reference, and the escaped/restored bytes around it; the `mailto:` and auto-link spellings, the angle form, a restored target beside a restored text; inside a rendered span, twice in one flow, in a footnote's extracted text, and end to end through the real parse path.
* The corpus-wide fold-parity audit's divergence set is **unchanged** — no golden source writes an attribute list *and* a masked construct in one display text — and no new divergence appeared.
* Coverage is diff-neutral (`macros/links.rs` 17 missed regions / 8 missed lines, `macros/image.rs` 4 / 1 — both unchanged from `origin/inline-ast`).
* Preflight green: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items`.

Nothing further is wired in, as with every prep piece before it. With this the bracket half is closed for the two link families; what remains of the restore-the-value class is the `image:`/`icon:` STEM target and its bracket's `fallback=`, both blocked on the same fold-time `web_path`, plus the keeps.

Design doc updated with the increment's own "landed as" narrative and its Phase 4 checklist entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsYqrHRRqkx1S7MtMneqox)_