### PR TITLE
feat: Recognize the passthrough a prohibited prefix hides (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -4829,6 +4829,69 @@ Each phase is a reviewable unit with a clear exit gate.
   closing character, and the character-replacements step's consume-across-levels case — and the
   keeps.
 
+  *Step 6 prep landed as (the passthrough pass's prohibited-prefix retry, the last of its own two
+  named deferrals):* the sibling increment's closing sentence, taken in order. `INLINE_PASS`'
+  two attribute-list-prefixed options open with `\b{start-half}`, which does not by itself exclude
+  the `\`/`:`/`;` prefix Asciidoctor's own pattern rejects with a lookbehind Rust's regex engine
+  does not have, so
+  [`InlinePassReplacer`](../../parser/src/content/passthroughs.rs) answers it at *run* time: it
+  writes the rejected match's first character back verbatim and runs `INLINE_PASS.replace_all`
+  again over the rest of that same match. The tree had only the first half of that — it dropped
+  such a match — and the increment's finding is that the second half is the load-bearing one. The
+  retry is not a formality that re-confirms a rejection: it routinely recognizes a *different,
+  shorter* construct the leading `[` was hiding, most often the bare unconstrained form over the
+  very same body (`index:[attrs]+text+` → a literal `[attrs]` and an **ordinary** passthrough over
+  `text`, so no `Styled` span and no `x-` monospace), which is content the tree was leaving
+  entirely literal.
+
+  Reproducing it needed no new mechanism either, only a shape change to the scan:
+  `find_bare_attrlisted_matches`' capture loop moves into a
+  [`collect_bare_pass_matches`](../../parser/src/content/inline_builder/passthrough_step.rs) that
+  scans a *sub-range* of the level's match string and appends to a shared match list, and the
+  prohibited case calls it again over the same match minus its leading `[` instead of skipping.
+  Because both options open with `\[` (nothing in either alternative precedes the bracket), the
+  character split off is always that one ASCII byte, and the `[` no match now covers is emitted by
+  [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) as an ordinary
+  gap — the same composition the escaped-bracket increment leaned on, reached from the other
+  direction. Recursion terminates because each retry region is strictly shorter than the match
+  that produced it. Scanning a slice is what the string replacer does too (its retry sees `rem`,
+  not the level), so word boundaries and `^` are computed against the same text in both; the one
+  cost is that a capture's offsets are then relative to the slice, so an `offset` is threaded into
+  the two node builders that read them and rebased there — pinned by a test that asserts the built
+  leaf's `location` is the body's own source bytes rather than a range shifted left by the retry's
+  start. The prefix test itself keeps reading the level string's own preceding byte where the
+  replacer reads its *output* so far, the one-byte approximation this scan has always made; at the
+  start of a retry region it is exact by construction, since the byte before is the `[` the retry
+  just split off.
+
+  What reaches parity is all three prohibited prefixes, both options (the backtick one finds
+  nothing to retry — `` x-]`text` `` matches neither an attribute-list option, whose bracket the
+  retry just consumed, nor the bare form, which needs a `+` — so the construct falls to the later
+  quotes step, exactly as the replacer's own empty retry leaves it), the `x-` marker the retry's
+  ordinary form drops, a body carrying specials and quote syntax, an attribute list carrying a
+  special, in flow, spanning a newline, twice in one flow, beside an unprefixed twin that still
+  builds its `Styled` span, the delimiter escapes the retry's own second scan honors
+  (`index:[attrs]\+text+`, and the two-backslash form it declines), and — the shape the sibling
+  increment named — writing **both** of this pass's escapes at once (`\[attrs]\++text++`), where
+  the delimiter escape wins the first pass's branch and the literal `++text++` it leaves behind
+  sits behind exactly the `\` this second pass declines, so only the retry reaches the `+text+`
+  inside it. Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the
+  group-parity corpus, and the structural recorder cross-check; a whole-document test drives both
+  shapes end to end through the real parse path. Re-running the corpus-wide fold-parity audit
+  shows two of the `asciidoctor` port's own golden fixtures **gone** from the divergence set —
+  `should_support_constrained_passthrough_in_monospace_span_preceded_by_escaped_boxed_attrlist_with_transitional_role`
+  and its `*foo*` twin, where the retry reaches a `+bar+` nested inside an escaped `` [x-]`…` ``
+  — and no new divergence; coverage is diff-neutral, and as with every prep piece before it,
+  nothing further is wired in.
+
+  What still defers is no longer anything this pass named for itself: with both its deferrals
+  closed, the remainder is the boundary-class halves the sibling increments named — a macro body
+  class wanting more than one presented character, the closing character, and the
+  character-replacements step's consume-across-levels case — plus the keeps, and the
+  bare-attrlisted body whose content the *first* pass already recognizes
+  (`[method x-]+pass:[<b>]+`), which is the module's own `range_is_verbatim` boundary rather than
+  a gap in this pass's recognition.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5637,6 +5700,28 @@ Each phase is a reviewable unit with a clear exit gate.
        reached with the delimited sub-range, so the discarded list is discarded by construction.
        The formerly pinned divergence becomes a parity test. See the step's own "landed as" note
        above. What this pass still defers is its **prohibited-prefix** retry.
+
+     - ✅ **prep (the prohibited-prefix retry).** The passthrough-extraction pass's last named
+       deferral, and its own last: `INLINE_PASS`' two attribute-list-prefixed options open with
+       `\b{start-half}`, which does not exclude the `\`/`:`/`;` prefix Asciidoctor rejects with a
+       lookbehind Rust's regex engine lacks, so
+       [`InlinePassReplacer`](../../parser/src/content/passthroughs.rs) writes the rejected
+       match's first character back and re-scans the rest of that same match. That retry is
+       load-bearing rather than a re-confirmed rejection — it routinely finds a *shorter*
+       construct the leading `[` was hiding (`index:[attrs]+text+` → a literal `[attrs]` and an
+       **ordinary** passthrough over `text`) — so dropping the match, as the tree did, left real
+       content literal. The capture loop moves into a
+       [`collect_bare_pass_matches`](../../parser/src/content/inline_builder/passthrough_step.rs)
+       that scans a sub-range of the level's match string, and the prohibited case calls it again
+       over the match minus its leading `[` (always one ASCII byte, since both options open with
+       `\[`); the bracket no match covers is an ordinary
+       [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) gap, so no
+       variant or shape moves — only an `offset` threaded into the two node builders that read
+       capture offsets, since a retry's captures are relative to the slice it scanned. Writing
+       **both** of this pass's escapes at once (`\[attrs]\++text++`) lands here too, and the
+       formerly pinned divergence becomes a parity test. See the step's own "landed as" note
+       above. What this pass still defers is nothing it named for itself; what remains is the
+       sibling increments' boundary-class halves and the keeps.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -850,6 +850,8 @@ mod tests {
             "a +++<b>raw</b>+++ passthrough",
             r"an escaped \[attrs]++<b>*x*</b>++ bracket",
             r"an escaped \[x-]++*bold*++ bracket",
+            "a prohibited index:[attrs]+text+ prefix",
+            r"a prohibited \[x-]`text` prefix",
             "inline pass:[<i>x</i>] macro",
             "math $$a < b$$ here",
             "a +literal *stars*+ b",
@@ -974,6 +976,14 @@ mod tests {
         // while the unescaped one still builds its `Styled` span.
         assert_parity(
             r"An escaped \[.role *x*]++<b>raw</b>++ beside [.role]++<b>raw</b>++ and *bold*.",
+        );
+
+        // A prohibited prefix ahead of an attribute-list-prefixed bare form:
+        // the retry keeps `[.role]` literal — substituted by the later steps
+        // like any other flow — and recognizes the bare `+…+` inside it,
+        // beside the unprefixed twin that still builds its `Styled` span.
+        assert_parity(
+            "An index:[.role]+<b>raw</b>+ beside [.role]+<b>raw</b>+ and *bold* and image:foo.png[Alt].",
         );
 
         // Inline STEM beside a quoted span and a character replacement.
@@ -2030,6 +2040,11 @@ mod tests {
                 // text around it, while the delimited remainder the pair's
                 // second match builds is opaque to every step either way.
                 r"\[a<b]++x < y++ and a < b",
+                // A prohibited prefix ahead of that same bracket: the retry's
+                // kept `[a<b]` prefix is ordinary flow here too, so whether
+                // its `<` is escaped is again the *order's* decision, while
+                // the `+…+` the retry recognizes stays opaque either way.
+                "index:[a<b]+x < y+ and a < b",
                 // Multi-line, so a run spanning a newline is split the same
                 // way as a single-line one.
                 "first < line\nsecond & line\nthird > line",

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -81,16 +81,31 @@ use crate::{
 /// double-dollar forms, an absent attrlist means no stored `type_`, so
 /// `PassthroughRestoreReplacer` never wraps the restored text in a rendered
 /// span. Unlike the two attribute-list-prefixed bare forms above (matched via
-/// `\b{start-half}`, which does not by itself exclude a `\`/`:`/`;` prefix),
-/// this form's own pattern already excludes that "prohibited prefix" — and the
-/// word-boundary rule the doc comment on [`find_bare_attrlisted_matches`]
-/// explains — directly in its *consuming* boundary group (`[^\w;:\\]`), so no
-/// runtime retry is needed: a match simply cannot start where the pattern's
-/// own character class would reject it. The boundary character it does
-/// consume (present unless the match sits at the very start of the level) is
-/// not part of the construct — it is kept as literal text before the node,
-/// reusing the same kept-prefix [`MacroMatch`] sub-range the auto-link
-/// increment introduced.
+/// `\b{start-half}`, which does not by itself exclude a `\`/`:`/`;` prefix and
+/// so needs the retry below), this form's own pattern already excludes that
+/// "prohibited prefix" — and the word-boundary rule the doc comment on
+/// [`collect_bare_pass_matches`] explains — directly in its *consuming*
+/// boundary group (`[^\w;:\\]`), so no retry is needed for it: a match simply
+/// cannot start where the pattern's own character class would reject it. The
+/// boundary character it does consume (present unless the match sits at the
+/// very start of the level) is not part of the construct — it is kept as
+/// literal text before the node, reusing the same kept-prefix [`MacroMatch`]
+/// sub-range the auto-link increment introduced.
+///
+/// A **prohibited prefix** ahead of either attribute-list-prefixed bare form
+/// (`index:[attrs]+text+`, `` \[x-]`text` ``) is answered the way the string
+/// replacer answers it, for want of a lookbehind: the match's first character
+/// — always its `[` — is written back verbatim and the *rest of that same
+/// match* is scanned again ([`collect_bare_pass_matches`], recursively). The
+/// second scan routinely recognizes a different, shorter construct the
+/// bracket was hiding — for the plus form, the bare unconstrained form over
+/// the same body, so the attribute list ends up a literal prefix and the body
+/// an *ordinary* passthrough rather than a `Styled` span — and for the
+/// backtick form it finds nothing, leaving the construct to the later quotes
+/// step. Writing both of this pass's escapes at once
+/// (`\[attrs]\++text++`) lands here as well: the delimiter escape wins the
+/// first pass's branch, and the literal `++text++` it leaves behind sits
+/// behind exactly the `\` this second pass declines.
 ///
 /// A **`pass:` macro carrying an explicit substitution list**
 /// (`pass:c,q[…]`) folds through [`build_pass_macro_subs_value`], the same
@@ -369,13 +384,9 @@ fn find_passthrough_matches<'src>(
 /// and the bare unconstrained form with no attribute list (`+text+`, built by
 /// [`build_bare_unconstrained_match`]).
 ///
-/// The two attribute-list-prefixed options also need a lookbehind the string
-/// replacer works around with a retry loop (`InlinePassReplacer`'s
-/// "prohibited prefix" check): a match immediately preceded by `\`, `:`, or
-/// `;` is not really a passthrough. This increment does not reproduce that
-/// retry for *them*; instead it simply leaves such a match unrecognized, a
-/// documented divergence pinned by a test. The bare unconstrained form needs
-/// no such handling — see [`build_bare_unconstrained_match`].
+/// The scan is [`collect_bare_pass_matches`], which is recursive so that the
+/// two attribute-list-prefixed options can reproduce the string replacer's
+/// own **prohibited-prefix retry**; see its doc comment.
 fn find_bare_attrlisted_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -384,26 +395,81 @@ fn find_bare_attrlisted_matches<'src>(
 ) -> Vec<MacroMatch<'src>> {
     let mut matches = Vec::new();
 
-    for caps in INLINE_PASS.captures_iter(s) {
+    collect_bare_pass_matches(s, 0..s.len(), pieces, root, parser, &mut matches);
+
+    matches
+}
+
+/// Scans `s[region]` for [`INLINE_PASS`] matches, appending each to `matches`
+/// in increasing order of `full.start` (what [`rebuild_macro_level`] wants).
+/// Every offset a capture reports is relative to the scanned slice, so
+/// `region.start` is added back to reach the level-wide offsets a
+/// [`MacroMatch`] carries.
+///
+/// The two attribute-list-prefixed options need a lookbehind the string
+/// replacer works around with a **retry** (`InlinePassReplacer`'s "prohibited
+/// prefix" check, whose comment names the missing lookaround as its reason): a
+/// match immediately preceded by `\`, `:`, or `;` is not really a passthrough,
+/// so the replacer writes the match's *first character* back verbatim and runs
+/// `INLINE_PASS.replace_all` again over the rest of that same match. That
+/// second scan is not a no-op — it routinely recognizes a *different*,
+/// shorter construct inside the rejected match, most often the bare
+/// unconstrained form the leading `[` was hiding (`index:[attrs]+text+` →
+/// a literal `[attrs]` and a bare passthrough over `text`) — which is why the
+/// retry is reproduced here rather than approximated by leaving the whole
+/// match literal.
+///
+/// This function *is* that retry: the prohibited case recurses over the same
+/// match minus its first character, and the `[` it leaves behind is emitted
+/// by [`rebuild_macro_level`] as an ordinary gap, since no match covers it.
+/// Both options begin with `\[` (nothing in either alternative precedes the
+/// bracket), so the character split off is always that one ASCII byte.
+/// Recursion terminates because each retry region is strictly shorter than
+/// the match that produced it.
+///
+/// The prefix test reads the level string's own preceding byte where the
+/// replacer tests its *output* so far — the same one-byte approximation this
+/// scan has always made, and exact wherever the two agree. At the start of a
+/// retry region it is exact by construction: the byte before is the `[` the
+/// retry just split off, which is not a prohibited character (the replacer's
+/// freshly-empty `dest` likewise rejects nothing there).
+///
+/// The bare unconstrained form needs no retry at all — see
+/// [`build_bare_unconstrained_match`].
+fn collect_bare_pass_matches<'src>(
+    s: &str,
+    region: std::ops::Range<usize>,
+    pieces: &[Piece],
+    root: Span<'src>,
+    parser: &Parser,
+    matches: &mut Vec<MacroMatch<'src>>,
+) {
+    // `region` is always a byte range this function itself derived from a
+    // match on `s`, so it is in bounds and on character boundaries and `get`
+    // always succeeds. The fallback is not a case to handle: an empty
+    // haystack yields no captures, which is exactly what a region naming no
+    // text should contribute.
+    let haystack = s.get(region.clone()).unwrap_or_default();
+    let offset = region.start;
+
+    for caps in INLINE_PASS.captures_iter(haystack) {
         // `unwrap` on group 0 is safe: a capture always has an overall match.
         #[allow(clippy::unwrap_used)]
         let whole = caps.get(0).unwrap();
 
-        let full = whole.start()..whole.end();
+        let full = (offset + whole.start())..(offset + whole.end());
 
         let is_backtick = caps.get(1).is_some();
         let is_plus_attrlisted = caps.get(3).is_some();
 
         if !is_backtick && !is_plus_attrlisted {
             // Option 3: the bare unconstrained form (no attribute list).
-            if let Some(m) = build_bare_unconstrained_match(&caps, &full, pieces, root, parser) {
+            if let Some(m) =
+                build_bare_unconstrained_match(&caps, &full, offset, pieces, root, parser)
+            {
                 matches.push(m);
             }
 
-            continue;
-        }
-
-        if !range_is_verbatim(pieces, &full) {
             continue;
         }
 
@@ -413,6 +479,23 @@ fn find_bare_attrlisted_matches<'src>(
             .and_then(|i| s.as_bytes().get(i))
             .is_some_and(|b| matches!(b, b'\\' | b':' | b';'))
         {
+            // Honor the prohibited prefix by retrying over this match minus
+            // its leading `[`, exactly as `InlinePassReplacer` does.
+            //
+            // This sits *ahead* of the `range_is_verbatim` gate below, which
+            // it used to follow: what the retry recognizes is a sub-range of
+            // this match, and that sub-range can be verbatim where the whole
+            // match is not (an opaque piece inside the attribute list the
+            // retry is about to leave literal, say). Nothing is admitted
+            // unchecked by the move — every match the retry does produce
+            // passes this same gate, or `build_bare_unconstrained_match`'s
+            // own copy of it, on its own range.
+            collect_bare_pass_matches(s, (full.start + 1)..full.end, pieces, root, parser, matches);
+
+            continue;
+        }
+
+        if !range_is_verbatim(pieces, &full) {
             continue;
         }
 
@@ -430,7 +513,7 @@ fn find_bare_attrlisted_matches<'src>(
 
                 matches.push(MacroMatch {
                     kind: MacroMatchKind::Unescape {
-                        backslash: group4.start(),
+                        backslash: offset + group4.start(),
                     },
                     full,
                 });
@@ -439,8 +522,15 @@ fn find_bare_attrlisted_matches<'src>(
             }
         }
 
-        let node =
-            build_bare_attrlisted_passthrough_node(&caps, &full, is_backtick, pieces, root, parser);
+        let node = build_bare_attrlisted_passthrough_node(
+            &caps,
+            &full,
+            offset,
+            is_backtick,
+            pieces,
+            root,
+            parser,
+        );
 
         matches.push(MacroMatch {
             kind: MacroMatchKind::Node {
@@ -450,8 +540,6 @@ fn find_bare_attrlisted_matches<'src>(
             full,
         });
     }
-
-    matches
 }
 
 /// Builds one [`MacroMatch`] for a bare unconstrained [`INLINE_PASS`] match
@@ -480,9 +568,14 @@ fn find_bare_attrlisted_matches<'src>(
 /// Returns `None` for a non-verbatim match (crossing an escaped special or a
 /// rendered span), left unrecognized exactly as every other macro family in
 /// this module defers one.
+///
+/// `offset` is where the scanned slice starts in the level's match string —
+/// non-zero inside a [`collect_bare_pass_matches`] retry — and is added back
+/// to every capture offset this reads.
 fn build_bare_unconstrained_match<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
+    offset: usize,
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
@@ -495,12 +588,13 @@ fn build_bare_unconstrained_match<'src>(
     // matches) is always preceded immediately by the construct's opening `+`.
     #[allow(clippy::unwrap_used)]
     let body_m = caps.get(8).unwrap();
-    let delim_start = body_m.start() - 1;
+    let body = (offset + body_m.start())..(offset + body_m.end());
+    let delim_start = body.start - 1;
 
     if let Some(escape) = caps.get(7) {
         return Some(MacroMatch {
             kind: MacroMatchKind::Unescape {
-                backslash: escape.start(),
+                backslash: offset + escape.start(),
             },
             full: full.clone(),
         });
@@ -508,7 +602,7 @@ fn build_bare_unconstrained_match<'src>(
 
     let consumed = delim_start..full.end;
     let location = source_slice(pieces, consumed.clone(), root);
-    let body_span = source_slice(pieces, body_m.start()..body_m.end(), root);
+    let body_span = source_slice(pieces, body, root);
     let value = passthrough_text(body_span.data(), &SubstitutionGroup::Verbatim, parser);
 
     Some(MacroMatch {
@@ -735,9 +829,14 @@ fn build_attrlisted_passthrough_node<'src>(
 /// `[… x-]`) — but its format mark (`` ` ``) keeps `subs` at `Verbatim`
 /// regardless, mirroring `InlinePassReplacer`'s `format_mark != '`'` guard:
 /// only the plus form's `old_behavior` switches to the `Normal` group.
+///
+/// `offset` is where the scanned slice starts in the level's match string —
+/// non-zero inside a [`collect_bare_pass_matches`] retry — and is added back
+/// to every capture offset this reads.
 fn build_bare_attrlisted_passthrough_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
+    offset: usize,
     is_backtick: bool,
     pieces: &[Piece],
     root: Span<'src>,
@@ -753,14 +852,22 @@ fn build_bare_attrlisted_passthrough_node<'src>(
 
     #[allow(clippy::unwrap_used)]
     let attrlist_m = attrlist.unwrap();
-    let attrlist_span = source_slice(pieces, attrlist_m.start()..attrlist_m.end(), root);
+    let attrlist_span = source_slice(
+        pieces,
+        (offset + attrlist_m.start())..(offset + attrlist_m.end()),
+        root,
+    );
 
     // Both the backtick body (group 2, requiring at least one non-space
     // character) and the plus body (group 5) are mandatory captures of
     // whichever alternative matched — never a genuinely absent one.
     #[allow(clippy::unwrap_used)]
     let body_m = body.unwrap();
-    let body_span = source_slice(pieces, body_m.start()..body_m.end(), root);
+    let body_span = source_slice(
+        pieces,
+        (offset + body_m.start())..(offset + body_m.end()),
+        root,
+    );
 
     let (attrlist_span, old_behavior) = split_old_behavior_attrlist(attrlist_span);
 
@@ -1220,6 +1327,42 @@ mod tests {
             // Beside ordinary flow and next to other constructs.
             "*bold* +text+ _em_",
             "a copyright (C) then +text+",
+            // The two *attribute-list-prefixed* options behind that same
+            // prohibited prefix, which their own pattern does not exclude
+            // and which the string replacer answers with a retry over the
+            // match minus its leading `[`. For the plus option that retry
+            // routinely finds the bare unconstrained form the bracket was
+            // hiding — a literal `[attrs]` prefix and an *ordinary*
+            // passthrough over the body, so no `Styled` span and no `x-`
+            // monospace — while the backtick option finds nothing there and
+            // leaves the whole construct to the later quotes step. All three
+            // prefixes, the `x-` marker the retry's ordinary form drops, a
+            // body carrying specials and quote syntax, an attribute list
+            // carrying a special, in flow, spanning a newline, twice in one
+            // flow, beside an unprefixed twin, and the delimiter escapes the
+            // retry's own second scan honors.
+            "index:[attrs]+text+",
+            r"a\[attrs]+text+",
+            "a;[attrs]+text+",
+            "see index:[foo]+bar+ end",
+            "index:[x-]+text+",
+            "index:[method x-]+save()+",
+            "index:[attrs]+<b>*x*</b>+",
+            "index:[a<b]+text+",
+            "index:[attrs]+multi\nline+",
+            "index:[attrs]+text+ and [attrs]+text+",
+            "a:[b]+x+ c:[d]+y+",
+            r"index:[attrs]\+text+",
+            r"index:[attrs]\\+text+",
+            "x:[x-]`text`",
+            r"a\[x-]`text`",
+            "x;[method x-]`text`",
+            // Writing *both* escapes at once: the delimiter escape wins the
+            // first pass's branch, and the literal `++text++` it leaves
+            // behind then sits behind exactly the `\` this second pass
+            // declines — so it is the retry, not the ordinary scan, that
+            // recognizes the shorter `+text+` inside it.
+            r"\[attrs]\++text++",
         ];
 
         for source in fixtures {
@@ -1531,24 +1674,151 @@ mod tests {
     }
 
     #[test]
-    fn a_prohibited_prefix_before_a_bare_attrlisted_form_is_a_documented_divergence() {
+    fn a_prohibited_prefix_before_a_bare_attrlisted_form_retries_over_the_rest() {
         // The string pipeline's own `InlinePassReplacer` retries around a
         // match immediately preceded by `\`, `:`, or `;` (no lookbehind in
-        // Rust's regex engine) — this increment does not reproduce the
-        // retry, so such a match is simply left unrecognized.
+        // Rust's regex engine): it writes the match's first character back
+        // verbatim and re-scans the rest. That retry is not a no-op — here it
+        // finds the bare unconstrained form the leading `[` was hiding — so
+        // the attribute list stays a literal prefix and the body becomes an
+        // *ordinary* passthrough: a plain `Raw` leaf, never the `Styled` span
+        // the same source without the prefix builds.
         let source = "index:[attrs]+text+";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::Styled(_))),
-            "a prohibited-prefix match must be left unrecognized: {nodes:?}"
+            "a prohibited-prefix match must not build a Styled span: {nodes:?}"
         );
 
-        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
-        let golden = golden_passthroughs(source);
+        let raws: Vec<_> = nodes
+            .iter()
+            .filter(|n| matches!(n, InlineNode::Raw { .. }))
+            .collect();
 
-        assert_ne!(folded, golden);
-        assert_eq!(folded, source);
+        assert_eq!(raws.len(), 1, "expected exactly one Raw leaf: {nodes:?}");
+        assert_raw(raws[0], "text");
+
+        assert_eq!(
+            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+            golden_passthroughs(source)
+        );
+    }
+
+    #[test]
+    fn a_prohibited_prefix_before_a_bare_backtick_form_finds_nothing_to_retry() {
+        // The retry's other half. Splitting `` [x-]`text` `` after its `[`
+        // leaves `` x-]`text` ``, which neither `INLINE_PASS` option can
+        // match (both attribute-list options need the bracket the retry just
+        // consumed, and there is no `+` for the bare unconstrained one), so
+        // the second scan contributes nothing and the whole construct is left
+        // for the later quotes step — which is exactly what the string
+        // replacer's own empty retry leaves behind, hence parity.
+        for source in ["x:[x-]`text`", r"a\[x-]`text`", "x;[method x-]`text`"] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Raw { .. })),
+                "the retry must find no passthrough for {source:?}: {nodes:?}"
+            );
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_passthroughs(source),
+                "for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn both_escapes_at_once_leave_the_retry_to_recognize_the_remainder() {
+        // `\[attrs]\++text++` writes both of the attribute-list-prefixed
+        // escapes at once. The *delimiter* escape wins the first pass's
+        // branch (`handle_quoted_text`'s own `escape_count > 0` arm, which
+        // never builds a passthrough), so what reaches the bare-form second
+        // pass is a literal `\[attrs]++text++` — whose `[attrs]+…+` match
+        // sits behind exactly the `\` that pass declines. Only the retry
+        // reaches the `+text+` inside it, so this shape is the one that
+        // fails outright without one.
+        let source = r"\[attrs]\++text++";
+        let nodes = build_src(Span::new(source));
+
+        let raws: Vec<_> = nodes
+            .iter()
+            .filter(|n| matches!(n, InlineNode::Raw { .. }))
+            .collect();
+
+        assert_eq!(raws.len(), 1, "expected exactly one Raw leaf: {nodes:?}");
+        assert_raw(raws[0], "+text");
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+        assert_eq!(folded, r"\[attrs]+text+");
+        assert_eq!(folded, golden_passthroughs(source));
+    }
+
+    #[test]
+    fn a_prohibited_prefix_before_a_bare_attrlisted_form_keeps_its_source_offsets() {
+        // The retry scans a *slice* of the level's match string, so every
+        // offset its captures report is relative to that slice and has to be
+        // rebased before it can name a source span. Pin that arithmetic where
+        // it is observable: the `Raw` leaf's location must be the body's own
+        // source bytes, not a range shifted left by the retry's start.
+        let source = Span::new("see index:[foo]+bar+ end");
+        let nodes = build_src(source);
+
+        let raws: Vec<_> = nodes
+            .iter()
+            .filter(|n| matches!(n, InlineNode::Raw { .. }))
+            .collect();
+
+        assert_eq!(raws.len(), 1, "expected exactly one Raw leaf: {nodes:?}");
+        assert_raw(raws[0], "bar");
+
+        // `+bar+`, the construct the retry recognized — the boundary `]`
+        // ahead of it stays literal, exactly as it does without a prefix.
+        assert_eq!(raws[0].span(), source.slice(15..20));
+    }
+
+    #[test]
+    fn a_real_documents_prohibited_prefix_passthroughs_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shape that named
+        // this increment: a tree that skipped the retry would leave
+        // `index:[attrs]+text+` entirely literal and regress the moment
+        // `rendered_html()` becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "== A heading\n",
+            "\n",
+            "The index:[attrs]+text+ form keeps its bracket, unlike [attrs]+text+.",
+            "\n\n",
+            r"Writing both escapes at once, \[attrs]\++text++, lands there too.",
+            "\n",
+        ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
     }
 
     #[test]
@@ -1861,7 +2131,7 @@ mod tests {
     fn a_prohibited_prefix_before_a_bare_unconstrained_form_needs_no_retry() {
         // Unlike the two attribute-list-prefixed bare forms (which need a
         // documented divergence for this — see
-        // `a_prohibited_prefix_before_a_bare_attrlisted_form_is_a_documented_divergence`),
+        // `a_prohibited_prefix_before_a_bare_attrlisted_form_retries_over_the_rest`),
         // the bare unconstrained form's own pattern already excludes a `\`,
         // `:`, or `;` prefix in its consuming boundary group, so this is
         // parity, not a divergence: the passthrough is correctly left

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -827,6 +827,8 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "a +++<b>raw</b>+++ passthrough",
         r"an escaped \[attrs]++<b>*x*</b>++ bracket",
         r"an escaped \[x-]++*bold*++ bracket",
+        "a prohibited index:[attrs]+text+ prefix",
+        r"a prohibited \[x-]`text` prefix",
         "inline pass:[<i>x</i>] macro",
         "math $$a < b$$ here",
         "a +literal *stars*+ b",
@@ -898,6 +900,10 @@ fn shapes_match_across_combined_constructs() {
 
     assert_shapes(
         r"An escaped \[.role *x*]++<b>raw</b>++ beside [.role]++<b>raw</b>++ and *bold*.",
+    );
+
+    assert_shapes(
+        "An index:[.role]+<b>raw</b>+ beside [.role]+<b>raw</b>+ and *bold* and image:foo.png[Alt].",
     );
 
     assert_shapes("Equation stem:[x^2+y^2=z^2] appears in *bold* text with (C) 2024.");


### PR DESCRIPTION
The next inline-ast increment, taken straight from the sibling increment's closing sentence: the passthrough-extraction pass's **prohibited-prefix retry**, the last of its own two named deferrals.

## The gap

`INLINE_PASS`' two attribute-list-prefixed options open with `\b{start-half}`, which does not by itself exclude the `\`/`:`/`;` prefix Asciidoctor rejects with a lookbehind Rust's regex engine does not have. So [`InlinePassReplacer`](https://github.com/asciidoc-rs/asciidoc-parser/blob/inline-ast/parser/src/content/passthroughs.rs) answers it at *run* time: it writes the rejected match's first character back verbatim and runs `INLINE_PASS.replace_all` again over the rest of that same match.

The tree had only the first half of that — it dropped such a match — and the increment's finding is that the **second half is the load-bearing one**. The retry is not a formality that re-confirms a rejection: it routinely recognizes a *different, shorter* construct the leading `[` was hiding, most often the bare unconstrained form over the very same body:

```
index:[attrs]+text+   →   a literal `[attrs]` and an *ordinary* passthrough over `text`
```

— content the tree was leaving entirely literal.

## The change

No new mechanism, only a shape change to the scan:

- `find_bare_attrlisted_matches`' capture loop moves into a `collect_bare_pass_matches` that scans a **sub-range** of the level's match string and appends to a shared match list.
- The prohibited case calls it again over the same match minus its leading `[` instead of skipping. Both options open with `\[`, so the character split off is always that one ASCII byte, and the bracket no match now covers is emitted by `rebuild_macro_level` as an **ordinary gap** — the same composition the escaped-bracket increment leaned on, reached from the other direction. No variant, gate, or shape moves.
- Recursion terminates because each retry region is strictly shorter than the match that produced it.
- Scanning a slice is what the string replacer does too (its retry sees `rem`, not the level), so word boundaries and `^` are computed against the same text in both. The one cost is that a capture's offsets are then relative to the slice, so an `offset` is threaded into the two node builders that read them and rebased there — pinned by a test asserting the built leaf's `location` is the body's own source bytes rather than a range shifted left by the retry's start.
- The `range_is_verbatim` gate moves *after* the prohibited check (a retry's sub-range can be verbatim where the whole match is not); nothing is admitted unchecked, since every match the retry produces passes that same gate on its own range.

## What reaches parity

All three prohibited prefixes; both options (the backtick one finds nothing to retry — `` x-]`text` `` matches neither an attribute-list option, whose bracket the retry just consumed, nor the bare form, which needs a `+` — so the construct falls to the later quotes step, exactly as the replacer's own empty retry leaves it); the `x-` marker the retry's ordinary form drops; a body carrying specials and quote syntax; an attribute list carrying a special; in flow; spanning a newline; twice in one flow; beside an unprefixed twin that still builds its `Styled` span; the delimiter escapes the retry's own second scan honors; and — the shape the sibling increment named — writing **both** of this pass's escapes at once (`\[attrs]\++text++`), where the delimiter escape wins the first pass's branch and the literal `++text++` it leaves behind sits behind exactly the `\` this second pass declines, so only the retry reaches the `+text+` inside it.

The formerly pinned `a_prohibited_prefix_before_a_bare_attrlisted_form_is_a_documented_divergence` becomes a parity test that also asserts the shape (a `Text` prefix and a plain `Raw` leaf, never the `Styled` span the unprefixed spelling builds). Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check; a whole-document test drives the shapes end to end through the real parse path.

## Verification

- Full preflight green: `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items`.
- **Corpus-wide fold-parity audit** rebuilt as a throwaway patch and run on this branch and on `origin/inline-ast`: **no new divergence**, and two of the `asciidoctor` port's own golden fixtures are **gone** from the set — `should_support_constrained_passthrough_in_monospace_span_preceded_by_escaped_boxed_attrlist_with_transitional_role` and its `*foo*` twin, where the retry reaches a `+bar+` nested inside an escaped `` [x-]`…` ``. Patch reverted before committing.
- **Coverage diff-neutral**: `passthrough_step.rs` holds at 22 missed regions / 10 missed lines, unchanged from `origin/inline-ast`; `inline_builder/mod.rs` stays at 100%.
- Nothing further is wired in — as with every prep piece before it, this is additive.

## What still defers

Nothing this pass named for itself: with both its deferrals closed, the remainder is the boundary-class halves the sibling increments named — a macro body class wanting more than one presented character, the closing character, and the character-replacements step's consume-across-levels case — plus the keeps, and the bare-attrlisted body whose content the *first* pass already recognizes (`[method x-]+pass:[<b>]+`), which is the module's own `range_is_verbatim` boundary rather than a gap in this pass's recognition.

The design doc gains its "*Step 6 prep landed as (…)*" narrative note and a Phase 4 checklist entry, matching every prior increment on this branch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxadijfeKPtGProbwkuYNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxadijfeKPtGProbwkuYNZ)_