### PR TITLE
feat: Recognize an attribute-list display text enclosing a rendered span, for the link families (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5284,6 +5284,61 @@ Each phase is a reviewable unit with a clear exit gate.
   Re-running the corpus-wide fold-parity audit shows **two** golden fixtures gone from the
   divergence set and no new divergence; coverage is diff-neutral, and nothing further is wired in.
 
+  *Step 6 prep landed as (an attribute-list display text enclosing a rendered span — the two
+  link families):* the same capture the cross-reference family closed, for the two families that
+  hold a real [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` on the node. Their
+  display text comes back from the same parse, so it needs the same token; what was different is
+  that a token has to *leave* that parse with something in it, since
+  [`Ref::attrs`](../../parser/src/inlines/ref_node.rs) rides on the node and
+  `render_link` reads more out of it than the display text.
+
+  A masked construct always had a body for that —
+  [`Passthroughs::restore_to`](../../parser/src/content/passthroughs.rs) splices exactly those
+  bytes into the string pipeline's own finished string, so restoring one into a parsed value is
+  faithful wherever the value goes. A rendered span has no such body, and the design has said so
+  since the class was opened: its markup exists only at fold time. The finding is that it has one
+  for *this* purpose. [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs)
+  gains a [`Tokened`](../../parser/src/content/inline_builder/macros/image.rs) kind; under
+  `MaskedOrRendered` it admits any opaque piece and pairs it with the **build-time fold**, taken
+  with the parser's own renderer — the same trade
+  [`restorable_body`](../../parser/src/content/inline_builder/macros/image.rs) already makes for a
+  `Stem`, and the very bytes the string replacer's own attribute list holds there.
+
+  What makes that safe is that the frozen bytes never reach output. The display text is carried
+  **structurally** — [`restored_value_children`](../../parser/src/content/inline_builder/macros/mod.rs)
+  splices each piece's own *node* into the children, so the fold renders the span with whatever
+  renderer the fold is using — and the frozen copy only ever lands in the node's `attrs`, which
+  no renderer reads for the display text. Every *other* slot is one `render_link` writes out (an
+  `id`, a `title`, a `role`, a `window`, an option), where a frozen body would put the built-in
+  backend's markup in a custom backend's output, so a token reaching one defers the whole match:
+  [`rendered_token_escaped_the_display_text`](../../parser/src/content/inline_builder/macros/links.rs)
+  draws that per-**slot** boundary, and a *masked* piece is exempt from it for the reason above.
+  The split-agreement check
+  ([`tokened_split_agrees`](../../parser/src/content/inline_builder/macros/mod.rs)) applies here
+  too, and one more thing falls out of writing the walk this way: `tokened_bracket` now walks the
+  level **piece by piece** rather than copying the gaps between the tokened ones, because a byte
+  of the match string may belong to no piece at all — `styled_sibling_boundaries` wraps a
+  placeholder in the two characters its rendering presents to a neighbour, and copying them would
+  splice a stray `<` and `>` into the parsed value.
+
+  What reaches parity is the golden spelling from the language docs
+  (`https://chat.asciidoc.org[*project chat*^,role=green]`), each family with the span at either
+  edge and in the middle, each named attribute `render_link` reads with the span in the positional
+  value beside it, other span kinds and two spans in one text, the `^` new-window suffix riding
+  after the span, and a collapsed newline. Fixtures join the whole-pipeline broad sweep and
+  combined-constructs corpus and the structural recorder cross-check. Re-running the corpus-wide
+  fold-parity audit shows that golden fixture **gone** from the divergence set and no new
+  divergence; coverage is diff-neutral, and nothing further is wired in.
+
+  With this the rendered-span class is closed for every family that has a display text to carry.
+  What remains of it is the **image** family's attribute list, the one capture with none: every
+  value its bracket holds — an `alt`, a `title`, a `width` — is one `render_image` writes out, so
+  the per-slot rule above puts all of them on the wrong side. Closing it needs a value the fold
+  *materializes* rather than one frozen at build time, which is a shape no increment has needed
+  yet; it is left for the maintainer to weigh against the cutover, and the golden it holds
+  (`image:pause.png[title=*Pause* and Resume]`) keeps its divergence test. Beyond it the
+  remainder is unchanged: the boundary-class halves the sibling increments named, plus the keeps.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6243,6 +6298,24 @@ Each phase is a reviewable unit with a clear exit gate.
        escaped-bracket retry's own re-scan inherits the lift, closing a second golden fixture; the
        two attribute-list-prefixed bare forms keep the verbatim gate, so `[method x-]+pass:[<b>]+`
        stays deferred. See the step's own "landed as" note above.
+
+     - ✅ **prep (an attribute-list display text enclosing a rendered span — the two link
+       families).** The same capture the cross-reference family closed, for the two families that
+       hold a real [`Attrlist`](../../parser/src/attributes/attrlist.rs)`<'src>` on the node. A
+       token has to *leave* their parse with something in it, since
+       [`Ref::attrs`](../../parser/src/inlines/ref_node.rs) rides on the node — and a rendered span
+       turns out to have a body for that purpose after all:
+       [`tokened_bracket`](../../parser/src/content/inline_builder/macros/image.rs) gains a
+       [`Tokened`](../../parser/src/content/inline_builder/macros/image.rs) kind whose
+       `MaskedOrRendered` admits any opaque piece and pairs it with the **build-time fold**, the
+       same trade `restorable_body` already makes for a `Stem`. It is safe because those bytes
+       never reach output: the display text is carried structurally (the fold renders the span
+       itself), and the frozen copy only lands in `attrs`, which no renderer reads for it. Every
+       other slot is one `render_link` writes out, so a token reaching one defers the match. The
+       walk also moves piece by piece, so a placeholder's sibling-boundary characters are not
+       copied into the parsed value. See the step's own "landed as" note above. The **image**
+       family's bracket — the one capture with no display text to carry — is what remains of the
+       class, and needs a fold-*materialized* value rather than a frozen one.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -9,7 +9,7 @@ use crate::{
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
-            fold::fold_stem,
+            fold::{fold_html, fold_stem},
             quotes::{
                 LevelContext, Piece, build_match_string, charref_entity, source_slice, text_slice,
             },
@@ -823,12 +823,17 @@ fn bracket_attrlist<'src>(
         return parse_attrlist(bracket, parser);
     }
 
+    // The image family stays at [`Tokened::Masked`]: every value its bracket
+    // holds is one `render_image` writes out (an `alt`, a `title`, a
+    // `width`), so a rendered piece frozen into one would put the built-in
+    // backend's markup in a custom backend's output.
     let (tokened, masked) = tokened_bracket(
         bracket_text,
         &bracket_range,
         nodes,
         pieces,
-        parser.renderer.as_ref(),
+        parser,
+        Tokened::Masked,
     );
 
     let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
@@ -849,13 +854,46 @@ fn bracket_attrlist<'src>(
 /// one from the other is what keeps the two spellings of "what this token
 /// restores to" from drifting.
 pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
-    /// The masked node — a [`Raw`](InlineNode::Raw) passthrough or a
-    /// [`Stem`](InlineNode::Stem) expression — the token stands for.
+    /// The node the token stands for — a [`Raw`](InlineNode::Raw) passthrough
+    /// or a [`Stem`](InlineNode::Stem) expression, and (under
+    /// [`Tokened::MaskedOrRendered`]) any other opaque piece.
     pub(in crate::content::inline_builder) node: &'a InlineNode<'src>,
 
     /// What the token restores to: exactly what the fold of
     /// [`node`](Self::node) emits (see [`restorable_body`]).
     pub(in crate::content::inline_builder) body: Cow<'a, str>,
+
+    /// Whether this piece is markup the **fold** writes rather than a *masked*
+    /// construct whose body the string pipeline itself splices.
+    ///
+    /// The distinction is what a caller admitting both has to act on. A masked
+    /// construct's body is known at build time in the same sense the string
+    /// pipeline knows it — `Passthroughs::restore_to` splices exactly these
+    /// bytes into its own finished string — so restoring it into a parsed
+    /// value is faithful wherever that value goes. A *rendered* piece's markup
+    /// is a function of the renderer, and [`body`](Self::body) freezes it with
+    /// the parser's own; that is right for a value nothing emits (it is what
+    /// the string replacer's own attribute list holds there) and wrong for one
+    /// a renderer writes out, since a custom backend would then see the
+    /// built-in backend's markup. A caller admitting these must therefore
+    /// carry the value **structurally** and refuse a match whose token reached
+    /// a slot the fold reads — see [`text_attrlist`](super::links).
+    pub(in crate::content::inline_builder) rendered: bool,
+}
+
+/// Which pieces [`tokened_bracket`] gives a token to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::content::inline_builder) enum Tokened {
+    /// Only a **masked** construct — a passthrough or a STEM expression —
+    /// whose body the string pipeline itself splices over its own sentinel.
+    /// The bracket's parsed values may then be restored wherever they go.
+    Masked,
+
+    /// Also any other **opaque** piece: a rendered span, an
+    /// earlier-recognized macro node. Its body is the build-time fold, which
+    /// only a caller that carries the value structurally and refuses a token
+    /// in a slot the fold reads may use (see [`MaskedPiece::rendered`]).
+    MaskedOrRendered,
 }
 
 /// Rewrites a macro **bracket**'s own match-string bytes so each masked piece
@@ -890,15 +928,21 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
     range: &std::ops::Range<usize>,
     nodes: &'a [InlineNode<'src>],
     pieces: &[Piece],
-    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+    admits: Tokened,
 ) -> (String, Vec<MaskedPiece<'a, 'src>>) {
+    let renderer = parser.renderer.as_ref();
+
     let mut tokened = String::new();
     let mut masked_pieces: Vec<MaskedPiece<'a, 'src>> = Vec::new();
 
-    // In match-string coordinates; `bracket_text` is indexed relative to
-    // `range.start`.
-    let mut cursor = range.start;
-
+    // Walked **piece by piece** rather than by copying the gaps between the
+    // tokened ones, because a byte of the match string may belong to no piece
+    // at all: `styled_sibling_boundaries` wraps an opaque span's placeholder
+    // in the two characters its own rendering presents to a neighbour (the `<`
+    // and `>` of a tag), which exist for *recognition* and stand for markup
+    // the token already carries whole. Copying them would splice a stray `<`
+    // and `>` into the parsed value beside the piece.
     for piece in pieces {
         let p_start = piece.s_start;
         let p_end = piece.s_start + piece.s_len;
@@ -908,45 +952,57 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
             continue;
         }
 
-        if !piece.atomic {
-            continue;
-        }
+        let lo = p_start.max(range.start);
+        let hi = p_end.min(range.end);
 
         // The discriminant and the body are one step: `restorable_body`
         // answers `Some` for exactly the nodes `node_is_restorable` admits
         // (pinned by `restorable_body_agrees_with_node_is_restorable`), so
         // gating on one before producing the other would leave a branch no
-        // input can take. A piece this skips is an atomic one the *gate*
-        // admitted for another reason — a `CharRef` leaf the match string
-        // gives real bytes to.
-        let Some(masked) = nodes.get(piece.node_index).and_then(|node| {
-            restorable_body(node, renderer).map(|body| MaskedPiece { node, body })
-        }) else {
-            continue;
-        };
+        // input can take. A piece this leaves untokened contributes its own
+        // bytes: a `Text` run's, or a `CharRef` leaf's canonical entity, which
+        // are the string replacer's own bytes there.
+        let masked = piece
+            .atomic
+            .then(|| nodes.get(piece.node_index))
+            .flatten()
+            .and_then(|node| {
+                if let Some(body) = restorable_body(node, renderer) {
+                    return Some(MaskedPiece {
+                        node,
+                        body,
+                        rendered: false,
+                    });
+                }
 
-        // A masked piece is atomic and never sliced, so an overlapping one
-        // lies wholly inside the range and `p_start`/`p_end` are safe bounds.
-        tokened.push_str(
-            bracket_text
-                .get(cursor.saturating_sub(range.start)..p_start.saturating_sub(range.start))
-                .unwrap_or_default(),
-        );
+                if admits == Tokened::Masked || charref_entity(node).is_some() {
+                    return None;
+                }
 
-        tokened.push_str(&format!("\u{96}{n}\u{97}", n = masked_pieces.len()));
-        masked_pieces.push(masked);
-        cursor = p_end;
+                Some(MaskedPiece {
+                    node,
+                    body: Cow::Owned(fold_html(std::slice::from_ref(node), renderer, parser)),
+                    rendered: true,
+                })
+            });
+
+        match masked {
+            Some(masked) => {
+                tokened.push_str(&format!("\u{96}{n}\u{97}", n = masked_pieces.len()));
+                masked_pieces.push(masked);
+            }
+
+            None => tokened.push_str(
+                bracket_text
+                    .get(lo.saturating_sub(range.start)..hi.saturating_sub(range.start))
+                    .unwrap_or_default(),
+            ),
+        }
     }
 
     if masked_pieces.is_empty() {
         return (bracket_text.to_string(), masked_pieces);
     }
-
-    tokened.push_str(
-        bracket_text
-            .get(cursor.saturating_sub(range.start)..)
-            .unwrap_or_default(),
-    );
 
     (tokened, masked_pieces)
 }

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -7,8 +7,11 @@
 use super::computed_value_children;
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind,
-    image::{range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
-    macro_text_children, rebuild_macro_level, restored_value_children,
+    image::{
+        MaskedPiece, Tokened, range_is_restorable, range_is_verbatim, restorable_body,
+        tokened_bracket,
+    },
+    macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
 };
 use crate::{
     Parser, Span,
@@ -1541,6 +1544,40 @@ struct TextAttrlist<'src> {
     restores: Vec<InlineNode<'src>>,
 }
 
+/// Whether any [`rendered`](MaskedPiece::rendered) piece's token came back
+/// from the parse in a slot other than the **first positional** attribute —
+/// the one slot [`text_attrlist`]'s caller carries structurally.
+///
+/// Every other slot is a value `render_link` writes out (an `id`, a `title`,
+/// a `role`, a `window`, an option), where a body frozen with the parser's own
+/// renderer would put the built-in backend's markup in a custom backend's
+/// output. A *masked* piece is exempt: its body is what the string pipeline
+/// itself splices, so it is faithful wherever it lands.
+fn rendered_token_escaped_the_display_text(
+    attrs: &Attrlist<'_>,
+    masked: &[MaskedPiece<'_, '_>],
+) -> bool {
+    let rendered: Vec<String> = masked
+        .iter()
+        .enumerate()
+        .filter(|(_, piece)| piece.rendered)
+        .map(|(n, _)| format!("\u{96}{n}\u{97}"))
+        .collect();
+
+    attrs.attributes().enumerate().any(|(index, attribute)| {
+        // `attributes()` yields every attribute in order, so index 0 is the
+        // first positional one whenever the list has any positional attribute
+        // at all; a named attribute there is not a display text and is checked
+        // like the rest.
+        let is_display_text = index == 0 && attribute.name().is_none();
+
+        !is_display_text
+            && rendered
+                .iter()
+                .any(|token| attribute.value().contains(token.as_str()))
+    })
+}
+
 /// Parses a link's bracketed **display text** as the [`Attrlist`]`<'src>` its
 /// node carries, mirroring what the string replacers parse: a
 /// newline-normalized copy of the (pre-`\]`-unescape) bracketed text, joined
@@ -1616,10 +1653,6 @@ fn text_attrlist<'src>(
     parser: &Parser,
     pre_restore: &[usize],
 ) -> Option<TextAttrlist<'src>> {
-    if !range_is_restorable(nodes, pieces, &text_range) {
-        return None;
-    }
-
     let normalized = raw_text.replace('\n', " ");
     let verbatim_range = text_range.clone();
     let source = source_slice(pieces, text_range.clone(), root);
@@ -1636,7 +1669,7 @@ fn text_attrlist<'src>(
         });
     }
 
-    // A masked piece is atomic, so a range holding one never took the
+    // A tokened piece is atomic, so a range holding one never took the
     // verbatim path above. Tokening leaves a range holding none byte-identical
     // to `normalized`, so both paths below read the same string.
     let (tokened, masked) = tokened_bracket(
@@ -1644,10 +1677,35 @@ fn text_attrlist<'src>(
         &text_range,
         nodes,
         pieces,
-        parser.renderer.as_ref(),
+        parser,
+        Tokened::MaskedOrRendered,
     );
 
     let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
+
+    // Two things have to hold before a token may stand for a **rendered**
+    // piece, and they are independent.
+    //
+    // First the *split* must land where the string replacer's own parse of the
+    // markup lands. A token carries none of the `,` / `=` / `"` the split
+    // reads, and the replacer's markup may (`link:x[a *b, c* d,role=hl]`), so
+    // the two are compared parse against parse — see [`tokened_split_agrees`].
+    //
+    // Then the value must be one nothing emits. A rendered piece's body is
+    // frozen with the parser's own renderer (see [`MaskedPiece::rendered`]),
+    // which is faithful for the display text — it becomes the node's children,
+    // carrying each piece's own node — and wrong for every other slot, each of
+    // which `render_link` writes out. This is the same per-**slot** boundary
+    // `pre_restore` below draws.
+    let carried: Vec<InlineNode<'src>> = masked.iter().map(|piece| piece.node.clone()).collect();
+
+    if !tokened_split_agrees(&tokened, &carried, parser) {
+        return None;
+    }
+
+    if rendered_token_escaped_the_display_text(&attrs, &masked) {
+        return None;
+    }
 
     if masked.is_empty() {
         return Some(TextAttrlist {
@@ -4390,33 +4448,6 @@ mod tests {
     }
 
     #[test]
-    fn a_formal_url_attribute_list_text_over_a_rendered_span_is_a_documented_divergence() {
-        // A text carrying an attribute list is parsed as a real
-        // `Attrlist<'src>` from the source's own bytes, and a placeholder
-        // inside a *parsed* value has no node it can be mapped back to — the
-        // same reason the cross-reference and `link:`/`mailto:` macro families
-        // defer their own `Attrlist`-bearing capture. That one text shape keeps
-        // the stricter gate outright.
-        //
-        // If this boundary is ever lifted, fold these fixtures into the parity
-        // corpus above.
-        for source in [
-            "https://example.org[a *b* c,role=hl]",
-            "https://example.org[a *b* c,window=_blank]",
-        ] {
-            let nodes = build_src(Span::new(source));
-
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "an attribute-list text crossing a rendered span must stay literal: {nodes:?}"
-            );
-
-            // The string pipeline, by contrast, *does* build a link here.
-            assert!(golden_macros(source).contains("<a href"));
-        }
-    }
-
-    #[test]
     fn a_span_whose_markup_perturbs_the_inline_link_pattern_is_a_documented_divergence() {
         // What the structural recovery cannot do is make the *recognition*
         // agree in every case: the string replacer matches over the span's
@@ -5088,26 +5119,76 @@ mod tests {
     }
 
     #[test]
-    fn a_link_text_attribute_list_over_a_rendered_span_is_a_documented_divergence() {
-        // A text carrying an attribute list is parsed as a real
-        // `Attrlist<'src>` from the source's own bytes, and a placeholder
-        // inside a *parsed* value has no node it can be mapped back to — the
-        // same reason the cross-reference family defers its own
-        // `Attrlist`-bearing capture. That one text shape keeps the stricter
-        // gate outright, for both the `link:` (`=`) and `mailto:` (`,`)
-        // spellings.
-        //
-        // If this boundary is ever lifted, fold these fixtures into the parity
-        // corpus above.
-        for source in [
+    fn fold_matches_the_string_pipeline_for_an_attribute_list_text_enclosing_a_span() {
+        // The last capture of the rendered-span class, for both link families.
+        // A text carrying an attribute list gets its display text back from a
+        // *parse*, so a placeholder inside the parsed value used to have no
+        // node it could be mapped back to. It has one now: the piece is
+        // tokened before the split like a masked construct
+        // ([`Tokened::MaskedOrRendered`]) and spliced back into the node's
+        // **children** as the node itself, so the fold still renders it.
+        for fixture in [
+            // The golden spelling, from the language docs.
+            "Chat with other AsciiDoc users in the \
+             https://chat.asciidoc.org[*project chat*^,role=green].",
+            // Each family, with the span at either edge and in the middle.
+            "link:index.html[*bold*,role=hl]",
             "link:index.html[a *b* c,role=hl]",
+            "link:index.html[a *b*,role=hl]",
+            "https://example.org[*bold*,role=hl]",
+            "https://example.org[a *b* c,window=_blank]",
             "mailto:a@example.org[a *b* c,Subj]",
+            "mailto:a@example.org[*bold*,Subj]",
+            // Each named attribute `render_link` reads, with the span in the
+            // *positional* value beside it.
+            "link:index.html[*bold*,title=T]",
+            "link:index.html[*bold*,id=x]",
+            "link:index.html[*a*,window=_blank]",
+            "link:index.html[*a*,role=hl,title=T]",
+            // Other span kinds, and two spans in one text.
+            "link:index.html[`code`,role=hl]",
+            "link:index.html[[.r]#x# here,role=hl]",
+            "link:index.html[*a* and _b_,role=hl]",
+            // The `^` new-window suffix riding after the span, and a
+            // collapsed newline.
+            "https://example.org[`code`^,role=green]",
+            "link:index.html[*a*\nb,role=hl]",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(fixture)), &HtmlSubstitutionRenderer {}),
+                golden_macros(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_span_in_a_rendered_attribute_defers_the_match() {
+        // The boundary this does *not* move, drawn per **slot**. A rendered
+        // piece's body is frozen with the parser's own renderer, which is
+        // faithful only for a value nothing emits — the display text, which
+        // becomes the node's children and carries each piece's own node. Every
+        // other slot is one `render_link` writes out, where the frozen markup
+        // would be the built-in backend's in a custom backend's output, so a
+        // span there defers the whole match. The split-agreement check is the
+        // other half, and defers for a different reason: see the fixtures
+        // below.
+        for source in [
+            "link:index.html[x,role=*b*]",
+            "link:index.html[x,title=*b*]",
+            "https://example.org[x,role=*b*]",
+            // And the other half of the two checks: a span whose own markup
+            // carries a character the split reads, so the string replacer's
+            // list divides where the token cannot — the match's very extent
+            // differs, and it is deferred rather than recognized.
+            "link:index.html[a *b, c* d,role=hl]",
+            "https://example.org[a *b, c* d,role=hl]",
         ] {
             let nodes = build_src(Span::new(source));
 
             assert!(
                 nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "an attribute-list text crossing a rendered span must stay literal: {nodes:?}"
+                "a span in a rendered attribute must stay literal: {nodes:?}"
             );
 
             // The string pipeline, by contrast, *does* build a link here.

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -211,7 +211,13 @@
 //!   parser rather than the bytes: it parses the tokened text *and* the
 //!   restored markup and compares them attribute by attribute
 //!   ([`tokened_split_agrees`](macros::tokened_split_agrees)), deferring the
-//!   match whenever the two readings differ about its extent. An
+//!   match whenever the two readings differ about its extent. The two **link**
+//!   families take the same move through
+//!   [`tokened_bracket`](macros::image::tokened_bracket), which under
+//!   [`Tokened::MaskedOrRendered`](macros::image::Tokened) admits a rendered
+//!   piece and pairs it with the build-time fold — faithful for a value
+//!   nothing emits, which is exactly the display text, and refused for every
+//!   other slot `render_link` writes out. An
 //!   image's attribute list — the one capture with no display text to carry —
 //!   still defers it outright. An anchor
 //!   renders from its id alone, so it is recognized whenever that id does not


### PR DESCRIPTION
> Stacked on #1243 → #1242 → #1241; the base retargets as each merges. The diff shown here is this increment alone.

The same capture the cross-reference family closed in #1241, for the two families that hold a real `Attrlist<'src>` on the node.

## The boundary

Their display text comes back from the same parse, so it needs the same token. What was different is that a token has to *leave* that parse with something in it, since `Ref::attrs` rides on the node and `render_link` reads more out of it than the display text.

A **masked** construct always had a body for that — `Passthroughs::restore_to` splices exactly those bytes into the string pipeline's own finished string, so restoring one into a parsed value is faithful wherever the value goes. A rendered span has no such body, and the design has said so since the class was opened: its markup exists only at fold time.

## The lift

It has one for *this* purpose. `tokened_bracket` gains a `Tokened` kind; under `MaskedOrRendered` it admits any opaque piece and pairs it with the **build-time fold**, taken with the parser's own renderer — the same trade `restorable_body` already makes for a `Stem`, and the very bytes the string replacer's own attribute list holds there.

What makes that safe is that **the frozen bytes never reach output**:

- the display text is carried *structurally* — `restored_value_children` splices each piece's own **node** into the children, so the fold renders the span with whatever renderer the fold is using;
- the frozen copy only ever lands in the node's `attrs`, which no renderer reads for the display text.

Every *other* slot is one `render_link` writes out (an `id`, a `title`, a `role`, a `window`, an option), where a frozen body would put the built-in backend's markup in a custom backend's output — so a token reaching one defers the whole match (`rendered_token_escaped_the_display_text`). A masked piece is exempt from that rule, for the reason above. The split-agreement check from #1241 applies here too.

One more thing falls out of writing the walk this way: `tokened_bracket` now walks the level **piece by piece** rather than copying the gaps between the tokened ones, because a byte of the match string may belong to no piece at all — `styled_sibling_boundaries` wraps a placeholder in the two characters its rendering presents to a neighbour, and copying them would splice a stray `<` and `>` into the parsed value.

## What still defers

With this the rendered-span class is closed for every family that has a display text to carry. What remains of it is the **image** family's attribute list, the one capture with none: every value its bracket holds — an `alt`, a `title`, a `width` — is one `render_image` writes out, so the per-slot rule above puts all of them on the wrong side.

Closing that needs a value the fold **materializes** rather than one frozen at build time, which is a shape no increment has needed yet. I've left it for you to weigh against the cutover rather than inventing the public shape for it; the golden it holds (`image:pause.png[title=*Pause* and Resume]`) keeps its divergence test, and the design-doc note records the reasoning.

## Tests

Parity reaches the golden spelling from the language docs (`https://chat.asciidoc.org[*project chat*^,role=green]`), each family with the span at either edge and in the middle, each named attribute `render_link` reads with the span in the positional value beside it, other span kinds and two spans in one text, the `^` new-window suffix riding after the span, and a collapsed newline. Both formerly pinned divergence tests become that parity test, plus one deferral test covering the two independent reasons a match still defers (a span in a rendered attribute; a span whose markup moves the split).

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — the `chat.asciidoc.org` golden **gone** from the divergence set, **no new divergence** (14 records remain, all documented keeps or the image capture above)
- Coverage — exactly diff-neutral (3 and 12 uncovered regions in the two changed files, before and after; all test-assertion arms or pre-existing)

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_