### PR TITLE
feat: Recognize an escaped attribute-list bracket's passthrough (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4769,6 +4769,66 @@ Each phase is a reviewable unit with a clear exit gate.
   body class wanting more than one presented character, the closing character, and the
   character-replacements step's consume-across-levels case — and the keeps.
 
+  *Step 6 prep landed as (an escaped attribute-list bracket, one match's source doing two
+  things):* with the boundary and restore-the-value classes closed down to their keeps, re-running
+  the corpus-wide fold-parity audit and classifying what remains by *source* leaves the
+  passthrough-extraction pass's own last named deferral — an **escaped bracket** ahead of a
+  delimited passthrough (`\[attrs]++text++`), pinned since step 5d part 2 landed as
+  `an_escaped_attrlist_bracket_is_a_documented_divergence` and exercised by
+  [`Passthroughs`](../../parser/src/content/passthroughs.rs)' own golden fixture. The string
+  replacer's [`handle_quoted_text`](../../parser/src/content/passthroughs.rs) does *two* things
+  there — writes the bracket back as a literal `[attrs]` prefix with its backslash dropped, then
+  stores the delimited text as an **ordinary** passthrough, its attribute list discarded rather
+  than carried — where
+  [`find_passthrough_matches`](../../parser/src/content/inline_builder/passthrough_step.rs) could
+  express one or the other and so left the whole construct literal.
+
+  Closing it needed no new mechanism at all, which is the increment's own finding: the shape its
+  divergence note called "a kept-literal-prefix-with-one-dropped-char, plus a node for the
+  remainder, a shape neither
+  [`MacroMatchKind`](../../parser/src/content/inline_builder/macros/mod.rs) variant expresses" is
+  not one match wanting a third variant but **two adjacent matches** —
+  an [`Unescape`](../../parser/src/content/inline_builder/macros/mod.rs) over the bracket, then a
+  [`Node`](../../parser/src/content/inline_builder/macros/mod.rs) over the delimited remainder —
+  and [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) already
+  composes any two adjacent matches, gap by gap, without knowing they came from one regex capture.
+  The node the second match carries is
+  [`build_passthrough_node`](../../parser/src/content/inline_builder/passthrough_step.rs)' — the
+  unattrlisted builder every bare `+++`/`++`/`$$` form already uses — reached with the *delimited*
+  sub-range rather than the whole match, so the discarded attribute list is discarded by
+  construction: there is no `Styled` wrapper to suppress and no `x-` marker to not honor, because
+  the branch that reads them is never entered. Nothing else in the module changes, and no variant,
+  gate, or signature moves.
+
+  What reaches parity is every boundary an escaped bracket can precede (`+++`, `++`, `$$`), the
+  `x-` marker whose monospace-and-`Normal`-subs treatment the escape *removes*, a body carrying
+  markup and specials (escaped for `++`/`$$`, raw for `+++`, with quotes never running over either),
+  the escaped form beside its unescaped twin in one flow, a kept prefix carrying a special
+  character and one carrying quote syntax — both substituted by the later steps exactly as the
+  string pipeline substitutes its own literal `[attrs]` — the construct in flow and spanning a
+  newline, and the same under the never-escapes group-parity orders, where whether the prefix's
+  `<` is escaped is the *order's* decision while the remainder stays opaque either way. The
+  formerly pinned divergence becomes a parity test that also asserts the shape: a `Text` prefix and
+  a plain [`Raw`](../../parser/src/inlines/inline_node.rs) leaf, never the `Styled` span the
+  unescaped spelling builds. Fixtures join the whole-pipeline broad sweep and combined-constructs
+  corpus, the group-parity corpus, and — unlike the boundary-class increments, whose shapes a
+  [`RecordingRenderer`](../../parser/src/content/inline_tree.rs)'s marker perturbs — the
+  **structural recorder cross-check**, which reads them normally (the marker sits outside the
+  markup it wraps, and nothing here reads a neighbour's boundary character); a whole-document test
+  drives both shapes end to end through the real parse path. Re-running the corpus-wide fold-parity
+  audit shows the `Passthroughs` fixture **gone** from the divergence set and no new divergence;
+  coverage is diff-neutral, and as with every prep piece before it, nothing further is wired in.
+
+  What still defers in this pass is its other named deferral, the **prohibited-prefix** retry the
+  string replacer works around by hand for the two bare attribute-list-prefixed forms
+  (`index:[attrs]+text+`, ``\[x-]`text` ``), which keeps its own divergence test — and which is
+  where writing *both* escapes at once (`\[attrs]\++text++`) lands, the delimiter escape winning
+  the branch and the literal `++text++` it leaves behind sitting behind exactly the `\` that
+  second pass declines. Beyond that the remainder is unchanged: the boundary-class halves the
+  sibling increments named — a macro body class wanting more than one presented character, the
+  closing character, and the character-replacements step's consume-across-levels case — and the
+  keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5561,6 +5621,22 @@ Each phase is a reviewable unit with a clear exit gate.
        classification and the bytes. The family's gate is deleted rather than relaxed (the stripped
        bytes are a literal `;`, `:`, or `)`, which no opaque piece can supply), and the formerly
        pinned divergence becomes a parity test. See the step's own "landed as" note above.
+
+     - ✅ **prep (an escaped attribute-list bracket).** The passthrough-extraction pass's own last
+       named deferral: `\[attrs]++text++`, where the string replacer writes the bracket back as a
+       literal `[attrs]` prefix *and* stores the delimited text as an **ordinary** passthrough
+       (its attribute list discarded), while
+       [`find_passthrough_matches`](../../parser/src/content/inline_builder/passthrough_step.rs)
+       could express one or the other. The shape its divergence note called one neither
+       [`MacroMatchKind`](../../parser/src/content/inline_builder/macros/mod.rs) variant expresses
+       turns out to be **two adjacent matches** — an `Unescape` over the bracket, then a `Node`
+       over the delimited remainder — which
+       [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) already
+       composes, so no variant, gate, or signature moves. The node is the unattrlisted
+       [`build_passthrough_node`](../../parser/src/content/inline_builder/passthrough_step.rs)
+       reached with the delimited sub-range, so the discarded list is discarded by construction.
+       The formerly pinned divergence becomes a parity test. See the step's own "landed as" note
+       above. What this pass still defers is its **prohibited-prefix** retry.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -848,6 +848,8 @@ mod tests {
             "[[mid-anchor]] after the anchor",
             "text before anchor:named[Ref Text] and after",
             "a +++<b>raw</b>+++ passthrough",
+            r"an escaped \[attrs]++<b>*x*</b>++ bracket",
+            r"an escaped \[x-]++*bold*++ bracket",
             "inline pass:[<i>x</i>] macro",
             "math $$a < b$$ here",
             "a +literal *stars*+ b",
@@ -965,6 +967,14 @@ mod tests {
 
         // A delimited passthrough beside a quoted span and an image macro.
         assert_parity("+++<u>raw</u>+++ combined with *bold* and image:foo.png[Alt Text].");
+
+        // An *escaped* attribute-list bracket beside its unescaped twin: the
+        // escaped one keeps a literal `[.role]` prefix — itself substituted
+        // by the later steps, quotes included — and an ordinary passthrough,
+        // while the unescaped one still builds its `Styled` span.
+        assert_parity(
+            r"An escaped \[.role *x*]++<b>raw</b>++ beside [.role]++<b>raw</b>++ and *bold*.",
+        );
 
         // Inline STEM beside a quoted span and a character replacement.
         assert_parity("Equation stem:[x^2+y^2=z^2] appears in *bold* text with (C) 2024.");
@@ -2014,6 +2024,12 @@ mod tests {
                 // what it presents — again its rendering, not the order.
                 "[width=10]##x ##https://example.org and a < b",
                 "[width=10]##x ##doc@example.org and a < b",
+                // An escaped attribute-list bracket, whose kept literal
+                // prefix is ordinary flow from here on: whether its `<` is
+                // escaped is the *order's* decision, exactly as it is for the
+                // text around it, while the delimited remainder the pair's
+                // second match builds is opaque to every step either way.
+                r"\[a<b]++x < y++ and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -115,13 +115,15 @@ use crate::{
 /// last, after both passthrough passes). This step is **additive**: nothing
 /// is wired into the parse path.
 ///
-/// One more attribute-list-prefixed corner case is deferred: an **escaped
-/// bracket** (`\[attrs]++text++`) unescapes to a literal `[attrs]` prefix
-/// *and* still recognizes the delimited text as an ordinary (non-attrlisted)
-/// passthrough — a kept-literal-prefix-with-one-dropped-char, plus a node for
-/// the remainder, a shape neither [`MacroMatchKind`] variant expresses. Left
-/// unrecognized (a documented divergence); see
-/// `an_escaped_attrlist_bracket_is_a_documented_divergence`.
+/// An **escaped bracket** (`\[attrs]++text++`) unescapes to a literal
+/// `[attrs]` prefix *and* still recognizes the delimited text after it — as an
+/// *ordinary* (non-attrlisted) passthrough, since `handle_quoted_text` drops
+/// the attribute list on that branch rather than storing it. One match's
+/// source doing two things is expressed as a **pair** of matches — an
+/// [`Unescape`](MacroMatchKind::Unescape) over the bracket, then a
+/// [`Node`](MacroMatchKind::Node) over the delimited remainder — which
+/// [`rebuild_macro_level`] composes exactly as it composes any two adjacent
+/// matches, so neither [`MacroMatchKind`] variant grows a new shape.
 ///
 /// An **escaped triple- or double-plus** (`\+++text+++`, `\++text++`) drops
 /// its backslash and keeps the delimited text literal at the pass-macro
@@ -208,12 +210,17 @@ fn apply_bare_attrlisted_pass_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
-/// Finds every passthrough at this level, skipping the one form
-/// [`apply_passthroughs`] still documents as deferred: an attribute-list-
-/// prefixed match whose *bracket* is escaped (`\[attrs]++text++`). A
-/// *delimiter* escape (`[attrs]\++text++`) is not deferred: it becomes an
-/// [`Unescape`](MacroMatchKind::Unescape) that drops one backslash and leaves
-/// the rest literal, exactly like an unattrlisted delimiter escape.
+/// Finds every passthrough at this level.
+///
+/// The two attribute-list-prefixed escapes take different shapes, mirroring
+/// `handle_quoted_text`'s own two branches. A *delimiter* escape
+/// (`[attrs]\++text++`) becomes one
+/// [`Unescape`](MacroMatchKind::Unescape) that drops a backslash and leaves
+/// the rest — the attrlist brackets included — literal, exactly like an
+/// unattrlisted delimiter escape. A *bracket* escape (`\[attrs]++text++`)
+/// becomes a **pair**: an [`Unescape`](MacroMatchKind::Unescape) over the
+/// bracket, then a [`Node`](MacroMatchKind::Node) over the delimited
+/// remainder, which the string replacer stores without its attribute list.
 fn find_passthrough_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -268,11 +275,53 @@ fn find_passthrough_matches<'src>(
 
             if &caps[1] == "\\" {
                 // `\[attrs]++text++`: the bracket unescapes to a literal
-                // `[attrs]`, but the delimited text is still recognized as
-                // an *ordinary* (non-attrlisted) passthrough — a
-                // kept-literal-prefix-plus-node shape neither
-                // `MacroMatchKind` variant expresses. Deferred; see
-                // `an_escaped_attrlist_bracket_is_a_documented_divergence`.
+                // `[attrs]` prefix, and the delimited text after it is still
+                // recognized — as an *ordinary* (non-attrlisted)
+                // passthrough, since `handle_quoted_text` drops the
+                // attribute list on this branch rather than storing it. That
+                // is one match's worth of source doing two things, which is
+                // exactly what a **pair** of matches expresses: an
+                // `Unescape` over the bracket alone, then a `Node` over the
+                // delimited remainder. `rebuild_macro_level` composes them
+                // as it composes any two adjacent matches, so neither
+                // `MacroMatchKind` variant needs to grow a new shape.
+                //
+                // Group 1 is the whole match's first byte whenever the
+                // attrlist alternative participates (nothing in the pattern
+                // precedes it), so the backslash offset is the match start;
+                // `unwrap` is safe for the same reason `caps[1]` above is.
+                #[allow(clippy::unwrap_used)]
+                let escape = caps.get(1).unwrap();
+
+                // The opening delimiter begins the recognized remainder.
+                // Exactly one of groups 4/7/10 participates whenever a
+                // delimited alternative matches at all.
+                #[allow(clippy::unwrap_used)]
+                let boundary = caps
+                    .get(4)
+                    .or_else(|| caps.get(7))
+                    .or_else(|| caps.get(10))
+                    .unwrap();
+
+                let delimited = boundary.start()..full.end;
+
+                matches.push(MacroMatch {
+                    kind: MacroMatchKind::Unescape {
+                        backslash: escape.start(),
+                    },
+                    full: full.start..delimited.start,
+                });
+
+                let node = build_passthrough_node(&caps, &delimited, pieces, root, parser);
+
+                matches.push(MacroMatch {
+                    kind: MacroMatchKind::Node {
+                        consumed: delimited.clone(),
+                        node: Box::new(node),
+                    },
+                    full: delimited,
+                });
+
                 continue;
             }
 
@@ -1121,6 +1170,26 @@ mod tests {
             // The bare-plus form's own delimiter escape: dropped backslash,
             // literal remainder, no further pass to re-scan a residue.
             r"[attrs]\+text+",
+            // A *bracket* escape is the other branch: the bracket unescapes
+            // to a literal prefix and the delimited remainder is still a
+            // passthrough — an ordinary one, so no `Styled` span and, for
+            // `++`, no `x-` monospace either. Every boundary, in flow,
+            // beside its unescaped twin, with a special character and with
+            // quote syntax in the kept prefix (both substituted normally
+            // there, exactly as the string pipeline substitutes its own
+            // literal `[attrs]`), and spanning a newline.
+            r"\[attrs]++text++",
+            r"abc \[attrs]++text++",
+            r"\[.role]+++*bold*+++",
+            r"\[.role]$$<b>*x*</b>$$",
+            r"\[x-]++*bold* and _em_++",
+            r"\[attrs]++<b>*x*</b>++",
+            r"a \[.role]++text++ b",
+            r"\[attrs]++one++ and [attrs]++two++",
+            r"\[a<b]++text++",
+            r"\[.a*b*c]++text++",
+            r"*bold* \[attrs]++text++ _em_",
+            "multi\nline \\[x-]++text\nmore++ end",
             // The `x-` marker's `Normal`-order body extracts a nested
             // passthrough/STEM/footnote/macro rather than walking over it as
             // plain text (`SubstitutionGroup::Normal`'s `run_pipeline`
@@ -1388,27 +1457,77 @@ mod tests {
     }
 
     #[test]
-    fn an_escaped_attrlist_bracket_is_a_documented_divergence() {
-        // `\[attrs]++text++` unescapes to a literal `[attrs]` prefix *and*
-        // still recognizes the delimited text as an ordinary (non-attrlisted)
-        // passthrough — a kept-literal-prefix-with-one-dropped-char, plus a
-        // node for the remainder, a shape neither `MacroMatchKind` variant
-        // expresses. Left fully unrecognized here.
+    fn an_escaped_attrlist_bracket_keeps_its_prefix_and_builds_a_plain_raw_leaf() {
+        // `\[attrs]++text++` is one match's source doing two things: the
+        // bracket unescapes to a literal `[attrs]` prefix, and the delimited
+        // text after it is still recognized — as an *ordinary*
+        // (non-attrlisted) passthrough, since `handle_quoted_text` drops the
+        // attribute list on this branch. The pair of matches that expresses
+        // it yields a `Text` prefix and a plain `Raw` leaf, *not* the
+        // `Styled` span an unescaped `[attrs]++text++` builds.
         let source = r"\[attrs]++text++";
         let nodes = build_src(Span::new(source));
 
         assert!(
-            nodes
-                .iter()
-                .all(|n| !matches!(n, InlineNode::Raw { .. } | InlineNode::Styled(_))),
-            "an escaped attrlist bracket must be left unrecognized: {nodes:?}"
+            nodes.iter().all(|n| !matches!(n, InlineNode::Styled(_))),
+            "an escaped attrlist bracket must not build a Styled span: {nodes:?}"
         );
 
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        let golden = golden_passthroughs(source);
+        let raws: Vec<_> = nodes
+            .iter()
+            .filter(|n| matches!(n, InlineNode::Raw { .. }))
+            .collect();
 
-        assert_eq!(folded, source);
-        assert_ne!(folded, golden);
+        assert_eq!(raws.len(), 1, "expected exactly one Raw leaf: {nodes:?}");
+        assert_raw(raws[0], "text");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_real_documents_escaped_attrlist_brackets_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shape that named
+        // this increment: an escaped attribute-list bracket must keep its
+        // literal prefix *and* build the delimited remainder, so a tree that
+        // left the whole construct literal — or that wrapped the remainder in
+        // the `Styled` span its unescaped twin gets — would regress the moment
+        // `rendered_html()` becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            r"An escaped \[attrs]++<b>*x*</b>++ bracket.",
+            "\n\n",
+            r"The \[x-]++*bold*++ marker does not survive the escape, unlike [x-]++*bold*++.",
+            "\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -825,6 +825,8 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "[[mid-anchor]] after the anchor",
         "text before anchor:named[Ref Text] and after",
         "a +++<b>raw</b>+++ passthrough",
+        r"an escaped \[attrs]++<b>*x*</b>++ bracket",
+        r"an escaped \[x-]++*bold*++ bracket",
         "inline pass:[<i>x</i>] macro",
         "math $$a < b$$ here",
         "a +literal *stars*+ b",
@@ -893,6 +895,10 @@ fn shapes_match_across_combined_constructs() {
     );
 
     assert_shapes("+++<u>raw</u>+++ combined with *bold* and image:foo.png[Alt Text].");
+
+    assert_shapes(
+        r"An escaped \[.role *x*]++<b>raw</b>++ beside [.role]++<b>raw</b>++ and *bold*.",
+    );
 
     assert_shapes("Equation stem:[x^2+y^2=z^2] appears in *bold* text with (C) 2024.");
 


### PR DESCRIPTION
Closes the passthrough-extraction pass's own last named deferral: `\[attrs]++text++`, pinned since step 5d part 2 landed as `an_escaped_attrlist_bracket_is_a_documented_divergence` and exercised by `Passthroughs`' own golden fixture (`abc \[attrs]++text++`).

The string replacer's `handle_quoted_text` does *two* things there — writes the bracket back as a literal `[attrs]` prefix with its backslash dropped, then stores the delimited text as an **ordinary** passthrough, its attribute list discarded rather than carried — while `find_passthrough_matches` could express one or the other, and so left the whole construct literal.

## The finding

The shape its divergence note called "a kept-literal-prefix-with-one-dropped-char, plus a node for the remainder, a shape neither `MacroMatchKind` variant expresses" is not one match wanting a third variant. It is **two adjacent matches** — an `Unescape` over the bracket, then a `Node` over the delimited remainder — and `rebuild_macro_level` already composes any two adjacent matches, gap by gap, without knowing they came from one regex capture.

So no variant, gate, or signature moves. The node the second match carries is the unattrlisted `build_passthrough_node` — the builder every bare `+++`/`++`/`$$` form already uses — reached with the *delimited* sub-range rather than the whole match, so the discarded attribute list is discarded by construction: there is no `Styled` wrapper to suppress and no `x-` marker to not honor, because the branch that reads them is never entered.

## What reaches parity

Every boundary an escaped bracket can precede (`+++`, `++`, `$$`); the `x-` marker whose monospace-and-`Normal`-subs treatment the escape *removes*; a body carrying markup and specials (escaped for `++`/`$$`, raw for `+++`, quotes never running over either); the escaped form beside its unescaped twin in one flow; a kept prefix carrying a special character and one carrying quote syntax — both substituted by the later steps exactly as the string pipeline substitutes its own literal `[attrs]`; the construct in flow and spanning a newline; and the same under the never-escapes group-parity orders, where whether the prefix's `<` is escaped is the *order's* decision while the remainder stays opaque either way.

The formerly pinned divergence becomes a parity test that also asserts the shape: a `Text` prefix and a plain `Raw` leaf, never the `Styled` span the unescaped spelling builds.

Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and — unlike the boundary-class increments, whose shapes a `RecordingRenderer`'s marker perturbs — the **structural recorder cross-check**, which reads these normally. A whole-document test drives both shapes end to end through the real parse path.

## What still defers

This pass's other named deferral, the **prohibited-prefix** retry the string replacer works around by hand for the two bare attribute-list-prefixed forms (`index:[attrs]+text+`, ``\[x-]`text` ``), which keeps its own divergence test — and which is also where writing *both* escapes at once (`\[attrs]\++text++`) lands: the delimiter escape wins the branch, and the literal `++text++` it leaves behind sits behind exactly the `\` that second pass declines.

Beyond that the remainder is unchanged: the boundary-class halves the sibling increments named — a macro body class wanting more than one presented character, the closing character, and the character-replacements step's consume-across-levels case — and the keeps.

## Checks

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items` — all clean.
- Corpus-wide fold-parity audit (tree building forced on for every parse in the suite), run on this branch and on `origin/inline-ast`: the divergence set strictly **shrank** — the `Passthroughs` golden fixture is gone and no new divergence appeared.
- Coverage is diff-neutral: `passthrough_step.rs` holds at 22 missed regions / 10 missed lines, `inline_builder/mod.rs` at 0/0, workspace totals unchanged at 561/316.

As with every prep piece before it, nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk5vFCHYHDAtDmV5DnpK2Q)_