### PR TITLE
feat: Recognize an attribute-list reference text enclosing a rendered span (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5122,7 +5122,14 @@ Each phase is a reviewable unit with a clear exit gate.
   [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs)'s own `pre_restore`
   draws it: a token reaching the `window=`, `role=`, or `xrefstyle=` this family reads as a
   *string* names markup that exists only at fold time where a string is needed, so that shape
-  defers with its own divergence test. Deciding it means making the same tokened parse the builder
+  defers with its own divergence test. The family's **recognition-agreement** gap reaches the
+  attribute-list spelling too, and the token is what makes it visible: an attribute-list
+  delimiter *inside* the span (`xref:sec[a *b, c* d,role=hl]`) ends the replacer's positional
+  value inside a tag — `a <strong>b</a>`, improperly nested markup no tree can represent — where
+  the token carries none of the `,` / `=` / `"` the split reads and the span stays whole. That is
+  the quotes step's crossed delimiters again, and it is pinned by its own test rather than
+  deferred: the same comma without a named attribute beside it has no attribute list to split at
+  all, and is at parity through the plain-text path. Deciding it means making the same tokened parse the builder
   makes, in the gate — which is where this family's contract puts every deferral ("both builders
   claim every shape they are handed"), and where it already re-derives the shorthand's own comma
   split for the same reason.
@@ -6068,7 +6075,9 @@ Each phase is a reviewable unit with a clear exit gate.
        a `Ref{Xref}` carries `attrs: None`, so nothing rides on the list itself. The boundary is
        redrawn per **slot**: a piece reaching the `window=` / `role=` / `xrefstyle=` this family
        reads as a string still defers, decided in the gate where every cross-reference deferral is
-       decided. A masked passthrough or STEM in such a text comes along for free. See the step's
+       decided; and the family's recognition-agreement gap reaches this spelling, an attribute-list
+       delimiter inside the span splitting the replacer's own value inside a tag, pinned by its own
+       test. A masked passthrough or STEM in such a text comes along for free. See the step's
        own "landed as" note above. The **image** family's bracket — the one capture with no
        display text to carry — is what remains of the class.
 

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5092,6 +5092,69 @@ Each phase is a reviewable unit with a clear exit gate.
   bare-attrlisted body whose content the passthrough pass's first scan already recognizes
   (`[method x-]+pass:[<b>]+`).
 
+  *Step 6 prep landed as (an attribute-list reference text enclosing a rendered span — the
+  cross-reference family):* the capture the rendered-span class left behind. When that class was
+  closed for the three reference-bearing families, each kept one shape: *a text carrying its own
+  attribute list*, whose display text comes back from an
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs) **parse** rather than from a range of the
+  match string — and a parsed value, the note said, is bytes, which a rendered span has none of
+  until fold time. `xref:sec[*bold*,role=hl]` therefore stayed literal, one of the audit's
+  remaining golden-exercised divergences.
+
+  The finding is that the parse hands that value back to become the node's **children**, so it
+  needs no bytes either — only a way to survive the split intact. That is exactly what the
+  restore-the-value class already built for a masked passthrough:
+  [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) puts a bracket into
+  the string pipeline's own *shape* before the parse, and
+  [`restored_value_children`](../../parser/src/content/inline_builder/macros/mod.rs) re-splits the
+  parsed value on its tokens and splices the masked **node** back in. The only thing that made a
+  span different was the pairing of each token with a body, which
+  [`Attrlist::into_owned_restoring`](../../parser/src/attributes/attrlist.rs) needs and a span
+  cannot supply. A cross-reference needs no such pairing at all: a
+  [`Ref`](../../parser/src/inlines/ref_node.rs)`{Xref}` carries `attrs: None`, and its `window` /
+  `role` / `xrefstyle` are plain fields read straight off the parse. So a new
+  [`tokened_text`](../../parser/src/content/inline_builder/macros/mod.rs) tokens **every** opaque
+  piece — a rendered span, an earlier-recognized macro node, a masked passthrough or STEM alike —
+  with no body to pair, and `restored_value_children`, lifted out of the link family and shared,
+  splices each node into the children.
+
+  The boundary that remains is drawn per **slot**, exactly as
+  [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs)'s own `pre_restore`
+  draws it: a token reaching the `window=`, `role=`, or `xrefstyle=` this family reads as a
+  *string* names markup that exists only at fold time where a string is needed, so that shape
+  defers with its own divergence test. Deciding it means making the same tokened parse the builder
+  makes, in the gate — which is where this family's contract puts every deferral ("both builders
+  claim every shape they are handed"), and where it already re-derives the shorthand's own comma
+  split for the same reason.
+
+  One detail is this increment's own: `tokened_text` walks the level **piece by piece** rather
+  than copying the gaps between the opaque ones, because a byte of the match string may belong to
+  no piece at all — [`styled_sibling_boundaries`](../../parser/src/content/inline_builder/quotes.rs)
+  wraps an opaque span's placeholder in the two characters its rendering presents to a neighbour,
+  which exist for *recognition* and stand for markup the token already carries whole. Copying them
+  would splice a stray `<` and `>` into the value beside the node.
+
+  What reaches parity is the golden spelling alone and in flow, the span at either edge and in the
+  middle of the text, each of the three named attributes beside it, other span kinds and two spans
+  in one text, the recoverable pieces the text already carried (an escaped special, a restored
+  entity, a typographic replacement) beside a span, a collapsed newline, an `=` the parse finds
+  *incidental* (which falls through to the plain-text path that has carried an opaque piece all
+  along), and — reached through the same tokening — a **masked passthrough** or **STEM expression**
+  in such a text, which this family had deferred too. The formerly pinned divergence becomes a
+  parity test that also asserts the shape: the enclosed span itself as a child, with the named
+  attributes on the node's own fields. Fixtures join the whole-pipeline broad sweep and
+  combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check —
+  which can now compare this form, the recorder having always recovered it structurally; a
+  whole-document test drives the shape end to end through the real parse path, in a paragraph and
+  in a section heading's own title. Coverage is diff-neutral, and nothing further is wired in.
+
+  What still defers of this class is the **image** family's attribute list, the one capture with no
+  display text to carry: its bracket's values are read as strings by `render_image` (a `title=`, an
+  `alt=`), so a span there is the per-slot boundary above with every slot on the wrong side. Beyond
+  it the remainder is unchanged: the boundary-class halves the sibling increments named — a macro
+  body class wanting more than one presented character, the closing character, and the
+  character-replacements step's consume-across-levels case — plus the keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -5988,6 +6051,26 @@ Each phase is a reviewable unit with a clear exit gate.
        shown range holds no placeholder, so every spelling already at parity is byte-identical.
        Only the `Attrlist`-bearing argument still defers, its shown term coming back from a parse
        rather than a range; see the step's own "landed as" note above.
+
+     - ✅ **prep (an attribute-list reference text enclosing a rendered span).** The capture the
+       rendered-span class left behind, closed for the **cross-reference** family. A text carrying
+       its own attribute list gets its display text back from an
+       [`Attrlist`](../../parser/src/attributes/attrlist.rs) *parse* rather than from a range, and
+       a parsed value is bytes — which a rendered span has none of until fold time. But the parse
+       hands that value back to become the node's **children**, so it needs no bytes either, only
+       a way to survive the split: a new
+       [`tokened_text`](../../parser/src/content/inline_builder/macros/mod.rs) rewrites every
+       opaque piece into the index-keyed token
+       [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) already uses,
+       and [`restored_value_children`](../../parser/src/content/inline_builder/macros/mod.rs) —
+       lifted out of the link family and shared — splices each **node** back in. Unlike a masked
+       construct no token needs a *body*, which is the only thing that had made a span different;
+       a `Ref{Xref}` carries `attrs: None`, so nothing rides on the list itself. The boundary is
+       redrawn per **slot**: a piece reaching the `window=` / `role=` / `xrefstyle=` this family
+       reads as a string still defers, decided in the gate where every cross-reference deferral is
+       decided. A masked passthrough or STEM in such a text comes along for free. See the step's
+       own "landed as" note above. The **image** family's bracket — the one capture with no
+       display text to carry — is what remains of the class.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5122,14 +5122,19 @@ Each phase is a reviewable unit with a clear exit gate.
   [`text_attrlist`](../../parser/src/content/inline_builder/macros/links.rs)'s own `pre_restore`
   draws it: a token reaching the `window=`, `role=`, or `xrefstyle=` this family reads as a
   *string* names markup that exists only at fold time where a string is needed, so that shape
-  defers with its own divergence test. The family's **recognition-agreement** gap reaches the
-  attribute-list spelling too, and the token is what makes it visible: an attribute-list
-  delimiter *inside* the span (`xref:sec[a *b, c* d,role=hl]`) ends the replacer's positional
-  value inside a tag — `a <strong>b</a>`, improperly nested markup no tree can represent — where
-  the token carries none of the `,` / `=` / `"` the split reads and the span stays whole. That is
-  the quotes step's crossed delimiters again, and it is pinned by its own test rather than
-  deferred: the same comma without a named attribute beside it has no attribute list to split at
-  all, and is at parity through the plain-text path. Deciding it means making the same tokened parse the builder
+  defers with its own divergence test.
+
+  The token is also what makes the *split* reproducible — a bracket's `,` / `=` / `"` are the
+  only bytes it reads, and a placeholder carries none of them — but the replacer splits over the
+  piece's own **markup**, which may: `xref:sec[a *b, c* d,role=hl]` renders
+  `a <strong>b, c</strong> d`, whose list splits at the comma *inside* the tag and ends the
+  anchor there. Rather than guess at that from the bytes — an ordinary `*bold*` hides nothing,
+  while `[.r]#x#` renders a `"` and an `=` the split reads harmlessly — the gate asks the parser:
+  [`tokened_split_agrees`](../../parser/src/content/inline_builder/macros/mod.rs) parses the
+  tokened text *and* the restored markup and compares them attribute by attribute, expanding the
+  tokened side's tokens first, so a split that moved shows up as a value that differs. Where the
+  two readings differ about the match's own extent the match is **deferred**, not recognized and
+  pinned: the tree never claims a construct the rendered document does not agree with. Deciding it means making the same tokened parse the builder
   makes, in the gate — which is where this family's contract puts every deferral ("both builders
   claim every shape they are handed"), and where it already re-derives the shorthand's own comma
   split for the same reason.
@@ -6075,9 +6080,11 @@ Each phase is a reviewable unit with a clear exit gate.
        a `Ref{Xref}` carries `attrs: None`, so nothing rides on the list itself. The boundary is
        redrawn per **slot**: a piece reaching the `window=` / `role=` / `xrefstyle=` this family
        reads as a string still defers, decided in the gate where every cross-reference deferral is
-       decided; and the family's recognition-agreement gap reaches this spelling, an attribute-list
-       delimiter inside the span splitting the replacer's own value inside a tag, pinned by its own
-       test. A masked passthrough or STEM in such a text comes along for free. See the step's
+       decided. The token also has to make the *split* reproducible, which it does exactly when no
+       character the split reads is hidden inside a piece — so the gate parses the tokened text and
+       the restored markup and compares them attribute by attribute
+       ([`tokened_split_agrees`](../../parser/src/content/inline_builder/macros/mod.rs)),
+       deferring a match whose two readings differ about its extent. A masked passthrough or STEM in such a text comes along for free. See the step's
        own "landed as" note above. The **image** family's bracket — the one capture with no
        display text to carry — is what remains of the class.
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1,9 +1,14 @@
 //! Auto-link, formal-URL-link, and `link:`/`mailto:` macro recognition.
 
+// Referenced by the doc comments below, whose own rebuild is the one this
+// family reaches through `restored_value_children`; the code no longer calls
+// it directly.
+#[allow(unused_imports)]
+use super::computed_value_children;
 use super::{
-    ComputedSpecials, MacroMatch, MacroMatchKind, computed_value_children,
+    ComputedSpecials, MacroMatch, MacroMatchKind,
     image::{range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
-    macro_text_children, rebuild_macro_level,
+    macro_text_children, rebuild_macro_level, restored_value_children,
 };
 use crate::{
     Parser, Span,
@@ -1684,54 +1689,6 @@ fn text_attrlist<'src>(
         escaped: true,
         restores,
     })
-}
-
-/// Rebuilds a computed display text that still holds
-/// [`tokened_bracket`] tokens as the node's children: each token becomes the
-/// masked node itself, and the bytes around it take
-/// [`computed_value_children`]'s own rebuild.
-///
-/// Splicing the node rather than its bytes is what keeps the fold honest. A
-/// [`Raw`](InlineNode::Raw) leaf's body is emitted verbatim and a
-/// [`Stem`](InlineNode::Stem) leaf's is rendered at fold time — which is
-/// exactly what `Passthroughs::restore_to` splices into the string pipeline's
-/// own display text — where those same bytes spliced into a
-/// [`Text`](InlineNode::Text) would be escaped a second time (design §3.4):
-/// `link:x[++<b>a</b>++,role=hl]` would show `&amp;lt;b&amp;gt;` against the
-/// golden's `&lt;b&gt;`.
-///
-/// The walk is index-keyed and left to right, like
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own: each
-/// token is sought only in the bytes after the previous one, and a token the
-/// parse dropped (a value the split discarded) is simply not found, leaving
-/// the ones after it to splice by their own index.
-fn restored_value_children<'src>(
-    text: &str,
-    restores: &[InlineNode<'src>],
-    location: Span<'src>,
-    specials: ComputedSpecials,
-) -> Vec<InlineNode<'src>> {
-    let mut children: Vec<InlineNode<'src>> = Vec::new();
-    let mut rest = text;
-
-    for (n, node) in restores.iter().enumerate() {
-        let token = format!("\u{96}{n}\u{97}");
-
-        if let Some(pos) = rest.find(&token) {
-            children.append(&mut computed_value_children(
-                rest.get(..pos).unwrap_or_default(),
-                location,
-                specials,
-            ));
-
-            children.push(node.clone());
-            rest = rest.get(pos + token.len()..).unwrap_or_default();
-        }
-    }
-
-    children.append(&mut computed_value_children(rest, location, specials));
-
-    children
 }
 
 /// The bare e-mail auto-link pass at a level: matches [`INLINE_EMAIL`] over the

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -15,7 +15,9 @@ use ui::{kbd_btn_macros_level, menu_macros_level};
 use xref::xref_macros_level;
 
 use super::{
-    quotes::{LevelContext, Piece, emit_range, source_slice, special_entity, text_slice},
+    quotes::{
+        LevelContext, Piece, charref_entity, emit_range, source_slice, special_entity, text_slice,
+    },
     special_chars::{Masked, unescaped_value_children},
 };
 use crate::{
@@ -628,6 +630,159 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
     }
 
     emit_range(nodes, pieces, cursor..range.end, out);
+}
+
+/// Rewrites the **opaque** pieces inside one computed text's own match-string
+/// bytes into index-keyed `\u{96}`*n*`\u{97}` tokens, returning that text
+/// alongside the nodes those tokens stand for.
+///
+/// This is [`tokened_bracket`](image::tokened_bracket)'s counterpart for a
+/// value that is **carried structurally** rather than restored as bytes, and
+/// the two differ in exactly one way. A masked passthrough or STEM expression
+/// has a body known at build time, so `tokened_bracket` pairs each token with
+/// it and the caller can splice those bytes back into a *parsed* value. A
+/// rendered [`Styled`](crate::inlines::Styled) span — or any
+/// earlier-recognized macro node — has no such body: its markup exists only
+/// when the tree is folded. There is still nothing to restore *into bytes*,
+/// but there is something to carry: the **node**. So this tokens every atomic
+/// piece [`build_match_string`](super::quotes::build_match_string) stands in
+/// as one placeholder, whatever kind it is, and the caller splices each node
+/// back through [`restored_value_children`].
+///
+/// Why tokening at all, when the placeholder is already one opaque character:
+/// so the split sees the string pipeline's own **shape** there. The
+/// replacer parses an attribute list over the piece's *markup*, which carries
+/// no `,`/`=`/`"` the split could read differently than it reads a token —
+/// and a bare placeholder, being a single `Co` character, would be
+/// indistinguishable from one *inside* a value once the parse hands that value
+/// back. The token's index is what makes the walk back out
+/// unambiguous, exactly as it is for
+/// [`tokened_bracket`](image::tokened_bracket).
+///
+/// Renumbering is per call, from zero, so a token the parse drops shifts none
+/// of the ones that survive.
+pub(super) fn tokened_text<'src>(
+    text: &str,
+    range: &std::ops::Range<usize>,
+    nodes: &[InlineNode<'src>],
+    pieces: &[Piece],
+) -> (String, Vec<InlineNode<'src>>) {
+    let mut tokened = String::new();
+    let mut carried: Vec<InlineNode<'src>> = Vec::new();
+
+    // Walked **piece by piece** rather than by copying the gaps between the
+    // opaque ones, because a byte of the match string may belong to no piece
+    // at all: `styled_sibling_boundaries` wraps an opaque span's placeholder
+    // in the two characters its own rendering presents to a neighbour (the `<`
+    // and `>` of a tag), which exist for *recognition* and stand for markup
+    // this token already carries whole. Copying them would splice a stray `<`
+    // and `>` into the value beside the node.
+    for piece in pieces {
+        let p_start = piece.s_start;
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the range.
+        if p_end <= range.start || p_start >= range.end {
+            continue;
+        }
+
+        let lo = p_start.max(range.start);
+        let hi = p_end.min(range.end);
+
+        // The pieces that become a token are the **opaque** ones — atomic, and
+        // not one of the three [`CharRef`](InlineNode::CharRef) leaves
+        // [`build_match_string`](super::quotes::build_match_string) gives real
+        // bytes to. Every other piece contributes its own bytes as it stands:
+        // those are the string replacer's bytes there, so the split reads them
+        // identically and the caller's own rebuild
+        // ([`computed_value_children`]) already knows how to unwind them.
+        let opaque = piece
+            .atomic
+            .then(|| nodes.get(piece.node_index))
+            .flatten()
+            .filter(|node| charref_entity(node).is_none());
+
+        match opaque {
+            Some(node) => {
+                tokened.push_str(&format!("\u{96}{n}\u{97}", n = carried.len()));
+                carried.push(node.clone());
+            }
+
+            None => tokened.push_str(
+                text.get(lo.saturating_sub(range.start)..hi.saturating_sub(range.start))
+                    .unwrap_or_default(),
+            ),
+        }
+    }
+
+    if carried.is_empty() {
+        return (text.to_string(), carried);
+    }
+
+    (tokened, carried)
+}
+
+/// Rebuilds a computed value that still holds [`tokened_text`] /
+/// [`tokened_bracket`](image::tokened_bracket) tokens as a node's children:
+/// each token becomes the node it stands for, and the bytes around it take
+/// [`computed_value_children`]'s own rebuild.
+///
+/// Splicing the node rather than its bytes is what keeps the fold honest. A
+/// [`Raw`](InlineNode::Raw) leaf's body is emitted verbatim and a
+/// [`Stem`](InlineNode::Stem) leaf's is rendered at fold time — which is
+/// exactly what `Passthroughs::restore_to` splices into the string pipeline's
+/// own display text — where those same bytes spliced into a
+/// [`Text`](InlineNode::Text) would be escaped a second time (design §3.4):
+/// `link:x[++<b>a</b>++,role=hl]` would show `&amp;lt;b&amp;gt;` against the
+/// golden's `&lt;b&gt;`. A rendered
+/// [`Styled`](crate::inlines::Styled) span has no bytes to splice at all —
+/// its markup exists only at fold time — so for it the node *is* the only
+/// honest reading.
+///
+/// The walk is index-keyed and left to right, like
+/// [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own: each
+/// token is sought only in the bytes after the previous one, and a token the
+/// parse dropped (a value the split discarded) is simply not found, leaving
+/// the ones after it to splice by their own index.
+pub(super) fn restored_value_children<'src>(
+    text: &str,
+    restores: &[InlineNode<'src>],
+    location: Span<'src>,
+    specials: ComputedSpecials,
+) -> Vec<InlineNode<'src>> {
+    let mut children: Vec<InlineNode<'src>> = Vec::new();
+    let mut rest = text;
+
+    for (n, node) in restores.iter().enumerate() {
+        let token = format!("\u{96}{n}\u{97}");
+
+        if let Some(pos) = rest.find(&token) {
+            children.append(&mut computed_value_children(
+                rest.get(..pos).unwrap_or_default(),
+                location,
+                specials,
+            ));
+
+            children.push(node.clone());
+            rest = rest.get(pos + token.len()..).unwrap_or_default();
+        }
+    }
+
+    children.append(&mut computed_value_children(rest, location, specials));
+
+    children
+}
+
+/// Whether `value` — one attribute the parse handed back — still holds a
+/// [`tokened_text`] token, which means an opaque piece landed in a value the
+/// caller reads as a **string** rather than carrying structurally.
+///
+/// A node has no bytes there, so such a match is deferred. This is the same
+/// per-*slot* boundary
+/// [`text_attrlist`](links)'s own `pre_restore` draws, reached for the
+/// stronger reason: a masked construct at least has a body to splice.
+pub(super) fn holds_carried_token(value: &str) -> bool {
+    value.contains('\u{96}')
 }
 
 /// Rebuilds a value the macros step **computed** off the level's match string

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -22,6 +22,7 @@ use super::{
 };
 use crate::{
     Parser, Span,
+    attributes::{Attrlist, AttrlistContext},
     content::restored_entity_pattern,
     inlines::{CharRef, InlineNode},
     strings::CowStr,
@@ -72,7 +73,7 @@ pub(super) enum ComputedSpecials {
 /// (`doc@example.org`), replacing each with an
 /// [`Image`](InlineNode::Image), [`Ui`](InlineNode::Ui), or
 /// [`Ref`](InlineNode::Ref) node. An image node carries its own owned
-/// [`Attrlist`](crate::attributes::Attrlist) — the step that makes a macro node
+/// [`Attrlist`] — the step that makes a macro node
 /// *self-describing*, so the fold reconstructs the render parameters and calls
 /// the same `render_image`/`render_icon` the string step calls; a UI node
 /// carries the keys / label / menu path the string replacer computed, so its
@@ -147,7 +148,7 @@ pub(super) enum ComputedSpecials {
 /// its own child with no gate at all. What keeps
 /// the stricter gate is never a *family* now, only the one **capture** that
 /// must ride on the node as a real
-/// [`Attrlist`](crate::attributes::Attrlist)`<'src>`, parsed from the source's
+/// [`Attrlist`]`<'src>`, parsed from the source's
 /// own bytes: a link's attribute-list-bearing display text and an image's
 /// non-empty bracket (a cross-reference's own attribute list is parsed from a
 /// normalized *copy*, so it takes both lifts). The auto-link family
@@ -722,6 +723,92 @@ pub(super) fn tokened_text<'src>(
     (tokened, carried)
 }
 
+/// The bytes the **string replacer's own haystack** holds for a text
+/// [`tokened_text`] tokened: each token replaced by what the fold of the node
+/// it stands for emits, with the parser's own renderer — the renderer the
+/// string pipeline ran.
+///
+/// This is the other half of the token's contract. Tokening is what makes the
+/// attribute-list *split* reproducible: a bracket's `,` / `=` / `"` are the
+/// only bytes it reads, and an opaque piece's placeholder carries none of
+/// them. But the replacer splits over the piece's own **markup**, which may:
+/// `xref:sec[a *b, c* d,role=hl]` renders `a <strong>b, c</strong> d`, and its
+/// list splits at the comma *inside* the tag. A caller compares the two
+/// parses to find out (see [`tokened_split_agrees`]).
+pub(super) fn restored_markup_text(
+    tokened: &str,
+    carried: &[InlineNode<'_>],
+    parser: &Parser,
+) -> String {
+    let mut out = tokened.to_string();
+
+    for (n, node) in carried.iter().enumerate() {
+        let markup =
+            super::fold::fold_html(std::slice::from_ref(node), parser.renderer.as_ref(), parser);
+
+        out = out.replace(&format!("\u{96}{n}\u{97}"), &markup);
+    }
+
+    out
+}
+
+/// Whether an attribute list parsed from a [`tokened_text`] text splits the
+/// same way the string replacer's own parse of the **markup** does.
+///
+/// A token stands in for markup the replacer really sees, so the two parses
+/// agree exactly when no character the split reads is hidden inside a piece.
+/// Rather than guess at that from the bytes — an ordinary `*bold*` hides
+/// nothing, while `[.r]#x#` renders a `"` and an `=` that the split
+/// nonetheless reads harmlessly — this asks the parser: it compares the two
+/// lists attribute by attribute, expanding the tokened side's tokens first, so
+/// a split that moved shows up as a value that differs.
+///
+/// It answers only the *split*, not what the caller then does with each value.
+/// A token reaching a value the caller reads as a **string** — a
+/// cross-reference's `window=` / `role=` / `xrefstyle=` — splits identically
+/// on both sides and still has no bytes the caller can use, so a caller with
+/// such a slot asks [`holds_carried_token`] about it as well.
+pub(super) fn tokened_split_agrees(
+    tokened: &str,
+    carried: &[InlineNode<'_>],
+    parser: &Parser,
+) -> bool {
+    let restored = restored_markup_text(tokened, carried, parser);
+
+    let tokened_attrs = Attrlist::parse(Span::new(tokened), parser, AttrlistContext::Inline)
+        .item
+        .item;
+
+    let restored_attrs = Attrlist::parse(Span::new(&restored), parser, AttrlistContext::Inline)
+        .item
+        .item;
+
+    let tokened_list: Vec<_> = tokened_attrs.attributes().collect();
+    let restored_list: Vec<_> = restored_attrs.attributes().collect();
+
+    tokened_list.len() == restored_list.len()
+        && tokened_list
+            .iter()
+            .zip(restored_list.iter())
+            .all(|(tokened_attr, restored_attr)| {
+                tokened_attr.name() == restored_attr.name()
+                    && restored_markup_text(tokened_attr.value(), carried, parser)
+                        == restored_attr.value()
+            })
+}
+
+/// Whether `value` — one attribute the parse handed back — still holds a
+/// [`tokened_text`] token, which means an opaque piece landed in a value the
+/// caller reads as a **string** rather than carrying structurally.
+///
+/// A node has no bytes there, so such a match is deferred. This is the same
+/// per-*slot* boundary [`text_attrlist`](links)'s own `pre_restore` draws,
+/// reached for the stronger reason: a masked construct at least has a body to
+/// splice.
+pub(super) fn holds_carried_token(value: &str) -> bool {
+    value.contains('\u{96}')
+}
+
 /// Rebuilds a computed value that still holds [`tokened_text`] /
 /// [`tokened_bracket`](image::tokened_bracket) tokens as a node's children:
 /// each token becomes the node it stands for, and the bytes around it take
@@ -773,25 +860,13 @@ pub(super) fn restored_value_children<'src>(
     children
 }
 
-/// Whether `value` — one attribute the parse handed back — still holds a
-/// [`tokened_text`] token, which means an opaque piece landed in a value the
-/// caller reads as a **string** rather than carrying structurally.
-///
-/// A node has no bytes there, so such a match is deferred. This is the same
-/// per-*slot* boundary
-/// [`text_attrlist`](links)'s own `pre_restore` draws, reached for the
-/// stronger reason: a masked construct at least has a body to splice.
-pub(super) fn holds_carried_token(value: &str) -> bool {
-    value.contains('\u{96}')
-}
-
 /// Rebuilds a value the macros step **computed** off the level's match string
 /// as the children a node shows, taking whichever half of design §3.4.1
 /// `specials` names.
 ///
 /// A computed value is the one thing this step reads as *bytes* rather than
 /// carrying structurally: it comes back from an
-/// [`Attrlist`](crate::attributes::Attrlist) parse, so there is no range of
+/// [`Attrlist`] parse, so there is no range of
 /// nodes to rebuild it from and its classification has to be re-derived from
 /// the bytes themselves. What those bytes are worth is exactly what
 /// [`ComputedSpecials`] answers — see its two halves,

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -726,7 +726,8 @@ pub(super) fn tokened_text<'src>(
 /// The bytes the **string replacer's own haystack** holds for a text
 /// [`tokened_text`] tokened: each token replaced by what the fold of the node
 /// it stands for emits, with the parser's own renderer — the renderer the
-/// string pipeline ran.
+/// string pipeline ran. A **masked** construct's token is left alone: the
+/// replacer's own haystack holds a sentinel there too.
 ///
 /// This is the other half of the token's contract. Tokening is what makes the
 /// attribute-list *split* reproducible: a bracket's `,` / `=` / `"` are the
@@ -743,6 +744,16 @@ pub(super) fn restored_markup_text(
     let mut out = tokened.to_string();
 
     for (n, node) in carried.iter().enumerate() {
+        // A **masked** construct is left as its token. The replacer's haystack
+        // holds its own `\u{96}`*n*`\u{97}` sentinel there — not the body,
+        // which `Passthroughs::restore_to` splices only after every step has
+        // run — so the two sides already agree on those bytes, and expanding
+        // one here would compare the tokened split against a string the
+        // replacer never split.
+        if image::node_is_restorable(node) {
+            continue;
+        }
+
         let markup =
             super::fold::fold_html(std::slice::from_ref(node), parser.renderer.as_ref(), parser);
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1,8 +1,14 @@
 //! Cross-reference recognition (`xref:id[…]`, `<<id>>`).
 
+// Referenced by the doc comments below, whose own rebuild is the one this
+// family reaches through `restored_value_children`; the code no longer calls
+// it directly.
+#[allow(unused_imports)]
+use super::computed_value_children;
 use super::{
-    ComputedSpecials, MacroMatch, MacroMatchKind, computed_value_children,
+    ComputedSpecials, MacroMatch, MacroMatchKind, holds_carried_token,
     image::range_has_no_opaque_piece, macro_text_children, rebuild_macro_level,
+    restored_value_children, tokened_text,
 };
 use crate::{
     Parser, Span,
@@ -248,14 +254,28 @@ fn find_xref_matches<'src>(
                 #[allow(clippy::unwrap_used)]
                 let target = caps.get(3).unwrap();
 
-                // A text carrying an `=` is read as an attribute list, whose
-                // parsed positional value no placeholder can be mapped back
-                // out of, so that one text shape keeps the gate too.
+                // A text carrying an `=` is read as an attribute list. Its
+                // *positional* value becomes the node's children, so an opaque
+                // piece there is carried as the node itself
+                // ([`tokened_text`]); a piece reaching one of the three values
+                // this family reads as a **string** — a `window=`, a `role=`,
+                // an `xrefstyle=` — has no bytes to be read as, and that shape
+                // alone keeps the gate. Deciding it means performing the same
+                // tokened parse the builder performs, on the same bytes: this
+                // gate already re-derives the shorthand's own comma split for
+                // the same reason.
                 let attrlist_text = caps.get(4).filter(|text| text.as_str().contains('='));
 
                 range_has_no_opaque_piece(nodes, pieces, &(target.start()..target.end()))
                     && attrlist_text.is_none_or(|text| {
                         range_has_no_opaque_piece(nodes, pieces, &(text.start()..text.end()))
+                            || attrlist_text_carries_its_opaque_pieces(
+                                text.as_str(),
+                                &(text.start()..text.end()),
+                                nodes,
+                                pieces,
+                                parser,
+                            )
                     })
             }
         };
@@ -306,6 +326,69 @@ fn find_xref_matches<'src>(
     }
 
     matches
+}
+
+/// Whether an attribute-list display text enclosing an opaque piece can be
+/// **carried** — the one thing [`find_xref_matches`]'s gate still asks of such
+/// a text.
+///
+/// A [`Ref`]`{Xref}` node holds no [`Attrlist`] of its own: its display text
+/// becomes children, and its `window` / `role` / `xrefstyle` are plain strings
+/// read off the parse. So the boundary is drawn per **slot** rather than per
+/// family, exactly as [`text_attrlist`](super::links)'s own `pre_restore` draws
+/// it — a token in the positional value is a node the caller splices back
+/// ([`restored_value_children`]), while a token in any of the three computed
+/// values names markup that exists only at fold time where a string is needed,
+/// and the whole match is left literal.
+///
+/// The tokened parse this makes is the same one
+/// [`xref_macro_text`] makes to build, over the same bytes. Re-deriving it
+/// here is what keeps the deferral decision in the gate, where this family's
+/// own contract puts it ("both builders claim every shape they are handed").
+///
+/// Reached only for a text the caller's own
+/// [`range_has_no_opaque_piece`] has already refused, so the tokening below
+/// always produces at least one token; a text carrying none would answer
+/// `true` here, which is what that caller already decided for itself.
+fn attrlist_text_carries_its_opaque_pieces(
+    raw_text: &str,
+    text_range: &std::ops::Range<usize>,
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+    parser: &Parser,
+) -> bool {
+    let (tokened, _carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
+
+    let attrlist = Attrlist::parse(Span::new(&tokened), parser, AttrlistContext::Inline)
+        .item
+        .item;
+
+    // An incidental `=` (the parse finds no named attribute) leaves the whole
+    // text as the sole positional value, which the builder then rebuilds as
+    // plain text through [`macro_text_children`] — a path that carries any
+    // node structurally already.
+    let named_attributes_split = attrlist
+        .nth_attribute(1)
+        .is_none_or(|first| first.value() != tokened);
+
+    if !named_attributes_split {
+        return true;
+    }
+
+    let window_is_clean = attrlist
+        .named_attribute("window")
+        .is_none_or(|a| !holds_carried_token(a.value()));
+
+    let xrefstyle_is_clean = attrlist
+        .named_attribute("xrefstyle")
+        .is_none_or(|a| !holds_carried_token(a.value()));
+
+    let roles_are_clean = !attrlist
+        .roles()
+        .iter()
+        .any(|role| holds_carried_token(role));
+
+    window_is_clean && xrefstyle_is_clean && roles_are_clean
 }
 
 /// The match-string range of a `<<…>>` shorthand's **id half**: its inner up to
@@ -426,7 +509,20 @@ fn xref_macro_text<'src>(
     }
 
     if raw_text.contains('=') {
-        let normalized = raw_text.replace('\n', " ");
+        // Tokened before the parse, so an opaque piece the text encloses reads
+        // to the split as the one indivisible run the string replacer's own
+        // markup is there (see [`tokened_text`]). A text enclosing none comes
+        // back byte-identical, which is every list that was already at parity.
+        #[allow(clippy::unwrap_used)]
+        let text_range = text_span.unwrap();
+
+        let (normalized, carried) = tokened_text(
+            &raw_text.replace('\n', " "),
+            &(text_range.start()..text_range.end()),
+            nodes,
+            pieces,
+        );
+
         let attrlist = Attrlist::parse(Span::new(&normalized), parser, AttrlistContext::Inline)
             .item
             .item;
@@ -451,12 +547,6 @@ fn xref_macro_text<'src>(
             let children = match first.filter(|s| !s.is_empty()) {
                 None => vec![],
                 Some(text) => {
-                    // `text_span` is always `Some` here: it is `None` only
-                    // when `raw_text` is empty, which returns above before
-                    // reaching this branch.
-                    #[allow(clippy::unwrap_used)]
-                    let span = text_span.unwrap();
-
                     // The parsed positional attribute is a synthesized value
                     // with no `'src` slice of its own (it comes from the
                     // normalized, attrlist-parsed copy, not the source
@@ -464,9 +554,13 @@ fn xref_macro_text<'src>(
                     // span (design §4.4), mirroring the synthesized-value
                     // location policy `apply_attribute_references` already
                     // establishes.
-                    let location = source_slice(pieces, span.start()..span.end(), root);
+                    let location = source_slice(pieces, text_range.start()..text_range.end(), root);
 
-                    computed_value_children(&text, location, specials)
+                    // Each token this value still holds becomes the node it
+                    // stands for, so an enclosed span is carried as the
+                    // construct itself and rendered at fold time; the bytes
+                    // around it take the same rebuild a token-free value does.
+                    restored_value_children(&text, &carried, location, specials)
                 }
             };
 
@@ -681,6 +775,35 @@ mod tests {
             InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => reference,
 
             other => panic!("expected an xref Ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scratch_probe2() {
+        for fixture in [
+            "See xref:sec[*bold*,role=hl].",
+            "xref:sec[*bold*,role=hl]",
+            "xref:sec[*a* b,window=_blank]",
+            "xref:sec[*a*,xrefstyle=full]",
+            "xref:sec[a *b* c,role=hl]",
+            "xref:sec[`code`,role=hl]",
+            "xref:sec[*a*]",
+            "xref:sec[*a*,role=*b*]",
+            "xref:sec[*a*,window=*b*]",
+            "xref:sec[++<b>x</b>++,role=hl]",
+            "xref:sec[*a*,role=hl,window=_blank]",
+            "xref:sec[a &copy; *b*,role=hl]",
+            "xref:sec[a < *b*,role=hl]",
+            "xref:sec[*a*\nb,role=hl]",
+            "xref:sec[image:x.png[]]",
+            "<<sec,*bold*>>",
+        ] {
+            let folded = fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {});
+            let gold = golden_xref(fixture);
+            println!(
+                "{fixture:?}\n  tree = {folded:?}\n  gold = {gold:?}\n  {}",
+                if folded == gold { "OK" } else { "DIVERGE" }
+            );
         }
     }
 
@@ -1643,24 +1766,108 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_text_crossing_a_rendered_span_is_a_documented_divergence() {
-        // The one text shape that keeps the stricter gate. A text carrying an
-        // `=` is read as an attribute list, and its display text comes back
-        // from that *parse* rather than from a range of the match string — so
-        // a placeholder inside the parsed value has no node to map back to,
-        // exactly as the image and link families' own `Attrlist`-bearing
-        // captures cannot be rebuilt from one. The reference is therefore left
-        // unrecognized where the string pipeline builds one over the markup.
-        let source = "xref:sec[*bold*,role=hl]";
-        let nodes = build_src(Span::new(source));
+    fn fold_matches_the_string_pipeline_for_an_attribute_list_text_enclosing_a_span() {
+        // The text shape that used to keep the stricter gate. A text carrying
+        // an `=` is read as an attribute list, and its display text comes back
+        // from that *parse* rather than from a range — but the value that
+        // parse hands back is the node's **children**, so an enclosed
+        // construct needs no bytes: it is tokened before the split
+        // ([`tokened_text`]) and spliced back as the node itself
+        // ([`restored_value_children`]).
+        for fixture in [
+            // The golden spelling, alone and in flow.
+            "xref:sec[*bold*,role=hl]",
+            "See xref:sec[*bold*,role=hl].",
+            // The span at either edge and in the middle of the text.
+            "xref:sec[*a* b,role=hl]",
+            "xref:sec[a *b*,role=hl]",
+            "xref:sec[a *b* c,role=hl]",
+            // Each of the three named attributes this family reads, with the
+            // span in the *positional* value beside it.
+            "xref:sec[*a* b,window=_blank]",
+            "xref:sec[*a* b,xrefstyle=full]",
+            "xref:sec[*a* b,role=hl,window=_blank]",
+            // Other span kinds, and two spans in one text.
+            "xref:sec[`code` here,role=hl]",
+            "xref:sec[[.r]#x# here,role=hl]",
+            "xref:sec[*a* and _b_,role=hl]",
+            // Beside the recoverable pieces the text already carried: an
+            // escaped special, a restored entity, a typographic replacement.
+            "xref:sec[a < *b*,role=hl]",
+            "xref:sec[a &copy; *b*,role=hl]",
+            "xref:sec[a (C) *b*,role=hl]",
+            // A newline the parse's own normalization collapses, on either
+            // side of the span.
+            "xref:sec[*a*\nb,role=hl]",
+            // An `=` the parse finds **incidental** — no attribute name can
+            // hold the spaces before it, so the whole text stays the sole
+            // positional value and the builder falls through to its plain-text
+            // path, which has carried an opaque piece structurally all along.
+            "xref:sec[a *b* c=d]",
+            "xref:sec[*b* c=d]",
+            // The shorthand spelling is unchanged: its reference text never
+            // carried an attribute list at all.
+            "<<sec,*bold*>>",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {}),
+                golden_xref(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "an attribute-list text crossing a rendered span must be left unrecognized: {nodes:?}"
-        );
+    #[test]
+    fn an_attribute_list_text_enclosing_a_span_carries_it_as_children() {
+        // The shape behind the parity above: the enclosed span itself is a
+        // child, not the markup it will fold to, and the named attributes the
+        // parse split off still reach the node's own plain fields.
+        let nodes = build_src(Span::new("xref:sec[*bold* here,role=hl]"));
 
-        // The string pipeline, by contrast, does build a reference here.
-        assert!(golden_xref(source).contains("<a href"));
+        assert_eq!(nodes.len(), 1);
+        let reference = assert_xref(&nodes[0]);
+
+        assert_eq!(reference.target.as_ref(), "sec");
+        assert_eq!(reference.roles.len(), 1);
+        assert_eq!(reference.roles[0].as_ref(), "hl");
+
+        match &reference.children[..] {
+            [InlineNode::Styled(styled), InlineNode::Text { value, .. }] => {
+                assert_eq!(styled.location.data(), "*bold*");
+
+                // The bytes around the token take the same rebuild every
+                // attribute-list value takes: an owned run off the parse,
+                // whose location is the bracketed text's own coarse span
+                // (design §4.4).
+                assert_eq!(value.as_ref(), " here");
+            }
+
+            other => panic!("expected a span and a text run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_span_in_a_computed_attribute_is_a_documented_divergence() {
+        // The boundary this increment does *not* move, drawn per **slot**: a
+        // `window=`, a `role=`, or an `xrefstyle=` is read as a **string**,
+        // and an enclosed span has no bytes to be read as — its markup exists
+        // only at fold time. The reference is therefore left unrecognized
+        // where the string pipeline builds one over the markup, with the
+        // span's own tags rendered verbatim into the attribute.
+        for source in [
+            "xref:sec[*a*,role=*b*]",
+            "xref:sec[a,window=*b*]",
+            "xref:sec[a,xrefstyle=*b*]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a span in a computed attribute must be left unrecognized: {nodes:?}"
+            );
+
+            assert!(golden_xref(source).contains("<a href"));
+        }
     }
 
     #[test]
@@ -2165,5 +2372,67 @@ mod tests {
             rendered,
             "the block's tree must fold to its own rendered string"
         );
+    }
+
+    #[test]
+    fn a_real_documents_attribute_listed_xref_text_over_a_span_reaches_its_tree() {
+        // End-to-end, through the real parse path, on the shape that named this
+        // increment: an attribute-list reference text enclosing a rendered
+        // span. The block's tree folds to the rendered string byte-for-byte —
+        // the span's markup written once, by the fold — and carries the
+        // reference as a node rather than the literal macro it used to. Driven
+        // in block content and in a heading's own title, whose `Title` group
+        // runs the same macros step.
+        use crate::blocks::{Block, FindBlocks, IsBlock};
+
+        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+            "[#install]\n",
+            "== See xref:install[the *bold* steps,role=hl]\n",
+            "\n",
+            "See xref:install[the *bold* steps,role=hl] for details.\n",
+        ));
+
+        let block = doc
+            .descendant_blocks()
+            .find(|b| {
+                b.rendered_html_content()
+                    .is_some_and(|c| c.contains("for details"))
+            })
+            .unwrap();
+
+        let rendered = block.rendered_html_content().unwrap();
+        let inlines = block.inlines().unwrap();
+
+        assert!(
+            rendered.contains(r#"class="hl""#) && rendered.contains("<strong>bold</strong>"),
+            "rendered: {rendered}"
+        );
+
+        assert_eq!(
+            fold_html(inlines, &HtmlSubstitutionRenderer {}),
+            rendered,
+            "the block's tree must fold to its own rendered string"
+        );
+
+        let mut folded_titles = 0;
+
+        for block in doc.descendant_blocks() {
+            let Block::Section(section) = block else {
+                continue;
+            };
+
+            assert_eq!(
+                fold_html(
+                    section.section_title_inlines(),
+                    &HtmlSubstitutionRenderer {}
+                ),
+                section.section_title(),
+                "fold diverged from the rendered section title"
+            );
+
+            folded_titles += 1;
+        }
+
+        assert_eq!(folded_titles, 1, "expected the heading to carry a tree");
     }
 }

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -8,7 +8,7 @@ use super::computed_value_children;
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind, holds_carried_token,
     image::range_has_no_opaque_piece, macro_text_children, rebuild_macro_level,
-    restored_value_children, tokened_text,
+    restored_value_children, tokened_split_agrees, tokened_text,
 };
 use crate::{
     Parser, Span,
@@ -350,6 +350,9 @@ fn find_xref_matches<'src>(
 /// [`range_has_no_opaque_piece`] has already refused, so the tokening below
 /// always produces at least one token; a text carrying none would answer
 /// `true` here, which is what that caller already decided for itself.
+///
+/// It also refuses a match whose two readings disagree about its extent — see
+/// [`tokened_split_agrees`].
 fn attrlist_text_carries_its_opaque_pieces(
     raw_text: &str,
     text_range: &std::ops::Range<usize>,
@@ -357,7 +360,13 @@ fn attrlist_text_carries_its_opaque_pieces(
     pieces: &[Piece],
     parser: &Parser,
 ) -> bool {
-    let (tokened, _carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
+    let (tokened, carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
+
+    // The split must land where the string replacer's own parse of the markup
+    // lands — otherwise the two disagree about the match's very extent.
+    if !tokened_split_agrees(&tokened, &carried, parser) {
+        return false;
+    }
 
     let attrlist = Attrlist::parse(Span::new(&tokened), parser, AttrlistContext::Inline)
         .item
@@ -375,6 +384,8 @@ fn attrlist_text_carries_its_opaque_pieces(
         return true;
     }
 
+    // And no token may reach one of the three values this family reads as a
+    // **string**: a node has no bytes there.
     let window_is_clean = attrlist
         .named_attribute("window")
         .is_none_or(|a| !holds_carried_token(a.value()));
@@ -1818,48 +1829,44 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_delimiter_inside_a_span_is_a_documented_divergence() {
-        // The recognition-agreement gap this spelling inherits, and the same
-        // one the plain reference text already documents: the string replacer
-        // splits its attribute list over the span's **markup**, where this
-        // splits over one token that carries none of the `,` / `=` / `"` the
-        // split reads. A comma inside a span therefore ends the replacer's
-        // positional value *inside* a tag — it renders `a <strong>b</a>`,
-        // improperly nested markup no tree can represent — where the builder
-        // keeps the span whole. It is the quotes step's crossed delimiters
-        // again: the markup-perturbed reading against the tree's well-formed
-        // one, and this is the shape that pins it.
+    fn an_attribute_list_delimiter_inside_a_span_defers_the_match() {
+        // The token is what makes the split reproducible — a bracket's `,` /
+        // `=` / `"` are the only bytes it reads, and a placeholder carries
+        // none of them. But the string replacer splits over the piece's own
+        // **markup**, which may: `a *b, c* d` renders `a <strong>b, c</strong>
+        // d`, whose list splits at the comma *inside* the tag, ending the
+        // anchor there. Where the two readings differ about the match's own
+        // extent the match is **deferred** rather than recognized, so the tree
+        // never claims a construct the rendered document does not agree with.
         for source in [
             "xref:sec[a *b, c* d,role=hl]",
             "xref:sec[a `b, c` d,role=hl]",
         ] {
-            let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
-            let golden = golden_xref(source);
+            let nodes = build_src(Span::new(source));
 
-            assert_ne!(
-                folded, golden,
-                "expected the documented divergence to still reproduce; the boundary may have \
-                 been lifted — if so, fold this fixture into the parity corpus above"
-            );
-
-            // The builder keeps the span whole and the named attribute it
-            // split off; the string pipeline cuts the anchor short inside the
-            // span's own opening tag.
-            assert!(folded.contains(r#"class="hl""#), "{folded:?}");
             assert!(
-                golden.contains("</a>") && !golden.contains(" d</a>"),
-                "{golden:?}"
+                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
+                "a hidden attribute-list delimiter must defer the match: {nodes:?}"
             );
+
+            // The string pipeline does build one — cut short inside the span.
+            assert!(golden_xref(source).contains("<a href"));
         }
 
-        // Without a *named* attribute to split off, there is no attribute list
-        // at all — the `=`/`,` probe finds the whole text is one positional
-        // value — so the same comma is at parity through the plain-text path.
-        let source = "xref:sec[a *b, c* d]";
-        assert_eq!(
-            fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
-            golden_xref(source)
-        );
+        // The boundary of the class, from both sides. Without a *named*
+        // attribute to split off there is no attribute list at all, so the
+        // same comma is at parity through the plain-text path; and a span
+        // whose markup carries no delimiter is recognized however many
+        // quotes and equals signs its own rendering holds
+        // (`[.r]#x#` renders a `"` and an `=` the split reads harmlessly),
+        // which is why the test is the two parses rather than the bytes.
+        for source in ["xref:sec[a *b, c* d]", "xref:sec[[.r]#x# here,role=hl]"] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_xref(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -779,35 +779,6 @@ mod tests {
     }
 
     #[test]
-    fn scratch_probe2() {
-        for fixture in [
-            "See xref:sec[*bold*,role=hl].",
-            "xref:sec[*bold*,role=hl]",
-            "xref:sec[*a* b,window=_blank]",
-            "xref:sec[*a*,xrefstyle=full]",
-            "xref:sec[a *b* c,role=hl]",
-            "xref:sec[`code`,role=hl]",
-            "xref:sec[*a*]",
-            "xref:sec[*a*,role=*b*]",
-            "xref:sec[*a*,window=*b*]",
-            "xref:sec[++<b>x</b>++,role=hl]",
-            "xref:sec[*a*,role=hl,window=_blank]",
-            "xref:sec[a &copy; *b*,role=hl]",
-            "xref:sec[a < *b*,role=hl]",
-            "xref:sec[*a*\nb,role=hl]",
-            "xref:sec[image:x.png[]]",
-            "<<sec,*bold*>>",
-        ] {
-            let folded = fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {});
-            let gold = golden_xref(fixture);
-            println!(
-                "{fixture:?}\n  tree = {folded:?}\n  gold = {gold:?}\n  {}",
-                if folded == gold { "OK" } else { "DIVERGE" }
-            );
-        }
-    }
-
-    #[test]
     fn fold_matches_the_string_pipeline_through_xrefs() {
         // For each fixture, folding the single-pass tree (all five steps)
         // reproduces the string pipeline's output byte-for-byte. This is the
@@ -1844,6 +1815,51 @@ mod tests {
 
             other => panic!("expected a span and a text run, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn an_attribute_list_delimiter_inside_a_span_is_a_documented_divergence() {
+        // The recognition-agreement gap this spelling inherits, and the same
+        // one the plain reference text already documents: the string replacer
+        // splits its attribute list over the span's **markup**, where this
+        // splits over one token that carries none of the `,` / `=` / `"` the
+        // split reads. A comma inside a span therefore ends the replacer's
+        // positional value *inside* a tag — it renders `a <strong>b</a>`,
+        // improperly nested markup no tree can represent — where the builder
+        // keeps the span whole. It is the quotes step's crossed delimiters
+        // again: the markup-perturbed reading against the tree's well-formed
+        // one, and this is the shape that pins it.
+        for source in [
+            "xref:sec[a *b, c* d,role=hl]",
+            "xref:sec[a `b, c` d,role=hl]",
+        ] {
+            let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+            let golden = golden_xref(source);
+
+            assert_ne!(
+                folded, golden,
+                "expected the documented divergence to still reproduce; the boundary may have \
+                 been lifted — if so, fold this fixture into the parity corpus above"
+            );
+
+            // The builder keeps the span whole and the named attribute it
+            // split off; the string pipeline cuts the anchor short inside the
+            // span's own opening tag.
+            assert!(folded.contains(r#"class="hl""#), "{folded:?}");
+            assert!(
+                golden.contains("</a>") && !golden.contains(" d</a>"),
+                "{golden:?}"
+            );
+        }
+
+        // Without a *named* attribute to split off, there is no attribute list
+        // at all — the `=`/`,` probe finds the whole text is one positional
+        // value — so the same comma is at parity through the plain-text path.
+        let source = "xref:sec[a *b, c* d]";
+        assert_eq!(
+            fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1787,6 +1787,12 @@ mod tests {
             // path, which has carried an opaque piece structurally all along.
             "xref:sec[a *b* c=d]",
             "xref:sec[*b* c=d]",
+            // (A **masked** construct in the same text is exercised against
+            // the *whole* pipeline instead — `golden_xref` deliberately skips
+            // the passthrough-extraction pass, so the two sides would read
+            // different text here. See
+            // `fold_matches_the_real_pipeline_for_a_masked_construct_in_an_attribute_list_text`.)
+            //
             // The shorthand spelling is unchanged: its reference text never
             // carried an attribute list at all.
             "<<sec,*bold*>>",

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -156,8 +156,8 @@
 //!   entity's own bytes, and a replacement's built-in rendering
 //!   ([`replacement_entity`](quotes::replacement_entity)), which are the
 //!   string pipeline's own haystack bytes there. The
-//!   one capture still holding that boundary in these families is a display text
-//!   carrying an attribute list, parsed as a real
+//!   one capture still holding that boundary in the two **link** families is a
+//!   display text carrying an attribute list, parsed as a real
 //!   [`Attrlist`]`<'src>` from the source's own
 //!   bytes rather than the escaped copy the replacer parses; the auto-link
 //!   family keeps one narrower deferral of its own, a **bare URL whose
@@ -183,9 +183,17 @@
 //!   over one placeholder, which leaves a handful of documented divergences of
 //!   extent (a `]` or a `&gt;&gt;` inside the span, markup carrying the
 //!   replacer's own attribute-list `=`/`,` probe beside a comma), each the
-//!   markup-perturbed reading against the tree's well-formed one. An image's
-//!   attribute list — the one capture with no display text to carry — still
-//!   defers it outright. An anchor
+//!   markup-perturbed reading against the tree's well-formed one. A
+//!   **cross-reference** carries it through its *attribute-list* text too
+//!   (`xref:sec[*bold*,role=hl]`): the value that parse hands back becomes the
+//!   node's children, so each opaque piece is tokened before the split
+//!   ([`tokened_text`](macros::tokened_text)) and spliced back as the node
+//!   itself ([`restored_value_children`](macros::restored_value_children)).
+//!   The boundary is then drawn per **slot** rather than per family — a piece
+//!   reaching the `window=` / `role=` / `xrefstyle=` this family reads as a
+//!   *string* has no bytes to be read as, and that shape alone defers. An
+//!   image's attribute list — the one capture with no display text to carry —
+//!   still defers it outright. An anchor
 //!   renders from its id alone, so it is recognized whenever that id does not
 //!   cross a rendered span — its character class rules out an escaped special
 //!   entirely. Unlike every other reference-bearing family, an anchor is now
@@ -792,6 +800,7 @@ mod tests {
             "see <<target,Tom & Jerry>> now",
             "xref:other.adoc#frag[Other] doc",
             "xref:target[a < b & c] doc",
+            "xref:target[the *bold* steps,role=hl] doc",
             "link:a&b.html[x] macro",
             "link:index.html[Tom & Jerry] macro",
             "mailto:a&b@example.org[] address",
@@ -1407,6 +1416,15 @@ mod tests {
         // re-renders exactly the markup the string replacer captured.
         assert_parity_with(
             "See xref:{id}[the *bold* steps] and <<{id},a _slanted_ label>> about {product}.",
+            with_xref_attributes,
+        );
+
+        // The same text carrying an **attribute list**, whose parsed positional
+        // value is the node's children too: each opaque piece is tokened before
+        // the split and spliced back as the node itself, while the named
+        // attributes the split takes off reach the node's own plain fields.
+        assert_parity_with(
+            "See xref:{id}[the *bold* steps,role=hl] and xref:{id}[a `code` label,window=_blank].",
             with_xref_attributes,
         );
 
@@ -2039,6 +2057,10 @@ mod tests {
                 // is opaque exactly as it is under the normal one, and the
                 // classification must reach the children it recovered.
                 "xref:sec[a *bold* c] and a < b",
+                // And the same text carrying an attribute list, whose parsed
+                // positional value is tokened before the split and spliced back
+                // as the span's own node.
+                "xref:sec[a *bold* c,role=hl] and a < b",
                 // The same, for the `link:`/`mailto:` macro's own display text
                 // — the second family to carry an opaque piece structurally —
                 // and for the auto-link / formal-URL family's, the third.

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -1437,6 +1437,16 @@ mod tests {
             with_xref_attributes,
         );
 
+        // A **masked** construct in such a text: the string replacer's own
+        // haystack holds a sentinel there too, so the split-agreement check
+        // leaves its token alone rather than comparing the tokened split
+        // against a body the replacer only splices at the very end. Driven
+        // through the whole pipeline, which is the only harness that runs the
+        // passthrough-extraction pass on both sides.
+        assert_parity(
+            "See xref:sec[a ++<b>x</b>++ b,role=hl] and xref:sec[*a* and stem:[x^2],role=hl].",
+        );
+
         // The same lift where the opaque piece is a **masked passthrough** —
         // the one opaque class the string pipeline also holds as a placeholder
         // of its own, since it restores passthroughs only after every step.

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -192,12 +192,15 @@
 //!   The boundary is then drawn per **slot** rather than per family — a piece
 //!   reaching the `window=` / `role=` / `xrefstyle=` this family reads as a
 //!   *string* has no bytes to be read as, and that shape alone defers. The
-//!   recognition-agreement gap above extends here too, and the token is what
-//!   makes it visible: an attribute-list delimiter *inside* the span
-//!   (`xref:sec[a *b, c* d,role=hl]`) ends the replacer's positional value
-//!   inside a tag — improperly nested markup no tree can represent — where the
-//!   token carries none of the `,`/`=`/`"` the split reads and the span stays
-//!   whole. An
+//!   token is what makes the *split* reproducible — a bracket's `,` / `=` / `"`
+//!   are the only bytes it read, and a placeholder carries none of them — but
+//!   the replacer splits over the piece's own **markup**, which may
+//!   (`xref:sec[a *b, c* d,role=hl]` renders `a <strong>b, c</strong> d`,
+//!   whose list splits at the comma inside the tag). So the gate asks the
+//!   parser rather than the bytes: it parses the tokened text *and* the
+//!   restored markup and compares them attribute by attribute
+//!   ([`tokened_split_agrees`](macros::tokened_split_agrees)), deferring the
+//!   match whenever the two readings differ about its extent. An
 //!   image's attribute list — the one capture with no display text to carry —
 //!   still defers it outright. An anchor
 //!   renders from its id alone, so it is recognized whenever that id does not

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -191,7 +191,13 @@
 //!   itself ([`restored_value_children`](macros::restored_value_children)).
 //!   The boundary is then drawn per **slot** rather than per family — a piece
 //!   reaching the `window=` / `role=` / `xrefstyle=` this family reads as a
-//!   *string* has no bytes to be read as, and that shape alone defers. An
+//!   *string* has no bytes to be read as, and that shape alone defers. The
+//!   recognition-agreement gap above extends here too, and the token is what
+//!   makes it visible: an attribute-list delimiter *inside* the span
+//!   (`xref:sec[a *b, c* d,role=hl]`) ends the replacer's positional value
+//!   inside a tag — improperly nested markup no tree can represent — where the
+//!   token carries none of the `,`/`=`/`"` the split reads and the span stays
+//!   whole. An
 //!   image's attribute list — the one capture with no display text to carry —
 //!   still defers it outright. An anchor
 //!   renders from its id alone, so it is recognized whenever that id does not

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -787,6 +787,7 @@ fn shapes_match_across_a_broad_general_purpose_sweep() {
         "see <<target,Tom & Jerry>> now",
         "xref:other.adoc#frag[Other] doc",
         "xref:target[a < b & c] doc",
+        "xref:target[the *bold* steps,role=hl] doc",
         "link:a&b.html[x] macro",
         "link:index.html[Tom & Jerry] macro",
         "mailto:a&b@example.org[] address",
@@ -1145,6 +1146,11 @@ fn shapes_match_across_combined_constructs() {
     // recovers from the rendered markup, so the two constructions can finally
     // be compared for this form.
     assert_shapes("See xref:sec[the *bold* steps] and <<sec,a _slanted_ label>> here.");
+
+    // The same text carrying an **attribute list**, whose parsed positional
+    // value is those same children — tokened before the split and spliced back
+    // as the span's own node.
+    assert_shapes("See xref:sec[the *bold* steps,role=hl] here.");
 
     // The `link:`/`mailto:` macro's own version of that lift, the second family
     // to take it — comparable here for the same reason.

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1202,16 +1202,16 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 
 #[test]
 fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
-    // `xref:sec[*bold*,role=hl]` is a documented builder divergence (an
-    // *attribute-list* display text crossing a rendered span is left
-    // unrecognized, since its display text comes back from a parse rather
-    // than from a range the span's node can be recovered out of), so the
-    // tree holds *fewer* cross-reference nodes than the string pipeline
-    // deferred. The positional resolution mirror must detect the count
-    // mismatch and skip — leaving the tree in its honest unresolved state —
-    // rather than assign destinations to the wrong nodes (or panic).
+    // `xref:sec[*bold*,role=*hl*]` is a documented builder divergence (a
+    // rendered span reaching a value this family reads as a **string** — a
+    // `role=`, a `window=`, an `xrefstyle=` — is left unrecognized, since a
+    // span's markup exists only at fold time), so the tree holds *fewer*
+    // cross-reference nodes than the string pipeline deferred. The positional
+    // resolution mirror must detect the count mismatch and skip — leaving the
+    // tree in its honest unresolved state — rather than assign destinations to
+    // the wrong nodes (or panic).
     let mut parser = Parser::default().with_inline_tree(true);
-    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=hl].");
+    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=*hl*].");
 
     // The rendered output is unaffected (the string pipeline is
     // authoritative), …


### PR DESCRIPTION
The capture the rendered-span class left behind, closed for the **cross-reference** family.

## The boundary

When that class was closed for the three reference-bearing families, each kept one shape: *a text carrying its own attribute list*, whose display text comes back from an `Attrlist` **parse** rather than from a range of the match string — and a parsed value, the note said, is bytes, which a rendered span has none of until fold time. `xref:sec[*bold*,role=hl]` therefore stayed literal, one of the corpus-wide audit's remaining golden-exercised divergences.

## The lift

The parse hands that value back to become the node's **children**, so it needs no bytes either — only a way to survive the split intact. That is exactly what the restore-the-value class already built for a masked passthrough: `tokened_bracket` puts a bracket into the string pipeline's own *shape* before the parse, and `restored_value_children` re-splits the parsed value on its tokens and splices the masked **node** back in.

The only thing that made a span different was the pairing of each token with a *body*, which `Attrlist::into_owned_restoring` needs and a span cannot supply. A cross-reference needs no such pairing at all: a `Ref{Xref}` carries `attrs: None`, and its `window` / `role` / `xrefstyle` are plain fields read straight off the parse. So:

- a new `tokened_text` tokens **every** opaque piece — a rendered span, an earlier-recognized macro node, a masked passthrough or STEM alike — with no body to pair;
- `restored_value_children`, lifted out of the link family and now shared in `macros/mod.rs`, splices each node into the children.

One detail is this increment's own: `tokened_text` walks the level **piece by piece** rather than copying the gaps between the opaque ones, because a byte of the match string may belong to no piece at all — `styled_sibling_boundaries` wraps an opaque span's placeholder in the two characters its rendering presents to a neighbour, which exist for *recognition* and stand for markup the token already carries whole. Copying them would splice a stray `<` and `>` into the value beside the node.

## What still defers

The boundary is redrawn per **slot**, exactly as `text_attrlist`'s own `pre_restore` draws it: a token reaching the `window=`, `role=`, or `xrefstyle=` this family reads as a *string* names markup that exists only at fold time where a string is needed, so that shape defers with its own divergence test. Deciding it means making the same tokened parse the builder makes, in the gate — which is where this family's contract puts every deferral ("both builders claim every shape they are handed"), and where it already re-derives the shorthand's own comma split for the same reason.

Of the class as a whole, the **image** family's attribute list remains — the one capture with no display text to carry, since its bracket's values are read as strings by `render_image`.

## Tests

Parity reaches the golden spelling alone and in flow, the span at either edge and in the middle of the text, each of the three named attributes beside it, other span kinds and two spans in one text, the recoverable pieces the text already carried (an escaped special, a restored entity, a typographic replacement) beside a span, a collapsed newline, an `=` the parse finds *incidental* (which falls through to the plain-text path that has carried an opaque piece all along), and — reached through the same tokening — a **masked passthrough** or **STEM expression** in such a text, which this family had deferred too.

The formerly pinned divergence becomes a parity test that also asserts the shape: the enclosed span itself as a child, with the named attributes on the node's own fields. Fixtures join the whole-pipeline broad sweep and combined-constructs corpus, the group-parity corpus, and the structural recorder cross-check — which can now compare this form, the recorder having always recovered it structurally. A whole-document test drives the shape end to end through the real parse path, in a paragraph and in a section heading's own title.

`xref_mirror_is_skipped_when_the_tree_defers_a_reference_form` moves to the form that still defers (`role=*hl*`), since its old fixture is now recognized.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — `See xref:sec[*bold*,role=hl].` **gone** from the divergence set; the only additions to it are fixtures this PR introduces (two recorder-sweep entries, whose `rendered` carries the recorder's own markers, and the divergence test's swapped `role=*hl*` form)
- Coverage — diff-neutral; every uncovered region in the changed files is pre-existing or an `other => panic!(…)` fallback arm inside a test assertion. Two dead defensive branches this increment would otherwise have added were removed rather than left untested

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_