### PR TITLE
feat: Recognize a link macro whose own marker is not verbatim (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5167,6 +5167,57 @@ Each phase is a reviewable unit with a clear exit gate.
   body class wanting more than one presented character, the closing character, and the
   character-replacements step's consume-across-levels case — plus the keeps.
 
+  *Step 6 prep landed as (a `link:`/`mailto:` macro whose own marker is not verbatim — the
+  family's last non-verbatim rule):* the one boundary in this module drawn around neither a
+  *piece* nor a *capture* but around the node's own **`location`**. Three passes recognize a
+  link — the auto-link / formal-URL family, the `link:`/`mailto:` macro, and the bare e-mail
+  address — and the string pipeline runs them as three passes over the whole content, so the
+  asset catalog fills in *pass* order rather than document order.
+  [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs) replays
+  that by walking the tree three times, which needs to know which pass built each node; it
+  answered by reading the node's `location` back and asking whether it starts with a literal
+  `link:` / `mailto:`. That made the location load-bearing, so a macro whose own marker is not
+  verbatim source had to be **deferred**: a *wholly* expanded macro (`:m: link:index.html[Docs]`,
+  then `{m}`), one reached through a wholly-synthesized seed, and one written inside markup an
+  earlier step of the same order flattened — three separate documented divergences, each pinned
+  with the same "if this boundary is ever lifted (with a signal that does not depend on the
+  location), fold this fixture into the parity corpus" note.
+
+  The signal is the node's to carry, and Phase 4's whole business is making nodes
+  **self-describing**. [`Ref`](../../parser/src/inlines/ref_node.rs) gains
+  `link_form: Option<`[`LinkForm`](../../parser/src/inlines/ref_node.rs)`>`, set by whichever
+  pass builds the node and `None` for a cross-reference, and the registration walk reads it
+  instead of re-deriving anything. The field earns its place on its own terms rather than as an
+  internal marker: the three spellings render alike but are *written* differently, so a consumer
+  writing AsciiDoc back out needs exactly this to reproduce the source, and one reporting on a
+  document can tell an explicit macro from an automatically-recognized URL — the same kind of
+  fact an [`Image`](../../parser/src/inlines/image.rs)'s `is_icon` and an
+  [`Anchor`](../../parser/src/inlines/anchor.rs)'s `is_bibliography` already carry. With it the
+  `range_is_verbatim` call on the marker is **deleted rather than relaxed**, and the private
+  `link_form` function with it.
+
+  All three formerly pinned divergences become parity tests. What reaches parity is the whole
+  macro from one expansion alone and in flow, the `mailto:` spelling, a macro whose marker and
+  target both come from expansions, one beside the two other link spellings (whose own
+  registration passes run before and after this one), one inside a rendered span, one in a
+  wholly-synthesized seed (a filtered multi-line block), and one inside flattened markup under
+  `subs=quotes,specialcharacters,macros`. A separate corpus drives the **registration order**
+  through the real pipeline on both sides — the thing the location used to be read for —
+  including an expanded macro interleaved with a bare URL and a bare address, so the three-pass
+  order is pinned for the newly-recognized form as it already is for the verbatim one. A
+  structural test asserts the shape: a `Macro`-form node whose `location` is the whole attribute
+  reference, design §4.4's coarse span. The recorder cross-check adds `link_form` to its list of
+  one-sided-richness exemptions, beside `is_icon` and an anchor's `reftext`: all three spellings
+  render to the same `<a …>` markup, which is all the recorder has to recover from.
+  Re-running the corpus-wide fold-parity audit shows both golden-exercised fixtures **gone** from
+  the divergence set and no new divergence; coverage is diff-neutral, and nothing further is
+  wired in.
+
+  With this the `link:`/`mailto:` family draws no boundary the other macro families do not. What
+  remains of the rendered-span class is the **image** family's attribute list, the one capture
+  with no display text to carry; beyond it the remainder is unchanged — the boundary-class halves
+  the sibling increments named, plus the keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6087,6 +6138,24 @@ Each phase is a reviewable unit with a clear exit gate.
        deferring a match whose two readings differ about its extent. A masked passthrough or STEM in such a text comes along for free. See the step's
        own "landed as" note above. The **image** family's bracket — the one capture with no
        display text to carry — is what remains of the class.
+
+     - ✅ **prep (a `link:`/`mailto:` macro whose own marker is not verbatim).** The one boundary
+       in this module drawn around neither a piece nor a capture but around the node's own
+       **`location`**. The string pipeline registers links in *pass* order rather than document
+       order, so
+       [`apply_link_side_effects`](../../parser/src/content/inline_builder/macros/links.rs) walks
+       the tree three times — and it told the passes apart by reading the node's `location` back
+       and asking whether it starts with a literal `link:` / `mailto:`. That made the location
+       load-bearing, deferring every macro whose marker is not verbatim source: a wholly expanded
+       `{m}`, one in a wholly-synthesized seed, and one inside markup an earlier step of the same
+       order flattened. The signal is the node's to carry, which is Phase 4's whole business:
+       [`Ref`](../../parser/src/inlines/ref_node.rs) gains
+       `link_form: Option<`[`LinkForm`](../../parser/src/inlines/ref_node.rs)`>`, set by whichever
+       pass builds it — a fact a consumer writing AsciiDoc back out needs in its own right, like
+       an image's `is_icon` — and the marker's `range_is_verbatim` call is deleted rather than
+       relaxed. All three formerly pinned divergences become parity tests, with a separate corpus
+       driving the three-pass registration order through the real pipeline on both sides; see the
+       step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -700,6 +700,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
             children: vec![InlineNode::Text {
                 value: CowStr::from(loc.data()),

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -736,6 +736,7 @@ mod tests {
     fn resolved_xref_with_signifier(xrefstyle: Option<XrefStyle>) -> InlineNode<'static> {
         InlineNode::Ref(Ref {
             variant: RefVariant::Xref,
+            link_form: None,
             target: CowStr::from("install"),
             children: vec![],
             roles: vec![],

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1299,6 +1299,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
             children: anchor,
             roles: vec![],

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2533,6 +2533,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
             children: image,
             roles: vec![],

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -21,7 +21,7 @@ use crate::{
             special_chars::Masked,
         },
     },
-    inlines::{InlineNode, Ref, RefVariant},
+    inlines::{InlineNode, LinkForm, Ref, RefVariant},
     parser::{InlineSubstitutionRenderer, has_dangerous_scheme},
     strings::CowStr,
 };
@@ -666,6 +666,7 @@ fn build_inline_link_node<'src>(
 
     let node = InlineNode::Ref(Ref {
         variant: RefVariant::Link,
+        link_form: Some(LinkForm::AutoOrFormal),
         target: CowStr::from(target),
         children,
         roles,
@@ -730,8 +731,8 @@ fn build_inline_link_node<'src>(
 /// Like the rest of this additive builder it performs no `register_link` side
 /// effect; [`apply_link_side_effects`] stages that for the cutover, and needs
 /// no angle-specific case — an angle node is `InlineLinkReplacer`'s own pass,
-/// so [`link_form`] already classifies it as
-/// [`AutoOrFormal`](LinkForm::AutoOrFormal) from its `location` and `target`.
+/// so it records the same [`AutoOrFormal`](LinkForm::AutoOrFormal)
+/// [`link_form`](crate::inlines::Ref::link_form) its non-angle sibling does.
 ///
 /// [`InlineLinkReplacer`]: crate::content::macros
 fn build_angle_link_node<'src>(
@@ -818,6 +819,7 @@ fn build_angle_link_node<'src>(
 
     let node = InlineNode::Ref(Ref {
         variant: RefVariant::Link,
+        link_form: Some(LinkForm::AutoOrFormal),
         target: CowStr::from(target),
         children,
         roles: vec![CowStr::from("bare")],
@@ -872,20 +874,18 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// - **Auto-links and formal-URL links** (`https://example.org`, `https://example.org[text]`)
 ///   are matched by a *different* pattern (`INLINE_LINK`, with its bare-URL
 ///   trailing-punctuation handling) and are a separate later increment.
-/// - **A macro whose own `link:`/`mailto:` marker is not verbatim** — a
-///   *wholly* expanded macro (`:m: link:index.html[Docs]`, then `{m}`) — is
-///   deferred. Its target and bracketed text could be read from the match
-///   string like every other value here, but the node's `location` would then
-///   fall back to the expansion's coarse span (design §4.4), and that location
-///   is the very signal [`link_form`] reads to tell this pass's nodes apart
-///   from the other two link passes' when [`apply_link_side_effects`] replays
-///   the string pipeline's own family-pass registration order. A macro whose
-///   marker *is* written in the source (`link:{url}[Docs]`,
-///   `mailto:{addr}[Team]`) keeps an honest location and is recognized.
 ///
-/// Apart from that marker, a [`synthesized`](Piece::synthesized) run is
-/// admitted: the target and display text are read out of the level's match
-/// string, which carries an expanded value's bytes exactly.
+/// A [`synthesized`](Piece::synthesized) run is admitted throughout, the
+/// macro's own `link:`/`mailto:` **marker** included: the target and display
+/// text are read out of the level's match string, which carries an expanded
+/// value's bytes exactly, and only the node's `location` falls back to the
+/// expansion's coarse span (design §4.4). A *wholly* expanded macro
+/// (`:m: link:index.html[Docs]`, then `{m}`) used to defer for that location
+/// alone — it was the signal that told this pass's nodes from the other two
+/// link passes' when [`apply_link_side_effects`] replays the string
+/// pipeline's family-pass registration order — and no longer does: the node
+/// records the spelling itself, on
+/// [`Ref::link_form`](crate::inlines::Ref::link_form).
 ///
 /// An **escaped special** ([`CharRef`](InlineNode::CharRef)`::Special`) is
 /// admitted too, in an attribute-list text as much as anywhere else
@@ -1046,29 +1046,19 @@ fn find_link_macro_matches<'src>(
         // rendered-span note. The `link:`/`mailto:` marker and the brackets
         // need no gate of their own: those bytes are literal, and no atomic
         // piece — a placeholder, or an entity delimited by `&` and `;` — can
-        // supply them. (The marker keeps its own stricter, verbatim gate
-        // below, for `link_form`'s sake; a text carrying an attribute list
-        // has its own gate inside `text_attrlist`, since its display text
-        // comes back from a *parse*: a masked construct is tokened through
-        // that parse and restored after it, a rendered span still deferred.)
+        // supply them. The marker needs no gate of its own either, now that
+        // the node records which spelling built it
+        // ([`Ref::link_form`](crate::inlines::Ref::link_form)) rather than
+        // having it re-derived from `location` — so a *wholly* expanded macro
+        // (`:m: link:index.html[Docs]`, then `{m}`) is recognized, with only
+        // its `location` taking design §4.4's coarse span. A text carrying an
+        // attribute list has its own gate inside `text_attrlist`, since its
+        // display text comes back from a *parse*: a masked construct is
+        // tokened through that parse and restored after it, a rendered span
+        // still deferred.
         if let Some(target) = caps.get(3)
             && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
-            continue;
-        }
-
-        // The macro's own `link:`/`mailto:` marker must be verbatim source, so
-        // the node's `location` still starts with it — the signal
-        // [`link_form`] reads (see [`link_macro_level`]'s own scope note). The
-        // marker runs from the match's start to wherever the target group
-        // begins; one of groups 2 (empty target) and 3 always participates.
-        let marker = full.start
-            ..caps
-                .get(2)
-                .or_else(|| caps.get(3))
-                .map_or(full.end, |m| m.start());
-
-        if !range_is_verbatim(pieces, &marker) {
             continue;
         }
 
@@ -1497,6 +1487,7 @@ pub(super) fn build_link_node<'src>(
 
     Some(InlineNode::Ref(Ref {
         variant: RefVariant::Link,
+        link_form: Some(LinkForm::Macro),
         target: CowStr::from(target),
         children,
         roles,
@@ -1932,6 +1923,7 @@ fn build_email_node<'src>(
 
     InlineNode::Ref(Ref {
         variant: RefVariant::Link,
+        link_form: Some(LinkForm::Email),
         target: CowStr::from(format!("mailto:{address}")),
         children: macro_text_children(address, range, false, nodes, pieces, root),
         roles: vec![],
@@ -1989,14 +1981,13 @@ fn build_email_node<'src>(
 /// registers as `["https://a.example", "b.html"]`, not `["b.html",
 /// "https://a.example"]`), so this function makes **three** passes over the
 /// tree — all auto-link/formal-URL matches first, then all `link:`/`mailto:`
-/// macro matches, then all bare addresses — rather than one. [`link_form`]
-/// tells them apart from the node's own `location` and `target` (a
-/// `link:`/`mailto:` macro's location always starts with its literal prefix,
-/// and only a bare address yields a `mailto:` target without one;
-/// [`inline_link_level`] never builds a node for `INLINE_LINK`'s own
-/// link-macro branch, deferring that whole form to [`link_macro_level`] — see
-/// [`inline_link_level`]'s own doc comment — so this is a reliable,
-/// no-recomputation signal, not a heuristic).
+/// macro matches, then all bare addresses — rather than one.
+/// [`Ref::link_form`](crate::inlines::Ref::link_form) tells them apart: each
+/// pass records the spelling on the node it builds, so this reads a fact
+/// rather than re-deriving one. (It used to be re-derived from the node's
+/// `location` and `target`, which cost this family a deferral — a macro whose
+/// own literal marker was not verbatim source had no location to read — see
+/// [`link_macro_level`]'s own scope note.)
 ///
 /// Recurses into every container a `Ref` node can be nested inside —
 /// [`Styled`](InlineNode::Styled), another [`Ref`](InlineNode::Ref) (a link's
@@ -2013,28 +2004,13 @@ pub(crate) fn apply_link_side_effects(nodes: &[InlineNode<'_>], parser: &Parser)
     register_links_of_form(nodes, parser, LinkForm::Email);
 }
 
-/// Which of the three link-recognizing passes built a
-/// [`Ref`](InlineNode::Ref) node — see [`apply_link_side_effects`]'s own
-/// "Registration order" note.
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum LinkForm {
-    /// An auto-link or formal-URL link, built by [`inline_link_level`].
-    AutoOrFormal,
-
-    /// A `link:`/`mailto:` macro, built by [`link_macro_level`].
-    Macro,
-
-    /// A bare e-mail address, built by [`email_level`].
-    Email,
-}
-
 /// Walks `nodes`, registering only the [`Ref`](InlineNode::Ref)`{Link}` nodes
 /// of the given `form`, in document order.
 fn register_links_of_form(nodes: &[InlineNode<'_>], parser: &Parser, form: LinkForm) {
     for node in nodes {
         match node {
             InlineNode::Ref(reference) => {
-                if reference.variant == RefVariant::Link && link_form(reference) == form {
+                if reference.link_form == Some(form) {
                     parser.register_link(reference.target.to_string());
                 }
 
@@ -2054,25 +2030,6 @@ fn register_links_of_form(nodes: &[InlineNode<'_>], parser: &Parser, form: LinkF
     }
 }
 
-/// Tells which pass built a link [`Ref`](InlineNode::Ref) node from its own
-/// `location` and `target`: only [`link_macro_level`] ever builds a node whose
-/// matched source starts with a literal `link:`/`mailto:` prefix, and — of the
-/// two passes left — only [`email_level`] builds one whose target carries the
-/// `mailto:` scheme ([`inline_link_level`]'s own targets always carry one of
-/// [`INLINE_LINK`]'s `https?`/`file`/`ftp`/`irc` schemes instead). See
-/// [`apply_link_side_effects`]'s own doc comment.
-fn link_form(reference: &Ref<'_>) -> LinkForm {
-    let text = reference.location.data();
-
-    if text.starts_with("link:") || text.starts_with("mailto:") {
-        LinkForm::Macro
-    } else if reference.target.starts_with("mailto:") {
-        LinkForm::Email
-    } else {
-        LinkForm::AutoOrFormal
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
@@ -2086,7 +2043,7 @@ mod tests {
     use crate::{
         HasSpan, Parser, Span,
         content::inline_builder::build,
-        inlines::{CharRef, InlineNode, SpanForm, StyleVariant},
+        inlines::{CharRef, InlineNode, LinkForm, SpanForm, StyleVariant},
         parser::{DefaultPathResolver, HtmlSubstitutionRenderer},
         strings::CowStr,
     };
@@ -6216,9 +6173,9 @@ mod tests {
         // The angle form is `InlineLinkReplacer`'s own branch — the *first* of
         // the three link passes — so it registers alongside (and in source
         // order with) the auto-links and formal-URL links, before any
-        // `link:`/`mailto:` macro. `link_form` reaches that classification with
-        // no angle-specific case: the node's location does not start with a
-        // `link:`/`mailto:` prefix, and its target is not a `mailto:` one.
+        // `link:`/`mailto:` macro. It needs no angle-specific case: the node
+        // records the same `AutoOrFormal` `link_form` its non-angle sibling
+        // does.
         let source = "link:b.html[B] then <https://a.example> then https://c.example";
         let parser = Parser::default().with_catalog_assets(true);
         let nodes = build_with(Span::new(source), &parser);
@@ -6420,6 +6377,11 @@ mod tests {
                 "link:index.html[Docs]",
                 ModificationContext::Anywhere,
             )
+            .with_intrinsic_attribute(
+                "mailto-src",
+                "mailto:team@example.org[Team]",
+                ModificationContext::Anywhere,
+            )
     }
 
     /// The real, public pipeline's output for `source` — the golden for the
@@ -6528,29 +6490,93 @@ mod tests {
     }
 
     #[test]
-    fn a_wholly_expanded_link_macro_is_a_documented_divergence() {
+    fn fold_matches_the_string_pipeline_for_a_wholly_expanded_link_macro() {
         // A `link:`/`mailto:` macro whose own marker comes from the expansion
-        // has no location starting with that marker, and that location is the
-        // signal `link_form` reads to replay the string pipeline's family-pass
-        // registration order. Rather than build a node the side-effect walk
-        // would then mis-attribute, the macro is left literal.
-        //
-        // If this boundary is ever lifted (with a signal that does not depend
-        // on the location), fold this fixture into the parity corpus above.
+        // is recognized now that the node records which spelling built it
+        // ([`Ref::link_form`]) instead of having it re-derived from
+        // `location` — the signal `apply_link_side_effects` reads to replay
+        // the string pipeline's family-pass registration order. Only the
+        // node's `location` takes design §4.4's coarse span. This closes the
+        // divergence `a_wholly_expanded_link_macro_is_a_documented_divergence`
+        // used to pin, per its own "if this boundary is ever lifted" note.
         let parser = expanding_parser();
-        let source = "see {link-src} now";
 
-        let nodes = build(Span::new(source), &parser, None);
+        for fixture in [
+            // The whole macro from one expansion, alone and in flow.
+            "{link-src}",
+            "see {link-src} now",
+            // The `mailto:` spelling, and a macro whose marker *and* target
+            // both come from expansions.
+            "write {mailto-src} now",
+            "see {link-src} and {link-src} now",
+            // Beside the two other link spellings, whose own registration
+            // passes run before and after this one.
+            "see {link-src} and https://example.org and doc@example.org now",
+            // Inside a rendered span, where the macros step descends.
+            "*see {link-src} now*",
+            // A marker written in the source still keeps its honest location.
+            "see link:{url}[{label}] now",
+        ] {
+            assert_eq!(
+                fold_html(
+                    &build(Span::new(fixture), &parser, None),
+                    &HtmlSubstitutionRenderer {}
+                ),
+                golden_normal(fixture, &parser),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
 
-        assert!(
-            nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-            "a wholly expanded link macro must stay literal: {nodes:?}"
-        );
+    #[test]
+    fn a_wholly_expanded_link_macro_keeps_a_coarse_location_and_its_form() {
+        // The shape behind that parity: the node is a `Macro`-form link — the
+        // signal the registration walk reads — with the whole attribute
+        // reference as its `location`, design §4.4's coarse fallback.
+        let parser = expanding_parser();
+        let nodes = build(Span::new("see {link-src} now"), &parser, None);
 
-        assert!(
-            golden_normal(source, &parser).contains("<a href"),
-            "the golden fixture stopped recognizing the link"
-        );
+        let reference = nodes
+            .iter()
+            .find_map(|n| match n {
+                InlineNode::Ref(reference) => Some(reference),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected a Ref node: {nodes:?}"));
+
+        assert_eq!(reference.link_form, Some(LinkForm::Macro));
+        assert_eq!(reference.target.as_ref(), "index.html");
+        assert_eq!(reference.location.data(), "{link-src}");
+    }
+
+    #[test]
+    fn matches_the_golden_pipelines_registration_for_expanded_link_macros() {
+        // The registration order that used to depend on the node's location:
+        // an expanded macro registers in the *macro* pass, between the two URL
+        // link forms' pass and the bare-e-mail one's, wherever it stands in
+        // the source. Driven through the real pipeline on both sides, since
+        // these fixtures need the `AttributeReferences` step.
+        for fixture in [
+            "{link-src}",
+            "see {link-src} now",
+            "see {link-src} and https://example.org now",
+            "https://a.example then {link-src} then doc@example.org",
+            "doc@example.org then {link-src}",
+            "{link-src} then link:b.html[B]",
+        ] {
+            let builder_parser = expanding_parser().with_catalog_assets(true);
+            let nodes = build(Span::new(fixture), &builder_parser, None);
+            apply_link_side_effects(&nodes, &builder_parser);
+
+            let golden_parser = expanding_parser().with_catalog_assets(true);
+            golden_normal(fixture, &golden_parser);
+
+            assert_eq!(
+                builder_parser.catalog().links(),
+                golden_parser.catalog().links(),
+                "registered links diverged for {fixture:?}"
+            );
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1397,6 +1397,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
             children: vec![InlineNode::Text {
                 value: CowStr::from(root.data()),

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -471,6 +471,7 @@ fn build_xref_node<'src>(
 
     InlineNode::Ref(Ref {
         variant: RefVariant::Xref,
+        link_form: None,
         target: CowStr::from(target),
         children,
         roles,
@@ -725,6 +726,7 @@ fn build_xref_shorthand_node<'src>(
 
     InlineNode::Ref(Ref {
         variant: RefVariant::Xref,
+        link_form: None,
         target: CowStr::from(target),
         children,
         roles: vec![],

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -116,7 +116,18 @@
 //!   escaped `&`, or one abutting an already-recognized construct (whose
 //!   *rendered* last character the pattern's mismatch-prefix group reads and a
 //!   placeholder hides — the same boundary the auto-link family's own required
-//!   prefix already enforces), is deferred. Each family reuses the shared
+//!   prefix already enforces), is deferred. A link node also records **which
+//!   of the three spellings** wrote it
+//!   ([`Ref::link_form`](crate::inlines::Ref::link_form)) — a fact a consumer
+//!   writing AsciiDoc back out needs, and the one
+//!   [`apply_link_side_effects`](macros::links::apply_link_side_effects) reads
+//!   to fill the asset catalog in the order AsciiDoc's own substitution does
+//!   (three passes over the whole content, not document order). Recording it
+//!   on the node rather than re-deriving it from the node's `location` is what
+//!   lets a `link:`/`mailto:` macro be recognized when its own marker is not
+//!   verbatim source — a *wholly* expanded macro (`:m: link:index.html[Docs]`,
+//!   then `{m}`), one in a wholly-synthesized seed, and one written inside
+//!   markup an earlier step of the same order flattened. Each family reuses the shared
 //!   pattern the string step
 //!   matches with ([`INLINE_IMAGE_MACRO`](crate::content::INLINE_IMAGE_MACRO), [`INLINE_KBD_BTN_MACRO`](crate::content::INLINE_KBD_BTN_MACRO),
 //!   [`INLINE_MENU_MACRO`](crate::content::INLINE_MENU_MACRO), [`INLINE_LINK_MACRO`](crate::content::INLINE_LINK_MACRO), [`INLINE_LINK`](crate::content::INLINE_LINK),
@@ -1637,11 +1648,7 @@ mod tests {
             // A cross-reference in a wholly-synthesized seed, in both
             // spellings: nothing on a `Ref{Xref}` node is `Span`-typed, so its
             // target and reference text come from the match string (or
-            // `text_slice`) rather than an `'src` slice. The `link:`/`mailto:`
-            // macro, whose own literal marker must be verbatim, still
-            // defers — see
-            // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
-            // below.
+            // `text_slice`) rather than an `'src` slice.
             (
                 "  see <<target>> and\n  xref:other[the other one]",
                 "see <<target>> and\nxref:other[the other one]",
@@ -1650,13 +1657,16 @@ mod tests {
             // macro in either spelling of its bracket: neither needs an `'src`
             // slice — an empty attribute list parses from a zero-length span,
             // and a non-empty one is parsed from the match string and owned
-            // off it. The `link:`/`mailto:` macro, whose own literal marker
-            // must be verbatim, still defers — see
-            // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
-            // below.
+            // off it. The `link:`/`mailto:` macro joins them now that the node
+            // records its own spelling (`Ref::link_form`) rather than having it
+            // re-derived from `location`.
             (
                 "  visit https://example.org[the site]\n  or https://plain.example",
                 "visit https://example.org[the site]\nor https://plain.example",
+            ),
+            (
+                "  read link:index.html[the docs]\n  or mailto:team@example.org[write]",
+                "read link:index.html[the docs]\nor mailto:team@example.org[write]",
             ),
             (
                 "  see image:sunset.jpg[] and\n  icon:home[] here",
@@ -2551,27 +2561,34 @@ mod tests {
         }
 
         /// A documented divergence the flattening policy inherits rather than
-        /// introduces: a `link:`/`mailto:` **macro** written inside a node an
+        /// closed: a `link:`/`mailto:` **macro** written inside a node an
         /// earlier step turned into markup.
         ///
         /// The flattened markup is a *synthesized* run — its value is the
         /// fold, which has no `'src` slice of its own — and that pass alone
-        /// among the macro families requires its own `link:`/`mailto:` marker
-        /// to be verbatim, because
-        /// [`link_form`](macros::links::link_form) tells this pass's nodes
-        /// from the other link passes' by whether the node's `location` starts
-        /// with that literal marker (the "no new node field" signal that
-        /// replays the string pipeline's family-pass registration order). It
-        /// is the same boundary a wholly expanded `{m}` macro already has —
-        /// reached here through a flattened span instead of an attribute
-        /// expansion.
-        ///
-        /// Every other family reads what it needs from the level's match
-        /// string and is recognized in flattened text just as the string
-        /// pipeline recognizes it in the escaped tags; the corpus above pins
-        /// an auto-link, an image macro, and a footnote doing exactly that.
+        /// among the macro families used to require its own `link:`/`mailto:`
+        /// marker to be verbatim, because the family told this pass's nodes
+        /// from the other link passes' by whether the node's `location`
+        /// started with that literal marker. It no longer does: the node
+        /// records its own spelling
+        /// ([`Ref::link_form`](crate::inlines::Ref::link_form)), which is what
+        /// [`apply_link_side_effects`](macros::links::apply_link_side_effects)
+        /// reads to replay the string pipeline's family-pass registration
+        /// order. So this reads like every other family — which computes what
+        /// it needs from the level's match string and is recognized in
+        /// flattened text just as the string pipeline recognizes it in the
+        /// escaped tags; the corpus above pins an auto-link, an image macro,
+        /// and a footnote doing the same.
         #[test]
-        fn a_link_macro_inside_flattened_markup_is_a_documented_divergence() {
+        fn a_link_macro_inside_flattened_markup_folds_to_the_string_pipelines_bytes() {
+            // Under an order that escapes *after* a markup-producing step, the
+            // quotes step's own output is flattened into one `Text` for the
+            // escaping step to split — so a `link:` macro written inside it
+            // sits in a wholly-synthesized run. That used to defer, because
+            // this family required its own marker to be verbatim source; the
+            // node now records its spelling instead (`Ref::link_form`), so the
+            // macro is recognized and the fold reproduces the string
+            // pipeline's own bytes.
             let (group, invalid) =
                 SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters,macros");
             assert!(invalid.is_empty());
@@ -2587,15 +2604,7 @@ mod tests {
             let nodes = build_group(&group, source, &built_parser);
             let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
 
-            assert_ne!(
-                built, golden,
-                "expected the documented divergence to still reproduce; the boundary may have \
-                 been lifted — if so, fold this fixture into the parity corpus above"
-            );
-            assert_eq!(
-                built,
-                "&lt;strong&gt;a link:index.html[Docs] b&lt;/strong&gt;"
-            );
+            assert_eq!(built, golden);
         }
     }
 
@@ -2614,14 +2623,14 @@ mod tests {
     /// value (see [`apply_attribute_references`]'s own doc comment), now
     /// reached at the tree's root instead of a nested splice.
     ///
-    /// The second — exercised by this test's own fixture — is a
+    /// The second — exercised by this test's own fixture — *was* a
     /// `link:`/`mailto:` macro whose own marker is not verbatim, which a
-    /// wholly-synthesized seed guarantees: that marker is what keeps the
-    /// node's `location` telling this pass's nodes from the other link
-    /// passes' when
+    /// wholly-synthesized seed guarantees. That marker used to be what told
+    /// this pass's nodes from the other link passes' when
     /// [`apply_link_side_effects`](macros::links::apply_link_side_effects)
-    /// replays the string pipeline's registration order (see
-    /// [`link_macro_level`](macros::links::link_macro_level)).
+    /// replays the string pipeline's registration order; the node now records
+    /// its own spelling ([`Ref::link_form`](crate::inlines::Ref::link_form))
+    /// instead, so the macro is recognized here too.
     ///
     /// Everything else is recognized here, including an image macro with an
     /// *empty* bracket and every URL-link spelling — both exercised by the
@@ -2632,7 +2641,14 @@ mod tests {
     /// of which computes every value it holds from the match string or
     /// [`text_slice`](quotes::text_slice)).
     #[test]
-    fn a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized() {
+    fn a_macro_construct_is_recognized_when_the_whole_seed_is_synthesized() {
+        // A wholly-synthesized seed — a filtered, multi-line block whose joined
+        // text has no contiguous `'src` slice — used to defer every macro
+        // family needing its own verbatim marker. The `link:`/`mailto:` family
+        // was the last one holding that rule, and it no longer needs it: the
+        // node records which spelling built it (`Ref::link_form`) rather than
+        // having it re-derived from `location`. So the macro is recognized
+        // here too, with only its `location` taking design §4.4's coarse span.
         let filtered = "see link:https://example.org[Example] here";
         let source = "  see link:https://example.org[Example] here";
 
@@ -2652,11 +2668,6 @@ mod tests {
         );
         let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
 
-        assert_ne!(
-            built, golden,
-            "expected the documented divergence to still reproduce; the boundary may have \
-             been lifted — if so, fold this fixture back into the parity sweep above"
-        );
-        assert_eq!(built, "see link:https://example.org[Example] here");
+        assert_eq!(built, golden);
     }
 }

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -313,6 +313,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
             children: vec![InlineNode::Text {
                 value: CowStr::from(loc.data()),

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -703,6 +703,7 @@ mod tests {
 
         let reference = InlineNode::Ref(Ref {
             variant: RefVariant::Link,
+            link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
             children: vec![InlineNode::Text {
                 value: CowStr::from(loc.data()),
@@ -930,6 +931,7 @@ mod tests {
             }),
             InlineNode::Ref(Ref {
                 variant: RefVariant::Link,
+                link_form: Some(crate::inlines::LinkForm::Macro),
                 target: CowStr::from("https://example.com"),
                 children: child(),
                 roles: vec![],

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -867,6 +867,11 @@ fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
                 window,
             } => InlineNode::Ref(Ref {
                 variant: *variant,
+                // The Strategy-A recorder recovers a link from its rendered
+                // `<a …>` markup, which the three spellings share, so it has
+                // no way to tell them apart; the single-pass builder sets this
+                // honestly (as with an image's `is_icon`).
+                link_form: None,
                 target: CowStr::from(target.clone()),
                 children: to_inline(children, span),
                 roles: roles.iter().cloned().map(CowStr::from).collect(),
@@ -925,6 +930,9 @@ fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
             window,
         } => InlineNode::Ref(Ref {
             variant: *variant,
+            // Not distinguishable from the rendered markup — see the container
+            // arm above.
+            link_form: None,
             target: CowStr::from(target.clone()),
             children: vec![],
             roles: roles.iter().cloned().map(CowStr::from).collect(),

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -158,6 +158,7 @@ mod tests {
             }),
             InlineNode::Ref(Ref {
                 variant: RefVariant::Link,
+                link_form: Some(crate::inlines::LinkForm::Macro),
                 target: CowStr::from("https://example.com"),
                 children: vec![],
                 roles: vec![],

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -53,7 +53,7 @@ mod inline_node;
 pub use inline_node::InlineNode;
 
 mod ref_node;
-pub use ref_node::{Ref, RefVariant};
+pub use ref_node::{LinkForm, Ref, RefVariant};
 
 mod stem;
 pub use stem::{Stem, StemNotation};

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -88,6 +88,20 @@ pub struct Ref<'src> {
     /// always `None` for an [`Xref`](RefVariant::Xref).
     pub attrs: Option<Attrlist<'src>>,
 
+    /// For a [`Link`](RefVariant::Link), which of AsciiDoc's three link
+    /// spellings the source used; `None` for a cross-reference.
+    ///
+    /// The three spellings render alike but are *written* differently — a
+    /// `link:`/`mailto:` macro, a URL standing on its own (or carrying a
+    /// bracketed text), and a bare e-mail address — so a consumer that writes
+    /// AsciiDoc back out needs this to reproduce the source, and one that
+    /// reports on a document can tell an explicit macro from an
+    /// automatically-recognized URL. It is also what lets the asset catalog be
+    /// filled in the order AsciiDoc's own substitution performs, which runs
+    /// the three spellings as three separate passes over the whole content
+    /// rather than in document order.
+    pub link_form: Option<LinkForm>,
+
     /// The source location of the whole reference.
     pub location: Span<'src>,
 }
@@ -96,6 +110,22 @@ impl<'src> HasSpan<'src> for Ref<'src> {
     fn span(&self) -> Span<'src> {
         self.location
     }
+}
+
+/// Which of AsciiDoc's three link spellings a [`Ref`]`{Link}` was written as
+/// (see [`Ref::link_form`]).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinkForm {
+    /// A URL written on its own (`https://example.org`), optionally carrying a
+    /// bracketed display text (`https://example.org[Docs]`) or angle brackets
+    /// (`<https://example.org>`).
+    AutoOrFormal,
+
+    /// A `link:`/`mailto:` macro (`link:index.html[Docs]`).
+    Macro,
+
+    /// A bare e-mail address written in the flow (`doc@example.org`).
+    Email,
 }
 
 /// Whether a [`Ref`] is a link or a cross-reference. ASG: `variant`.

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -55,6 +55,9 @@
 //! - `is_icon` (on [`Image`]) — the recorder's own recorded marker does not
 //!   distinguish `icon:` from `image:` (both fold through the same kind), so it
 //!   always reports `false`; the builder sets it honestly.
+//! - `link_form` (on [`Ref`]) — all three link spellings render to the same `<a
+//!   …>` markup, which is all the recorder has to recover from, so it is always
+//!   `None` there; the builder records which pass built the node.
 //!
 //! Several more differences are structural rather than field-level, so they
 //! are handled by the comparator itself instead of being excluded outright.
@@ -587,6 +590,14 @@ fn assert_node_equivalent(r: &InlineNode<'_>, b: &InlineNode<'_>, source: &str) 
         (InlineNode::Ref(rr), InlineNode::Ref(br)) => {
             assert_eq!(rr.variant, br.variant, "Ref variant differs for {source:?}");
             assert_eq!(rr.target, br.target, "Ref target differs for {source:?}");
+
+            // `link_form` is intentionally never compared: the recorder
+            // recovers a link from its rendered `<a …>` markup, which all
+            // three spellings share, so it is always `None` there, while the
+            // builder carries the spelling as a structural fact (the same
+            // one-sided richness an anchor's `reftext` and an image's
+            // `is_icon` have).
+            let _ = (&rr.link_form, &br.link_form);
 
             // When a `Link`'s display text carried its own attribute list,
             // `render_link` (and so `fold_link`) reads `role`/`window`

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2279,6 +2279,7 @@ fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
 fn unresolved_xref() -> InlineNode<'static> {
     crate::inlines::InlineNode::Ref(crate::inlines::Ref {
         variant: RefVariant::Xref,
+        link_form: None,
         target: "tgt".into(),
         children: vec![],
         roles: vec![],
@@ -2306,6 +2307,7 @@ fn defining_footnote(children: Vec<InlineNode<'static>>) -> InlineNode<'static> 
 fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
     InlineNode::Ref(crate::inlines::Ref {
         variant: RefVariant::Link,
+        link_form: Some(crate::inlines::LinkForm::Macro),
         target: "https://example.org".into(),
         children,
         roles: vec![],


### PR DESCRIPTION
> Stacked on #1241 — base retargets to `inline-ast` when that merges. The diff shown here is this increment alone.

The one boundary in this module drawn around neither a *piece* nor a *capture* but around the node's own **`location`**.

## The boundary

Three passes recognize a link — the auto-link / formal-URL family, the `link:`/`mailto:` macro, and the bare e-mail address — and the string pipeline runs them as three passes over the whole content, so the asset catalog fills in *pass* order rather than document order. `apply_link_side_effects` replays that by walking the tree three times, which needs to know which pass built each node; it answered by reading the node's `location` back and asking whether it starts with a literal `link:` / `mailto:`.

That made the location load-bearing, so a macro whose own marker is not verbatim source had to be **deferred** — three separate documented divergences, each pinned with the same *"if this boundary is ever lifted (with a signal that does not depend on the location), fold this fixture into the parity corpus"* note:

- a *wholly* expanded macro (`:m: link:index.html[Docs]`, then `{m}`);
- one reached through a wholly-synthesized seed (a filtered multi-line block);
- one written inside markup an earlier step of the same order flattened (`subs=quotes,specialcharacters,macros`).

## The lift

The signal is the node's to carry, and Phase 4's whole business is making nodes **self-describing**. `Ref` gains `link_form: Option<LinkForm>`, set by whichever pass builds the node and `None` for a cross-reference, and the registration walk reads it instead of re-deriving anything. With it the marker's `range_is_verbatim` call is **deleted rather than relaxed**, and the private `link_form` function with it.

The field earns its place on its own terms rather than as an internal marker: the three spellings render alike but are *written* differently, so a consumer writing AsciiDoc back out needs exactly this to reproduce the source, and one reporting on a document can tell an explicit macro from an automatically-recognized URL — the same kind of fact an `Image`'s `is_icon` and an `Anchor`'s `is_bibliography` already carry.

## Tests

All three formerly pinned divergences become parity tests. Parity reaches the whole macro from one expansion alone and in flow, the `mailto:` spelling, a macro whose marker *and* target both come from expansions, one beside the two other link spellings (whose own registration passes run before and after this one), one inside a rendered span, one in a wholly-synthesized seed, and one inside flattened markup.

A separate corpus drives the **registration order** through the real pipeline on both sides — the thing the location used to be read for — including an expanded macro interleaved with a bare URL and a bare address, so the three-pass order is pinned for the newly-recognized form as it already is for the verbatim one. A structural test asserts the shape: a `Macro`-form node whose `location` is the whole attribute reference, design §4.4's coarse span.

The recorder cross-check adds `link_form` to its list of one-sided-richness exemptions, beside `is_icon` and an anchor's `reftext`: all three spellings render to the same `<a …>` markup, which is all the recorder has to recover from.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — `see {link-src} now` and `*a link:index.html[Docs] b*` **gone** from the divergence set, **no new divergence** (the third closed case is a `build_from_value` test, not a parse, so it is not in the corpus)
- Coverage — diff-neutral; every uncovered region in the changed files is pre-existing or an `other => panic!(…)` fallback arm inside a test assertion

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_