### PR TITLE
feat: Recognize the flow term nested in an escaped shorthand (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1180,7 +1180,8 @@ Each phase is a reviewable unit with a clear exit gate.
   the node can hold an `Attrlist<'src>`, as the link/xref macros defer the same — deferred at the
   time, closed by a step 6 prep below, which finds the node needs no such list at all); the one
   escaped paren-wrapped shorthand the string replacer re-renders (`\(((x)))` → `(x)`) is likewise
-  left literal.
+  left literal — also at the time, and also closed by a step 6 prep below, as a *pair* of matches
+  rather than a new node shape.
   As throughout the additive builder, this performs *no* recognition side effect (the HTML backend
   builds no index, so the string replacer has none to skip either). This step is **additive**: nothing
   is wired into the parse path. Inline `Stem` is handled at passthrough time (step 5), not in the
@@ -4958,6 +4959,67 @@ Each phase is a reviewable unit with a clear exit gate.
   consume-across-levels case — plus the keeps, and the bare-attrlisted body whose content the
   passthrough pass's first scan already recognizes (`[method x-]+pass:[<b>]+`).
 
+  *Step 6 prep landed as (the escaped paren-wrapped shorthand, the index-term family's other named
+  deferral):* the sibling increment's closing sentence, taken in order — the half of what it named
+  that this family does own, the other half being the module-wide `range_is_verbatim` boundary. An
+  **escaped** index-term shorthand drops its backslash and keeps the rest literal, which is what the
+  builder did for every spelling of it; the string replacer has one exception, and its own branch
+  says why: *an escaped concealed term still processes a nested flow term*. Where the escaped
+  match's `encl_text` is itself **paren-wrapped**
+  ([`InlineIndextermReplacer`](../../parser/src/content/macros.rs)'s
+  `encl_text.starts_with('(') && encl_text.ends_with(')')`), the replacer strips those wrapping
+  parentheses off and renders what is left as a *visible* term between two literal parens, so
+  `\(((x)))` collapses to `(x)` rather than staying literal. The tree left the whole match literal
+  and pinned the difference — the shape Asciidoctor's own
+  `should only escape enclosing brackets if concealed index term is preceded by a backslash` spells,
+  which is where the corpus-wide fold-parity audit's remainder was still holding it.
+
+  Closing it needed no new mechanism, only the observation that this is **one match's source doing
+  two things** — the shape the escaped-attribute-list bracket increment already answered — so it
+  becomes a *pair* of matches that
+  [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) composes as it
+  composes any two adjacent ones: an
+  [`Unescape`](../../parser/src/content/inline_builder/macros/mod.rs) whose match **is** the
+  backslash it drops (so it emits nothing, exactly what the replacer does with that byte), then a
+  [`Node`](../../parser/src/content/inline_builder/macros/mod.rs) over the rest whose `consumed`
+  sub-range stops one byte inside each end — the same kept-parenthesis
+  narrowing the unescaped spellings already use for a single adjacent paren, applied to both ends at
+  once. Neither `MacroMatchKind` variant, nor the node, nor any gate or signature moves; the nested
+  term itself takes the visible branch's whole existing arithmetic (`normalize_index_text` then
+  `strip_see_and_seealso`), since it *is* that branch. The look-ahead bookkeeping falls out too: the
+  pair's `Node` half carries the `is_skip` the absorbed parens imply and a `rendered_nonempty` that
+  is unconditionally true — two kept parentheses are output whatever the term renders to — so a
+  concealed term sitting beside one is consumed rather than left literal by the
+  [`Cow::Borrowed`](../../parser/src/internal/regex.rs) no-op the level would otherwise be.
+
+  The family's *other* deferral is untouched and still decides first: the nested term is a shown
+  one, so a term crossing an opaque span is unreconstructable from this level's escaped string and
+  `\(((*bold* term)))` keeps the plain escaped shape with its own divergence test. What reaches
+  parity is the shape itself alone and in flow, a `see` / `see-also` clause stripped to its primary,
+  a newline collapsed and a term trimmed, a special character and a restored entity and a
+  typographic replacement in the shown text, an empty nested term, the trailing-paren absorption
+  running first so the wrapper's right half is a paren the closing pair absorbed
+  (`\(((x))))`, `\((((x))))`), the literal-staying twins beside it (`\((x))`, `\(((x))`,
+  `\((x)))`, `\indexterm:[x]`), twice in one flow, beside a rendered span, inside one, and the
+  nested term arriving from an **expanded value**. The formerly pinned divergence becomes a parity
+  test that also asserts the shape: a literal `(`, one visible `IndexTerm`, a literal `)`, and the
+  node's location the match minus the backslash the pair's first match drops. Fixtures join the
+  whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the
+  structural recorder cross-check; a whole-document test drives the shape end to end through the
+  real parse path, in a paragraph and in a section heading's own title. Re-running the corpus-wide
+  fold-parity audit shows that golden fixture **gone** from the divergence set and no new
+  divergence; coverage is diff-neutral, and as with every prep piece before it, nothing further is
+  wired in.
+
+  What still defers in this family is now only the half that was never its own: a **visible term
+  crossing a rendered span**, in every spelling — shorthand, macro, attribute list, and this
+  increment's nested one — which is the module-wide `range_is_verbatim` boundary. Beyond the
+  family the remainder is unchanged: the boundary-class halves the sibling increments named — a
+  macro body class wanting more than one presented character, the closing character, and the
+  character-replacements step's consume-across-levels case — plus the keeps, and the
+  bare-attrlisted body whose content the passthrough pass's first scan already recognizes
+  (`[method x-]+pass:[<b>]+`).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5808,6 +5870,30 @@ Each phase is a reviewable unit with a clear exit gate.
        "landed as" note above. What still defers in this family is that span-crossing term (the
        module-wide `range_is_verbatim` boundary) and the escaped paren-wrapped shorthand
        `\(((x)))`; beyond it the remainder is unchanged.
+
+     - ✅ **prep (the escaped paren-wrapped shorthand).** The half of that closing sentence the
+       index-term family actually owns. An escaped shorthand drops its backslash and stays
+       literal, which is what the builder did for every spelling; the string replacer has one
+       exception, and its own branch says why — *an escaped concealed term still processes a
+       nested flow term*. Where the escaped match's `encl_text` is itself paren-wrapped,
+       [`InlineIndextermReplacer`](../../parser/src/content/macros.rs) strips those parentheses
+       off and renders what is left as a **visible** term between two literal parens, so
+       `\(((x)))` collapses to `(x)` — the shape Asciidoctor's own
+       `should only escape enclosing brackets…` golden spells, and where the audit's remainder
+       was holding it. It is one match's source doing two things, so it becomes the *pair* the
+       escaped-attribute-list bracket increment already answered with: an
+       [`Unescape`](../../parser/src/content/inline_builder/macros/mod.rs) whose match **is** the
+       backslash it drops, then a [`Node`](../../parser/src/content/inline_builder/macros/mod.rs)
+       whose `consumed` sub-range stops one byte inside each end — the family's own
+       kept-parenthesis narrowing, applied to both ends at once — which
+       [`rebuild_macro_level`](../../parser/src/content/inline_builder/macros/mod.rs) composes as
+       it composes any two adjacent matches. No variant, node field, gate, or signature moves;
+       the nested term takes the visible branch's existing arithmetic because it *is* that
+       branch. The formerly pinned divergence becomes a parity test that also asserts the shape.
+       See the step's own "landed as" note above. What still defers in this family is now only
+       the half that was never its own: a visible term crossing a rendered span, in every
+       spelling, which is the module-wide `range_is_verbatim` boundary; beyond it the remainder
+       is unchanged.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -215,10 +215,7 @@ fn find_indexterm_matches<'src>(
         let extra = s[whole.end()..].bytes().take_while(|b| *b == b')').count();
         let full = whole.start()..(whole.end() + extra);
 
-        if let Some(m) = build_indexterm_shorthand_match(inner, extra, full, escaped, pieces, root)
-        {
-            matches.push(m);
-        }
+        push_indexterm_shorthand_matches(inner, extra, full, escaped, pieces, root, &mut matches);
     }
 
     matches
@@ -363,8 +360,8 @@ fn shown_macro_term(arg: String, parser: &Parser) -> String {
     positional.unwrap_or(arg)
 }
 
-/// Builds the [`MacroMatch`] for an index-term **shorthand** (`((term))`,
-/// `(((primary, secondary, tertiary)))`), or `None` when the visible term
+/// Pushes the [`MacroMatch`]es for an index-term **shorthand** (`((term))`,
+/// `(((primary, secondary, tertiary)))`) — none at all when the visible term
 /// crosses an opaque span (see [`find_indexterm_matches`]).
 ///
 /// `inner` is the text between the outermost `((` and `))` (match group 3);
@@ -384,42 +381,115 @@ fn shown_macro_term(arg: String, parser: &Parser) -> String {
 /// [`rebuild_macro_level`] emits that edge `(`/`)` as literal text — the same
 /// sub-range mechanism the auto-link pass uses for a bare URL's kept prefix.
 ///
-/// An **escaped** shorthand (`\((…))`) drops its backslash and stays literal
-/// (an [`Unescape`](MacroMatchKind::Unescape)); the one string-replacer form
-/// that instead re-renders an escaped *paren-wrapped* term (`\(((x)))` →
-/// `(x)`) is left literal here, a documented divergence pinned by a test.
-fn build_indexterm_shorthand_match<'src>(
+/// # The two escaped spellings
+///
+/// An **escaped** shorthand (`\((…))`) drops its backslash and keeps the rest —
+/// absorbed parens included — literal, an
+/// [`Unescape`](MacroMatchKind::Unescape) matching the string replacer's plain
+/// `caps[0][1..]` byte-for-byte.
+///
+/// An escaped **paren-wrapped** one (`\(((x)))`) is the exception, and the
+/// replacer's own branch says why: *an escaped concealed term still processes a
+/// nested flow term*. It strips the wrapping parentheses off `encl_text` and
+/// renders what is left as a **visible** term between two literal parens, so
+/// `\(((x)))` collapses to `(x)` rather than staying literal. That is one
+/// match's source doing two things, which is exactly what a **pair** of matches
+/// expresses — an [`Unescape`](MacroMatchKind::Unescape) over the backslash
+/// alone, then a [`Node`](MacroMatchKind::Node) over the rest with a kept paren
+/// at *each* end of its `consumed` sub-range — and
+/// [`rebuild_macro_level`] composes the pair as it composes any two adjacent
+/// matches, so neither [`MacroMatchKind`] variant grows a new shape. It is the
+/// same composition the escaped-attribute-list bracket
+/// ([`passthrough_step`](super::super::passthrough_step)) reaches from the
+/// other direction; only the kept-paren narrowing is this family's own, and it
+/// is the narrowing the unescaped spellings above already use, applied to both
+/// ends at once.
+fn push_indexterm_shorthand_matches<'src>(
     inner: &str,
     extra: usize,
     full: std::ops::Range<usize>,
     escaped: bool,
     pieces: &[Piece],
     root: Span<'src>,
-) -> Option<RecognizedIndexterm<'src>> {
-    // An escaped shorthand drops its backslash and keeps the rest (including any
-    // absorbed parens) literal. The one form the string replacer treats
-    // specially — an escaped, paren-wrapped `\(((x)))`, which it collapses to
-    // `(x)` — is left literal here, a divergence documented and pinned by a
-    // test. Every other escaped spelling matches the string replacer's plain
-    // `caps[0][1..]` byte-for-byte.
-    if escaped {
-        return Some(RecognizedIndexterm {
-            macro_match: MacroMatch {
-                kind: MacroMatchKind::Unescape {
-                    backslash: full.start,
-                },
-                full,
-            },
-            rendered_nonempty: true,
-            is_skip: extra > 0,
-        });
-    }
-
+    matches: &mut Vec<RecognizedIndexterm<'src>>,
+) {
     // `encl_text` = the enclosed text plus any absorbed trailing parens, exactly
     // as the string replacer builds it before classifying.
     let mut encl_text = inner.to_string();
     for _ in 0..extra {
         encl_text.push(')');
+    }
+
+    if escaped {
+        // The escaped branch's own classification: a paren-wrapped `encl_text`
+        // is the nested flow term the replacer still renders (see this
+        // function's doc comment); anything else stays literal.
+        let nested = encl_text
+            .strip_prefix('(')
+            .and_then(|t| t.strip_suffix(')'))
+            // A shown term crossing an opaque span is unreconstructable from
+            // this level's escaped string, so the family's own recognition
+            // boundary decides first and the match keeps the literal shape —
+            // the same deferral every other visible spelling takes, pinned by
+            // its own divergence test.
+            .filter(|nested| !nested.contains(SPAN_PLACEHOLDER));
+
+        let Some(nested) = nested else {
+            matches.push(RecognizedIndexterm {
+                macro_match: MacroMatch {
+                    kind: MacroMatchKind::Unescape {
+                        backslash: full.start,
+                    },
+                    full,
+                },
+                rendered_nonempty: true,
+                is_skip: extra > 0,
+            });
+
+            return;
+        };
+
+        // The backslash alone. An `Unescape` whose match *is* the character it
+        // drops emits nothing, which is what the replacer does with this one.
+        matches.push(RecognizedIndexterm {
+            macro_match: MacroMatch {
+                kind: MacroMatchKind::Unescape {
+                    backslash: full.start,
+                },
+                full: full.start..(full.start + 1),
+            },
+            rendered_nonempty: false,
+            is_skip: false,
+        });
+
+        // Everything after it: the nested term, with the wrapping parenthesis at
+        // each end left outside `consumed` so `rebuild_macro_level` emits both
+        // as the literal text the replacer pushes around the rendered term.
+        let term_full = (full.start + 1)..full.end;
+        let consumed = (term_full.start + 1)..(term_full.end - 1);
+
+        let node = InlineNode::IndexTerm(IndexTerm {
+            terms: vec![CowStr::from(strip_see_and_seealso(&normalize_index_text(
+                nested, false,
+            )))],
+            visible: true,
+            location: source_slice(pieces, term_full.clone(), root),
+        });
+
+        matches.push(RecognizedIndexterm {
+            macro_match: MacroMatch {
+                kind: MacroMatchKind::Node {
+                    consumed,
+                    node: Box::new(node),
+                },
+                full: term_full,
+            },
+            // The two kept parentheses are output whatever the term renders to.
+            rendered_nonempty: true,
+            is_skip: extra > 0,
+        });
+
+        return;
     }
 
     // Classify the term, mirroring the string replacer's paren stripping. `term`
@@ -447,7 +517,7 @@ fn build_indexterm_shorthand_match<'src>(
         // crossing a synthesized run is recognized, exactly as in the macro
         // form's own check above.
         if term_src.contains(SPAN_PLACEHOLDER) {
-            return None;
+            return;
         }
 
         let term = strip_see_and_seealso(&normalize_index_text(term_src, false));
@@ -480,7 +550,7 @@ fn build_indexterm_shorthand_match<'src>(
     // match's first `(`; an `after` keeps its last `)`.
     let consumed = (full.start + usize::from(before))..(full.end - usize::from(after));
 
-    Some(RecognizedIndexterm {
+    matches.push(RecognizedIndexterm {
         macro_match: MacroMatch {
             kind: MacroMatchKind::Node {
                 consumed,
@@ -490,7 +560,7 @@ fn build_indexterm_shorthand_match<'src>(
         },
         rendered_nonempty,
         is_skip: extra > 0,
-    })
+    });
 }
 
 #[cfg(test)]
@@ -1007,7 +1077,8 @@ mod tests {
         let parser = Parser::default()
             .with_intrinsic_attribute("term", "coffee", ModificationContext::Anywhere)
             .with_intrinsic_attribute("second", "brewing", ModificationContext::Anywhere)
-            .with_intrinsic_attribute("shorthand", "((tea))", ModificationContext::Anywhere);
+            .with_intrinsic_attribute("shorthand", "((tea))", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("escaped", "\\(((tea)))", ModificationContext::Anywhere);
 
         let fixtures = [
             // The visible shorthand and macro spellings, whole and partial.
@@ -1029,6 +1100,14 @@ mod tests {
             "x {shorthand} y",
             // A kept literal parenthesis beside an expanded term.
             "x (((({term}))) y",
+            // The escaped paren-wrapped spelling, whose nested term is the same
+            // shown text read from the same synthesized run — the two kept
+            // parens are the level's own bytes either side of it.
+            "x \\((({term}))) y",
+            // The same spelling arriving *whole* from an expanded value, so the
+            // two kept parens are themselves sliced out of the synthesized run
+            // (as is the backslash the pair's first match drops).
+            "x {escaped} y",
         ];
 
         for source in fixtures {
@@ -1087,16 +1166,183 @@ mod tests {
     }
 
     #[test]
-    fn an_escaped_paren_wrapped_shorthand_is_a_documented_divergence() {
+    fn fold_matches_the_string_pipeline_through_escaped_paren_wrapped_shorthands() {
         // The one escaped shorthand the string replacer re-renders rather than
-        // leaving literal: an escaped, paren-wrapped `\(((x)))`, which it
-        // collapses to `(x)`. The builder drops the backslash and keeps the rest
-        // literal (`(((x)))`), a documented divergence — every other escaped
-        // spelling matches byte-for-byte (pinned by the corpus above).
-        let source = "\\(((x)))";
-        let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+        // leaving literal: a paren-wrapped `\(((x)))`, whose wrapping parens it
+        // strips off `encl_text` before rendering what is left as a **visible**
+        // term between two literal parens ("an escaped concealed term still
+        // processes a nested flow term"), so the whole thing collapses to
+        // `(x)`. The builder expresses that as a pair of matches — an
+        // `Unescape` over the backslash alone, then a `Node` whose `consumed`
+        // sub-range keeps a paren at each end — and folds to the same bytes.
+        for fixture in [
+            // The shape itself, alone and in flow.
+            r"\(((x)))",
+            r"a \(((x))) b",
+            r"\(((a, b, c)))",
+            // The nested term takes the *visible* branch's whole arithmetic: a
+            // `see` / `see-also` clause is stripped to the primary term (the
+            // separators are `&gt;&gt;` / `&amp;&gt;` entities by macro time)…
+            r"\(((Coffee >> Beans)))",
+            r"\(((Coffee &> Tea)))",
+            // …a newline is collapsed to a space and the term is trimmed…
+            "\\(((multi\nline)))",
+            r"\((( spaced )))",
+            // …and a special character, a restored entity, and a typographic
+            // replacement all reach the shown text as the same entity bytes the
+            // string pipeline holds there.
+            r"\(((a < b)))",
+            r"\(((a &copy; b)))",
+            r"\(((Tom (C) Jerry)))",
+            r"\(((O'Reilly)))",
+            // An empty nested term shows nothing between the kept parens.
+            r"\((()))",
+            r"\((( )))",
+            // The trailing-paren absorption still runs first, so what is
+            // wrapped can itself carry parens — the extra `)` that the closing
+            // pair absorbed is the wrapper's own right half.
+            r"\(((x))))",
+            r"\((((x))))",
+            r"\(((x)))))",
+            r"\((((x)))",
+            // Beside its own literal-staying twins, whose `encl_text` is not
+            // paren-wrapped and which therefore only drop a backslash.
+            r"\((x))\(((y)))",
+            r"\indexterm:[x]\(((y)))",
+            // Twice in one flow, and beside constructs the earlier steps
+            // recognized.
+            r"\(((x))) \(((y)))",
+            r"*bold* \(((x))) _em_",
+            // Recognized inside a rendered span (the macros step descends).
+            r"_\(((x))) in em_",
+            // The shown term makes the substitution's output non-empty, so a
+            // concealed term beside it is consumed rather than left literal by
+            // the `Cow::Borrowed` no-op the level would otherwise be.
+            r"\(((x)))(((y)))",
+            r"\(((x))) and (((y)))",
+            r"(((y))) and \(((x)))",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {}),
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
 
-        assert_eq!(folded, "(((x)))");
-        assert_eq!(golden_macros(source), "(x)");
+    #[test]
+    fn an_escaped_paren_wrapped_shorthand_becomes_a_term_between_two_literal_parens() {
+        // The shape the pair of matches produces: the backslash is gone, the
+        // wrapping parentheses ride beside the node as literal text, and the
+        // node is an ordinary visible term. Its location covers the match
+        // *minus* the backslash the pair's first match drops — the kept parens
+        // included, as every other shorthand node's location includes its own.
+        let nodes = build_src(Span::new("x \\(((coffee))) y"));
+
+        assert_eq!(nodes.len(), 5);
+        assert_text(&nodes[0], "x ", 1, 1);
+        assert_text(&nodes[1], "(", 1, 4);
+
+        let index_term = assert_index_term(&nodes[2]);
+        assert!(index_term.visible);
+        assert_eq!(index_term.terms.len(), 1);
+        assert_eq!(index_term.terms[0].as_ref(), "coffee");
+        assert_eq!(index_term.location.data(), "(((coffee)))");
+        assert_eq!(index_term.location.line(), 1);
+        assert_eq!(index_term.location.col(), 4);
+
+        assert_text(&nodes[3], ")", 1, 15);
+        assert_text(&nodes[4], " y", 1, 16);
+    }
+
+    #[test]
+    fn a_real_documents_escaped_paren_wrapped_shorthands_fold_to_their_rendered_strings() {
+        // End-to-end, through the real parse path, on the shape that named this
+        // increment: an escaped paren-wrapped shorthand renders as its nested
+        // term between two literal parens, so a tree that left the whole match
+        // literal would regress the moment `rendered_html()` becomes a fold of
+        // this tree. Driven in block content and in a heading's own title,
+        // whose `Title` group runs the same macros step.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = crate::Parser::default()
+            .with_inline_tree(true)
+            .parse(concat!(
+                "== A \\(((Coffee))) heading\n",
+                "\n",
+                "An escaped \\(((Coffee >> Beans))) term keeps its parens,\n",
+                "and \\((()))  shows nothing between them.\n",
+            ));
+
+        let mut folded_blocks = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert!(rendered.contains("(Coffee)"), "rendered: {rendered:?}");
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded_blocks += 1;
+        }
+
+        assert_eq!(folded_blocks, 1, "expected the paragraph to carry a tree");
+
+        let mut folded_titles = 0;
+
+        for block in doc.descendant_blocks() {
+            let crate::blocks::Block::Section(section) = block else {
+                continue;
+            };
+
+            assert_eq!(section.section_title(), "A (Coffee) heading");
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    section.section_title_inlines(),
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                section.section_title(),
+                "fold diverged from the rendered section title"
+            );
+
+            folded_titles += 1;
+        }
+
+        assert_eq!(folded_titles, 1, "expected the heading to carry a tree");
+    }
+
+    #[test]
+    fn an_escaped_paren_wrapped_term_over_a_span_is_a_documented_divergence() {
+        // The recognition boundary this spelling does *not* move: the nested
+        // term is a shown one, so a term crossing a rendered span is
+        // unreconstructable from this level's escaped match string and the
+        // family's own deferral decides first — the match keeps the plain
+        // escaped shape (backslash dropped, the rest literal) that every other
+        // escaped spelling takes. The string pipeline, by contrast, folds the
+        // span markup into the shown term and keeps only the wrapping parens.
+        let source = "\\(((*bold* term)))";
+        let nodes = build_src(Span::new(source));
+
+        assert!(
+            nodes.iter().all(|n| !matches!(n, InlineNode::IndexTerm(_))),
+            "a nested term crossing a span must be left unrecognized: {nodes:?}"
+        );
+
+        let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+        assert_eq!(folded, "(((<strong>bold</strong> term)))");
+        assert_eq!(golden_macros(source), "(<strong>bold</strong> term)");
     }
 }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -202,7 +202,11 @@
 //!   `((term))`) is deferred only when its shown text crosses a rendered span —
 //!   an argument that is an **attribute list** (an `=`) is not deferred, since
 //!   the list only decides which of that argument's own bytes are shown and is
-//!   consumed rather than carried. The **UI**, **index-term**, and
+//!   consumed rather than carried. An escaped shorthand keeps its match literal
+//!   minus the backslash, *except* the paren-wrapped `\(((x)))`, which the
+//!   string replacer still renders as the flow term nested inside it: that one
+//!   becomes a **pair** of matches (the backslash's own, then the term's,
+//!   keeping a literal paren at each end). The **UI**, **index-term**, and
 //!   **cross-reference** families share the anchor's synthesized-run lift, and
 //!   for the same reason — none of those nodes carries a `Span`-typed field, so
 //!   a `kbd:`/`btn:`/`menu:` macro, an index term, or a cross-reference inside
@@ -848,6 +852,7 @@ mod tests {
             "indexterm:[primary, secondary]",
             "indexterm2:[shown]",
             "indexterm2:[Flash,see=HTML 5] then indexterm2:[see-also=\"CSS 3\"]",
+            r"an escaped \(((Coffee))) shorthand and its \((literal)) twin",
             "[[mid-anchor]] after the anchor",
             "text before anchor:named[Ref Text] and after",
             "a +++<b>raw</b>+++ passthrough",
@@ -1006,6 +1011,15 @@ mod tests {
         // nothing.
         assert_parity(
             "An indexterm2:[Coffee (C) Beans,see=Tea] term beside a ((Coffee (C) Beans)) one and link:x.html[O'Reilly,role=hl] and *bold*.",
+        );
+
+        // The escaped paren-wrapped shorthand — a *pair* of matches, where the
+        // backslash's own match drops it and the nested term rides between two
+        // kept parens — beside the escaped spellings that stay literal, a
+        // concealed term the shown one's output keeps from being the level's
+        // `Cow::Borrowed` no-op, and a character replacement inside the term.
+        assert_parity(
+            "An escaped \\(((Tom (C) Jerry >> Cartoons))) term beside \\((literal)) and (((concealed))) and *bold*.",
         );
 
         // UI macros (kbd/menu, gated on `experimental`) beside a quoted span.
@@ -1968,6 +1982,13 @@ mod tests {
                 // bytes either way.
                 "an indexterm2:[a & b,region=Kona] term",
                 "an indexterm2:[Coffee,region=a < b] term",
+                // The escaped paren-wrapped shorthand's nested term, carrying
+                // the same bare special. What an order decides here is only
+                // which bytes the term is read from; the two kept parens beside
+                // it are the level's own either way, and the backslash the
+                // pair's first match drops is never a special.
+                r"an escaped \(((a & b))) term",
+                r"an escaped \(((a &lt; b))) term",
                 // The same value written as the *entity spelling* of a
                 // special, for each of the three families that compute an
                 // attribute-list value. Under these orders nothing escaped it,

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -823,6 +823,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "indexterm:[primary, secondary]",
         "indexterm2:[shown]",
         "indexterm2:[Flash,see=HTML 5] then indexterm2:[see-also=\"CSS 3\"]",
+        r"an escaped \(((Coffee))) shorthand and its \((literal)) twin",
         "[[mid-anchor]] after the anchor",
         "text before anchor:named[Ref Text] and after",
         "a +++<b>raw</b>+++ passthrough",


### PR DESCRIPTION
The index-term family's other named deferral — the half it actually owns; the other half is the module-wide `range_is_verbatim` boundary.

## The divergence

An **escaped** index-term shorthand drops its backslash and keeps the rest literal, which is what the builder did for every spelling of it. The string replacer has one exception, and its own branch says why: *an escaped concealed term still processes a nested flow term*. Where the escaped match's `encl_text` is itself **paren-wrapped** (`InlineIndextermReplacer`'s `encl_text.starts_with('(') && encl_text.ends_with(')')`), the replacer strips those wrapping parentheses off and renders what is left as a *visible* term between two literal parens, so `\(((x)))` collapses to `(x)` rather than staying literal.

The tree left the whole match literal and pinned the difference — the shape Asciidoctor's own `should only escape enclosing brackets if concealed index term is preceded by a backslash` golden spells, which is where the corpus-wide fold-parity audit's remainder was still holding it.

## The fix

No new mechanism, only the observation that this is **one match's source doing two things** — the shape the escaped-attribute-list bracket increment (#1231) already answered. It becomes a *pair* of matches that `rebuild_macro_level` composes as it composes any two adjacent ones:

- an `Unescape` whose match **is** the backslash it drops, so it emits nothing — exactly what the replacer does with that byte;
- a `Node` over the rest whose `consumed` sub-range stops one byte inside each end — the same kept-parenthesis narrowing the unescaped spellings already use for a single adjacent paren, applied to both ends at once.

Neither `MacroMatchKind` variant, nor the node, nor any gate or signature moves. The nested term takes the visible branch's whole existing arithmetic (`normalize_index_text` then `strip_see_and_seealso`), since it *is* that branch. The look-ahead bookkeeping falls out too: the pair's `Node` half carries the `is_skip` the absorbed parens imply and a `rendered_nonempty` that is unconditionally true — two kept parentheses are output whatever the term renders to — so a concealed term sitting beside one is consumed rather than left literal by the `Cow::Borrowed` no-op the level would otherwise be.

## What is still deferred

The family's other deferral is untouched and still decides first: the nested term is a shown one, so a term crossing an opaque span is unreconstructable from this level's escaped string and `\(((*bold* term)))` keeps the plain escaped shape with its own divergence test. That leaves the family with only the half that was never its own — a visible term crossing a rendered span, in every spelling — which is the module-wide `range_is_verbatim` boundary.

## Tests

The formerly pinned divergence becomes a parity test that also asserts the shape (a literal `(`, one visible `IndexTerm`, a literal `)`, and the node's location the match minus the backslash the pair's first match drops). What reaches parity: the shape alone and in flow; a `see` / `see-also` clause stripped to its primary; a newline collapsed and a term trimmed; a special character, a restored entity, and a typographic replacement in the shown text; an empty nested term; the trailing-paren absorption running first so the wrapper's right half is a paren the closing pair absorbed (`\(((x))))`, `\((((x))))`); the literal-staying twins beside it (`\((x))`, `\(((x))`, `\((x)))`); twice in one flow; beside a rendered span and inside one; and the nested term — or the whole construct — arriving from an expanded value.

Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check; a whole-document test drives the shape end to end through the real parse path, in a paragraph and in a section heading's own title.

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5363 passed)
- `cargo +nightly doc --no-deps --document-private-items` clean
- **Coverage diff-neutral** — `indexterm.rs` holds at 6 missed regions / 3 missed lines / 1 missed function, the same pre-existing `other => panic!(…)` test-assertion arms as on `origin/inline-ast`; `inline_builder/mod.rs` stays at 100%.
- **Corpus-wide fold-parity audit** re-run on this branch and on `origin/inline-ast`: the `escape_only_enclosing_brackets` golden fixture is **gone** from the divergence set, and there are **no new divergences**.

As with every prep piece before it, nothing further is wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCeM1Q4hitpcEBifKCVzGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCeM1Q4hitpcEBifKCVzGj)_