### PR TITLE
feat: Classify a computed value by where the escaping step sits (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4672,6 +4672,59 @@ Each phase is a reviewable unit with a clear exit gate.
   `window=`/`opts=`/`link=` the renderer *decides* on reading restored bytes, and an author's own
   sentinel-shaped bytes surviving the tree's per-token restore.
 
+  *Step 6 prep landed as (a computed value classified by where the escaping step sits):* the one
+  divergence the class above left behind that was not a *keep* — an author's own `&lt;` in a
+  **computed** value under an effective order that never escaped, which
+  [`escaped_value_children`](../../parser/src/content/inline_builder/macros/mod.rs) unwound one
+  level too far — closed exactly as its own note prescribed: "by where the escaping step actually
+  sits", which needed the effective order threaded down to each family. A computed value is the one
+  thing the macros step reads as *bytes* rather than carrying structurally (it comes back from an
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs) parse, so there is no range of nodes to
+  rebuild it from), and an attribute list is parsed under *any* order that runs `Macros` — so both
+  readings of `&lt;` are reachable, and picking one by assumption was the bug.
+
+  A new [`ComputedSpecials`](../../parser/src/content/inline_builder/macros/mod.rs) carries the
+  decision, made in [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) where the
+  order is in hand — the same seam, and the same shape, as
+  [`SplicedSpecials`](../../parser/src/content/inline_builder/attribute_refs.rs) already uses for
+  the attribute-references step — and
+  [`computed_value_children`](../../parser/src/content/inline_builder/macros/mod.rs) dispatches to
+  one of two halves: the existing trichotomy unwind when the escaping step has already run, and a
+  new [`unescaped_value_children`](../../parser/src/content/inline_builder/special_chars.rs) when
+  it has not, which reaches for
+  [`split_text`](../../parser/src/content/inline_builder/special_chars.rs) — the very splitter
+  [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs) uses
+  over the finished tree — so the two cannot drift on what a literal special is worth. The
+  condition is the step's **position**, not its presence, which is what makes the second half cover
+  an order that escapes *after* `Macros` too: there the final classification pass never runs, and
+  `flatten_prior_markup` folds the node's markup before the escaping step splits the result, so the
+  value has to be classified here or not at all. That is a real gain rather than a hypothetical
+  one — under `subs=attributes,macros,specialcharacters` the cross-reference family (the one
+  family the string pipeline is still holding as a deferred placeholder when the escaping step
+  runs, so `flatten_prior_markup` leaves it alone) now reaches parity in **both** spellings, where
+  a bare `<` had diverged.
+
+  What reaches parity is the four-cell truth table — a `<` and a `&lt;` in a computed value,
+  against an order that escapes first and one that never escapes — over all three families that
+  compute one (the `link:`/`mailto:` macro's `=` list, the auto-link / formal-URL family's, and the
+  cross-reference macro's), plus the same three fixtures folded into the never-escapes group-parity
+  corpus beside a restored entity and a masked passthrough in the same value. Threading changed
+  fourteen signatures and no node kind, gate, or builder body. Re-running the corpus-wide
+  fold-parity audit shows the three fixtures **gone** from the divergence set and no new
+  divergence; coverage is diff-neutral, with one consequence worth recording: the escaped half's
+  bare-`&` arm, which the never-escapes corpus used to be the only thing exercising, is now
+  unreachable through any order — every `&` in a
+  level's match string belongs to a `CharRef` leaf that opens a class, and a *literal* one is a
+  `Raw` leaf the match string stands in as an opaque placeholder — so it is kept as the scan's
+  totality arm and pinned by a direct unit test instead. As with every prep piece before it,
+  nothing further is wired in.
+
+  With this, every §3.4.1 classification the builder makes is decided by where the steps actually
+  sit rather than by where a fragment came from. What remains of the audit's own remainder are the
+  boundary-class halves the sibling increments named — a macro body class wanting more than one
+  presented character, the closing character, and the character-replacements step's
+  consume-across-levels case — and the keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5431,6 +5484,26 @@ Each phase is a reviewable unit with a clear exit gate.
        the same move. See the step's own "landed as" note above. Only the keeps remain: the
        cross-reference family's and a `mailto:` subject/body's pre-restore boundaries, and the
        well-formed readings.
+
+     - ✅ **prep (a computed value classified by where the escaping step sits).** The last
+       divergence the restore-the-value class left that was not a *keep*, and the last §3.4.1
+       classification the builder still made by assumption: a value the macros step **computes**
+       off the level's match string — the one thing it reads as bytes rather than carrying
+       structurally, since it comes back from an
+       [`Attrlist`](../../parser/src/attributes/attrlist.rs) parse — was always read as
+       already-escaped, so under an order that never escaped an author's own `&lt;` was unwound one
+       level too far. A new
+       [`ComputedSpecials`](../../parser/src/content/inline_builder/macros/mod.rs), decided in
+       [`build_for_group`](../../parser/src/content/inline_builder/mod.rs) exactly as
+       [`SplicedSpecials`](../../parser/src/content/inline_builder/attribute_refs.rs) is and
+       threaded down to the three families that compute such a value, carries the decision, and
+       [`computed_value_children`](../../parser/src/content/inline_builder/macros/mod.rs)
+       dispatches to the existing unwind or to a new
+       [`unescaped_value_children`](../../parser/src/content/inline_builder/special_chars.rs) that
+       reuses `classify_unescaped_specials`' own splitter. The condition is the step's *position*,
+       not its presence, so an order that escapes **after** `Macros` takes the second half too —
+       which brings the cross-reference family to parity there in both spellings. See the step's
+       own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1067,9 +1067,12 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::{
-        super::super::test_support::{
-            assert_styled, assert_text, build_src, build_through_quotes, fold_html, golden_macros,
-            golden_macros_with,
+        super::{
+            super::test_support::{
+                assert_styled, assert_text, build_src, build_through_quotes, fold_html,
+                golden_macros, golden_macros_with,
+            },
+            ComputedSpecials,
         },
         node_is_restorable, restorable_body,
     };
@@ -1658,6 +1661,7 @@ mod tests {
                 Span::new(source),
                 &Parser::default(),
                 Masked::UNKNOWN,
+                ComputedSpecials::Escaped,
             );
 
             assert!(

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1,7 +1,7 @@
 //! Auto-link, formal-URL-link, and `link:`/`mailto:` macro recognition.
 
 use super::{
-    MacroMatch, MacroMatchKind, escaped_value_children,
+    ComputedSpecials, MacroMatch, MacroMatchKind, computed_value_children,
     image::{
         range_is_restorable, range_is_verbatim, range_is_verbatim_or_synthesized, restorable_body,
         tokened_bracket,
@@ -196,6 +196,7 @@ pub(super) fn inline_link_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes, masked);
 
@@ -210,7 +211,7 @@ pub(super) fn inline_link_level<'src>(
     // coordinates — see `apply_macro_families`'s own doc comment.
     let (s, pieces) = ctx.shift(s, pieces);
 
-    let matches = find_inline_link_matches(&nodes, &s, &pieces, root, parser);
+    let matches = find_inline_link_matches(&nodes, &s, &pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
@@ -231,6 +232,7 @@ fn find_inline_link_matches<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
@@ -249,7 +251,7 @@ fn find_inline_link_matches<'src>(
             continue;
         }
 
-        match build_inline_link_node(&n, &full, nodes, pieces, root, parser) {
+        match build_inline_link_node(&n, &full, nodes, pieces, root, parser, specials) {
             Some(m) => matches.push(m),
 
             // A deferred or invalid form (an escaped scheme is handled inside as
@@ -322,6 +324,7 @@ fn build_inline_link_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> Option<MacroMatch<'src>> {
     // `scheme_match` is always present (no branch can match without it); fall
     // through defensively if it is somehow absent.
@@ -627,7 +630,7 @@ fn build_inline_link_node<'src>(
             // family's own attribute-list value is rebuilt — and each masked
             // construct the value still holds a token for as the node itself,
             // whose fold emits the bytes `restore_to` splices there.
-            restored_value_children(&link_text, &restores, text_location)
+            restored_value_children(&link_text, &restores, text_location, specials)
         } else {
             // Parsed out of the source's own bytes, which are already logical
             // text carrying no entity to undo: one synthesized `Text`.
@@ -949,6 +952,7 @@ pub(super) fn link_macro_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes, masked);
 
@@ -963,7 +967,7 @@ pub(super) fn link_macro_level<'src>(
     // coordinates — see `apply_macro_families`'s own doc comment.
     let (s, pieces) = ctx.shift(s, pieces);
 
-    let matches = find_link_macro_matches(&nodes, &s, &pieces, root, parser);
+    let matches = find_link_macro_matches(&nodes, &s, &pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
@@ -988,6 +992,7 @@ fn find_link_macro_matches<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
@@ -1062,7 +1067,7 @@ fn find_link_macro_matches<'src>(
             continue;
         }
 
-        match build_link_node(&caps, &full, nodes, pieces, root, parser) {
+        match build_link_node(&caps, &full, nodes, pieces, root, parser, specials) {
             Some(node) => matches.push(MacroMatch {
                 kind: MacroMatchKind::Node {
                     consumed: full.clone(),
@@ -1197,12 +1202,13 @@ pub(super) fn restore_masked_passthroughs(
 ///   *computes*, out of an [`Attrlist`] parse (see [`text_attrlist`]). A parse
 ///   of the bracket's own verbatim `'src` slice yields logical text, so it
 ///   stays a single synthesized `Text` (that slice carries no entity to undo);
-///   a parse of the level's **match string** yields already-escaped text
-///   instead, so it is rebuilt through [`escaped_value_children`] — design
-///   §3.4's trichotomy — exactly as the cross-reference family's own
-///   attribute-list value is, with each **masked** construct that value still
-///   holds a token for spliced back in as its own node
-///   ([`restored_value_children`]).
+///   a parse of the level's **match string** yields the bytes the string
+///   replacer parsed instead, so it is rebuilt through
+///   [`computed_value_children`] — design §3.4's trichotomy under an order that
+///   has already escaped, and §3.4.1's literal reading under one that has not —
+///   exactly as the cross-reference family's own attribute-list value is, with
+///   each **masked** construct that value still holds a token for spliced back
+///   in as its own node ([`restored_value_children`]).
 ///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect — notably it does **not** `register_link` the target in the asset
@@ -1215,6 +1221,7 @@ pub(super) fn build_link_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> Option<InlineNode<'src>> {
     let location = source_slice(pieces, full.clone(), root);
 
@@ -1454,7 +1461,7 @@ pub(super) fn build_link_node<'src>(
             // family's own attribute-list value is rebuilt — and each masked
             // construct the value still holds a token for as the node itself,
             // whose fold emits the bytes `restore_to` splices there.
-            restored_value_children(&link_text, &restores, text_location)
+            restored_value_children(&link_text, &restores, text_location, specials)
         } else {
             // Parsed out of the source's own bytes, which are already logical
             // text carrying no entity to undo: one synthesized `Text`.
@@ -1509,9 +1516,9 @@ struct TextAttrlist<'src> {
     attrs: Attrlist<'src>,
 
     /// Whether [`text`](Self::text) came back from a parse of the level's
-    /// **match string** (already-escaped bytes) rather than of the source's own
-    /// (logical text). The caller rebuilds the former through
-    /// [`escaped_value_children`] so an entity in it is not escaped twice.
+    /// **match string** (the string replacer's own bytes) rather than of the
+    /// source's own (logical text). The caller rebuilds the former through
+    /// [`computed_value_children`] so an entity in it is not escaped twice.
     escaped: bool,
 
     /// Whether a real named attribute actually split off — the string
@@ -1681,8 +1688,8 @@ fn text_attrlist<'src>(
 
 /// Rebuilds a computed display text that still holds
 /// [`tokened_bracket`] tokens as the node's children: each token becomes the
-/// masked node itself, and the escaped bytes around it take
-/// [`escaped_value_children`]'s own trichotomy rebuild.
+/// masked node itself, and the bytes around it take
+/// [`computed_value_children`]'s own rebuild.
 ///
 /// Splicing the node rather than its bytes is what keeps the fold honest. A
 /// [`Raw`](InlineNode::Raw) leaf's body is emitted verbatim and a
@@ -1702,6 +1709,7 @@ fn restored_value_children<'src>(
     text: &str,
     restores: &[InlineNode<'src>],
     location: Span<'src>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let mut children: Vec<InlineNode<'src>> = Vec::new();
     let mut rest = text;
@@ -1710,9 +1718,10 @@ fn restored_value_children<'src>(
         let token = format!("\u{96}{n}\u{97}");
 
         if let Some(pos) = rest.find(&token) {
-            children.append(&mut escaped_value_children(
+            children.append(&mut computed_value_children(
                 rest.get(..pos).unwrap_or_default(),
                 location,
+                specials,
             ));
 
             children.push(node.clone());
@@ -1720,7 +1729,7 @@ fn restored_value_children<'src>(
         }
     }
 
-    children.append(&mut escaped_value_children(rest, location));
+    children.append(&mut computed_value_children(rest, location, specials));
 
     children
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -16,7 +16,7 @@ use xref::xref_macros_level;
 
 use super::{
     quotes::{LevelContext, Piece, emit_range, source_slice, special_entity, text_slice},
-    special_chars::Masked,
+    special_chars::{Masked, unescaped_value_children},
 };
 use crate::{
     Parser, Span,
@@ -24,6 +24,41 @@ use crate::{
     inlines::{CharRef, InlineNode},
     strings::CowStr,
 };
+
+/// Whether the escaping step has already run by the time the macros step reads
+/// a value off the level's match string.
+///
+/// Design §3.4.1 decides what a fragment is worth by *where the steps sit* in
+/// the group's effective order, not by where the fragment came from. The
+/// attribute-references step already makes that decision for the value it
+/// splices in
+/// ([`SplicedSpecials`](super::attribute_refs::SplicedSpecials)); this is the
+/// same decision for the one thing the macros step reads as bytes rather than
+/// carries structurally — an attribute list's positional value, which comes
+/// back from a *parse* and so has no range of nodes to rebuild from.
+///
+/// Both halves are decided in
+/// [`build_for_group`](super::build_for_group), where the effective order is
+/// in hand, and carried down to the families that compute such a value (the
+/// `link:`/`mailto:` macro, the auto-link / formal-URL family, and the
+/// cross-reference macro).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ComputedSpecials {
+    /// `SpecialCharacters` sits **before** `Macros` in this order, so a
+    /// computed value holds the already-escaped bytes the string replacer
+    /// parsed out of its own escaped haystack: `&lt;` is an escaped special
+    /// standing for a logical `<`, which [`escaped_value_children`] unwinds one
+    /// level so the fold escapes it back exactly once (§3.4).
+    Escaped,
+
+    /// No `SpecialCharacters` step has run yet — either the order has none at
+    /// all (`subs=attributes,macros`) or it runs *after* `Macros`
+    /// (`subs=macros,specialcharacters`) — so a computed value holds the
+    /// author's own bytes, which the string replacer splices in verbatim:
+    /// `&lt;` is six literal characters, not an escaped `<`, and
+    /// [`unescaped_value_children`] classifies it as such.
+    Verbatim,
+}
 
 /// The macros substitution, as a node transducer.
 ///
@@ -134,6 +169,7 @@ pub(super) fn apply_macros<'src>(
     root: Span<'src>,
     parser: &Parser,
     masked: Masked<'_>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     // The bibliography anchor (`[[[label]]]`) runs before every other family,
     // exactly as the string step runs its own `INLINE_BIBLIO_ANCHOR` pass
@@ -146,7 +182,7 @@ pub(super) fn apply_macros<'src>(
     // encloses.
     let nodes = biblio_anchor_level(nodes, root, parser, masked);
 
-    apply_macro_families(nodes, root, parser, LevelContext::ROOT, masked)
+    apply_macro_families(nodes, root, parser, LevelContext::ROOT, masked, specials)
 }
 
 /// Applies each macro family at this level — and, first, at every level nested
@@ -211,6 +247,7 @@ fn apply_macro_families<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     // Recurse into spans/refs first, matching the string pipeline's
     // whole-string pass. Each nested level is matched in the context its own
@@ -241,13 +278,13 @@ fn apply_macro_families<'src>(
 
             InlineNode::Styled(mut styled) => {
                 styled.children =
-                    apply_macro_families(styled.children, root, parser, inner, masked);
+                    apply_macro_families(styled.children, root, parser, inner, masked, specials);
                 InlineNode::Styled(styled)
             }
 
             InlineNode::Ref(mut reference) => {
                 reference.children =
-                    apply_macro_families(reference.children, root, parser, inner, masked);
+                    apply_macro_families(reference.children, root, parser, inner, masked, specials);
                 InlineNode::Ref(reference)
             }
 
@@ -274,11 +311,11 @@ fn apply_macro_families<'src>(
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro, mirroring the string step's
     // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
-    let nodes = inline_link_level(nodes, root, parser, ctx, masked);
+    let nodes = inline_link_level(nodes, root, parser, ctx, masked, specials);
 
     // The `link:`/`mailto:` macro runs after the auto-link pass, mirroring the
     // string step's order.
-    let nodes = link_macro_level(nodes, root, parser, ctx, masked);
+    let nodes = link_macro_level(nodes, root, parser, ctx, masked, specials);
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
     // families and before the anchor pass, exactly where the string step runs
@@ -296,7 +333,7 @@ fn apply_macro_families<'src>(
 
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
-    xref_macros_level(nodes, root, parser, ctx, masked)
+    xref_macros_level(nodes, root, parser, ctx, masked, specials)
 
     // Footnotes are **not** handled here. Every other family's recognition is
     // order-independent (no cross-node side effect), so it is safe for them to
@@ -593,6 +630,28 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
     emit_range(nodes, pieces, cursor..range.end, out);
 }
 
+/// Rebuilds a value the macros step **computed** off the level's match string
+/// as the children a node shows, taking whichever half of design §3.4.1
+/// `specials` names.
+///
+/// A computed value is the one thing this step reads as *bytes* rather than
+/// carrying structurally: it comes back from an
+/// [`Attrlist`](crate::attributes::Attrlist) parse, so there is no range of
+/// nodes to rebuild it from and its classification has to be re-derived from
+/// the bytes themselves. What those bytes are worth is exactly what
+/// [`ComputedSpecials`] answers — see its two halves,
+/// [`escaped_value_children`] and [`unescaped_value_children`].
+pub(super) fn computed_value_children<'src>(
+    text: &str,
+    location: Span<'src>,
+    specials: ComputedSpecials,
+) -> Vec<InlineNode<'src>> {
+    match specials {
+        ComputedSpecials::Escaped => escaped_value_children(text, location),
+        ComputedSpecials::Verbatim => unescaped_value_children(text, location),
+    }
+}
+
 /// Rebuilds an **already-escaped computed value** — a value a family read off
 /// the level's own match string rather than out of the tree, here a reference-
 /// or link-family attribute list's positional value — as the nodes that fold
@@ -625,15 +684,24 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
 /// literal `&` *does* survive into a verbatim run, and is left exactly as it
 /// is here, since neither class matches it.
 ///
-/// That last case is also this helper's one documented divergence, shared by
-/// every family that computes an attribute-list value: an attribute list is
-/// parsed under any order that runs `Macros`, but a value read off the match
-/// string is *assumed* escaped, so under an order that never escapes an
-/// author's own literal `&lt;` in a **non**-verbatim text is unwound one level
-/// too far. Deciding it the way §3.4.1 decides every other classification — by
-/// where the escaping step actually sits — needs the effective order threaded
-/// down to each family, which none has today. See
-/// `an_escaped_computed_value_under_an_order_that_never_escapes_is_a_documented_divergence`.
+/// That last branch — a bare `&` opening neither class — is what makes the scan
+/// total over arbitrary bytes, and no effective order reaches it: this half is
+/// called only for an order that has already escaped
+/// ([`ComputedSpecials::Escaped`], dispatched by
+/// [`computed_value_children`]), and under one of those every `&` in the
+/// level's match string belongs to a leaf that opens a class — a
+/// [`Special`](CharRef::Special)'s canonical entity, a restored
+/// [`Entity`](CharRef::Entity)'s own bytes, or a typographic
+/// [`Replacement`](CharRef::Replacement)'s numeric one. A *literal* `&` (an
+/// attribute expansion splicing one in after the escaping step) is a
+/// [`Raw`](InlineNode::Raw) leaf, which
+/// [`build_match_string`](super::quotes::build_match_string) stands in as an
+/// opaque placeholder carrying no `&` at all — so it never reaches a computed
+/// value as bytes. The branch is pinned by a direct unit test rather than by
+/// the corpus.
+///
+/// Visible past this module for [`unescaped_value_children`]'s own doc link
+/// alone; [`computed_value_children`] is the entry point every caller takes.
 pub(super) fn escaped_value_children<'src>(
     text: &str,
     location: Span<'src>,
@@ -671,9 +739,12 @@ pub(super) fn escaped_value_children<'src>(
             // does.
             entity.end()
         } else {
-            // A bare `&` that opens neither class (an effective order that
-            // never escaped, §3.4.1): ordinary logical text like any other
-            // byte.
+            // A bare `&` that opens neither class: ordinary logical text like
+            // any other byte. This is what makes the scan total over arbitrary
+            // bytes; no effective order presents one here (see this function's
+            // own doc comment), so it is pinned by
+            // [`a_bare_ampersand_in_a_computed_value_stays_logical_text`]
+            // rather than by the corpus.
             pending.push('&');
             '&'.len_utf8()
         };
@@ -719,7 +790,7 @@ mod tests {
 
     use super::{
         super::{special_chars::Masked, test_support::golden_macros_with},
-        apply_macro_side_effects, apply_macros,
+        ComputedSpecials, apply_macro_side_effects, apply_macros, escaped_value_children,
     };
     use crate::{
         Parser, Span,
@@ -727,7 +798,7 @@ mod tests {
             Content, SubstitutionGroup, SubstitutionStep,
             inline_builder::{build, build_for_group, fold_html},
         },
-        inlines::{InlineNode, Ref, RefVariant},
+        inlines::{CharRef, InlineNode, Ref, RefVariant},
         parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
         warnings::WarningType,
@@ -777,50 +848,131 @@ mod tests {
     }
 
     #[test]
-    fn an_escaped_computed_value_under_an_order_that_never_escapes_is_a_documented_divergence() {
+    fn a_computed_value_is_classified_by_where_the_escaping_step_sits() {
         // [`escaped_value_children`] reads its input as the *escaped* text a
         // family took off the level's match string, so it unwinds one level of
         // §3.4's trichotomy: `&lt;` becomes the logical `<` a `Text` node
-        // holds, which the fold escapes back. That is exact under every
-        // effective order that runs `SpecialCharacters` — which is every order
-        // that can produce an escaped special in the first place — but the
-        // value it rebuilds is an attribute list's positional value, and an
-        // attribute list is parsed under any order that runs `Macros`.
+        // holds, which the fold escapes back. That is exact under an order
+        // that runs `SpecialCharacters` **before** `Macros` — every built-in
+        // group — and exactly wrong under one that does not, where the same
+        // six bytes are the author's own and the string replacer splices them
+        // in untouched.
         //
-        // So under an order that never escapes, a display text whose range is
-        // *not* verbatim (here because an attribute expansion splices into it)
-        // and that carries an author's own literal `&lt;` is unwound one level
-        // too far: the tree folds it as `<` where the string pipeline, which
-        // escaped nothing, emits `&lt;`. Deciding this the way §3.4.1 decides
-        // every other classification — by where the escaping step actually
-        // sits in the group's effective order — needs that order threaded down
-        // to each macro family, which no family has today; until then all
-        // three families that compute an attribute-list value share the
-        // divergence.
-        //
-        // If that thread is ever added, fold these fixtures into the
-        // group-parity corpus in this module's `mod.rs`.
+        // An attribute list is parsed under *any* order that runs `Macros`, so
+        // both readings are reachable, and which one a value takes is decided
+        // the way §3.4.1 decides every other classification: by where the
+        // escaping step actually sits in the group's effective order. This
+        // pins that decision from both sides over one fixture per family — the
+        // three that compute an attribute-list value — so neither half can
+        // drift into the other's order.
         let parser = Parser::default().with_intrinsic_attribute(
             "product",
             "Widget",
             ModificationContext::Anywhere,
         );
 
-        for source in [
-            "xref:sec[{product} &lt; y,role=hl] here",
-            "link:index.html[{product} &lt; y,role=hl] here",
-            "https://example.org[{product} &lt; y,role=hl] here",
+        // Escapes before `Macros`, as every built-in group does.
+        let escaping = SubstitutionGroup::Custom(vec![
+            SubstitutionStep::SpecialCharacters,
+            SubstitutionStep::AttributeReferences,
+            SubstitutionStep::Macros,
+        ]);
+
+        // Never escapes at all — `subs=attributes,macros`.
+        let verbatim = SubstitutionGroup::Custom(vec![
+            SubstitutionStep::AttributeReferences,
+            SubstitutionStep::Macros,
+        ]);
+
+        // The value is non-verbatim in every fixture (an attribute expansion
+        // splices into it), which is what routes it through the computed-value
+        // rebuild rather than through `macro_text_children`'s own ranges.
+        for text in ["{product} < y", "{product} &lt; y"] {
+            for shape in [
+                "xref:sec[TEXT,role=hl] here",
+                "link:index.html[TEXT,role=hl] here",
+                "https://example.org[TEXT,role=hl] here",
+            ] {
+                let source = shape.replace("TEXT", text);
+
+                // The truth table this increment closes, in the order the two
+                // groups are declared above:
+                //
+                //   `<`     escaping → `&lt;`     (the escaping step ran, so
+                //                                  the value holds `&lt;`,
+                //                                  which unwinds to a logical
+                //                                  `<` the fold escapes back)
+                //   `<`     verbatim → `<`        (nothing escaped it, in
+                //                                  either pipeline)
+                //   `&lt;`  escaping → `&amp;lt;` (the escaping step escaped
+                //                                  the author's own `&`)
+                //   `&lt;`  verbatim → `&lt;`     (the author's six bytes,
+                //                                  spliced in untouched — the
+                //                                  cell that used to unwind
+                //                                  one level too far)
+                for (group, expected) in [
+                    (
+                        &escaping,
+                        if text.contains('&') {
+                            "Widget &amp;lt; y"
+                        } else {
+                            "Widget &lt; y"
+                        },
+                    ),
+                    (
+                        &verbatim,
+                        if text.contains('&') {
+                            "Widget &lt; y"
+                        } else {
+                            "Widget < y"
+                        },
+                    ),
+                ] {
+                    let mut content = Content::from(Span::new(&source));
+                    group.apply(&mut content, &parser, None);
+
+                    let nodes = build_for_group(
+                        group,
+                        CowStr::from(source.clone()),
+                        Span::new(&source),
+                        &parser,
+                        None,
+                    );
+
+                    let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+
+                    assert_eq!(folded, content.rendered_html(), "{source:?}");
+                    assert!(folded.contains(expected), "{source:?}: {folded:?}");
+                }
+            }
+        }
+
+        // The `Verbatim` half is *not* "the order has no escaping step" but
+        // "none has run yet", so it covers an order that escapes **after**
+        // `Macros` too. Only the cross-reference family can be pinned to
+        // parity there, because it is the one family whose node the string
+        // pipeline is still holding as a deferred placeholder when the
+        // escaping step runs — so `flatten_prior_markup` leaves it alone,
+        // where a link's already-emitted `<a …>` markup is escaped by the
+        // string pipeline and is the separate divergence
+        // `a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence`
+        // pins. Both spellings reach parity; the bare `<` did not before the
+        // decision became position-aware.
+        let escaping_last = SubstitutionGroup::Custom(vec![
+            SubstitutionStep::AttributeReferences,
+            SubstitutionStep::Macros,
+            SubstitutionStep::SpecialCharacters,
+        ]);
+
+        for (source, expected) in [
+            ("xref:sec[{product} < y,role=hl] here", "Widget < y"),
+            ("xref:sec[{product} &lt; y,role=hl] here", "Widget &lt; y"),
         ] {
             let mut content = Content::from(Span::new(source));
-            let group = SubstitutionGroup::Custom(vec![
-                SubstitutionStep::AttributeReferences,
-                SubstitutionStep::Macros,
-            ]);
-
-            group.apply(&mut content, &parser, None);
+            escaping_last.apply(&mut content, &parser, None);
 
             let nodes = build_for_group(
-                &group,
+                &escaping_last,
                 CowStr::from(source),
                 Span::new(source),
                 &parser,
@@ -829,14 +981,50 @@ mod tests {
 
             let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
 
-            assert_ne!(
-                folded,
-                content.rendered_html(),
-                "expected the documented divergence to still reproduce for {source:?}"
-            );
-
-            assert!(folded.contains("Widget < y"), "{folded:?}");
+            assert_eq!(folded, content.rendered_html(), "{source:?}");
+            assert!(folded.contains(expected), "{source:?}: {folded:?}");
         }
+    }
+
+    #[test]
+    fn a_bare_ampersand_in_a_computed_value_stays_logical_text() {
+        // The third arm of `escaped_value_children`'s scan — an `&` opening
+        // neither of the two recoverable classes — is what makes it total over
+        // arbitrary bytes, and no effective order presents one: the half runs
+        // only for an order that has already escaped, and there every `&` in
+        // the level's match string is a `CharRef` leaf's own entity, while a
+        // literal one is a `Raw` leaf the match string stands in as an opaque
+        // placeholder. So it is pinned directly, on the classification it
+        // makes: one logical `Text` run, which the fold escapes back to the
+        // `&amp;` the string pipeline would have emitted.
+        let src = Span::new("x");
+        let children = escaped_value_children("a & b &copy; c &lt; d", src);
+
+        assert_eq!(
+            children
+                .iter()
+                .filter(|n| matches!(n, InlineNode::Text { .. }))
+                .count(),
+            2,
+            "{children:?}"
+        );
+
+        // The bare `&` stays inside its own run as logical text; only the
+        // entity comes out as its own leaf, and only the escaped special is
+        // unwound.
+        assert!(
+            matches!(&children[0], InlineNode::Text { value, .. } if value.as_ref() == "a & b "),
+            "{children:?}"
+        );
+        assert!(
+            matches!(&children[1], InlineNode::CharRef { value: CharRef::Entity(e), .. }
+                if e.as_ref() == "&copy;"),
+            "{children:?}"
+        );
+        assert!(
+            matches!(&children[2], InlineNode::Text { value, .. } if value.as_ref() == " c < d"),
+            "{children:?}"
+        );
     }
 
     #[test]
@@ -982,7 +1170,13 @@ mod tests {
             location: root,
         });
 
-        let out = apply_macros(vec![reference], root, &Parser::default(), Masked::UNKNOWN);
+        let out = apply_macros(
+            vec![reference],
+            root,
+            &Parser::default(),
+            Masked::UNKNOWN,
+            ComputedSpecials::Escaped,
+        );
 
         // The reference survives, and its single child is now the recognized
         // image node.

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1,8 +1,8 @@
 //! Cross-reference recognition (`xref:id[…]`, `<<id>>`).
 
 use super::{
-    MacroMatch, MacroMatchKind, escaped_value_children, image::range_has_no_opaque_piece,
-    macro_text_children, rebuild_macro_level,
+    ComputedSpecials, MacroMatch, MacroMatchKind, computed_value_children,
+    image::range_has_no_opaque_piece, macro_text_children, rebuild_macro_level,
 };
 use crate::{
     Parser, Span,
@@ -87,6 +87,7 @@ pub(super) fn xref_macros_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes, masked);
 
@@ -105,7 +106,7 @@ pub(super) fn xref_macros_level<'src>(
     // coordinates — see `apply_macro_families`'s own doc comment.
     let (s, pieces) = ctx.shift(s, pieces);
 
-    let matches = find_xref_matches(&nodes, &s, &pieces, root, parser);
+    let matches = find_xref_matches(&nodes, &s, &pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
@@ -157,7 +158,7 @@ pub(super) fn xref_macros_level<'src>(
 /// the leaf folds back to its own bytes instead of being escaped
 /// twice — and the attribute-list branch, whose value comes back from a parse
 /// rather than from a range, re-derives the same split with
-/// [`escaped_value_children`].
+/// [`computed_value_children`].
 ///
 /// # A rendered span inside the reference text
 ///
@@ -208,6 +209,7 @@ fn find_xref_matches<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
@@ -291,7 +293,7 @@ fn find_xref_matches<'src>(
             Some(inner) => {
                 build_xref_shorthand_node(inner.clone(), &full, nodes, s, pieces, root, parser)
             }
-            None => build_xref_node(&caps, &full, nodes, pieces, root, parser),
+            None => build_xref_node(&caps, &full, nodes, pieces, root, parser, specials),
         };
 
         matches.push(MacroMatch {
@@ -356,6 +358,7 @@ fn build_xref_node<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> InlineNode<'src> {
     // Group 3 is the `xref:` macro target. It always participates here: the
     // pattern's two branches are mutually exclusive, and the caller routes a
@@ -368,7 +371,7 @@ fn build_xref_node<'src>(
 
     let raw_text = caps.get(4).map_or("", |m| m.as_str());
     let (children, window, roles, xrefstyle) =
-        xref_macro_text(raw_text, caps.get(4), nodes, pieces, root, parser);
+        xref_macro_text(raw_text, caps.get(4), nodes, pieces, root, parser, specials);
 
     let location = source_slice(pieces, full.clone(), root);
 
@@ -411,6 +414,7 @@ fn xref_macro_text<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
+    specials: ComputedSpecials,
 ) -> (
     Vec<InlineNode<'src>>,
     Option<CowStr<'src>>,
@@ -462,7 +466,7 @@ fn xref_macro_text<'src>(
                     // establishes.
                     let location = source_slice(pieces, span.start()..span.end(), root);
 
-                    escaped_value_children(&text, location)
+                    computed_value_children(&text, location, specials)
                 }
             };
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -369,7 +369,7 @@ use footnotes::apply_footnotes;
 // and future external callers today.
 #[allow(unused_imports)]
 pub(crate) use macros::apply_macro_side_effects;
-use macros::apply_macros;
+use macros::{ComputedSpecials, apply_macros};
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
@@ -589,12 +589,31 @@ pub(crate) fn build_for_group<'src>(
             }
 
             SubstitutionStep::Macros => {
+                // The one thing this step reads as *bytes* rather than
+                // carrying structurally is an attribute list's positional
+                // value: it comes back from a parse, so there is no range of
+                // nodes to rebuild it from and its classification has to be
+                // re-derived from the bytes. Whether those bytes are already
+                // escaped is decided by where the escaping step sits in this
+                // order — design §3.4.1 applied to the step's *position*,
+                // exactly as `SplicedSpecials` decides it for the step above —
+                // so it is decided here, where the order is in hand, and
+                // carried down as `ComputedSpecials`.
+                let specials = if steps
+                    .get(..position)
+                    .is_some_and(|behind| behind.contains(&SubstitutionStep::SpecialCharacters))
+                {
+                    ComputedSpecials::Escaped
+                } else {
+                    ComputedSpecials::Verbatim
+                };
+
                 // Footnotes are their own transducer, run once over the
                 // *whole* tree after every other macro family has been
                 // resolved at every level — see `apply_footnotes`'s doc
                 // comment for why this cannot be folded into `apply_macros`
                 // as an ordinary level pass.
-                let nodes = apply_macros(nodes, location, parser, Masked::known(&masked));
+                let nodes = apply_macros(nodes, location, parser, Masked::known(&masked), specials);
                 apply_footnotes(nodes, location, parser)
             }
 
@@ -1905,10 +1924,32 @@ mod tests {
                 "a &copy; b and image:x&copy;y.png[]",
                 // A cross-reference attribute-list text carrying a bare `&`,
                 // which only an order *without* `specialcharacters` can
-                // present: the value's own bytes open neither recoverable
-                // class, so `escaped_value_children` keeps the `&` as
-                // ordinary logical text.
+                // present: the parse hands back the author's own bytes, so
+                // `unescaped_value_children` classifies the `&` as the `Raw`
+                // leaf the classification pass would have made of it anyway.
                 "xref:sec[a & b,role=hl]",
+                // The same value written as the *entity spelling* of a
+                // special, for each of the three families that compute an
+                // attribute-list value. Under these orders nothing escaped it,
+                // so the six bytes are the author's own and the string
+                // replacer splices them in untouched — where reading them as
+                // an escaped special would unwind one level too far and fold
+                // `&lt;` back as a bare `<`. This is what `ComputedSpecials`
+                // decides (see
+                // `a_computed_value_is_classified_by_where_the_escaping_step_sits`,
+                // which pins the same fixtures from both sides).
+                "xref:sec[{product} &lt; y,role=hl] here",
+                "link:index.html[{product} &lt; y,role=hl] here",
+                "https://example.org[{product} &lt; y,role=hl] here",
+                // The same, with a *restored* entity beside it, so the one
+                // class this half still recognizes on its own — an entity the
+                // replacements step un-escaped, which folds verbatim either
+                // way — is exercised in the same value.
+                "link:index.html[{product} &copy; y,role=hl] here",
+                // And with a masked passthrough in the same text, so the
+                // token-splitting rebuild (`restored_value_children`) reaches
+                // this half too rather than only the escaped one.
+                "link:index.html[{product} &lt; ++<b>x</b>++,role=hl] here",
                 // A cross-reference reference text crossing a *rendered span*,
                 // carried as structured children: under these orders the span
                 // is opaque exactly as it is under the normal one, and the

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -132,6 +132,51 @@ pub(super) fn classify_unescaped_specials<'src>(
     out
 }
 
+/// Rebuilds a value the macros step **computed** off the level's match string
+/// under an effective order whose escaping step has not run by the time
+/// `Macros` reaches it — the
+/// [`Verbatim`](super::macros::ComputedSpecials::Verbatim) half of the decision
+/// [`ComputedSpecials`](super::macros::ComputedSpecials) carries, and the
+/// counterpart of
+/// [`escaped_value_children`](super::macros::escaped_value_children).
+///
+/// There is no entity to unwind here: the value's bytes are the author's own,
+/// which the string replacer splices into its output exactly as they stand. So
+/// this is the same classification [`classify_unescaped_specials`] performs
+/// over the finished tree — a literal `<`/`>`/`&` is a
+/// [`Raw`](InlineNode::Raw) leaf the fold emits verbatim, everything else a
+/// [`Text`](InlineNode::Text) run — reached through the very same
+/// [`split_text`], so the two cannot drift on what a literal special is worth.
+///
+/// Running it *here*, rather than leaving the value as one `Text` run for
+/// `classify_unescaped_specials` to split later, is what covers the second of
+/// the two orders this half serves: an order that escapes **after** `Macros`
+/// (`subs=macros,specialcharacters`) never reaches that final pass, and
+/// [`flatten_prior_markup`] folds this node's markup — including this value —
+/// before the escaping step splits the result.
+///
+/// An **empty** value yields no children at all, matching
+/// `escaped_value_children`'s own answer for one: unlike the empty `Text` a
+/// `<<id,>>` reference text is built with directly, an empty *computed* value
+/// is a value the caller has already filtered out.
+pub(super) fn unescaped_value_children<'src>(
+    text: &str,
+    location: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    if text.is_empty() {
+        return vec![];
+    }
+
+    let mut out = Vec::new();
+    split_text(
+        CowStr::from(text.to_string()),
+        location,
+        SpecialLeaf::Raw,
+        &mut out,
+    );
+    out
+}
+
 /// Splits a [`Text`](InlineNode::Text) node's logical `value` into alternating
 /// text runs and `<`/`>`/`&` leaves of the kind `leaf` names.
 ///


### PR DESCRIPTION
One more `inline-ast` increment: the last divergence the restore-the-value class left behind that was not a *keep*, and the last §3.4.1 classification the builder still made by assumption.

## The bug

A value the macros step **computes** off the level's match string — an attribute list's positional value, the one thing this step reads as *bytes* rather than carrying structurally, since it comes back from an `Attrlist` parse with no range of nodes to rebuild from — was always read as already-escaped. But an attribute list is parsed under *any* order that runs `Macros`, so both readings are reachable, and picking one by assumption was the bug: under an order that never escaped, an author's own `&lt;` was unwound one level too far and folded back as a bare `<`, where the string replacer splices the six bytes untouched.

`escaped_value_children`'s own doc named the remedy — "by where the escaping step actually sits" — and named what it needed: the effective order threaded down to each family.

## The change

A new `ComputedSpecials` carries the decision, made in `build_for_group` where the order is in hand — the same seam, and the same shape, as `SplicedSpecials` already uses for the attribute-references step — and `computed_value_children` dispatches to one of two halves:

- **`Escaped`** — the existing trichotomy unwind.
- **`Verbatim`** — a new `unescaped_value_children`, which reaches for `split_text`, the very splitter `classify_unescaped_specials` uses over the finished tree, so the two cannot drift on what a literal special is worth.

The condition is the step's **position**, not its presence, which is what makes the second half cover an order that escapes *after* `Macros` too: there the final classification pass never runs, and `flatten_prior_markup` folds the node's markup before the escaping step splits the result, so the value has to be classified here or not at all. That is a real gain rather than a hypothetical one — under `subs=attributes,macros,specialcharacters` the cross-reference family (the one family the string pipeline is still holding as a deferred placeholder when the escaping step runs, so `flatten_prior_markup` leaves it alone) now reaches parity in **both** spellings, where a bare `<` had diverged.

## What reaches parity

The four-cell truth table — a `<` and a `&lt;` in a computed value, against an order that escapes first and one that never escapes — over all three families that compute one (the `link:`/`mailto:` macro's `=` list, the auto-link / formal-URL family's, and the cross-reference macro's), plus the same three fixtures folded into the never-escapes group-parity corpus beside a restored entity and a masked passthrough in the same value. The test that had pinned this as a documented divergence becomes that truth table, exactly as its own note said to do if the thread were ever added.

## Notes

- Threading changed fourteen signatures and no node kind, gate, or builder body.
- Re-running the corpus-wide fold-parity audit shows the three fixtures **gone** from the divergence set and **no new divergence**.
- Coverage is diff-neutral on every touched file (missed regions/lines unchanged against `origin/inline-ast`), with one consequence worth recording: the escaped half's bare-`&` arm — which the never-escapes corpus used to be the only thing exercising — is now unreachable through any order (every `&` in a level's match string belongs to a `CharRef` leaf that opens a class, and a *literal* one is a `Raw` leaf the match string stands in as an opaque placeholder), so it is kept as the scan's totality arm and pinned by a direct unit test instead.
- As with every prep piece before it, nothing further is wired in.

With this, every §3.4.1 classification the builder makes is decided by where the steps actually sit rather than by where a fragment came from.

Preflight: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, and `cargo +nightly doc --no-deps --document-private-items` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JMoHtJomzi4UmtKm2M5nA

---
_Generated by [Claude Code](https://claude.ai/code/session_016JMoHtJomzi4UmtKm2M5nA)_