### PR TITLE
feat: Restore a masked STEM expression in the image family, closing the restore-the-value class (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4612,6 +4612,66 @@ Each phase is a reviewable unit with a clear exit gate.
   cross-reference family's pre-restore target, a `mailto:`'s subject and body for the same
   pre-restore reason, and the well-formed readings these six increments pinned.
 
+  *Step 6 prep landed as (a masked STEM expression in the `image:`/`icon:` family — the
+  restore-the-value class closed):* the class's last family, and the increment every note above
+  deferred in the same words — "the STEM target and its bracket's `fallback=`, both blocked on the
+  same fold-time `web_path`". Closing it meant exactly what those words prescribed: **keeping the
+  restore out of `web_path`'s way**, not widening a gate. The string pipeline's resolver never
+  sees a restored byte — its `web_path` runs while the masked construct is still the
+  `\u{96}`*n*`\u{97}` sentinel, an opaque run carrying no space to percent-encode, no backslash to
+  posixify (the platform-dependence that made this family defer), and no `/` or `.` for the
+  segment arithmetic to read — and `Passthroughs::restore_to` splices the body into the finished
+  `src` afterwards. The fold now reproduces that order at the same seam: an
+  [`Image`](../../parser/src/inlines/image.rs) node records which byte ranges of its restored
+  target came from a masked body (`restored_target_ranges` — the record
+  [`restore_masked_passthroughs`](../../parser/src/content/inline_builder/macros/links.rs) already
+  produces in the course of splicing, now kept), and the built-in renderer re-masks exactly those
+  ranges into index-keyed sentinel-shaped tokens, resolves, and splices the bodies back
+  ([`mask_restored_ranges`](../../parser/src/parser/inline_substitution_renderer.rs) /
+  [`splice_restored_bodies`](../../parser/src/parser/inline_substitution_renderer.rs) — index-keyed
+  as `restore_to` is, so a token the resolver's `..` arithmetic consumes is simply dropped, in
+  both pipelines). The bracket's own two `web_path`-bound values ride the same mechanism through
+  the attribute list:
+  [`ElementAttribute::into_owned_restoring`](../../parser/src/attributes/element_attribute.rs)
+  records each splice's range on the attribute, and an interactive SVG's `fallback=` and a
+  macro-level `imagesdir=` resolve over them masked — the directory's and the target's mask sets
+  sharing one token numbering where the resolver joins the two into one path.
+
+  With `web_path` out of the way, the gate split `Restorable` named is **deleted rather than
+  relaxed**: every restoring site admits both masked kinds
+  ([`node_is_restorable`](../../parser/src/content/inline_builder/macros/image.rs), now total over
+  the pair), `widen_masked_passthroughs` becomes
+  [`widen_masked_pieces`](../../parser/src/content/inline_builder/macros/image.rs) (the image
+  target's two-character class needs a STEM widened exactly as it needed a passthrough), and
+  [`masked_default_alt`](../../parser/src/content/inline_builder/macros/image.rs) takes a `Stem`
+  piece's body from [`restorable_body`](../../parser/src/content/inline_builder/macros/image.rs) —
+  the fold's own bytes, so the two directions cannot drift.
+
+  What reaches parity is the family's whole masked vocabulary: the wholly- and partially-masked
+  target in both macro forms and all three notations, the default-alt arithmetic over the masked
+  bytes, both masked kinds in one target and in one bracket, the split invariant (a `,` or `=`
+  inside a rendered body), named values, the positional slots, a role, target and bracket both
+  masked, a macro-level `imagesdir=` (masked directory, masked target, and both at once), an
+  interactive SVG's `fallback=` in all three masked spellings, a token dropped whole by the `..`
+  arithmetic, the shapes inside a rendered span, two in one flow, escapes, and end to end through
+  the real parse path; the staged side effect registers the honest restored target. The move also
+  closes a divergence this class had already pinned: the restored **space** the fold used to
+  percent-encode into the `src` (`image:pass:[My Documents/chart.png][]`) now stays out of
+  `web_path`'s way exactly as the sentinel did, so that test is a parity test now. A platform
+  pair pins the reason the family deferred this for so long: the fold is byte-identical under
+  either separator, and equal to the golden, whose own resolver only ever saw the sentinel.
+  Re-running the corpus-wide fold-parity audit shows the divergence set **unchanged** — no golden
+  source writes an image over a STEM expression — and no new divergence appeared. Coverage stays
+  diff-neutral, and as with every prep piece before it, nothing further is wired in.
+
+  With this the **restore-the-value class is closed**: every value any family computes, or parses
+  out of a bracket, admits both masked kinds. What remains are only the keeps: the
+  cross-reference family's pre-restore target and a `mailto:`'s subject and body (each golden
+  leaking the pipeline's own sentinel into an `href` no restore then reaches), and the
+  well-formed/safe readings the class's increments pinned — a restored `"` escaped by the fold, a
+  `window=`/`opts=`/`link=` the renderer *decides* on reading restored bytes, and an author's own
+  sentinel-shaped bytes surviving the tree's per-token restore.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5356,6 +5416,21 @@ Each phase is a reviewable unit with a clear exit gate.
        sentinel-shaped bytes each keep their divergence with their own test. See the step's own
        "landed as" note above. What remains of the class is the image family's STEM target and
        bracket, and the keeps.
+
+     - ✅ **prep (a masked STEM expression in the `image:`/`icon:` family — the
+       restore-the-value class closed).** The class's last family: target and bracket admit both
+       masked kinds, and the fold-time `web_path` this family alone sits behind runs with each
+       restored range **masked** back to the sentinel shape and spliced afterwards — the string
+       pipeline's own resolve-then-restore order, reproduced at the same seam.
+       [`Image::restored_target_ranges`](../../parser/src/inlines/image.rs) carries the record on
+       the node (`ImageRenderParams`/`IconRenderParams` hand it to the renderer), and
+       [`ElementAttribute::into_owned_restoring`](../../parser/src/attributes/element_attribute.rs)
+       records each splice for the bracket's two `web_path`-bound values (an interactive SVG's
+       `fallback=`, a macro-level `imagesdir=`). The `Restorable` gate split is deleted rather
+       than relaxed, and the formerly-pinned restored-space `src` divergence reaches parity by
+       the same move. See the step's own "landed as" note above. Only the keeps remain: the
+       cross-reference family's and a `mailto:` subject/body's pre-restore boundaries, and the
+       well-formed readings.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -112,6 +112,7 @@ impl<'src> Attrlist<'src> {
                 CowStr::from(self.source.data()),
                 bodies,
                 &mut [],
+                &mut Vec::new(),
             )),
         }
     }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -47,6 +47,16 @@ pub struct ElementAttribute<'src> {
     /// avoid substituting it a second time (which would, e.g., double-escape
     /// special characters).
     value_is_substituted: bool,
+
+    /// Byte ranges of `value` whose content
+    /// [`into_owned_restoring`](Self::into_owned_restoring) spliced in from a
+    /// masked passthrough or STEM expression, in ascending order; empty for
+    /// every other attribute. A consumer that re-processes the value as a
+    /// *path* — the built-in renderer's `web_path` resolution of a `fallback=`
+    /// or macro-level `imagesdir=` — masks these ranges around that resolution
+    /// and splices them back afterwards, reproducing the string pipeline's own
+    /// restore-after-resolve order (its resolver only ever sees the sentinel).
+    restored_value_ranges: Vec<std::ops::Range<usize>>,
 }
 
 impl std::fmt::Debug for ElementAttribute<'_> {
@@ -79,6 +89,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: self.positional_index,
             value_is_quoted: self.value_is_quoted,
             value_is_substituted: self.value_is_substituted,
+            restored_value_ranges: self.restored_value_ranges,
         }
     }
 
@@ -112,16 +123,30 @@ impl<'src> ElementAttribute<'src> {
     /// Substitution is **index-keyed**, as `restore_to` is, so a token whose
     /// index the caller did not supply is left as written rather than
     /// renumbering the ones that follow.
+    ///
+    /// Each splice's resulting byte range in the restored value is recorded
+    /// in [`restored_value_ranges`](Self::restored_value_ranges), so a
+    /// consumer that re-processes the value as a path can keep the restored
+    /// bytes out of that resolution's way (see the field's own doc comment).
     pub(crate) fn into_owned_restoring<'dst>(self, bodies: &[&str]) -> ElementAttribute<'dst> {
         let mut shorthand_item_indices = self.shorthand_item_indices;
+        let mut restored_value_ranges = Vec::new();
 
         ElementAttribute {
-            name: self.name.map(|name| restore_into(name, bodies, &mut [])),
-            value: restore_into(self.value, bodies, &mut shorthand_item_indices),
+            name: self
+                .name
+                .map(|name| restore_into(name, bodies, &mut [], &mut Vec::new())),
+            value: restore_into(
+                self.value,
+                bodies,
+                &mut shorthand_item_indices,
+                &mut restored_value_ranges,
+            ),
             shorthand_item_indices,
             positional_index: self.positional_index,
             value_is_quoted: self.value_is_quoted,
             value_is_substituted: self.value_is_substituted,
+            restored_value_ranges,
         }
     }
 
@@ -243,6 +268,7 @@ impl<'src> ElementAttribute<'src> {
                 positional_index: None,
                 value_is_quoted,
                 value_is_substituted,
+                restored_value_ranges: vec![],
             },
             offset,
             warnings,
@@ -273,6 +299,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: Some(1),
             value_is_quoted: false,
             value_is_substituted: false,
+            restored_value_ranges: vec![],
         }
     }
 
@@ -288,6 +315,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: Some(2),
             value_is_quoted: false,
             value_is_substituted: false,
+            restored_value_ranges: vec![],
         }
     }
 
@@ -583,6 +611,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: earlier.positional_index,
             value_is_quoted: false,
             value_is_substituted: false,
+            restored_value_ranges: vec![],
         }
     }
 
@@ -633,6 +662,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: self.positional_index,
             value_is_quoted: false,
             value_is_substituted: false,
+            restored_value_ranges: vec![],
         }
     }
 
@@ -648,6 +678,7 @@ impl<'src> ElementAttribute<'src> {
             positional_index: None,
             value_is_quoted: false,
             value_is_substituted: false,
+            restored_value_ranges: vec![],
         }
     }
 
@@ -671,6 +702,13 @@ impl<'src> ElementAttribute<'src> {
     /// [`value_is_quoted`](Self::value_is_quoted) field.
     pub(crate) fn value_is_quoted(&self) -> bool {
         self.value_is_quoted
+    }
+
+    /// Byte ranges of [`value`](Self::value) restored from a masked
+    /// passthrough or STEM expression. See the
+    /// [`restored_value_ranges`](Self::restored_value_ranges) field.
+    pub(crate) fn restored_value_ranges(&self) -> &[std::ops::Range<usize>] {
+        &self.restored_value_ranges
     }
 
     /// Return the attribute's value.
@@ -761,7 +799,9 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// A run that is not a well-formed token, or whose index `bodies` does not
 /// supply, is copied through verbatim — the same index-keyed leniency
 /// `restore_to` has, so an unsupplied index never renumbers the tokens after
-/// it. See [`ElementAttribute::into_owned_restoring`] for why the shift is
+/// it. Each splice's byte range in the restored text is appended to
+/// `restored_ranges`, in ascending order. See
+/// [`ElementAttribute::into_owned_restoring`] for why the shift is
 /// right where a re-derivation would not be.
 /// [`restore_tokens`] over a [`CowStr`], keeping the plain
 /// [`into_owned`](CowStr::into_owned) conversion — and with it the inline
@@ -771,15 +811,26 @@ pub(super) fn restore_into<'dst>(
     text: CowStr<'_>,
     bodies: &[&str],
     indices: &mut [usize],
+    restored_ranges: &mut Vec<std::ops::Range<usize>>,
 ) -> CowStr<'dst> {
     if bodies.is_empty() || !text.contains('\u{96}') {
         return text.into_owned();
     }
 
-    CowStr::from(restore_tokens(text.as_ref(), bodies, indices))
+    CowStr::from(restore_tokens(
+        text.as_ref(),
+        bodies,
+        indices,
+        restored_ranges,
+    ))
 }
 
-fn restore_tokens(text: &str, bodies: &[&str], indices: &mut [usize]) -> String {
+fn restore_tokens(
+    text: &str,
+    bodies: &[&str],
+    indices: &mut [usize],
+    restored_ranges: &mut Vec<std::ops::Range<usize>>,
+) -> String {
     let mut out = String::with_capacity(text.len());
     let mut cursor = 0usize;
 
@@ -823,6 +874,7 @@ fn restore_tokens(text: &str, bodies: &[&str], indices: &mut [usize]) -> String 
         };
 
         out.push_str(text.get(cursor..start).unwrap_or_default());
+        restored_ranges.push(out.len()..out.len() + body.len());
         out.push_str(body);
 
         delta = delta

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -244,6 +244,7 @@ fn fold_image(
     if image.is_icon {
         let params = IconRenderParams {
             target: image.target.as_ref(),
+            restored_target_ranges: &image.restored_target_ranges,
             alt,
             size: attrlist
                 .named_or_positional_attribute("size", 1)
@@ -256,6 +257,7 @@ fn fold_image(
     } else {
         let params = ImageRenderParams {
             target: image.target.as_ref(),
+            restored_target_ranges: &image.restored_target_ranges,
             alt,
             width: image.width.as_deref(),
             height: image.height.as_deref(),
@@ -664,6 +666,7 @@ mod tests {
         let hand_built = InlineNode::Image(Image {
             is_icon: false,
             target: CowStr::from("sunset.jpg"),
+            restored_target_ranges: vec![],
             alt: Some(CowStr::from("Sunset")),
             width: None,
             height: None,
@@ -677,6 +680,34 @@ mod tests {
         let macro_built = fold_html(&build_src(location), &renderer);
 
         assert_eq!(fold_html(&[hand_built], &renderer), macro_built);
+    }
+
+    #[test]
+    fn fold_skips_a_hand_built_restored_range_off_the_target() {
+        // The node types are public, so a consumer may hand-build an
+        // [`Image`](InlineNode::Image) whose `restored_target_ranges` do not
+        // fall on the target's own bytes (the builder never produces one).
+        // The renderer's masking skips such a range rather than splitting the
+        // target, so the fold still resolves and renders the plain path.
+        let location = Span::new("image:sunset.jpg[Sunset]");
+
+        let hand_built = InlineNode::Image(Image {
+            is_icon: false,
+            target: CowStr::from("sunset.jpg"),
+            restored_target_ranges: vec![3..99, 100..200],
+            alt: Some(CowStr::from("Sunset")),
+            width: None,
+            height: None,
+            attrs: None,
+            location,
+        });
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        assert!(
+            fold_html(&[hand_built], &renderer).contains(r#"src="sunset.jpg""#),
+            "a range off the target's bytes must not disturb the src"
+        );
     }
 
     /// A resolved cross-reference to a target that carries a signifier (a

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -49,10 +49,11 @@ pub(super) fn image_macros_level<'src>(
     // coordinates — see `apply_macro_families`'s own doc comment.
     let (s, pieces) = ctx.shift(s, pieces);
 
-    // …and with each masked passthrough's placeholder widened into the
-    // sentinel-shaped token the string pipeline's own haystack holds there —
-    // see `widen_masked_passthroughs` for why this family alone needs that.
-    let (s, pieces) = widen_masked_passthroughs(s, pieces, &nodes);
+    // …and with each masked passthrough's or STEM expression's placeholder
+    // widened into the sentinel-shaped token the string pipeline's own
+    // haystack holds there — see `widen_masked_pieces` for why this family
+    // alone needs that.
+    let (s, pieces) = widen_masked_pieces(s, pieces, &nodes);
 
     let matches = find_image_matches(&s, &pieces, root, parser, &nodes);
 
@@ -109,16 +110,19 @@ fn find_image_matches<'src>(
         // match. The **bracket** (group 2) comes back from a *parse* —
         // `bracket_attrlist` reads its bytes as content — so a placeholder
         // there would be read as literal text, and it keeps the opaque-piece
-        // gate: a rendered span in the bracket is left for a later increment,
-        // as is a masked passthrough (whose sentinel the string pipeline's
-        // `Attrlist::parse` swallows into a value that only *restores* after
-        // the split — reproducing that means restoring inside each parsed
-        // value, its own increment). The **target** (group 1) is the one
-        // value this family computes off the match string, and — like the
-        // `link:`/`mailto:` family's — it admits a masked passthrough,
-        // restored into the computed values exactly as
-        // `Passthroughs::restore_to` rewrites the rendered `src` (see
-        // [`range_is_restorable`] and [`restore_masked_passthroughs`]). The
+        // gate for a rendered span, admitting a masked passthrough or STEM
+        // expression (whose sentinel the string pipeline's `Attrlist::parse`
+        // swallows into a value that only *restores* after the split — the
+        // order [`tokened_bracket`] and
+        // [`Attrlist::into_owned_restoring`](Attrlist) reproduce). The
+        // **target** (group 1) is the one value this family computes off the
+        // match string, and — like the `link:`/`mailto:` family's — it
+        // admits both masked kinds, restored into the computed values
+        // exactly as `Passthroughs::restore_to` rewrites the rendered `src`
+        // (see [`range_is_restorable`] and [`restore_masked_passthroughs`];
+        // the fold-time `web_path` this family alone sits behind runs over
+        // the restored ranges *masked* — see
+        // [`Image::restored_target_ranges`](crate::inlines::Image)). The
         // macro name and the two square brackets need no gate of their own:
         // those bytes are literal, and no atomic piece — a placeholder, or an
         // entity delimited by `&` and `;` — can supply them.
@@ -126,17 +130,12 @@ fn find_image_matches<'src>(
             .get(2)
             .map_or(full.end..full.end, |m| m.start()..m.end());
 
-        if !range_is_restorable(nodes, pieces, &bracket, Restorable::Passthrough) {
+        if !range_is_restorable(nodes, pieces, &bracket) {
             continue;
         }
 
         if let Some(target) = caps.get(1)
-            && !range_is_restorable(
-                nodes,
-                pieces,
-                &(target.start()..target.end()),
-                Restorable::Passthrough,
-            )
+            && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
             continue;
         }
@@ -304,14 +303,15 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
     }
 }
 
-/// [`range_has_no_opaque_piece`], further admitting a **masked** piece — one
-/// of the kinds `kinds` names — for a value the caller *restores* rather than
-/// reads: the placeholder's bytes are not the string pipeline's (its haystack
-/// holds the `\u{96}`*n*`\u{97}` sentinel there), but the masked construct's
-/// own rendered body **is** known at build time — it is what
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
-/// the sentinel after the steps run — so a computed value that substitutes it
-/// for the placeholder (see [`restore_masked_passthroughs`](super::links))
+/// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a
+/// passthrough or a STEM expression — for a value the caller *restores*
+/// rather than reads: the placeholder's bytes are not the string pipeline's
+/// (its haystack holds the `\u{96}`*n*`\u{97}` sentinel there), but the
+/// masked construct's own rendered body **is** known at build time — it is
+/// what [`Passthroughs::restore_to`](crate::content::Passthroughs) splices
+/// over the sentinel after the steps run — so a computed value that
+/// substitutes it for the placeholder (see
+/// [`restore_masked_passthroughs`](super::links))
 /// finishes with exactly the restored string's bytes.
 ///
 /// That makes this gate right only for a value whose *recognition* treats the
@@ -321,9 +321,12 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
 /// and whose bytes reach the output (the `href`, and a bare macro's shown
 /// text) only in the restored rendered string; and the `image:`/`icon:`
 /// family's target, whose recognition needs the placeholder widened to the
-/// sentinel's own shape first ([`widen_masked_passthroughs`]) and whose one
+/// sentinel's own shape first ([`widen_masked_pieces`]), whose one
 /// pre-restore computation, the `default_alt` derivation, runs over the
-/// masked bytes itself ([`masked_default_alt`]); and the auto-link /
+/// masked bytes itself ([`masked_default_alt`]), and whose fold-time
+/// `web_path` runs over the restored ranges *masked* (see
+/// [`Image::restored_target_ranges`](crate::inlines::Image) — the string
+/// pipeline's own resolver only ever sees the sentinel); and the auto-link /
 /// formal-URL family's target, whose three URL classes swallow either
 /// spelling with no widening at all and whose two pre-restore decisions —
 /// rejecting a quoted URL, stripping a bare one's trailing punctuation — read
@@ -343,7 +346,6 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
     range: &std::ops::Range<usize>,
-    kinds: Restorable,
 ) -> bool {
     for piece in pieces {
         let p_start = piece.s_start;
@@ -358,10 +360,7 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
             continue;
         }
 
-        if nodes
-            .get(piece.node_index)
-            .is_some_and(|node| node_is_restorable(node, kinds))
-        {
+        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
             continue;
         }
 
@@ -373,36 +372,9 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
     true
 }
 
-/// Which masked kinds a caller is able to **restore**, and so which ones
-/// [`range_is_restorable`] admits for it.
-///
-/// The two kinds differ in one way that matters to a caller whose value the
-/// **fold** re-processes: a STEM expression's rendered body always carries a
-/// backslash (`\$…\$`, `\(…\)`), and the `image:`/`icon:` family's target
-/// is run through
-/// [`PathResolver::web_path`](crate::parser::PathResolver::web_path) at fold
-/// time — which *posixifies* the platform separator, rewriting `\` to `/` on
-/// a Windows-separator resolver. The string pipeline never has that problem:
-/// its `web_path` sees the backslash-free **sentinel**, and the restore pass
-/// splices the STEM bytes into the finished `src` afterwards. So the image
-/// family defers a masked STEM entirely rather than produce a `src` that
-/// differs by platform; the link families, whose targets reach the `href`
-/// with no such re-processing, take both kinds. See
-/// `an_image_target_over_a_stem_expression_is_a_documented_divergence`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in crate::content::inline_builder) enum Restorable {
-    /// A masked passthrough's [`Raw`](InlineNode::Raw) body only — for the
-    /// `image:`/`icon:` family, whose target the fold re-processes.
-    Passthrough,
-
-    /// Either masked kind — for the two link families.
-    PassthroughOrStem,
-}
-
-/// Reports whether `node` is one a computed value can **restore**, given the
-/// kinds its caller admits: a masked passthrough ([`Raw`](InlineNode::Raw))
-/// always, and a masked STEM expression ([`Stem`](InlineNode::Stem)) when
-/// `kinds` is [`Restorable::PassthroughOrStem`].
+/// Reports whether `node` is one a computed value can **restore**: a masked
+/// passthrough ([`Raw`](InlineNode::Raw)) or a masked STEM expression
+/// ([`Stem`](InlineNode::Stem)).
 ///
 /// These are exactly the two node kinds the *same* extraction pass
 /// ([`Passthroughs::extract_from`](crate::content::Passthroughs)) masks before
@@ -414,20 +386,26 @@ pub(in crate::content::inline_builder) enum Restorable {
 /// `Passthroughs::restore_to` splices over that sentinel once the steps have
 /// run.
 ///
+/// Every restoring family admits both kinds. The `image:`/`icon:` family's
+/// values are the only restored ones the **fold** re-processes —
+/// [`PathResolver::web_path`](crate::parser::PathResolver::web_path) resolves
+/// the target (and an interactive SVG's `fallback=`) into the `src`, and a
+/// rendered STEM body always carries a backslash `web_path` would posixify
+/// on a Windows-separator resolver — but that re-processing runs over the
+/// restored ranges *masked*, reproducing the string pipeline's own order
+/// (its `web_path` only ever sees the backslash-free sentinel; the restore
+/// splices the body in afterwards). See
+/// [`Image::restored_target_ranges`](crate::inlines::Image) and
+/// [`ElementAttribute`]'s own restored ranges.
+///
 /// This is the cheap discriminant half of [`restorable_body`], which produces
-/// those bytes: under [`Restorable::PassthroughOrStem`] the two return
-/// `true`/`Some` for the same set, pinned by
+/// those bytes: the two return `true`/`Some` for the same set, pinned by
 /// `restorable_body_agrees_with_node_is_restorable`. A gate uses this one so
 /// a range it is about to *reject* costs no rendering.
-pub(in crate::content::inline_builder) fn node_is_restorable(
-    node: &InlineNode<'_>,
-    kinds: Restorable,
-) -> bool {
-    match node {
-        InlineNode::Raw { .. } => true,
-        InlineNode::Stem(_) => kinds == Restorable::PassthroughOrStem,
-        _ => false,
-    }
+///
+/// [`ElementAttribute`]: crate::attributes::ElementAttribute
+pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'_>) -> bool {
+    matches!(node, InlineNode::Raw { .. } | InlineNode::Stem(_))
 }
 
 /// The bytes a [`node_is_restorable`] node restores to — the very text
@@ -487,7 +465,8 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
 /// bytes this match string carries, and the ones
 /// [`apply_image_side_effects`] registers). Only the node's `location` then
 /// takes design §4.4's coarse fallback. A target crossing a masked
-/// **passthrough** finishes into the restored bytes instead — see
+/// **passthrough** or **STEM** expression finishes into the restored bytes
+/// instead — see
 /// [`restore_masked_passthroughs`] and [`masked_default_alt`] — and the side
 /// effect registers that honest restored value where the string pipeline
 /// registers its own sentinel bytes verbatim (a wart the cutover deliberately
@@ -525,8 +504,8 @@ fn build_image_node<'src>(
 
     // Group 1 is the (optional) target; group 2 is the bracket text, which
     // always participates (it may be empty).
-    let target = match caps.get(1) {
-        None => CowStr::from(""),
+    let (target, restored_target_ranges) = match caps.get(1) {
+        None => (CowStr::from(""), Vec::new()),
 
         // Borrowed from `'src` for a verbatim target (§4.5), the expansion's
         // own exact bytes for a synthesized one. A target crossing an escaped
@@ -534,14 +513,16 @@ fn build_image_node<'src>(
         // where the match string holds an entity — so it falls back to the
         // match string's own bytes, which is what `text_slice` declines to
         // recover and precisely what the string replacer reads as `caps[1]`.
-        // A target crossing a masked **passthrough** finishes into the
-        // restored bytes — the `Raw` node's value substituted for its
-        // placeholder, the same rewrite `Passthroughs::restore_to` performs
-        // on the rendered `src` — while the `default_alt` *arithmetic* below
-        // stays on the bytes as matched, where the string replacer's own
-        // runs (see [`masked_default_alt`]). A masked **STEM** expression is
-        // deferred by this family's gate before it reaches here (see
-        // [`Restorable`]).
+        // A target crossing a masked **passthrough** or **STEM** expression
+        // finishes into the restored bytes — the node's own rendered body
+        // substituted for its placeholder, the same rewrite
+        // `Passthroughs::restore_to` performs on the rendered `src` — while
+        // the `default_alt` *arithmetic* below stays on the bytes as
+        // matched, where the string replacer's own runs (see
+        // [`masked_default_alt`]), and the node records which ranges of the
+        // restored target came from a masked body, so the fold-time
+        // `web_path` can keep them out of its own way (see
+        // [`Image::restored_target_ranges`](crate::inlines::Image)).
         Some(m) => {
             match restore_masked_passthroughs(
                 m.as_str(),
@@ -550,9 +531,12 @@ fn build_image_node<'src>(
                 pieces,
                 parser.renderer.as_ref(),
             ) {
-                Some(restored) => CowStr::from(restored),
-                None => text_slice(nodes, pieces, m.start()..m.end())
-                    .unwrap_or_else(|| CowStr::from(m.as_str().to_string())),
+                Some((restored, ranges)) => (CowStr::from(restored), ranges),
+                None => (
+                    text_slice(nodes, pieces, m.start()..m.end())
+                        .unwrap_or_else(|| CowStr::from(m.as_str().to_string())),
+                    Vec::new(),
+                ),
             }
         }
     };
@@ -569,11 +553,17 @@ fn build_image_node<'src>(
 
     // The default alt text derives from the target's basename, with `_`/`-`
     // read as spaces — exactly the string replacer's `default_alt`, which
-    // runs over the *masked* bytes (its haystack holds the passthrough
-    // sentinel), with the passthrough bodies restored into whatever survives
+    // runs over the *masked* bytes (its haystack holds the passthrough or
+    // STEM sentinel), with the masked bodies restored into whatever survives
     // the arithmetic.
     let default_alt = caps.get(1).map_or_else(String::new, |m| {
-        masked_default_alt(m.as_str(), &(m.start()..m.end()), nodes, pieces)
+        masked_default_alt(
+            m.as_str(),
+            &(m.start()..m.end()),
+            nodes,
+            pieces,
+            parser.renderer.as_ref(),
+        )
     });
 
     // Pre-extract the resolved alt/width/height into owned values, ending the
@@ -607,6 +597,7 @@ fn build_image_node<'src>(
     InlineNode::Image(Image {
         is_icon,
         target,
+        restored_target_ranges,
         alt,
         width,
         height,
@@ -615,28 +606,23 @@ fn build_image_node<'src>(
     })
 }
 
-/// Rewrites this level's match string so each masked **passthrough**'s
-/// placeholder becomes a sentinel-shaped token — `\u{96}`*n*`\u{97}`, the
-/// very bytes the string pipeline's own haystack holds there — moving the
-/// pieces into the rewritten string's coordinates (each
-/// [`Raw`](InlineNode::Raw) piece keeps its node, wider; every other piece
-/// keeps its bytes).
+/// Rewrites this level's match string so each masked **passthrough** or
+/// **STEM** expression's placeholder becomes a sentinel-shaped token —
+/// `\u{96}`*n*`\u{97}`, the very bytes the string pipeline's own haystack
+/// holds there — moving the pieces into the rewritten string's coordinates
+/// (each [`node_is_restorable`] piece keeps its node, wider; every other
+/// piece keeps its bytes).
 ///
 /// This family alone needs the widening because [`INLINE_IMAGE_MACRO`]'s
 /// target class is the one in this module that requires **two** characters
 /// (`[^:\s\[\n][^\[\n]*?[^\s\[\n]`): a target written wholly inside a
-/// passthrough (`image:++sunset.jpg++[]`) is a single placeholder character,
-/// which that class cannot match — where the string replacer's three-byte
-/// sentinel matches it exactly. Widening the placeholder to the sentinel's
-/// own shape makes recognition agree byte-for-byte with the string step
-/// without touching the shared pattern. (The `link:`/`mailto:` family's
-/// one-or-more target class never faced this, so its increment left the
-/// placeholder bare.)
-///
-/// A masked **STEM** expression is deliberately *not* widened here: this
-/// family defers it entirely (see [`range_is_restorable`]'s `kinds`
-/// parameter and [`Restorable::Passthrough`]), so widening it would only
-/// grow a match this level's gate then rejects.
+/// passthrough (`image:++sunset.jpg++[]`) or a STEM expression
+/// (`image:stem:[x][]`) is a single placeholder character, which that class
+/// cannot match — where the string replacer's three-byte sentinel matches it
+/// exactly. Widening the placeholder to the sentinel's own shape makes
+/// recognition agree byte-for-byte with the string step without touching the
+/// shared pattern. (The `link:`/`mailto:` family's one-or-more target class
+/// never faced this, so its increment left the placeholder bare.)
 ///
 /// The token's bytes never reach an output node: an unmatched token sits in
 /// a gap [`rebuild_macro_level`] re-emits from the piece's own *node*, a
@@ -647,14 +633,14 @@ fn build_image_node<'src>(
 /// are the literal macro name and `]`). The numbering is per level and
 /// exists only to keep tokens distinct; the string pipeline's own sentinel
 /// numbers are global to the content, and neither survives into any output.
-fn widen_masked_passthroughs(
+fn widen_masked_pieces(
     s: String,
     pieces: Vec<Piece>,
     nodes: &[InlineNode<'_>],
 ) -> (String, Vec<Piece>) {
     if !pieces
         .iter()
-        .any(|piece| matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })))
+        .any(|piece| nodes.get(piece.node_index).is_some_and(node_is_restorable))
     {
         return (s, pieces);
     }
@@ -675,7 +661,7 @@ fn widen_masked_passthroughs(
 
         let s_start = out.len();
 
-        if matches!(nodes.get(piece.node_index), Some(InlineNode::Raw { .. })) {
+        if nodes.get(piece.node_index).is_some_and(node_is_restorable) {
             out.push_str(&format!("\u{96}{n}\u{97}"));
             n += 1;
         } else {
@@ -698,11 +684,11 @@ fn widen_masked_passthroughs(
 
 /// The string replacer's `default_alt` derivation —
 /// `basename(&target.replace(['_', '-'], " "))` — performed over the
-/// **masked** bytes, with each masked passthrough's body restored into
-/// whatever survives the arithmetic.
+/// **masked** bytes, with each masked passthrough's or STEM expression's
+/// body restored into whatever survives the arithmetic.
 ///
 /// The string pipeline computes `default_alt` from its own haystack, where a
-/// masked passthrough is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
+/// masked construct is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
 /// carrying none of the bytes the arithmetic acts on (no `_`/`-` for the
 /// replace, no `/` or `.` for [`basename`]'s stem cut), so the derivation
 /// treats it as one indivisible character and the restore pass then splices
@@ -710,16 +696,16 @@ fn widen_masked_passthroughs(
 /// which is how `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"` where the
 /// verbatim spelling shows `a b c`, its underscores hidden from the replace
 /// inside the sentinel. This reproduces that byte-for-byte: each overlapping
-/// [`Raw`](InlineNode::Raw) piece's placeholder becomes the same
+/// [`node_is_restorable`] piece's placeholder becomes the same
 /// sentinel-shaped token, the arithmetic runs, and each *surviving* token is
-/// restored with its own node's value — index-keyed, as
+/// restored with its own node's body ([`restorable_body`]) — index-keyed, as
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) is, so a token
-/// the basename cut dropped (a passthrough wholly inside a directory prefix
-/// or an extension) does not shift the ones that survive. A token survives
-/// whole or is dropped whole: both of the cut points [`basename`] reads (the
-/// last `/`, the last `.`) are bytes no token contains.
+/// the basename cut dropped (a masked construct wholly inside a directory
+/// prefix or an extension) does not shift the ones that survive. A token
+/// survives whole or is dropped whole: both of the cut points [`basename`]
+/// reads (the last `/`, the last `.`) are bytes no token contains.
 ///
-/// A range holding no masked passthrough takes the plain derivation over the
+/// A range holding no masked construct takes the plain derivation over the
 /// match-string bytes — exactly what this family computed before the restore
 /// existed, since `masked` here is the same `caps[1]` the string replacer
 /// reads.
@@ -728,9 +714,10 @@ fn masked_default_alt(
     range: &std::ops::Range<usize>,
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
+    renderer: &dyn InlineSubstitutionRenderer,
 ) -> String {
     let mut tokened = String::new();
-    let mut values: Vec<&str> = Vec::new();
+    let mut values: Vec<Cow<'_, str>> = Vec::new();
 
     // In match-string coordinates; `masked` is indexed relative to
     // `range.start`.
@@ -745,11 +732,14 @@ fn masked_default_alt(
             continue;
         }
 
-        let Some(InlineNode::Raw { value, .. }) = nodes.get(piece.node_index) else {
+        let Some(value) = nodes
+            .get(piece.node_index)
+            .and_then(|node| restorable_body(node, renderer))
+        else {
             continue;
         };
 
-        // A `Raw` piece is one placeholder character, atomic and never
+        // A masked piece is one placeholder character, atomic and never
         // sliced, so an overlapping one lies wholly inside the range and
         // `p_start`/`p_end` are safe bounds.
         tokened.push_str(
@@ -758,7 +748,7 @@ fn masked_default_alt(
                 .unwrap_or_default(),
         );
         tokened.push_str(&format!("\u{96}{n}\u{97}", n = values.len()));
-        values.push(value.as_ref());
+        values.push(value);
         cursor = p_end;
     }
 
@@ -789,7 +779,7 @@ fn masked_default_alt(
 
         if let Some(pos) = rest.find(&token) {
             out.push_str(rest.get(..pos).unwrap_or_default());
-            out.push_str(value);
+            out.push_str(value.as_ref());
             rest = rest.get(pos + token.len()..).unwrap_or_default();
         }
     }
@@ -845,7 +835,6 @@ fn bracket_attrlist<'src>(
         nodes,
         pieces,
         parser.renderer.as_ref(),
-        Restorable::Passthrough,
     );
 
     let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
@@ -882,9 +871,9 @@ pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
 /// This is the *before the split* half of every bracket restore, and it exists
 /// so the text handed to [`Attrlist::parse`] is the same **shape** the string
 /// pipeline's own haystack has there. Two spellings have to be normalized into
-/// one: [`widen_masked_passthroughs`] has already rewritten a
-/// [`Raw`](InlineNode::Raw) piece to a sentinel-shaped token for the image
-/// family's *recognition*, but its numbering is per level, and any other
+/// one: [`widen_masked_pieces`] has already rewritten a masked piece to a
+/// sentinel-shaped token for the image family's *recognition*, but its
+/// numbering is per level, and for the link families' display-text list a
 /// masked piece is still the bare one-character
 /// [`SPAN_PLACEHOLDER`](super::super::quotes). Renumbering every restorable
 /// piece from zero, per bracket, is what lets the restore be **index-keyed**
@@ -894,23 +883,20 @@ pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
 /// [`Passthroughs::restore_to`](crate::content::Passthroughs) is unshifted by
 /// a sentinel that never reached the rendered string.
 ///
-/// Shared by the two families whose bracket comes back from a parse, each
-/// passing the `kinds` its own gate admits so the two cannot disagree about
-/// what a token may stand for: the `image:`/`icon:` bracket passes
-/// [`Restorable::Passthrough`] (a masked **STEM** is deferred there as it is
-/// in that family's target, and for the same `web_path` reason — see
-/// [`Restorable`], and
-/// `an_image_bracket_over_a_stem_expression_is_a_documented_divergence`),
-/// while the link families' display-text list
-/// ([`text_attrlist`](super::links)) passes
-/// [`Restorable::PassthroughOrStem`], having no such re-processing of its own.
+/// Shared by the two families whose bracket comes back from a parse — the
+/// `image:`/`icon:` bracket here, and the link families' display-text list
+/// ([`text_attrlist`](super::links)) — so the two cannot disagree about what
+/// a token may stand for: both masked kinds, the set [`node_is_restorable`]
+/// names. (The image bracket's one `web_path`-bound value, an interactive
+/// SVG's `fallback=`, resolves over its restored ranges *masked* — see
+/// [`ElementAttribute::into_owned_restoring`](crate::attributes::ElementAttribute) —
+/// so a STEM body's backslash never reaches the resolver there either.)
 pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
     bracket_text: &str,
     range: &std::ops::Range<usize>,
     nodes: &'a [InlineNode<'src>],
     pieces: &[Piece],
     renderer: &dyn InlineSubstitutionRenderer,
-    kinds: Restorable,
 ) -> (String, Vec<MaskedPiece<'a, 'src>>) {
     let mut tokened = String::new();
     let mut masked_pieces: Vec<MaskedPiece<'a, 'src>> = Vec::new();
@@ -932,19 +918,16 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
             continue;
         }
 
-        // The kinds gate and the body are one step: `restorable_body`
+        // The discriminant and the body are one step: `restorable_body`
         // answers `Some` for exactly the nodes `node_is_restorable` admits
         // (pinned by `restorable_body_agrees_with_node_is_restorable`), so
-        // splitting them would leave a branch no input can take. A piece this
-        // skips is an atomic one the *gate* admitted for another reason — a
-        // `CharRef` leaf the match string gives real bytes to.
-        let Some(masked) = nodes
-            .get(piece.node_index)
-            .filter(|node| node_is_restorable(node, kinds))
-            .and_then(|node| {
-                restorable_body(node, renderer).map(|body| MaskedPiece { node, body })
-            })
-        else {
+        // gating on one before producing the other would leave a branch no
+        // input can take. A piece this skips is an atomic one the *gate*
+        // admitted for another reason — a `CharRef` leaf the match string
+        // gives real bytes to.
+        let Some(masked) = nodes.get(piece.node_index).and_then(|node| {
+            restorable_body(node, renderer).map(|body| MaskedPiece { node, body })
+        }) else {
             continue;
         };
 
@@ -1088,7 +1071,7 @@ mod tests {
             assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_macros,
             golden_macros_with,
         },
-        Restorable, node_is_restorable, restorable_body,
+        node_is_restorable, restorable_body,
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -1692,7 +1675,7 @@ mod tests {
         // The differential corpus for an `image:`/`icon:` target crossing a
         // masked **passthrough** — the string pipeline swallows the
         // `\u{96}`*n*`\u{97}` sentinel into the target (the widened match
-        // string carries the same bytes, see [`widen_masked_passthroughs`])
+        // string carries the same bytes, see [`widen_masked_pieces`])
         // and the restore pass then splices the extracted body over every
         // sentinel in the rendered string, so the tree's computed target
         // substitutes the `Raw` node's value for its placeholder the same
@@ -1708,8 +1691,8 @@ mod tests {
             // `a b c`.
             "image:++sunset.jpg++[Alt]",
             "image:++a_b-c.jpg++[]",
-            // A `pass:[…]` target (a body `web_path` passes through — a
-            // space-carrying one keeps its own divergence test below).
+            // A `pass:[…]` target (a space-carrying body has its own test —
+            // `a_space_restored_into_an_image_target_stays_out_of_web_paths_way`).
             "image:pass:[chart,v2.png][]",
             "image:pass:[chart,v2.png][Chart,200]",
             // A passthrough covering only part of the target, at either edge
@@ -1723,6 +1706,11 @@ mod tests {
             // A URI target: both pipelines see a URI-ish haystack (the
             // scheme sits before the token) and preserve it verbatim.
             "image:https://++example.org/x++.png[]",
+            // `web_path`'s own `..` arithmetic consumes the masked segment,
+            // so the token never reaches the resolved path and its body is
+            // dropped — in both pipelines (the string pipeline's restore
+            // cannot find the sentinel either).
+            "image:++dropped++/../kept.png[]",
             // The icon form, which derives its default alt the same way.
             "icon:++a_b++[]",
             // A triple-plus passthrough (no substitutions on the body).
@@ -1820,15 +1808,17 @@ mod tests {
     }
 
     #[test]
-    fn a_space_restored_into_an_image_target_is_a_documented_divergence() {
-        // The renderer's `web_path` normalization runs at fold time over the
-        // node's *restored* target, so a space the passthrough smuggled past
-        // the target class is percent-encoded into the `src` — the
-        // well-formed reading — where the string pipeline normalized its
-        // space-free sentinel and the restore then spliced the raw space
-        // into the emitted attribute. The honest target itself (what the
-        // node stores, and what the staged side effect registers) is pinned
-        // by the tests around this one; only the emitted `src` bytes differ.
+    fn a_space_restored_into_an_image_target_stays_out_of_web_paths_way() {
+        // Formerly this module's own documented divergence: the fold-time
+        // `web_path` used to run over the node's *restored* target, so a
+        // space the passthrough smuggled past the target class was
+        // percent-encoded into the `src` where the string pipeline
+        // normalized its space-free sentinel and spliced the raw space in
+        // afterwards. The masked-resolve order closed it — `render_image`
+        // resolves the `src` with the node's
+        // [`restored_target_ranges`](Image) masked
+        // to the same sentinel shape and splices the bodies back in, so the
+        // space never reaches `web_path` in either pipeline.
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "image:pass:[My Documents/chart.png][]";
@@ -1836,19 +1826,16 @@ mod tests {
 
         let image = assert_image(&nodes[0]);
         assert_eq!(image.target.as_ref(), "My Documents/chart.png");
+        assert_eq!(image.restored_target_ranges, vec![0..22]);
 
         let golden = golden_passthroughs(source);
 
         assert!(
             golden.contains("src=\"My Documents/chart.png\""),
-            "expected the documented divergence to still reproduce: {golden:?}"
+            "expected the raw space in the golden src: {golden:?}"
         );
 
-        assert!(
-            fold_html(&nodes, &HtmlSubstitutionRenderer {})
-                .contains("src=\"My%20Documents/chart.png\""),
-            "the fold must emit the percent-encoded src"
-        );
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), golden);
     }
 
     #[test]
@@ -2076,36 +2063,56 @@ mod tests {
     }
 
     #[test]
-    fn an_image_bracket_over_a_stem_expression_is_a_documented_divergence() {
-        // The bracket admits exactly the kinds the *target* does
-        // ([`Restorable::Passthrough`]), and defers a masked STEM expression
-        // for the same reason the target does — see
-        // `an_image_target_over_a_stem_expression_is_a_documented_divergence`.
-        // The bracket has a `web_path`-bound value of its own: an
-        // interactive SVG's `fallback=` is run through `image_src`, so a
-        // restored body carrying a backslash — which *every* rendered STEM
-        // body does — would posixify on a Windows-separator resolver where
-        // the string pipeline's own `web_path` saw only the backslash-free
-        // sentinel.
+    fn fold_matches_the_string_pipeline_for_an_image_bracket_over_a_stem_expression() {
+        // The bracket admits a masked STEM expression exactly as it admits a
+        // masked passthrough — the two are one extraction pass's node kinds
+        // ([`node_is_restorable`]) — tokened through the parse and restored
+        // into the parsed values, with a `Stem` piece's body coming from its
+        // own fold ([`restorable_body`]). Formerly this family's documented
+        // deferral, blocked on the bracket's one `web_path`-bound value (an
+        // interactive SVG's `fallback=`, covered by its own corpus below):
+        // the masked-resolve order lifted it.
         use super::super::super::test_support::golden_passthroughs;
 
-        for source in ["image:x.png[stem:[y]]", "icon:home[stem:[y]]"] {
-            let nodes = build_src(Span::new(source));
+        let fixtures = [
+            // The positional alt, whole and beside plain text, and the
+            // `icon:` form.
+            "image:x.png[stem:[y]]",
+            "image:x.png[see stem:[y] here]",
+            "icon:home[stem:[y]]",
+            // The split invariant: a `,` or `=` inside the STEM body must
+            // not divide the list — the string pipeline's own parse only
+            // ever sees the sentinel.
+            "image:x.png[stem:[a,b]]",
+            "image:x.png[stem:[a=b],200]",
+            // Named values, the positional width slot, and a role.
+            "image:x.png[title=stem:[t]]",
+            "image:x.png[alt,stem:[2],50]",
+            "image:x.png[Sunset,role=stem:[r]]",
+            // The other STEM notations.
+            "image:x.png[latexmath:[y]]",
+            "image:x.png[asciimath:[y]]",
+            // Both masked kinds in one bracket, and target and bracket both
+            // masked.
+            "image:x.png[stem:[y] and ++z++]",
+            "image:stem:[t][stem:[u]]",
+            // In a rendered span, two in one flow, and escaped.
+            "*a image:x.png[stem:[y]] b*",
+            "image:x.png[stem:[a]] image:y.png[stem:[b]]",
+            "\\image:x.png[stem:[y]]",
+        ];
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image bracket over a STEM expression must stay literal: {nodes:?}"
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
             );
         }
-
-        // The string pipeline builds one, restoring the rendered expression
-        // into the `alt` after its own parse split the list.
-        let golden = golden_passthroughs("image:x.png[stem:[y]]");
-
-        assert!(
-            golden.contains(r#"alt="\$y\$""#),
-            "expected the documented divergence to still reproduce: {golden:?}"
-        );
     }
 
     #[test]
@@ -2118,7 +2125,7 @@ mod tests {
         // reproducing that wart, so this pins the policy with no
         // golden-catalog comparison — exactly as the link family's own
         // increment did.
-        let source = "image:++sunset photo.jpg++[] and image:pass:[My Documents/chart.png][]";
+        let source = "image:++sunset photo.jpg++[] and image:pass:[My Documents/chart.png][] and image:stem:[s].png[]";
         let parser = Parser::default().with_catalog_assets(true);
         let nodes = build_with(Span::new(source), &parser);
 
@@ -2131,7 +2138,10 @@ mod tests {
             .map(|i| i.target.clone())
             .collect();
 
-        assert_eq!(targets, ["sunset photo.jpg", "My Documents/chart.png"]);
+        assert_eq!(
+            targets,
+            ["sunset photo.jpg", "My Documents/chart.png", "\\$s\\$.png"]
+        );
     }
 
     #[test]
@@ -2150,6 +2160,9 @@ mod tests {
             "A sunset: image:++sunset_beach.jpg++[] under a masked name.\n",
             "\n",
             "See image:pass:[chart,v2.png][Chart] or icon:++a_b++[] today.\n",
+            "\n",
+            "A formula: image:stem:[E = mc^2].png[] as a target,\n",
+            "and image:x.png[stem:[a,b]] in a bracket.\n",
         ));
 
         let mut folded_blocks = 0;
@@ -2173,83 +2186,168 @@ mod tests {
             folded_blocks += 1;
         }
 
-        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
+        assert_eq!(folded_blocks, 3, "expected every paragraph to carry a tree");
     }
 
     #[test]
-    fn an_image_target_over_a_stem_expression_is_a_documented_divergence() {
-        // This family defers a masked **STEM** expression in the target,
-        // where the two link families restore it (see
-        // [`Restorable`]). The reason is the fold-time
-        // [`web_path`](crate::parser::PathResolver::web_path) seam this
-        // family alone sits behind, and it is the same one the passthrough
-        // increment already pinned for a restored *space*: the string
-        // pipeline runs `web_path` over its own **sentinel** and splices the
-        // extracted body into the finished `src` afterwards, so bytes
-        // `web_path` would rewrite never reach it — while a tree that
-        // restores at build time hands those bytes straight to `web_path`.
-        //
-        // For a passthrough that is an exotic body. For STEM it is *every*
-        // body: a rendered expression always carries a backslash (`\$…\$`,
-        // `\(…\)`), and `web_path` posixifies the platform separator — so on
-        // a Windows-separator resolver `image:stem:[x].png[]` would render
-        // `src="/$x/$.png"` against the golden's `src="\$x\$.png"`. Deferring
-        // keeps this family's `src` identical on every platform; restoring
-        // would make it differ by one.
+    fn fold_matches_the_string_pipeline_for_an_image_target_over_a_stem_expression() {
+        // Formerly this family's documented deferral — the last of the
+        // restore-the-value class. A masked STEM expression restores into
+        // the target exactly as a masked passthrough does (its body is
+        // [`fold_stem`](super::super::fold::fold_stem)'s own output), and
+        // the fold-time `web_path` this family alone sits behind runs over
+        // the node's [`restored_target_ranges`](Image) *masked*, so the
+        // backslash every rendered STEM body carries — and any `/`, `.`,
+        // or space a masked body smuggles past the target class — never
+        // reaches the resolver, in either pipeline.
         use super::super::super::test_support::golden_passthroughs;
 
-        for source in [
+        let fixtures = [
+            // The wholly-masked target, bare and with an extension, in both
+            // macro forms — and with an alt beside it.
             "image:stem:[x][]",
             "image:stem:[x].png[]",
             "icon:stem:[x][]",
-        ] {
-            let nodes = build_src(Span::new(source));
+            "image:stem:[x].png[Alt]",
+            // The other STEM notations.
+            "image:latexmath:[y].png[]",
+            "image:asciimath:[y].png[]",
+            // A partial mask: the default-alt arithmetic runs over the
+            // masked bytes (the visible `_` reads as a space, the visible
+            // extension comes off), with the surviving token restored.
+            "image:stem:[x]_suffix.png[]",
+            "image:dir/stem:[x].png[]",
+            // Both masked kinds in one target.
+            "image:++a++stem:[x].png[]",
+            // A macro-level `imagesdir=`: the resolver joins the directory
+            // and the masked target into one path, so the two mask sets
+            // share one token numbering.
+            "image:stem:[x].png[imagesdir=assets]",
+            "image:x.png[imagesdir=stem:[d]]",
+            "image:stem:[t].png[imagesdir=stem:[d]]",
+            "image:x.png[imagesdir=pass:[my docs]]",
+            // Two in one flow, inside a rendered span, and escaped.
+            "image:stem:[a][] icon:stem:[b][]",
+            "*see image:stem:[x].png[] here*",
+            "\\image:stem:[x].png[]",
+        ];
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Image(_))),
-                "an image target over a STEM expression must stay literal: {nodes:?}"
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build_src(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden_passthroughs(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
             );
         }
+    }
 
-        // The string pipeline does build one, restoring the rendered
-        // expression into the `src` after its own `web_path` ran.
-        let golden = golden_passthroughs("image:stem:[x].png[]");
+    #[test]
+    fn an_image_target_over_a_stem_expression_is_recognized() {
+        // The target is the restored bytes with the spliced ranges recorded
+        // on the node, and the default alt is the masked derivation — the
+        // rendered expression hides whole inside the sentinel, so the
+        // extension still comes off around it.
+        let nodes = build_src(Span::new("image:stem:[x].png[]"));
 
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.target.as_ref(), "\\$x\\$.png");
+        assert_eq!(image.restored_target_ranges, vec![0..5]);
+        assert_eq!(image.alt.as_deref(), Some("\\$x\\$"));
+
+        // Both masked kinds in one target, each range its own record.
+        let nodes = build_src(Span::new("image:++a++stem:[x].png[]"));
+
+        let image = assert_image(&nodes[0]);
+        assert_eq!(image.target.as_ref(), "a\\$x\\$.png");
+        assert_eq!(image.restored_target_ranges, vec![0..1, 1..6]);
+
+        // A verbatim target records none.
+        let nodes = build_src(Span::new("image:sunset.jpg[]"));
         assert!(
-            golden.contains("src=\"\\$x\\$.png\""),
-            "expected the documented divergence to still reproduce: {golden:?}"
+            assert_image(&nodes[0]).restored_target_ranges.is_empty(),
+            "a verbatim target must record no restored ranges"
         );
     }
 
     #[test]
-    fn an_image_target_over_a_stem_expression_is_platform_independent() {
-        // The reason the divergence above is a *deferral* rather than an
-        // accepted difference: with a Windows-separator path resolver, a
-        // restored STEM body would have its backslashes posixified into the
-        // `src`. Left literal, this family's output is identical under either
-        // separator — which is what this pins, since CI runs all three
-        // platforms and a restored target would only fail on one.
-        let source = "image:stem:[x].png[]";
+    fn fold_matches_the_string_pipeline_for_a_masked_fallback() {
+        // The bracket's one `web_path`-bound value: an interactive SVG's
+        // `fallback=` is run through `image_src` at fold time, so it
+        // resolves over the attribute's own restored ranges masked (see
+        // [`ElementAttribute::into_owned_restoring`](crate::attributes::ElementAttribute)) —
+        // the same order the target takes, at the same seam. Interactive
+        // SVGs render only below `SafeMode::Secure`, so this corpus runs
+        // under `Unsafe`, on both pipelines' side of the comparison.
+        use super::super::super::test_support::golden_passthroughs_with;
+        use crate::parser::SafeMode;
 
-        let posix = Parser::default().with_path_resolver(DefaultPathResolver {
-            file_separator: '/',
-        });
-
-        let windows = Parser::default().with_path_resolver(DefaultPathResolver {
-            file_separator: '\\',
-        });
+        let fixtures = [
+            "image:x.svg[opts=interactive,fallback=stem:[y].png]",
+            "image:x.svg[opts=interactive,fallback=pass:[my docs/f].png]",
+            "image:x.svg[Alt,opts=interactive,fallback=++a b++.png]",
+        ];
 
         let renderer = HtmlSubstitutionRenderer {};
 
-        let fold_with = |parser: &Parser| {
-            crate::content::inline_builder::fold_html(
-                &build_with(Span::new(source), parser),
-                &renderer,
-                parser,
-            )
-        };
+        for fixture in fixtures {
+            let parser = Parser::default().with_safe_mode(SafeMode::Unsafe);
 
-        assert_eq!(fold_with(&posix), fold_with(&windows));
+            let folded = crate::content::inline_builder::fold_html(
+                &build_with(Span::new(fixture), &parser),
+                &renderer,
+                &parser,
+            );
+
+            assert_eq!(
+                folded,
+                golden_passthroughs_with(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_target_over_a_stem_expression_is_platform_independent() {
+        // The reason this family deferred the restore for as long as it did:
+        // a rendered STEM body always carries a backslash, and `web_path`
+        // posixifies the platform separator, so a restore that reached the
+        // resolver would make the `src` differ by platform (CI runs all
+        // three). The masked resolve keeps the body away from the resolver,
+        // so the fold is byte-identical under either separator — and equal
+        // to the golden, whose own resolver only ever saw the sentinel.
+        use super::super::super::test_support::golden_passthroughs;
+
+        for source in [
+            "image:stem:[x].png[]",
+            "image:stem:[t].png[imagesdir=stem:[d]]",
+        ] {
+            let posix = Parser::default().with_path_resolver(DefaultPathResolver {
+                file_separator: '/',
+            });
+
+            let windows = Parser::default().with_path_resolver(DefaultPathResolver {
+                file_separator: '\\',
+            });
+
+            let renderer = HtmlSubstitutionRenderer {};
+
+            let fold_with = |parser: &Parser| {
+                crate::content::inline_builder::fold_html(
+                    &build_with(Span::new(source), parser),
+                    &renderer,
+                    parser,
+                )
+            };
+
+            let posix_fold = fold_with(&posix);
+
+            assert_eq!(posix_fold, fold_with(&windows));
+            assert_eq!(posix_fold, golden_passthroughs(source));
+        }
     }
 
     #[test]
@@ -2275,20 +2373,12 @@ mod tests {
         ];
 
         for node in &restorable {
-            assert!(
-                node_is_restorable(node, Restorable::PassthroughOrStem),
-                "expected restorable: {node:?}"
-            );
+            assert!(node_is_restorable(node), "expected restorable: {node:?}");
             assert!(
                 restorable_body(node, &renderer).is_some(),
                 "expected a body: {node:?}"
             );
         }
-
-        // Under `Passthrough` the STEM half is withheld, which is the image
-        // family's deferral — the `Raw` half is admitted either way.
-        assert!(node_is_restorable(&restorable[0], Restorable::Passthrough));
-        assert!(!node_is_restorable(&restorable[1], Restorable::Passthrough));
 
         let opaque = [
             InlineNode::Text {
@@ -2303,10 +2393,7 @@ mod tests {
         ];
 
         for node in &opaque {
-            assert!(
-                !node_is_restorable(node, Restorable::PassthroughOrStem),
-                "expected opaque: {node:?}"
-            );
+            assert!(!node_is_restorable(node), "expected opaque: {node:?}");
             assert!(
                 restorable_body(node, &renderer).is_none(),
                 "expected no body: {node:?}"

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3,8 +3,8 @@
 use super::{
     MacroMatch, MacroMatchKind, escaped_value_children,
     image::{
-        Restorable, range_is_restorable, range_is_verbatim, range_is_verbatim_or_synthesized,
-        restorable_body, tokened_bracket,
+        range_is_restorable, range_is_verbatim, range_is_verbatim_or_synthesized, restorable_body,
+        tokened_bracket,
     },
     macro_text_children, rebuild_macro_level,
 };
@@ -144,10 +144,10 @@ use crate::{
 /// A **masked** construct — a passthrough's [`Raw`](InlineNode::Raw) piece or
 /// a STEM expression's [`Stem`](InlineNode::Stem) one, the pair
 /// [`restorable_body`] names — is admitted in the target, this being the
-/// third and last family to take [`range_is_restorable`]. (Both kinds, unlike
-/// the `image:`/`icon:` family, which admits only the passthrough: this
-/// family's target reaches the `href` as computed, where that one's is
-/// re-processed by `web_path` at fold time — see [`Restorable`].) the string
+/// third and last family to take [`range_is_restorable`]. (This family's
+/// target reaches the `href` as computed; the `image:`/`icon:` family's is
+/// re-processed by `web_path` at fold time, over its restored ranges masked —
+/// see [`Image::restored_target_ranges`](crate::inlines::Image).) the string
 /// replacer swallows the `\u{96}`*n*`\u{97}` sentinel into its own target (both
 /// target classes admit it exactly as they admit the tree's placeholder, and
 /// the bare branch's trailing-character class admits the last byte of either
@@ -388,12 +388,7 @@ fn build_inline_link_node<'src>(
     // ASCII no single-character piece can supply.
     let computed_end = n.attrlist().map_or(full.end, |m| m.start());
 
-    if !range_is_restorable(
-        nodes,
-        pieces,
-        &(full.start..computed_end),
-        Restorable::PassthroughOrStem,
-    ) {
+    if !range_is_restorable(nodes, pieces, &(full.start..computed_end)) {
         return None;
     }
 
@@ -501,7 +496,7 @@ fn build_inline_link_node<'src>(
         parser.renderer.as_ref(),
     );
 
-    let target = restored.unwrap_or(target);
+    let target = restored.map_or(target, |(restored, _)| restored);
 
     // The display text becomes the node's children, located at the bracketed
     // text (a formal link) or the node itself (a bare link).
@@ -768,7 +763,7 @@ fn build_angle_link_node<'src>(
 
     let interior = scheme_m.start()..angle_url.end();
 
-    if !range_is_restorable(nodes, pieces, &interior, Restorable::PassthroughOrStem) {
+    if !range_is_restorable(nodes, pieces, &interior) {
         return None;
     }
 
@@ -793,7 +788,7 @@ fn build_angle_link_node<'src>(
         parser.renderer.as_ref(),
     );
 
-    let target = restored.unwrap_or(masked_target);
+    let target = restored.map_or(masked_target, |(restored, _)| restored);
 
     let link_text = hide_uri_scheme_text(&target, parser);
 
@@ -1047,12 +1042,7 @@ fn find_link_macro_matches<'src>(
         // comes back from a *parse*: a masked construct is tokened through
         // that parse and restored after it, a rendered span still deferred.)
         if let Some(target) = caps.get(3)
-            && !range_is_restorable(
-                nodes,
-                pieces,
-                &(target.start()..target.end()),
-                Restorable::PassthroughOrStem,
-            )
+            && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
             continue;
         }
@@ -1094,8 +1084,9 @@ fn find_link_macro_matches<'src>(
 
 /// Substitutes each **masked** construct's own rendered body for its
 /// placeholder in `masked` — the match-string bytes at `range`, which is the
-/// same span in the level's match-string coordinates — returning `None` when
-/// the range holds no masked construct (so a caller keeps the bytes it
+/// same span in the level's match-string coordinates — returning the restored
+/// text together with each splice's byte range in it, or `None` when the
+/// range holds no masked construct (so a caller keeps the bytes it
 /// already has).
 ///
 /// This is [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own
@@ -1120,8 +1111,16 @@ pub(super) fn restore_masked_passthroughs(
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
     renderer: &dyn InlineSubstitutionRenderer,
-) -> Option<String> {
+) -> Option<(String, Vec<std::ops::Range<usize>>)> {
     let mut out = String::new();
+
+    // Each splice's byte range in `out`, in ascending order — the record the
+    // `image:`/`icon:` family stores on its node so the fold-time `web_path`
+    // can keep the restored bytes out of its own way (see
+    // [`Image::restored_target_ranges`](crate::inlines::Image)); the link
+    // families, whose targets reach the `href` with no re-processing,
+    // discard it.
+    let mut restored_ranges = Vec::new();
 
     // In match-string coordinates; `masked` is indexed relative to
     // `range.start`.
@@ -1151,6 +1150,7 @@ pub(super) fn restore_masked_passthroughs(
                 .get(cursor.saturating_sub(range.start)..p_start.saturating_sub(range.start))
                 .unwrap_or_default(),
         );
+        restored_ranges.push(out.len()..out.len() + value.len());
         out.push_str(value.as_ref());
         cursor = p_end;
     }
@@ -1165,7 +1165,7 @@ pub(super) fn restore_masked_passthroughs(
             .unwrap_or_default(),
     );
 
-    Some(out)
+    Some((out, restored_ranges))
 }
 
 /// Builds one [`Ref`](InlineNode::Ref) link node from a recognized
@@ -1241,7 +1241,9 @@ pub(super) fn build_link_node<'src>(
         )
     });
 
-    let restored_target_str = restored.as_deref().unwrap_or(target_str);
+    let restored_target_str = restored
+        .as_ref()
+        .map_or(target_str, |(restored, _)| restored.as_str());
 
     let mut target = if is_mailto {
         format!("mailto:{restored_target_str}")
@@ -1611,7 +1613,7 @@ fn text_attrlist<'src>(
     parser: &Parser,
     pre_restore: &[usize],
 ) -> Option<TextAttrlist<'src>> {
-    if !range_is_restorable(nodes, pieces, &text_range, Restorable::PassthroughOrStem) {
+    if !range_is_restorable(nodes, pieces, &text_range) {
         return None;
     }
 
@@ -1640,7 +1642,6 @@ fn text_attrlist<'src>(
         nodes,
         pieces,
         parser.renderer.as_ref(),
-        Restorable::PassthroughOrStem,
     );
 
     let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
@@ -2524,9 +2525,10 @@ mod tests {
 
     #[test]
     fn a_stem_target_folds_identically_under_either_path_separator() {
-        // The regression guard for the seam that made the `image:`/`icon:`
-        // family defer STEM entirely (see
-        // `an_image_target_over_a_stem_expression_is_a_documented_divergence`):
+        // The regression guard for the seam that long made the
+        // `image:`/`icon:` family defer STEM entirely (now closed by the
+        // masked resolve — see
+        // `an_image_target_over_a_stem_expression_is_platform_independent`):
         // a rendered STEM body always carries a backslash, and
         // [`web_path`](crate::parser::PathResolver::web_path) posixifies the
         // platform separator. These two families never route a target through

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -905,8 +905,12 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             // The Strategy-A recorder does not distinguish `icon:` from
             // `image:` (both fold through its own recorded markers), so it
             // leaves this `false`; the single-pass builder sets it honestly.
+            // Likewise the restored ranges: the recorder's target is the
+            // rendered string's own (already-restored) bytes, with no record
+            // of which came from a masked construct.
             is_icon: false,
             target: CowStr::from(target.clone()),
+            restored_target_ranges: vec![],
             alt: alt.clone().map(CowStr::from),
             width: width.clone().map(CowStr::from),
             height: height.clone().map(CowStr::from),

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -354,6 +354,10 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
 
             let params = ImageRenderParams {
                 target,
+                // The string pipeline's target still carries the passthrough
+                // sentinel here; its restore pass runs over the rendered
+                // string afterwards, so there are no restored ranges to mask.
+                restored_target_ranges: &[],
                 alt: attrlist
                     .named_or_positional_attribute("alt", 1)
                     .map_or(default_alt, |a| {
@@ -373,6 +377,8 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
         } else {
             let params = IconRenderParams {
                 target,
+                // As above: the sentinel restore happens after rendering.
+                restored_target_ranges: &[],
                 alt: attrlist.named_attribute("alt").map_or(default_alt, |a| {
                     normalize_text_lf_escaped_bracket(a.value())
                 }),

--- a/parser/src/inlines/image.rs
+++ b/parser/src/inlines/image.rs
@@ -17,6 +17,25 @@ pub struct Image<'src> {
     /// The image target (the reference to the image), as written.
     pub target: CowStr<'src>,
 
+    /// Byte ranges of [`target`](Self::target) whose content was restored from
+    /// a masked passthrough or STEM expression (`image:++a b++[]`,
+    /// `image:stem:[x].png[]`), in ascending order; empty when the target
+    /// crossed none.
+    ///
+    /// Path resolution must treat each such range as one opaque run rather
+    /// than as path syntax: the substitution pipeline resolves the `src` while
+    /// each masked construct is still its `\u{96}`*n*`\u{97}` sentinel and
+    /// splices the body in afterwards, so none of its bytes — a space
+    /// `web_path` would percent-encode, a backslash it would posixify, a `/`
+    /// or `.` its segment arithmetic would read — ever reaches the resolver.
+    /// The built-in renderer reproduces that order by masking these ranges
+    /// around its own `web_path` call (see
+    /// [`ImageRenderParams::restored_target_ranges`]).
+    ///
+    /// [`ImageRenderParams::restored_target_ranges`]:
+    ///     crate::parser::ImageRenderParams::restored_target_ranges
+    pub restored_target_ranges: Vec<std::ops::Range<usize>>,
+
     /// The alt text, explicit or defaulted.
     pub alt: Option<CowStr<'src>>,
 

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -171,6 +171,7 @@ mod tests {
             InlineNode::Image(Image {
                 is_icon: false,
                 target: CowStr::from("photo.png"),
+                restored_target_ranges: vec![],
                 alt: None,
                 width: None,
                 height: None,

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -385,6 +385,18 @@ pub struct ImageRenderParams<'a> {
     /// Target (the reference to the image).
     pub target: &'a str,
 
+    /// Byte ranges of [`target`](Self::target) restored from a masked
+    /// passthrough or STEM expression, in ascending order; empty otherwise
+    /// (the string substitution pipeline always passes an empty list — its
+    /// target still carries the sentinel here, and its restore pass runs over
+    /// the rendered string afterwards). The built-in renderer resolves the
+    /// image's `src` with these ranges masked and splices them back in
+    /// afterwards, so path resolution treats each as one opaque run — the
+    /// same order the string pipeline itself applies (`web_path` over the
+    /// sentinel, the restore after). See
+    /// [`Image::restored_target_ranges`](crate::inlines::Image).
+    pub restored_target_ranges: &'a [std::ops::Range<usize>],
+
     /// Alt text (either explicitly set or defaulted).
     pub alt: String,
 
@@ -407,6 +419,13 @@ pub struct ImageRenderParams<'a> {
 pub struct IconRenderParams<'a> {
     /// Target (the reference to the image).
     pub target: &'a str,
+
+    /// Byte ranges of [`target`](Self::target) restored from a masked
+    /// passthrough or STEM expression, in ascending order; empty otherwise.
+    /// See [`ImageRenderParams::restored_target_ranges`] — the built-in
+    /// renderer resolves the icon URI with these ranges masked and splices
+    /// them back in afterwards.
+    pub restored_target_ranges: &'a [std::ops::Range<usize>],
 
     /// Alt text (either explicitly set or defaulted).
     pub alt: String,
@@ -605,13 +624,131 @@ impl HtmlSubstitutionRenderer {
     /// `imagesdir`. As with the document attribute, an absolute-URL target
     /// ignores the base entirely.
     ///
+    /// `restored_target_ranges` names the byte ranges of `target` restored
+    /// from a masked passthrough or STEM expression (see
+    /// [`ImageRenderParams::restored_target_ranges`]). Resolution runs with
+    /// each of them — and each restored range of the macro-level `imagesdir`
+    /// value — replaced by an index-keyed `\u{96}`*n*`\u{97}` token, the
+    /// bodies spliced back into the resolved path afterwards. This is the
+    /// string substitution pipeline's own order: its `web_path` only ever
+    /// sees the sentinel (no space to percent-encode, no backslash to
+    /// posixify, no `/` or `.` for the segment arithmetic to read), and
+    /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices the
+    /// body into the finished `src` — so a fold over restored values
+    /// reproduces the same bytes, identically on every platform.
+    ///
     /// [`image_uri`]: InlineSubstitutionRenderer::image_uri
-    fn image_src(&self, target: &str, attrlist: &Attrlist, parser: &Parser) -> String {
+    fn image_src(
+        &self,
+        target: &str,
+        restored_target_ranges: &[std::ops::Range<usize>],
+        attrlist: &Attrlist,
+        parser: &Parser,
+    ) -> String {
         match attrlist.named_attribute("imagesdir") {
-            Some(imagesdir) => normalize_web_path(target, parser, Some(imagesdir.value()), true),
-            None => self.image_uri(target, parser, None),
+            Some(imagesdir) => {
+                let dir_ranges = imagesdir.restored_value_ranges();
+
+                if restored_target_ranges.is_empty() && dir_ranges.is_empty() {
+                    return normalize_web_path(target, parser, Some(imagesdir.value()), true);
+                }
+
+                // The two masked values flow into one joined path, so their
+                // tokens share one numbering — the directory's first, since
+                // `web_path` prepends the start path and the splice is one
+                // left-to-right pass.
+                let (masked_dir, mut bodies) =
+                    mask_restored_ranges(imagesdir.value(), dir_ranges, 0);
+
+                let (masked_target, target_bodies) =
+                    mask_restored_ranges(target, restored_target_ranges, bodies.len());
+
+                bodies.extend(target_bodies);
+
+                splice_restored_bodies(
+                    &normalize_web_path(&masked_target, parser, Some(&masked_dir), true),
+                    &bodies,
+                )
+            }
+
+            None => {
+                if restored_target_ranges.is_empty() {
+                    return self.image_uri(target, parser, None);
+                }
+
+                let (masked_target, bodies) =
+                    mask_restored_ranges(target, restored_target_ranges, 0);
+
+                splice_restored_bodies(&self.image_uri(&masked_target, parser, None), &bodies)
+            }
         }
     }
+}
+
+/// Replaces each of `ranges` — ascending, non-overlapping byte ranges of
+/// `value` — with an index-keyed `\u{96}`*n*`\u{97}` token, numbered from
+/// `first_index`, returning the masked text alongside the bodies the tokens
+/// stand for.
+///
+/// The token spelling is the substitution pipeline's own passthrough sentinel,
+/// which is the point: handed to `web_path`, the masked text has the very
+/// shape the string pipeline's own resolver sees — an opaque run carrying no
+/// space, separator, or dot — so both resolve identically, and
+/// [`splice_restored_bodies`] then restores each body exactly where
+/// `Passthroughs::restore_to` splices its own. A range that does not fall on
+/// `value`'s character boundaries (no caller produces one) is skipped rather
+/// than split.
+fn mask_restored_ranges<'v>(
+    value: &'v str,
+    ranges: &[std::ops::Range<usize>],
+    first_index: usize,
+) -> (String, Vec<&'v str>) {
+    let mut masked = String::with_capacity(value.len());
+    let mut bodies: Vec<&'v str> = Vec::with_capacity(ranges.len());
+    let mut cursor = 0usize;
+
+    for range in ranges {
+        let Some(body) = value.get(range.start..range.end) else {
+            continue;
+        };
+
+        masked.push_str(value.get(cursor..range.start).unwrap_or_default());
+        masked.push_str(&format!("\u{96}{n}\u{97}", n = first_index + bodies.len()));
+        bodies.push(body);
+        cursor = range.end;
+    }
+
+    masked.push_str(value.get(cursor..).unwrap_or_default());
+
+    (masked, bodies)
+}
+
+/// Splices each of `bodies` over its own index-keyed `\u{96}`*n*`\u{97}`
+/// token in `resolved`, one left-to-right pass, and returns the result.
+///
+/// Index-keyed exactly as
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs) is: each token
+/// is sought only in the bytes after the previous splice, so a body that
+/// itself carries sentinel-shaped bytes is never re-matched as a later token,
+/// and a token the resolution dropped (a segment its `..` arithmetic
+/// consumed) is simply not found — the ones after it still restore, keyed by
+/// their own index.
+fn splice_restored_bodies(resolved: &str, bodies: &[&str]) -> String {
+    let mut out = String::with_capacity(resolved.len());
+    let mut rest = resolved;
+
+    for (n, body) in bodies.iter().enumerate() {
+        let token = format!("\u{96}{n}\u{97}");
+
+        if let Some(pos) = rest.find(&token) {
+            out.push_str(rest.get(..pos).unwrap_or_default());
+            out.push_str(body);
+            rest = rest.get(pos + token.len()..).unwrap_or_default();
+        }
+    }
+
+    out.push_str(rest);
+    out
 }
 
 impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
@@ -791,7 +928,12 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
     }
 
     fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
-        let src = self.image_src(params.target, params.attrlist, params.parser);
+        let src = self.image_src(
+            params.target,
+            params.restored_target_ranges,
+            params.attrlist,
+            params.parser,
+        );
         let alt_encoded = encode_attribute_value(params.alt.clone());
 
         // The dimension attributes (width, height, and title) are shared by the
@@ -851,7 +993,16 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             // that, the alt text) is nested inside for user agents that can't
             // display the object.
             let fallback = if let Some(fallback) = params.attrlist.named_attribute("fallback") {
-                let fallback_src = self.image_src(fallback.value(), params.attrlist, params.parser);
+                // A `fallback=` value restored from a masked construct
+                // resolves over its restored ranges masked, exactly as the
+                // target does — the one other value this renderer runs
+                // through `web_path`.
+                let fallback_src = self.image_src(
+                    fallback.value(),
+                    fallback.restored_value_ranges(),
+                    params.attrlist,
+                    params.parser,
+                );
                 format!(
                     r#"<img src="{fallback_src}" alt="{alt_encoded}"{dimension_attrs}>"#,
                     fallback_src = encode_attribute_value(fallback_src)
@@ -932,7 +1083,22 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
     }
 
     fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
-        let src = self.icon_uri(params.target, params.attrlist, params.parser);
+        // As in `render_image`, a target restored from a masked construct
+        // resolves with its restored ranges masked — the whole `icon_uri`
+        // computation included, since its extension probe (`has_extname`)
+        // must read the sentinel-shaped bytes the string pipeline's own
+        // probe reads — and the bodies splice back in afterwards.
+        let src = if params.restored_target_ranges.is_empty() {
+            self.icon_uri(params.target, params.attrlist, params.parser)
+        } else {
+            let (masked_target, bodies) =
+                mask_restored_ranges(params.target, params.restored_target_ranges, 0);
+
+            splice_restored_bodies(
+                &self.icon_uri(&masked_target, params.attrlist, params.parser),
+                &bodies,
+            )
+        };
 
         let img = if params.parser.is_attribute_set("icons") {
             let icons = params.parser.attribute_value("icons");


### PR DESCRIPTION
## What this closes

The restore-the-value class's last open item: a masked **STEM** expression in the `image:`/`icon:` family — the target and the bracket, together with the bracket's two `web_path`-bound values (`fallback=`, macro-level `imagesdir=`). Every prior increment of the class deferred this family in the same words: "blocked on the same fold-time `web_path` (closing them means keeping the restore out of `web_path`'s way, not widening a gate)".

## How

The string pipeline's resolver never sees a restored byte: `web_path` runs while the masked construct is still the `\u{96}`*n*`\u{97}` sentinel (no space to percent-encode, no backslash to posixify, no `/` or `.` for the segment arithmetic to read), and `Passthroughs::restore_to` splices the body into the finished `src` afterwards. This increment reproduces that order at the same seam:

- `Image::restored_target_ranges` (new field) records which byte ranges of the restored target came from a masked body — the record `restore_masked_passthroughs` already produces while splicing, now kept. `ImageRenderParams`/`IconRenderParams` hand it to the renderer.
- The built-in renderer's `image_src`/`render_icon` re-mask exactly those ranges into index-keyed sentinel-shaped tokens, resolve, and splice the bodies back (`mask_restored_ranges` / `splice_restored_bodies`) — index-keyed as `restore_to` is, so a token the resolver's `..` arithmetic consumes is dropped in both pipelines.
- `ElementAttribute::into_owned_restoring` records each splice's range on the attribute, so an interactive SVG's `fallback=` and a macro-level `imagesdir=` resolve over their restored ranges masked too — the directory's and the target's mask sets share one token numbering where the resolver joins the two into one path.

With `web_path` out of the way, the `Restorable` gate split is **deleted rather than relaxed**: every restoring site admits both masked kinds (`node_is_restorable`, now total over the pair), `widen_masked_passthroughs` becomes `widen_masked_pieces`, and `masked_default_alt` takes a `Stem` piece's body from `restorable_body` — the fold's own bytes, so the two directions cannot drift.

## Parity and the safety net

- New differential corpora: the STEM target (both macro forms, all three notations, partial masks, the default-alt arithmetic, both masked kinds in one target, `imagesdir=` in all combinations), the STEM bracket (split invariant, named values, positional slots, shorthand company), the masked `fallback=` (under `SafeMode::Unsafe`, all three masked spellings), plus the shapes inside a rendered span, doubled, escaped, and end to end through the real parse path.
- The formerly-pinned restored-space `src` divergence (`image:pass:[My Documents/chart.png][]`) reaches parity by the same move; its test is a parity test now.
- A platform pair pins the reason this family deferred for so long: the fold is byte-identical under either path separator, and equal to the golden.
- The staged `apply_image_side_effects` registers the honest restored target for a STEM target too.
- **Corpus-wide fold-parity audit** (tree seed forced on for every parse in the suite, before on `origin/inline-ast` vs. after): divergence set **unchanged** (230 records on both sides, `comm -13` empty) — no golden source writes an image over a STEM expression, and no new divergence appeared.

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5346 + 6 doctests)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage diff-neutral vs. `origin/inline-ast` per changed file (`cargo llvm-cov`); the two new resolver branches (a hand-built node's off-target range, a token dropped by `..` arithmetic) each got a test rather than staying unexercised.

Design doc: new "landed as" note and checklist entry (the class is closed; only the keeps remain — the cross-reference family's and a `mailto:` subject/body's pre-restore boundaries, and the pinned well-formed readings).

As with every prep piece before it, nothing further is wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SomcvUjSdYFa7Z86CwvSs

---
_Generated by [Claude Code](https://claude.ai/code/session_018SomcvUjSdYFa7Z86CwvSs)_