### PR TITLE
feat: Recognize an `indexterm2` term whose argument is an attribute list (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1177,8 +1177,10 @@ Each phase is a reviewable unit with a clear exit gate.
   deferred, each documented and pinned by a divergence test: a **visible term crossing a rendered
   span** (unreconstructable from the escaped string, the same verbatim boundary the other macro
   families document) and an **`indexterm2:[…]` carrying an attribute list** (an `=`, deferred until
-  the node can hold an `Attrlist<'src>`, as the link/xref macros defer the same); the one escaped
-  paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`) is likewise left literal.
+  the node can hold an `Attrlist<'src>`, as the link/xref macros defer the same — deferred at the
+  time, closed by a step 6 prep below, which finds the node needs no such list at all); the one
+  escaped paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`) is likewise
+  left literal.
   As throughout the additive builder, this performs *no* recognition side effect (the HTML backend
   builds no index, so the string replacer has none to skip either). This step is **additive**: nothing
   is wired into the parse path. Inline `Stem` is handled at passthrough time (step 5), not in the
@@ -4892,6 +4894,70 @@ Each phase is a reviewable unit with a clear exit gate.
   (`[method x-]+pass:[<b>]+`), which is the module's own `range_is_verbatim` boundary rather than
   a gap in this pass's recognition.
 
+  *Step 6 prep landed as (an `indexterm2:[…]` attribute list, and the deferral that was waiting
+  on nothing):* with the passthrough-extraction pass's own two deferrals closed, re-running the
+  corpus-wide fold-parity audit and classifying what remains by *source* leaves the **index-term**
+  family holding the largest golden-exercised share of it — and the one piece of that share whose
+  own note named a blocker: an `indexterm2:[…]` whose argument carries an `=`, deferred at step
+  4b(ii) part 4b "until the node can hold an `Attrlist<'src>`, as the link/xref macros defer the
+  same", and pinned since by `an_indexterm2_attribute_list_is_a_documented_divergence`. Two of the
+  `asciidoctor` port's own golden fixtures spell it —
+  `indexterm2:[Flash,see=HTML 5] and indexterm2:[HTML 5,see-also="CSS 3, SVG"] done.` and
+  `Only named indexterm2:[see=HTML 5] here.` — where the tree was leaving the whole macro literal.
+
+  The increment's finding is that the blocker had lapsed: the node needs no attribute list. An
+  `=` in the argument makes it an **attribute list whose first positional attribute is the shown
+  term** (`indexterm2:[Coffee, region=Kona]` shows `Coffee`), and everything else the list holds —
+  a `see`, a `see-also`, a `region` — names an entry in an index this crate's HTML backend does
+  not build, so it reaches the flow through nothing. The link and cross-reference families capture
+  their own [`Attrlist<'src>`](../../parser/src/attributes/attrlist.rs) because a role, an id, or a
+  `window=` there changes what the fold emits; an index term's whole render surface is
+  [`IndexTermRenderParams`](../../parser/src/parser/inline_substitution_renderer.rs), which carries
+  the shown term and nothing else. So a new
+  [`shown_macro_term`](../../parser/src/content/inline_builder/macros/indexterm.rs) *consumes* the
+  list where [`InlineIndextermReplacer`](../../parser/src/content/macros.rs) consumes it — the
+  same `Attrlist::parse` over the same normalized copy, the same `nth_attribute(1)`, the same
+  fall back to the whole argument when the list has no positional attribute at all — and the
+  [`IndexTerm`](../../parser/src/inlines/index_term.rs) node goes on holding the one
+  already-substituted shown text every other visible spelling gives it. No node field, variant, or
+  gate moves; only the level's `parser` is threaded down to the family, which every sibling family
+  already takes.
+
+  The argument is read from this level's escaped match string, which holds exactly what the string
+  pipeline's flat haystack holds at that position, so the two parse the same bytes — and the
+  family's *other* deferral is untouched and still decides first: a shown term crossing an opaque
+  span is unreconstructable from that string, so `indexterm2:[*bold* term,region=Kona]` stays
+  literal and keeps a divergence test, now written against the attribute-list spelling too. The
+  shorthand spelling has no attribute list to parse (the string replacer strips its ` >> ` /
+  ` &> ` clause instead, which the tree already mirrored), so it is unchanged.
+
+  What reaches parity is both golden spellings, a list with no positional attribute (shown
+  verbatim, `=` included), a quoted positional attribute whose own comma is not a separator, an
+  empty first positional attribute, a special character in either half (an entity in both pipelines
+  by macro time, so the list is parsed from the same escaped bytes), a typographic replacement and
+  a restored entity in the shown half, the macro in flow, twice in one flow, inside a rendered
+  span, spanning a newline that `normalize_index_text` collapses before either side parses, the
+  escaped form that still drops its backslash, the concealed spelling that ignores its argument
+  entirely, an attribute list arriving from an **expanded value** in either half, and the
+  never-escapes group-parity orders, where what the order decides is only which bytes the list is
+  parsed from. The formerly pinned divergence becomes a parity test that also asserts the shape:
+  one `IndexTerm` carrying `Coffee` and the whole macro's location, never an attribute list.
+  Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity
+  corpus, and the structural recorder cross-check; a whole-document test drives the shape end to
+  end through the real parse path, in a paragraph and in a section heading's own title. Re-running
+  the corpus-wide fold-parity audit shows both golden fixtures **gone** from the divergence set and
+  no new divergence; coverage is diff-neutral, and as with every prep piece before it, nothing
+  further is wired in.
+
+  What still defers in this family is what its own note named beside this one: a **visible term
+  crossing a rendered span** (both spellings), which is the module-wide `range_is_verbatim`
+  boundary rather than anything this family owns, and the one escaped paren-wrapped shorthand the
+  string replacer re-renders (`\(((x)))` → `(x)`). Beyond the family the remainder is unchanged:
+  the boundary-class halves the sibling increments named — a macro body class wanting more than
+  one presented character, the closing character, and the character-replacements step's
+  consume-across-levels case — plus the keeps, and the bare-attrlisted body whose content the
+  passthrough pass's first scan already recognizes (`[method x-]+pass:[<b>]+`).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5722,6 +5788,26 @@ Each phase is a reviewable unit with a clear exit gate.
        formerly pinned divergence becomes a parity test. See the step's own "landed as" note
        above. What this pass still defers is nothing it named for itself; what remains is the
        sibling increments' boundary-class halves and the keeps.
+
+     - ✅ **prep (an `indexterm2:[…]` attribute list).** The largest golden-exercised class the
+       audit's remainder held after the passthrough pass closed its own two deferrals, and the one
+       piece of it whose note named a blocker: an `indexterm2:[…]` argument carrying an `=`,
+       deferred at part 4b "until the node can hold an `Attrlist<'src>`". The blocker had lapsed —
+       an index term's whole render surface is
+       [`IndexTermRenderParams`](../../parser/src/parser/inline_substitution_renderer.rs), which
+       carries the shown term and nothing else, so the list decides only *which* of the argument's
+       own bytes are shown and is **consumed** rather than carried. A new
+       [`shown_macro_term`](../../parser/src/content/inline_builder/macros/indexterm.rs) does that
+       where [`InlineIndextermReplacer`](../../parser/src/content/macros.rs) does — the same
+       `Attrlist::parse` over the same normalized copy, the same `nth_attribute(1)`, the same fall
+       back to the whole argument where the list has no positional attribute
+       (`indexterm2:[see=HTML 5]`) — and no node field, variant, or gate moves. Two of the
+       `asciidoctor` port's golden fixtures reach parity; the family's *other* deferral still
+       decides first, so a shown term crossing an opaque span stays literal and keeps its
+       divergence test, now written against the attribute-list spelling too. See the step's own
+       "landed as" note above. What still defers in this family is that span-crossing term (the
+       module-wide `range_is_verbatim` boundary) and the escaped paren-wrapped shorthand
+       `\(((x)))`; beyond it the remainder is unchanged.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -3,7 +3,8 @@
 
 use super::{MacroMatch, MacroMatchKind, rebuild_macro_level};
 use crate::{
-    Span,
+    Parser, Span,
+    attributes::{Attrlist, AttrlistContext},
     content::{
         INLINE_INDEXTERM,
         inline_builder::{
@@ -24,6 +25,7 @@ use crate::{
 pub(super) fn indexterm_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
@@ -42,7 +44,7 @@ pub(super) fn indexterm_macros_level<'src>(
     // coordinates — see `apply_macro_families`'s own doc comment.
     let (s, pieces) = ctx.shift(s, pieces);
 
-    let matches = find_indexterm_matches(&s, &pieces, root);
+    let matches = find_indexterm_matches(&s, &pieces, root, parser);
 
     if matches.is_empty() {
         return nodes;
@@ -147,10 +149,13 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// earlier-recognized
 /// [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref), carried
 /// here as a single [`SPAN_PLACEHOLDER`] rather than its rendered markup). A
-/// visible term crossing such a span, or an `indexterm2:[…]` term carrying an
-/// attribute list (an `=`, whose first positional attribute becomes the shown
-/// term), is **deferred** — the match is left as literal source for a later
-/// increment, each pinned by a divergence test.
+/// visible term crossing such a span is **deferred** — the match is left as
+/// literal source for a later increment, pinned by a divergence test. An
+/// `indexterm2:[…]` term carrying an attribute list (an `=`, whose first
+/// positional attribute becomes the shown term) is *not*: the list decides
+/// only which of the argument's own bytes are shown, so
+/// [`shown_macro_term`] consumes it here and the node carries the same
+/// already-substituted text every other visible spelling gives it.
 ///
 /// A term crossing a [`synthesized`](Piece::synthesized) run (an attribute
 /// expansion, or — reached at a tree's root — a filtered multi-line block's
@@ -168,6 +173,7 @@ fn find_indexterm_matches<'src>(
     s: &str,
     pieces: &[Piece],
     root: Span<'src>,
+    parser: &Parser,
 ) -> Vec<RecognizedIndexterm<'src>> {
     let mut matches = Vec::new();
 
@@ -188,7 +194,7 @@ fn find_indexterm_matches<'src>(
             let arg = caps.get(2).unwrap().as_str();
 
             if let Some(m) =
-                build_indexterm_macro_match(is_visible, arg, full, escaped, pieces, root)
+                build_indexterm_macro_match(is_visible, arg, full, escaped, pieces, root, parser)
             {
                 matches.push(m);
             }
@@ -223,13 +229,13 @@ fn find_indexterm_matches<'src>(
 ///
 /// A concealed `indexterm:[…]` is always recognized (it renders nothing, so its
 /// argument is never reconstructed). A visible `indexterm2:[…]` is deferred
-/// when its argument crosses an opaque span (unreconstructable from the escaped
-/// string) or carries an attribute list (an `=` the node cannot hold yet) — see
-/// [`find_indexterm_matches`]. The visible term is normalized exactly as the
-/// string replacer does ([`normalize_index_text`] with bracket-unescaping) and
-/// baked into the node's `terms` in its already-substituted form, which is what
-/// `fold_index_term` feeds back to `render_index_term` for byte-identical
-/// output.
+/// only when its argument crosses an opaque span (unreconstructable from the
+/// escaped string) — see [`find_indexterm_matches`]. The visible term is
+/// normalized exactly as the string replacer does ([`normalize_index_text`]
+/// with bracket-unescaping), reduced through [`shown_macro_term`] when the
+/// argument is an attribute list, and baked into the node's `terms` in its
+/// already-substituted form, which is what `fold_index_term` feeds back to
+/// `render_index_term` for byte-identical output.
 fn build_indexterm_macro_match<'src>(
     is_visible: bool,
     arg: &str,
@@ -237,6 +243,7 @@ fn build_indexterm_macro_match<'src>(
     escaped: bool,
     pieces: &[Piece],
     root: Span<'src>,
+    parser: &Parser,
 ) -> Option<RecognizedIndexterm<'src>> {
     // An escape (`\indexterm:…`) drops the backslash and keeps the rest literal,
     // mirroring the string replacer's `caps[0][1..]`. A macro form always
@@ -267,14 +274,7 @@ fn build_indexterm_macro_match<'src>(
             return None;
         }
 
-        let term = normalize_index_text(arg, true);
-
-        // A term carrying an attribute list (an `=`) is parsed as an `Attrlist`
-        // the node cannot hold yet; deferred exactly as the link/xref macros
-        // defer their attribute-list text.
-        if term.contains('=') {
-            return None;
-        }
+        let term = shown_macro_term(normalize_index_text(arg, true), parser);
 
         let rendered_nonempty = !term.is_empty();
 
@@ -311,6 +311,56 @@ fn build_indexterm_macro_match<'src>(
         // The macro forms always `Continue`; only the shorthand can retry.
         is_skip: false,
     })
+}
+
+/// The text an `indexterm2:[…]` shows in the flow, given its already
+/// [`normalize_index_text`]-ed argument.
+///
+/// An argument carrying an `=` is an **attribute list**, whose first
+/// *positional* attribute is the shown term (`indexterm2:[Coffee,
+/// region=Kona]` shows `Coffee`); everything else it holds — a `see`, a
+/// `see-also`, a `region` — names the entry in an index this crate's HTML
+/// backend does not build, so it reaches the flow through nothing. Where the
+/// list has no positional attribute at all (`indexterm2:[see=HTML 5]`), the
+/// whole argument is shown verbatim, which is also the answer for an `=` that
+/// was never an attribute list to begin with.
+///
+/// This is [`InlineIndextermReplacer`]'s own arithmetic, reached with the same
+/// bytes: the argument is read from this level's escaped match string, which
+/// holds exactly what the string pipeline's flat haystack holds at that
+/// position — and the caller has already refused an argument crossing an
+/// opaque span, the one case where the two differ.
+///
+/// # Why the node needs no `Attrlist`
+///
+/// The link and cross-reference families capture the
+/// [`Attrlist<'src>`](Attrlist) their own bracket parses, because a role, an
+/// id, or a `window=` there changes what the fold emits. An index term's whole
+/// render surface is
+/// [`IndexTermRenderParams`](crate::parser::IndexTermRenderParams), which
+/// carries the shown term and nothing else — so the list is *consumed* here
+/// rather than carried, and the [`IndexTerm`] node goes on holding the same
+/// already-substituted shown text every other visible spelling gives it. That
+/// is what the deferral this closes was waiting on, and the answer is that it
+/// was waiting on nothing.
+///
+/// [`InlineIndextermReplacer`]: crate::content::macros
+fn shown_macro_term(arg: String, parser: &Parser) -> String {
+    if !arg.contains('=') {
+        return arg;
+    }
+
+    // Parsed over the normalized copy, exactly as the string replacer parses
+    // its own (`Attrlist::parse(Span::new(&arg), …)`): the value read back out
+    // is owned, so nothing borrows `'src` and the node keeps the coarse
+    // whole-match location design §4.4 gives a computed value.
+    let attrlist = Attrlist::parse(Span::new(&arg), parser, AttrlistContext::Inline)
+        .item
+        .item;
+
+    let positional = attrlist.nth_attribute(1).map(|a| a.value().to_string());
+
+    positional.unwrap_or(arg)
 }
 
 /// Builds the [`MacroMatch`] for an index-term **shorthand** (`((term))`,
@@ -757,22 +807,185 @@ mod tests {
     }
 
     #[test]
-    fn an_indexterm2_attribute_list_is_a_documented_divergence() {
-        // An `indexterm2:[…]` argument carrying an `=` splits into an attribute
-        // list whose first positional attribute is the shown term. The builder
-        // cannot carry that as an `Attrlist<'src>` yet, so it defers the whole
-        // macro (left literal), exactly as the link/xref macros defer their
-        // attribute-list text.
+    fn fold_matches_the_string_pipeline_through_indexterm2_attribute_lists() {
+        // An `indexterm2:[…]` argument carrying an `=` splits into an
+        // attribute list whose first *positional* attribute is the shown term;
+        // everything else it holds names an entry in an index the HTML backend
+        // does not build, so it reaches the flow through nothing. The builder
+        // reads the argument from this level's escaped match string — the same
+        // bytes the string pipeline's flat haystack holds there — and runs the
+        // replacer's own arithmetic over them ([`shown_macro_term`]).
+        for fixture in [
+            // The shown term is the first positional attribute.
+            "indexterm2:[Coffee, region=Kona]",
+            "a indexterm2:[Coffee, region=Kona] term",
+            // The two golden spellings of the `see` / `see-also` named
+            // attributes, which the macro form carries as attributes rather
+            // than as the shorthand's ` >> ` / ` &> ` clause.
+            "indexterm2:[Flash,see=HTML 5] and indexterm2:[HTML 5,see-also=\"CSS 3, SVG\"] done.",
+            // No positional attribute at all: the whole argument is shown
+            // verbatim, `=` included.
+            "Only named indexterm2:[see=HTML 5] here.",
+            "indexterm2:[region=Kona]",
+            // A quoted positional attribute, whose own comma is not a
+            // separator.
+            "indexterm2:[\"Coffee, Kona\",region=x]",
+            // An empty first positional attribute, which shows nothing.
+            "x indexterm2:[,region=Kona] y",
+            // A special character in either half: by macro time it is an
+            // entity in both pipelines, so the attribute list is parsed from
+            // the same escaped bytes on both sides.
+            "indexterm2:[a < b,region=Kona]",
+            "indexterm2:[Coffee,region=a < b]",
+            "indexterm2:[a &copy; b,region=Kona]",
+            // A typographic replacement inside the shown half — the third
+            // recoverable piece, whose match-string bytes are the entity the
+            // built-in backend renders it as.
+            "indexterm2:[Tom (C) Jerry,region=Kona]",
+            "indexterm2:[O'Reilly,see=Books]",
+            // In flow beside other constructs, twice in one flow, and inside a
+            // rendered span (the macros step descends into one).
+            "*bold* then indexterm2:[Coffee,region=Kona] here",
+            "indexterm2:[a,x=1] and indexterm2:[b,y=2]",
+            "_indexterm2:[Coffee,region=Kona] in em_",
+            // Spanning a newline, which `normalize_index_text` collapses to a
+            // space before either side parses the list.
+            "indexterm2:[Coffee,\nregion=Kona] end",
+            // An escaped attribute-list form still drops its backslash and
+            // stays literal.
+            "\\indexterm2:[Coffee,region=Kona]",
+            // The concealed spelling ignores its argument entirely, `=` or
+            // not.
+            "x indexterm:[Coffee,region=Kona] y",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {}),
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_indexterm2_attribute_list_becomes_a_node_carrying_only_its_shown_term() {
+        // The shape the increment asserts: the attribute list is *consumed*
+        // rather than carried. An index term's whole render surface is its
+        // shown term, so the node holds the same already-substituted text
+        // every other visible spelling gives it — and no `Attrlist`, which is
+        // what the deferral this closes had been waiting on.
         let source = "indexterm2:[Coffee, region=Kona]";
+        let nodes = build_src(Span::new(source));
+
+        assert_eq!(nodes.len(), 1);
+        let index_term = assert_index_term(&nodes[0]);
+
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms.len(), 1);
+        assert_eq!(index_term.terms[0].as_ref(), "Coffee");
+
+        // The location covers the whole macro, list included.
+        assert_eq!(index_term.location.data(), source);
+        assert_eq!(index_term.location.line(), 1);
+        assert_eq!(index_term.location.col(), 1);
+
+        // With no positional attribute the whole argument is the shown term.
+        let nodes = build_src(Span::new("indexterm2:[see=HTML 5]"));
+        let index_term = assert_index_term(&nodes[0]);
+
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms[0].as_ref(), "see=HTML 5");
+    }
+
+    #[test]
+    fn a_real_documents_indexterm2_attribute_lists_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shape that named
+        // this increment: an `indexterm2:[…]` whose argument is an attribute
+        // list must show the same term the rendered string carries — in a
+        // heading's own title as well as in block content — so a tree that
+        // left the macro literal would regress the moment `rendered_html()`
+        // becomes a fold of this tree.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = crate::Parser::default()
+            .with_inline_tree(true)
+            .parse(concat!(
+                "== A indexterm2:[Coffee,region=Kona] heading\n",
+                "\n",
+                "indexterm2:[Flash,see=HTML 5] has been supplanted by\n",
+                "indexterm2:[HTML 5,see-also=\"CSS 3, SVG\"].\n",
+                "\n",
+                "Only named indexterm2:[see=HTML 5] here.\n",
+            ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 2, "expected every paragraph to carry a tree");
+
+        // The heading's own title takes the same seam (its `Title` group runs
+        // the same macros step), so the shown term reaches a section title
+        // too, and that title's own tree folds to the bytes it rendered.
+        let mut folded_titles = 0;
+
+        for block in doc.descendant_blocks() {
+            let crate::blocks::Block::Section(section) = block else {
+                continue;
+            };
+
+            assert_eq!(section.section_title(), "A Coffee heading");
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    section.section_title_inlines(),
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                section.section_title(),
+                "fold diverged from the rendered section title"
+            );
+
+            folded_titles += 1;
+        }
+
+        assert_eq!(folded_titles, 1, "expected the heading to carry a tree");
+    }
+
+    #[test]
+    fn an_attribute_list_term_over_a_span_is_a_documented_divergence() {
+        // The recognition boundary the attribute list does *not* move: a shown
+        // term crossing a rendered span is unreconstructable from this level's
+        // escaped match string (the span is one placeholder here, not its
+        // markup), so the macro is still deferred — the `=` half is decided
+        // only once the argument's own bytes are in hand.
+        let source = "indexterm2:[*bold* term,region=Kona]";
         let nodes = build_src(Span::new(source));
 
         assert!(
             nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
-            "an attribute-list-in-text index term must be left unrecognized: {nodes:?}"
+            "a term crossing a span must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, shows the first positional term.
-        assert_eq!(golden_macros(source), "Coffee");
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert!(folded.contains("indexterm2:["));
+        assert_eq!(golden_macros(source), "<strong>bold</strong> term");
     }
 
     #[test]
@@ -802,6 +1015,12 @@ mod tests {
             "x ((hot {term})) y",
             "x indexterm2:[{term}] y",
             "x indexterm2:[hot {term}] y",
+            // The macro spelling's attribute list, whose shown term arrives
+            // from an expanded value — and whose *named* half does too, so the
+            // list is parsed from the synthesized run's own bytes on both
+            // sides.
+            "x indexterm2:[{term},region={second}] y",
+            "x indexterm2:[region={second}] y",
             // The concealed spellings (always recognized, but now over an
             // expanded value too).
             "x ((({term}, {second}))) y",

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -306,7 +306,7 @@ fn apply_macro_families<'src>(
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
     // `indexterm2:[…]`) run after image/icon and before the link families,
     // mirroring the string step's order.
-    let nodes = indexterm_macros_level(nodes, root, ctx, masked);
+    let nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
 
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro, mirroring the string step's

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -199,8 +199,10 @@
 //!   without deferring the whole anchor.
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
 //!   nothing, so it too is always recognized; a *visible* term (`indexterm2:[…]`,
-//!   `((term))`) is deferred only when its shown text crosses a rendered span or
-//!   carries an attribute list. The **UI**, **index-term**, and
+//!   `((term))`) is deferred only when its shown text crosses a rendered span —
+//!   an argument that is an **attribute list** (an `=`) is not deferred, since
+//!   the list only decides which of that argument's own bytes are shown and is
+//!   consumed rather than carried. The **UI**, **index-term**, and
 //!   **cross-reference** families share the anchor's synthesized-run lift, and
 //!   for the same reason — none of those nodes carries a `Span`-typed field, so
 //!   a `kbd:`/`btn:`/`menu:` macro, an index term, or a cross-reference inside
@@ -845,6 +847,7 @@ mod tests {
             "a ((flow term)) and (((c1, c2, c3))) end",
             "indexterm:[primary, secondary]",
             "indexterm2:[shown]",
+            "indexterm2:[Flash,see=HTML 5] then indexterm2:[see-also=\"CSS 3\"]",
             "[[mid-anchor]] after the anchor",
             "text before anchor:named[Ref Text] and after",
             "a +++<b>raw</b>+++ passthrough",
@@ -994,6 +997,15 @@ mod tests {
         // the entity the built-in backend renders it as.
         assert_parity(
             "image:a(C)b.png[Pause (C) Resume] beside link:x(C)y.html[O'Reilly]              and <<s(C)c,Tom (C) Jerry>> and a ((Coffee (C) Beans)) term.",
+        );
+
+        // An `indexterm2:[…]` attribute list beside the other families that
+        // parse one, and beside the shorthand spelling that has no such list:
+        // the shown term is the list's first positional attribute, while its
+        // `see` / `region` names an index entry that reaches the flow through
+        // nothing.
+        assert_parity(
+            "An indexterm2:[Coffee (C) Beans,see=Tea] term beside a ((Coffee (C) Beans)) one and link:x.html[O'Reilly,role=hl] and *bold*.",
         );
 
         // UI macros (kbd/menu, gated on `experimental`) beside a quoted span.
@@ -1948,6 +1960,14 @@ mod tests {
                 // `unescaped_value_children` classifies the `&` as the `Raw`
                 // leaf the classification pass would have made of it anyway.
                 "xref:sec[a & b,role=hl]",
+                // An `indexterm2:[…]` attribute list carrying the same bare
+                // special. Unlike the three families above, this one *shows*
+                // its computed value as flow text rather than splicing it into
+                // a target or a label, so what the order decides is only which
+                // bytes the list is parsed from — the shown term is those same
+                // bytes either way.
+                "an indexterm2:[a & b,region=Kona] term",
+                "an indexterm2:[Coffee,region=a < b] term",
                 // The same value written as the *entity spelling* of a
                 // special, for each of the three families that compute an
                 // attribute-list value. Under these orders nothing escaped it,

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -822,6 +822,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "a ((flow term)) and (((c1, c2, c3))) end",
         "indexterm:[primary, secondary]",
         "indexterm2:[shown]",
+        "indexterm2:[Flash,see=HTML 5] then indexterm2:[see-also=\"CSS 3\"]",
         "[[mid-anchor]] after the anchor",
         "text before anchor:named[Ref Text] and after",
         "a +++<b>raw</b>+++ passthrough",


### PR DESCRIPTION
One more `inline-ast` Phase 4, step 6 prep increment, additive as every prep before it: nothing new is wired into the parse path, and the flag still gates tree building.

## What this closes

With the passthrough-extraction pass's own two deferrals closed (#1231, #1232), re-running the corpus-wide fold-parity audit and classifying what remains by *source* leaves the **index-term** family holding the largest golden-exercised share of it — and the one piece of that share whose own note named a blocker: an `indexterm2:[…]` whose argument carries an `=`, deferred at step 4b(ii) part 4b *"until the node can hold an `Attrlist<'src>`, as the link/xref macros defer the same"*, and pinned since by `an_indexterm2_attribute_list_is_a_documented_divergence`.

Two of the `asciidoctor` port's own golden fixtures spell it, and the tree was leaving the whole macro literal:

- `indexterm2:[Flash,see=HTML 5] and indexterm2:[HTML 5,see-also="CSS 3, SVG"] done.` → `Flash and HTML 5 done.`
- `Only named indexterm2:[see=HTML 5] here.` → `Only named see=HTML 5 here.`

## The finding: the blocker had lapsed

An `=` in the argument makes it an **attribute list whose first positional attribute is the shown term** (`indexterm2:[Coffee, region=Kona]` shows `Coffee`), and everything else the list holds — a `see`, a `see-also`, a `region` — names an entry in an index this crate's HTML backend does not build, so it reaches the flow through nothing.

The link and cross-reference families capture their own `Attrlist<'src>` because a role, an id, or a `window=` there changes what the fold emits. An index term's whole render surface is `IndexTermRenderParams`, which carries the shown term and nothing else. So a new `shown_macro_term` **consumes** the list where `InlineIndextermReplacer` consumes it — the same `Attrlist::parse` over the same normalized copy, the same `nth_attribute(1)`, the same fall back to the whole argument when the list has no positional attribute at all — and the `IndexTerm` node goes on holding the one already-substituted shown text every other visible spelling gives it.

No node field, variant, or gate moves; only the level's `parser` is threaded down to the family, which every sibling family already takes.

## What the boundary still is

The argument is read from this level's escaped match string, which holds exactly what the string pipeline's flat haystack holds at that position, so the two parse the same bytes. The family's *other* deferral is untouched and still decides first: a shown term crossing an opaque span is unreconstructable from that string, so `indexterm2:[*bold* term,region=Kona]` stays literal and keeps a divergence test, now written against the attribute-list spelling too. The shorthand spelling has no attribute list to parse (the replacer strips its ` >> ` / ` &> ` clause instead, which the tree already mirrored) and is unchanged.

## Tests

The formerly pinned divergence becomes a parity corpus covering both golden spellings, a list with no positional attribute (shown verbatim, `=` included), a quoted positional attribute whose own comma is not a separator, an empty first positional attribute, a special character in either half, a typographic replacement and a restored entity in the shown half, the macro in flow, twice in one flow, inside a rendered span, spanning a newline that `normalize_index_text` collapses before either side parses, the escaped form, and the concealed spelling that ignores its argument entirely — plus a shape assertion (one `IndexTerm` carrying `Coffee` and the whole macro's location, never an attribute list), the expanded-value corpus in both halves, and a whole-document test driving the shape end to end through the real parse path, in a paragraph and in a section heading's own title.

Fixtures also join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check.

## Verification

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items` — all clean.
- **Corpus-wide fold-parity audit** (tree building forced on for every parse in the suite, run on this branch and on `origin/inline-ast`): both golden fixtures **gone** from the divergence set, **no new divergence**. (The one added raw-log line is the known recorder-marker artifact — a `RecordingRenderer` fixture whose `rendered` carries markers the audit's `HtmlSubstitutionRenderer` fold does not; that class is already ~200 lines of the base set.)
- **Coverage** is diff-neutral: `content/inline_builder/macros/indexterm.rs` holds at 6 missed regions / 3 missed lines / 1 missed function on both sides, and the workspace totals are unchanged.

## What still defers

In this family: the **visible term crossing a rendered span** (both spellings), which is the module-wide `range_is_verbatim` boundary rather than anything this family owns, and the one escaped paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`). Beyond it the remainder is unchanged — the boundary-class halves the sibling increments named (a macro body class wanting more than one presented character, the closing character, and the character-replacements step's consume-across-levels case), plus the keeps and the bare-attrlisted body the passthrough pass's first scan already recognizes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGsCXhAdzb9VNAnwJ1FRbA)_