### PR TITLE
feat: Cut an escaped special in half where a bare URL's strip does (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4725,6 +4725,50 @@ Each phase is a reviewable unit with a clear exit gate.
   presented character, the closing character, and the character-replacements step's
   consume-across-levels case — and the keeps.
 
+  *Step 6 prep landed as (a trailing-punctuation strip that cuts an escaped special in half):*
+  the auto-link family's own last-named gap — "the one form this family's escaped-special lift
+  does not reach", pinned since the lift landed as
+  `a_bare_url_whose_trailing_strip_would_split_a_special_is_a_documented_divergence` and reproduced
+  by two of the language description's own auto-link fixtures. A bare URL ending in a literal `&`,
+  `<`, or `>` reaches the macros step as that special's own entity, whose final `;` satisfies the
+  trailing-punctuation strip: the string replacer splits the entity happily (`href` ending `&amp`,
+  a literal `;` left after the link), while the tree's boundary fell *inside* a
+  [`CharRef`](../../parser/src/inlines/inline_node.rs) leaf and left the whole match literal.
+
+  Closing it needed one distinction rather than a new mechanism: a match boundary is answerable
+  exactly where a piece's **match-string bytes are the bytes its own fold emits**, which is true of
+  the three `CharRef` leaves and of nothing else the module stands in as a placeholder. There
+  either half *is* those bytes, so
+  [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) now cuts such a piece into two
+  [`Raw`](../../parser/src/inlines/inline_node.rs) leaves — each folding verbatim, so every
+  partition of the entity folds to the entity — while every other atomic piece, standing in for
+  markup that exists only at fold time, still clones whole. Neither half has an honest `'src` slice
+  of its own (the source holds one character, or `(C)`, where the match string holds an entity), so
+  both keep the leaf's whole `location`, design §4.4's coarse fallback. The classification is one
+  new [`charref_entity`](../../parser/src/content/inline_builder/quotes.rs), which
+  [`atomic_piece_is_recoverable`](../../parser/src/content/inline_builder/macros/image.rs) — the
+  `range_has_no_opaque_piece` predicate that used to spell the same three arms out a second time —
+  now delegates to, so the gate and the bytes it admits cannot disagree;
+  `charref_entity_matches_the_match_strings_own_bytes` pins both against
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs)' own arms.
+
+  The family's gate is then **deleted rather than relaxed**: the bytes the strip cuts off are a
+  literal `;`, `:`, or `)`, which no opaque piece can supply (the module stands one in as a single
+  non-ASCII placeholder), so the only piece the boundary can fall inside is a `Text` run or a
+  `CharRef` leaf and both are now cut. What reaches parity is all three escaped specials at a bare
+  URL's end, a restored entity (`&copy;`) and a typographic replacement (`(C)`) — the class's
+  other two leaves, split by the same cut — the two golden fixtures this closes, the strip's
+  two-byte `);` form over a leaf the link keeps whole, in flow, doubled, inside a rendered span,
+  escaped, under `hide-uri-scheme` (whose scheme count reaches past a split leaf as it does past
+  a whole one), the bracketed and angle spellings that apply no strip at all, and end to end
+  through the real parse path. Re-running the corpus-wide fold-parity audit shows those two
+  fixtures **gone** from the divergence set and no new divergence; coverage is diff-neutral, and
+  as with every prep piece before it, nothing further is wired in.
+
+  What still defers is unchanged: the boundary-class halves the sibling increments named — a macro
+  body class wanting more than one presented character, the closing character, and the
+  character-replacements step's consume-across-levels case — and the keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5504,6 +5548,19 @@ Each phase is a reviewable unit with a clear exit gate.
        not its presence, so an order that escapes **after** `Macros` takes the second half too —
        which brings the cross-reference family to parity there in both spellings. See the step's
        own "landed as" note above.
+
+     - ✅ **prep (a trailing strip that cuts an escaped special).** The auto-link family's own
+       last-named gap: a bare URL ending in a literal `&`, `<`, or `>` satisfies the
+       trailing-punctuation strip on that special's *entity*, which the string replacer splits and
+       the tree could not. A match boundary is answerable wherever a piece's match-string bytes are
+       the bytes its own fold emits — the three
+       [`CharRef`](../../parser/src/inlines/inline_node.rs) leaves and nothing else — so
+       [`emit_range`](../../parser/src/content/inline_builder/quotes.rs) cuts one into two
+       [`Raw`](../../parser/src/inlines/inline_node.rs) halves, each folding verbatim, and one new
+       [`charref_entity`](../../parser/src/content/inline_builder/quotes.rs) answers both that
+       classification and the bytes. The family's gate is deleted rather than relaxed (the stripped
+       bytes are a literal `;`, `:`, or `)`, which no opaque piece can supply), and the formerly
+       pinned divergence becomes a parity test. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -11,14 +11,13 @@ use crate::{
         inline_builder::{
             fold::fold_stem,
             quotes::{
-                LevelContext, Piece, build_match_string, replacement_entity, source_slice,
-                text_slice,
+                LevelContext, Piece, build_match_string, charref_entity, source_slice, text_slice,
             },
             special_chars::Masked,
         },
         normalize_text_lf_escaped_bracket,
     },
-    inlines::{CharRef, Image, InlineNode},
+    inlines::{Image, InlineNode},
     parser::{
         InlineSubstitutionRenderer, has_dangerous_scheme, has_dangerous_self_href, is_uri_ish,
     },
@@ -225,10 +224,11 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
 /// [`Text`](InlineNode::Text) run (verbatim or
 /// [`synthesized`](Piece::synthesized)) or any of the three
 /// [`CharRef`](InlineNode::CharRef) leaves, an *escaped special*
-/// ([`Special`](CharRef::Special)), a *restored entity*
-/// ([`Entity`](CharRef::Entity)), or a *typographic replacement*
-/// ([`Replacement`](CharRef::Replacement)) — rejecting only an **opaque**
-/// piece: a rendered [`Styled`](crate::inlines::Styled) span, an
+/// ([`Special`](crate::inlines::CharRef::Special)), a *restored entity*
+/// ([`Entity`](crate::inlines::CharRef::Entity)), or a *typographic
+/// replacement* ([`Replacement`](crate::inlines::CharRef::Replacement)) —
+/// rejecting only an **opaque** piece: a rendered
+/// [`Styled`](crate::inlines::Styled) span, an
 /// earlier-recognized macro node, or a masked passthrough or STEM expression,
 /// each of which [`build_match_string`] stands in as one
 /// `SPAN_PLACEHOLDER` rather than the markup or entity the string pipeline's
@@ -238,9 +238,10 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
 /// match-string bytes — a special's canonical entity (`&lt;`, `&gt;`,
 /// `&amp;`), a restored entity's own text (`&copy;`, `&#8217;`), a
 /// replacement's built-in rendering (`&#169;` for `(C)`, `&#8217;` for `'`,
-/// via [`replacement_entity`]) — are the very byte sequence the string
-/// pipeline's own haystack carries at that position, so a family that reads its
-/// values out of the match string sees exactly what the string replacer sees.
+/// via [`replacement_entity`](super::super::quotes::replacement_entity)) — are
+/// the very byte sequence the string pipeline's own haystack carries at that
+/// position, so a family that reads its values out of the match string sees
+/// exactly what the string replacer sees.
 /// What such a family cannot do is *slice* those bytes from `'src` (the source
 /// holds one character, or `(C)`, where the match string holds an entity, and
 /// `&amp;copy;` where it holds `&copy;`), so a value that must ride on the node
@@ -279,28 +280,21 @@ pub(in crate::content::inline_builder) fn range_has_no_opaque_piece(
 /// Tells whether one [`atomic`](Piece::atomic) piece is a leaf
 /// [`build_match_string`] gives real bytes to — the classification
 /// [`range_has_no_opaque_piece`] applies per overlapping piece (see its own
-/// doc comment for why exactly these three [`CharRef`] leaves qualify).
+/// doc comment for why exactly these three [`CharRef`](crate::inlines::CharRef)
+/// leaves qualify).
 fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool {
     // The atomic pieces `build_match_string` gives real bytes to are the
     // three `CharRef` leaves — an escaped special, a restored entity, and
     // a typographic replacement the built-in backend has a rendering for;
-    // everything else it stands in as one placeholder. The
-    // `replacement_entity` test mirrors that arm's own guard, so a
-    // hand-built node carrying a value no rule produces stays opaque here
-    // exactly as it does there.
-    match nodes.get(piece.node_index) {
-        Some(InlineNode::CharRef {
-            value: CharRef::Special(_) | CharRef::Entity(_),
-            ..
-        }) => true,
-
-        Some(InlineNode::CharRef {
-            value: CharRef::Replacement(value),
-            ..
-        }) => replacement_entity(value).is_some(),
-
-        _ => false,
-    }
+    // everything else it stands in as one placeholder. Asking
+    // [`charref_entity`](super::super::quotes::charref_entity) for those very
+    // bytes is what makes the classification and the match string agree by
+    // construction — including on a hand-built replacement carrying a value no
+    // rule produces, which stays opaque here exactly as it does there.
+    nodes
+        .get(piece.node_index)
+        .and_then(charref_entity)
+        .is_some()
 }
 
 /// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2,10 +2,7 @@
 
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind, computed_value_children,
-    image::{
-        range_is_restorable, range_is_verbatim, range_is_verbatim_or_synthesized, restorable_body,
-        tokened_bracket,
-    },
+    image::{range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
     macro_text_children, rebuild_macro_level,
 };
 use crate::{
@@ -463,19 +460,22 @@ fn build_inline_link_node<'src>(
         url_end = consumed_end;
 
         // The strip's arithmetic runs over the *match string*, exactly as the
-        // replacer's runs over its own escaped haystack — but the boundary it
-        // lands on must still be one a node list can be cut at, and an escaped
-        // special is one piece, not five bytes. A bare URL ending in a literal
-        // `&` reaches this pass as `…&amp;`, whose own final `;` satisfies the
-        // strip: the replacer happily splits the entity (target `…&amp`, suffix
-        // `;`), while here `consumed_end` would land *inside* a
-        // [`CharRef`](InlineNode::CharRef) leaf that
-        // [`emit_range`](super::super::quotes::emit_range) can only emit whole.
-        // Left literal, the one form this family's escaped-special lift does
-        // not reach.
-        if stripped > 0 && !range_is_verbatim_or_synthesized(pieces, &(consumed_end..full.end)) {
-            return None;
-        }
+        // replacer's runs over its own escaped haystack, and the boundary it
+        // lands on needs no gate of its own. The bytes it cuts off are a
+        // literal `;`, `:`, or `)` — which an **opaque** piece can never
+        // supply, since [`build_match_string`] stands one in as a single
+        // non-ASCII placeholder — so the only piece the boundary can fall
+        // inside is a [`Text`](InlineNode::Text) run or a
+        // [`CharRef`](InlineNode::CharRef) leaf, and
+        // [`emit_range`](super::super::quotes::emit_range) cuts both.
+        //
+        // A bare URL ending in a literal `&` is the shape that makes the
+        // second case reachable: it arrives here as `…&amp;`, whose own final
+        // `;` satisfies the strip, so the replacer splits the entity (target
+        // `…&amp`, a literal `;` after the link). Splitting the leaf
+        // reproduces that exactly — either half folds to its own bytes, so the
+        // two together fold to the entity the whole leaf would — where this
+        // family used to leave the whole match literal.
     }
 
     // A target crossing a **masked** construct finishes into the restored
@@ -2123,8 +2123,8 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::super::super::test_support::{
-        assert_entity, assert_link, assert_special_char, assert_styled, assert_text, build_src,
-        fold_html, golden_macros, golden_macros_with, link_text_of,
+        assert_entity, assert_link, assert_raw, assert_special_char, assert_styled, assert_text,
+        build_src, fold_html, golden_macros, golden_macros_with, link_text_of,
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -3208,6 +3208,10 @@ mod tests {
             "https://example.org/a&b[]",
             "<https://example.org/a&b>",
             "https://example.org/?a=1&b=2",
+            // And with the trailing strip splitting that special, whose two
+            // halves the scheme count reaches past exactly as it reaches past
+            // a whole one.
+            "https://example.org/a&",
         ];
 
         let renderer = HtmlSubstitutionRenderer {};
@@ -4657,25 +4661,82 @@ mod tests {
     }
 
     #[test]
-    fn a_bare_url_whose_trailing_strip_would_split_a_special_is_a_documented_divergence() {
+    fn fold_matches_the_string_pipeline_when_a_bare_urls_trailing_strip_splits_a_special() {
         // The trailing-punctuation strip keys off the target's *final
-        // character*, over the escaped text — so a bare URL ending in a literal
-        // `&` (whose match-string tail is `&amp;`) satisfies it on that
-        // entity's own `;`. The string replacer happily splits the entity
-        // (target `…/a&amp`, a literal `;` after the link); here the boundary
-        // would fall *inside* a `CharRef` leaf, which `emit_range` can only
-        // emit whole, so the link is left literal instead — the one form this
-        // family's escaped-special lift does not reach.
-        let source = "https://example.org/a&";
-        let nodes = build_src(Span::new(source));
+        // character*, over the escaped text — so a bare URL ending in a
+        // literal `&` (whose match-string tail is `&amp;`) satisfies it on
+        // that entity's own `;`. The string replacer splits the entity there
+        // (target `…/a&amp`, a literal `;` after the link), and the tree now
+        // reproduces that split rather than deferring to it: the boundary
+        // falls inside a `CharRef` leaf, which
+        // [`emit_range`](super::super::quotes::emit_range) cuts into two
+        // [`Raw`](InlineNode::Raw) halves — each folding to its own bytes, so
+        // the pair folds to exactly what the whole leaf would.
+        let fixtures = [
+            // The three escaped specials, each ending a bare URL.
+            "https://example.org/a&",
+            "https://example.org/a<",
+            "https://example.org/a>",
+            // The two shapes from the language description's own auto-link
+            // page that this closes: a `>` written after a URL, alone and
+            // doubled.
+            "See https://example.org> for details.",
+            "a https://example.org> b https://example.com> c",
+            // The other two leaves whose match-string bytes are their own — a
+            // *restored entity* and a *typographic replacement* — split the
+            // same way, for the same reason.
+            "https://example.org/?x=&copy;",
+            "https://example.org/a(C)",
+            // The strip's two-byte form (a `)` before the `;`), over a literal
+            // pair following a leaf the link keeps whole.
+            "https://example.org/(a&b);",
+            // In flow, doubled, inside a rendered span, and escaped.
+            "see https://example.org/a& now",
+            "https://example.org/a& https://example.org/b&",
+            "*https://example.org/a&*",
+            "\\https://example.org/a&",
+            // The bracketed and angle spellings apply no strip at all, so the
+            // leaf stays whole in both pipelines.
+            "https://example.org/a&[Docs]",
+            "https://example.org/a&[]",
+            "<https://example.org/a&>",
+            // An entity away from the boundary is untouched, as before.
+            "https://example.org/?a=1&b=2",
+        ];
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a bare URL whose strip splits a special must stay literal: {nodes:?}"
-        );
+        for fixture in fixtures {
+            assert_eq!(
+                fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {}),
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
 
-        // The string pipeline, by contrast, builds a link on the split entity.
-        assert!(golden_macros(source).contains(r#"href="https://example.org/a&amp""#));
+    #[test]
+    fn a_bare_urls_trailing_strip_cuts_a_special_into_two_raw_halves() {
+        // The parity above, read structurally: the target keeps the entity's
+        // leading bytes as the string replacer's own `href` does, the shown
+        // text carries them as a `Raw` leaf (a `Text` would have the fold
+        // escape the `&` a second time — design §3.4), and the `;` the strip
+        // left behind is the leaf's own remaining byte, emitted beside the
+        // link rather than duplicating the whole entity there.
+        let nodes = build_src(Span::new("https://example.org/a&"));
+
+        let reference = assert_link(&nodes[0]);
+        assert_eq!(reference.target.as_ref(), "https://example.org/a&amp");
+
+        assert_text(&reference.children[0], "https://example.org/a", 1, 1);
+
+        // Neither half has an honest `'src` slice of its own — the source
+        // holds one `&` where the match string holds five bytes — so both keep
+        // the leaf's whole location (design §4.4's coarse fallback).
+        let head = assert_raw(&reference.children[1], "&amp");
+        assert_eq!(head.data(), "&");
+
+        let tail = assert_raw(&nodes[1], ";");
+        assert_eq!(tail.data(), "&");
+        assert_eq!(tail.byte_offset(), head.byte_offset());
     }
 
     #[test]
@@ -5911,6 +5972,48 @@ mod tests {
         );
 
         assert_eq!(folded, "https://example.orgx");
+    }
+
+    #[test]
+    fn a_real_documents_split_special_auto_links_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shape that named
+        // this increment: a bare URL whose trailing-punctuation strip lands on
+        // an escaped special's own `;` must build the same split link the
+        // rendered string carries, so a tree that left it literal — or
+        // emitted the whole entity on either side of the cut — would regress
+        // the moment `rendered_html()` becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "See https://example.org> for details.\n",
+            "\n",
+            "Visit https://example.org/a& or https://example.org/b(C) today.\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1037,6 +1037,44 @@ pub(super) fn replacement_entity(value: &str) -> Option<&'static str> {
     })
 }
 
+/// The match-string bytes a [`CharRef`] leaf contributes — a
+/// [`Special`](CharRef::Special)'s canonical entity, a restored
+/// [`Entity`](CharRef::Entity)'s own text, or a typographic
+/// [`Replacement`](CharRef::Replacement)'s built-in rendering — or `None` for
+/// every other node, whose output bytes exist only at fold time and which
+/// [`build_match_string`] therefore stands in as one [`SPAN_PLACEHOLDER`].
+///
+/// These are the leaves whose match-string bytes are *exactly* the bytes their
+/// own fold emits, which is what lets a caller read them as bytes:
+/// [`range_has_no_opaque_piece`] admits a range crossing one, and
+/// [`emit_range`] slices one a range only partly covers. That equality is the
+/// whole content of this function, so it reads the same three arms
+/// [`build_match_string`] writes them with;
+/// `charref_entity_matches_the_match_strings_own_bytes` pins the two against
+/// each other so they cannot drift.
+///
+/// [`range_has_no_opaque_piece`]: super::macros::image::range_has_no_opaque_piece
+pub(super) fn charref_entity<'a>(node: &'a InlineNode<'_>) -> Option<&'a str> {
+    match node {
+        InlineNode::CharRef {
+            value: CharRef::Special(ch),
+            ..
+        } => Some(special_entity(*ch)),
+
+        InlineNode::CharRef {
+            value: CharRef::Entity(entity),
+            ..
+        } => Some(entity.as_ref()),
+
+        InlineNode::CharRef {
+            value: CharRef::Replacement(value),
+            ..
+        } => replacement_entity(value),
+
+        _ => None,
+    }
+}
+
 /// One accepted quote match at a level, in absolute match-string byte offsets.
 struct QuoteMatch {
     /// The whole match, `[start, end)`.
@@ -1439,6 +1477,13 @@ fn attributes_of_attrlist<'src>(
 /// Emits the original nodes covering the match-string range `[range.start,
 /// range.end)` into `out`, slicing a verbatim [`Text`](InlineNode::Text) run at
 /// the boundaries and cloning any atomic piece that falls inside.
+///
+/// An atomic piece a boundary *splits* is sliced too, but only for the leaves
+/// [`charref_entity`] names — the three [`CharRef`](InlineNode::CharRef)
+/// leaves, whose match-string bytes are exactly the bytes their own fold emits
+/// — each half emitted as a [`Raw`](InlineNode::Raw) leaf carrying those bytes
+/// verbatim. Every other atomic piece stands in for markup that exists only at
+/// fold time, so a boundary splitting one still clones it whole.
 pub(super) fn emit_range<'src>(
     nodes: &[InlineNode<'src>],
     pieces: &[Piece],
@@ -1466,11 +1511,51 @@ pub(super) fn emit_range<'src>(
         };
 
         if piece.atomic {
-            // An atomic piece should fall wholly inside the range; a boundary
-            // that splits one is a recognition edge this increment does not
-            // claim, so clone the whole piece and let the differential corpus
-            // catch any real divergence.
-            out.push(node.clone());
+            // An atomic piece falling wholly inside the range is emitted as
+            // its own node, which is the overwhelmingly common case.
+            if p_start >= range.start && p_end <= range.end {
+                out.push(node.clone());
+                continue;
+            }
+
+            // A boundary that *splits* one is answerable for exactly the
+            // leaves [`charref_entity`] names — the three
+            // [`CharRef`](InlineNode::CharRef) leaves, whose match-string
+            // bytes are the very bytes their own fold emits — because there
+            // either half **is** those bytes: a [`Raw`](InlineNode::Raw) leaf
+            // carrying them folds verbatim, so every partition of the entity
+            // folds to the entity, and a caller cutting one (a bare URL whose
+            // trailing-punctuation strip lands on an entity's own `;` — see
+            // `build_inline_link_node`) reproduces the string replacer's own
+            // split rather than deferring to it. Neither half has an honest
+            // `'src` slice of its own (the source holds one character, or
+            // `(C)`, where the match string holds an entity), so both keep the
+            // leaf's whole `location` — design §4.4's coarse fallback, the
+            // same one a synthesized run's slices already take.
+            //
+            // Every other atomic piece stands in for markup that exists only
+            // at fold time, one `SPAN_PLACEHOLDER` character with no bytes to
+            // slice, so a partial overlap there stays what it was: clone the
+            // whole piece and let the differential corpus catch any real
+            // divergence.
+            let Some(entity) = charref_entity(node) else {
+                out.push(node.clone());
+                continue;
+            };
+
+            let lo = range.start.max(p_start) - p_start;
+            let hi = range.end.min(p_end) - p_start;
+
+            // Every entity is ASCII, so both offsets are character boundaries
+            // within it; the crate forbids `unwrap`, so that lookup is spelled
+            // `unwrap_or_default` rather than as a branch no input reaches.
+            let sliced = entity.get(lo..hi).unwrap_or_default();
+
+            out.push(InlineNode::Raw {
+                value: CowStr::from(sliced.to_string()),
+                location: node.span(),
+            });
+
             continue;
         }
 
@@ -1707,8 +1792,8 @@ mod tests {
 
     use super::{
         super::test_support::{
-            assert_styled, assert_text, build_src, build_through_quotes, fold_html,
-            golden_passthroughs,
+            assert_raw, assert_special_char, assert_styled, assert_text, build_src,
+            build_through_quotes, fold_html, golden_passthroughs,
         },
         Masked,
     };
@@ -2937,6 +3022,164 @@ mod tests {
         assert_eq!(s_to_src(&pieces, 14, Bias::Start), 110);
         assert_eq!(s_to_src(&pieces, 14, Bias::End), 110);
         assert_eq!(s_to_src(&pieces, 16, Bias::Start), 112);
+    }
+
+    #[test]
+    fn emit_range_cuts_a_charref_leaf_into_raw_halves() {
+        use super::{build_match_string, emit_range};
+
+        // A boundary inside a `CharRef` leaf cuts it, because either half of
+        // its match-string bytes is what that half's own fold emits. The three
+        // leaves are cut alike; each half keeps the leaf's whole location
+        // (design §4.4), and the two concatenate back to the entity.
+        let source = Span::new("&(C)\u{a9}");
+
+        let nodes = vec![
+            InlineNode::CharRef {
+                value: CharRef::Special('&'),
+                location: source.slice(0..1),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Replacement("\u{a9}"),
+                location: source.slice(1..4),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Entity(CowStr::from("&copy;")),
+                location: source.slice(4..6),
+            },
+        ];
+
+        let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+        assert_eq!(s, "&amp;&#169;&copy;");
+
+        // One cut in each leaf, at its own final `;` — the boundary a bare
+        // auto-link's trailing-punctuation strip lands on.
+        for (range, head, tail, location) in [
+            (0..4, "&amp", ";", "&"),
+            (5..10, "&#169", ";", "(C)"),
+            (11..16, "&copy", ";", "\u{a9}"),
+        ] {
+            let mut out = Vec::new();
+            emit_range(&nodes, &pieces, range.clone(), &mut out);
+            assert_eq!(out.len(), 1, "{out:?}");
+            assert_eq!(assert_raw(&out[0], head).data(), location);
+
+            let mut out = Vec::new();
+            emit_range(&nodes, &pieces, range.end..range.end + 1, &mut out);
+            assert_eq!(out.len(), 1, "{out:?}");
+            assert_eq!(assert_raw(&out[0], tail).data(), location);
+        }
+
+        // A range covering a leaf whole still emits the leaf itself, which is
+        // what every caller before this one gets.
+        let mut out = Vec::new();
+        emit_range(&nodes, &pieces, 0..5, &mut out);
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_special_char(&out[0], '&');
+    }
+
+    #[test]
+    fn emit_range_keeps_an_opaque_piece_whole_at_a_cut() {
+        use super::{build_match_string, emit_range};
+        use crate::inlines::Styled;
+
+        // The other half of the rule: a piece standing in for markup that
+        // exists only at fold time has no bytes to cut, so a boundary
+        // splitting one clones it whole, exactly as before.
+        let source = Span::new("*x*");
+
+        let nodes = vec![InlineNode::Styled(Styled {
+            variant: StyleVariant::Strong,
+            form: SpanForm::Constrained,
+            id: None,
+            roles: vec![],
+            attrs: None,
+            children: vec![],
+            location: source,
+        })];
+
+        let (_, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+
+        // The placeholder is one three-byte character; a range covering its
+        // first byte alone still emits the span itself.
+        let mut out = Vec::new();
+        emit_range(&nodes, &pieces, 0..1, &mut out);
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_styled(&out[0], StyleVariant::Strong, SpanForm::Constrained);
+    }
+
+    #[test]
+    fn charref_entity_matches_the_match_strings_own_bytes() {
+        use super::{build_match_string, charref_entity};
+
+        // [`charref_entity`] answers the bytes [`build_match_string`] writes
+        // for the same node — the equality every caller reading a leaf as
+        // bytes rests on, and the one thing that could drift between the two
+        // lists of `CharRef` arms.
+        let source = Span::new("<>&(C)'\u{a9}x");
+
+        let nodes = vec![
+            InlineNode::CharRef {
+                value: CharRef::Special('<'),
+                location: source.slice(0..1),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Special('>'),
+                location: source.slice(1..2),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Special('&'),
+                location: source.slice(2..3),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Replacement("\u{a9}"),
+                location: source.slice(3..6),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Replacement("\u{2019}"),
+                location: source.slice(6..7),
+            },
+            InlineNode::CharRef {
+                value: CharRef::Entity(CowStr::from("&copy;")),
+                location: source.slice(7..9),
+            },
+            InlineNode::Text {
+                value: CowStr::from("x"),
+                location: source.slice(9..10),
+            },
+        ];
+
+        let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+
+        for piece in &pieces {
+            let node = &nodes[piece.node_index];
+            let bytes = &s[piece.s_start..piece.s_start + piece.s_len];
+
+            match charref_entity(node) {
+                // A leaf: its entity is exactly the piece's own bytes, and the
+                // piece is atomic (it is one indivisible node, cut only where
+                // both halves are its own bytes).
+                Some(entity) => {
+                    assert_eq!(entity, bytes, "{node:?}");
+                    assert!(piece.atomic, "{node:?}");
+                }
+
+                // Everything else is not a leaf — here the `Text` run, which
+                // is not atomic either.
+                None => assert!(!piece.atomic, "{node:?}"),
+            }
+        }
+
+        // A replacement carrying a value no rule produces is not a leaf: the
+        // one shape whose two answers agree by *exclusion*, since
+        // `build_match_string` stands it in as a placeholder.
+        assert!(
+            charref_entity(&InlineNode::CharRef {
+                value: CharRef::Replacement("\u{2603}"),
+                location: source,
+            })
+            .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
One increment on the `inline-ast` branch, additive as every prep piece before it: nothing further is wired in.

## The form

A bare URL ending in a literal `&`, `<`, or `>` reaches the macros step as that special's own entity, whose final `;` satisfies the trailing-punctuation strip. The string replacer splits the entity happily — an `href` ending `&amp`, a literal `;` left after the link — while the tree's boundary fell *inside* a `CharRef` leaf and the whole match was left literal. That was "the one form this family's escaped-special lift does not reach", pinned since the lift landed as `a_bare_url_whose_trailing_strip_would_split_a_special_is_a_documented_divergence`, and reproduced by two of the language description's own auto-link fixtures:

```
See https://example.org> for details.
a https://example.org> b https://example.com> c
```

## The move

One distinction rather than a new mechanism: a match boundary is answerable exactly where a piece's **match-string bytes are the bytes its own fold emits**, which is true of the three `CharRef` leaves and of nothing else the module stands in as a placeholder. There either half *is* those bytes, so `emit_range` now cuts such a piece into two `Raw` leaves — each folding verbatim, so every partition of the entity folds to the entity — while every other atomic piece, standing in for markup that exists only at fold time, still clones whole. Neither half has an honest `'src` slice of its own (the source holds one character, or `(C)`, where the match string holds an entity), so both keep the leaf's whole `location`: design §4.4's coarse fallback.

The classification is one new `charref_entity`, which `atomic_piece_is_recoverable` — the `range_has_no_opaque_piece` predicate that used to spell the same three arms out a second time — now delegates to, so the gate and the bytes it admits cannot disagree. `charref_entity_matches_the_match_strings_own_bytes` pins both against `build_match_string`'s own arms.

The family's own gate is then **deleted rather than relaxed**: the bytes the strip cuts off are a literal `;`, `:`, or `)`, which no opaque piece can supply (the module stands one in as a single non-ASCII placeholder), so the only piece the boundary can fall inside is a `Text` run or a `CharRef` leaf — and both are now cut.

## What reaches parity

All three escaped specials at a bare URL's end; a restored entity (`&copy;`) and a typographic replacement (`(C)`), the class's other two leaves, split by the same cut; the two golden fixtures above; the strip's two-byte `);` form over a leaf the link keeps whole; in flow, doubled, inside a rendered span, and escaped; under `hide-uri-scheme`, whose scheme count reaches past a split leaf as it does past a whole one; the bracketed and angle spellings, which apply no strip at all; and end to end through the real parse path. The formerly pinned divergence test becomes a parity test.

## Checks

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, and `cargo +nightly doc --no-deps --document-private-items` all clean.
- The corpus-wide fold-parity audit, run on this branch and on `origin/inline-ast`: the two fixtures above are **gone** from the divergence set and **no new divergence** appeared.
- Coverage is diff-neutral — missed-region and missed-line counts unchanged in all three touched files (`quotes.rs` 13/4, `links.rs` 17/8, `image.rs` 4/1, same as the base).

## Still deferred

Unchanged by this step: the boundary-class halves the sibling increments named — a macro body class wanting more than one presented character, the closing character, and the character-replacements step's consume-across-levels case — and the keeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLk9mZdSqgMPyo7MDGwuDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLk9mZdSqgMPyo7MDGwuDq)_