### PR TITLE
feat: Fold a section title's footnote-free reference text (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5339,6 +5339,61 @@ Each phase is a reviewable unit with a clear exit gate.
   (`image:pause.png[title=*Pause* and Resume]`) keeps its divergence test. Beyond it the
   remainder is unchanged: the boundary-class halves the sibling increments named, plus the keeps.
 
+  *Step 6 prep landed as (a section title's footnote-free reference text — the first sentinel
+  system to lose its reason to exist):* the increments above were all found by asking the
+  corpus-wide fold-parity audit what still diverges. This one was found by asking a different
+  question — *what breaks if `rendered_html()` becomes the fold today?* — run as a throwaway
+  experiment over the whole suite. The answer is encouragingly small, and its largest single
+  cluster is one root cause: a **footnote in a section heading**.
+
+  A footnote in a heading is a real, document-order footnote — it is numbered, and the heading
+  renders its marker — but that marker must not appear in the text a cross-reference to the
+  heading shows, nor in the id auto-generated from that text (issue #594). The string pipeline
+  needs two strings out of one title and cannot afford two renders (counters and
+  attribute-expanded footnotes would advance twice), so it renders **once** with the footnote
+  renderer bracketing each marker in a sentinel pair
+  ([`FOOTNOTE_MARKER_START`](../../parser/src/content/content.rs) …
+  [`FOOTNOTE_MARKER_END`](../../parser/src/content/content.rs), enabled for that render alone by
+  `Parser::mark_footnote_spans`), cuts the bracketed regions out
+  ([`strip_footnote_marker_spans`](../../parser/src/content/content.rs)), and then removes the
+  spent sentinels from the title's own rendering *and* from its deferred cross-reference template
+  ([`Content::remove_footnote_marker_sentinels`](../../parser/src/content/content.rs)).
+
+  A tree needs none of that. The footnote is a **node**, so the two strings are two folds of the
+  same tree, and "which regions were footnote markers" is a question about node kinds rather than
+  about bytes. [`fold_reference_text`](../../parser/src/content/inline_builder/fold.rs) is
+  [`fold_html`](../../parser/src/content/inline_builder/fold.rs) with each footnote's in-flow
+  marker omitted — the node **skipped** rather than folded to nothing, since `render_footnote` is
+  a backend's to define and one that emitted anything would leak it — and the omission recurses
+  exactly as the byte-level cut does over the whole rendered string, so a footnote inside a
+  rendered span or inside a cross-reference's own display text is omitted there too. Nothing else
+  about the fold changes: a `Footnotes` parameter threads down the recursion with `Marked` at
+  every existing call site.
+
+  A differential test pins the equivalence from **both** ends, over a corpus of titles: for each,
+  `fold_html` reproduces the heading's own rendering (sentinels removed) and `fold_reference_text`
+  reproduces the footnote-free text, each against the string pipeline's own two answers computed
+  the way `Section::parse` computes them. The corpus covers a title with no footnote at all
+  (where the two strings coincide and the strip is a no-op on both sides), one at either edge and
+  in the middle, two in one title, a named footnote, a marker nested inside a rendered span and
+  inside a cross-reference's display text, and a footnote beside each other construct a title can
+  carry.
+
+  This is the **first of the three sentinel systems** §4.2 names to lose its reason to exist.
+  Deleting it — along with `mark_footnote_spans`, `strip_footnote_marker_spans`, and
+  `remove_footnote_marker_sentinels` — is the cutover's own job, so as with every prep piece
+  before it nothing is wired in and the corpus-wide audit is unchanged.
+
+  *What the experiment says about what is left.* Forcing the tree on for every parse and making
+  `rendered` the fold leaves **15** of ~5,370 tests failing, in three clusters: this footnote
+  cluster (5), the documented keeps whose golden output the cutover deliberately changes for the
+  better (~5, each already carrying its own divergence test), and tests of the opt-in flag and of
+  the Strategy-A recorder harness that retire with the flag itself (~5). That is a far smaller
+  blast radius than "several sessions" suggested when this step was written — the prep work has
+  done its job — though the experiment is deliberately crude (it neither calls the staged side
+  effects nor sequences the fold against resolution), so the cutover's own ordering work is not
+  measured by it.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6316,6 +6371,20 @@ Each phase is a reviewable unit with a clear exit gate.
        copied into the parsed value. See the step's own "landed as" note above. The **image**
        family's bracket — the one capture with no display text to carry — is what remains of the
        class, and needs a fold-*materialized* value rather than a frozen one.
+
+     - ✅ **prep (a section title's footnote-free reference text).** The first of the three
+       sentinel systems §4.2 names to lose its reason to exist, and the first prep found by asking
+       *what breaks if `rendered_html()` becomes the fold today?* rather than by the fold-parity
+       audit. A footnote in a heading must not appear in the text a cross-reference shows nor in
+       the auto-generated id, and the string pipeline gets those two strings out of **one** render
+       by bracketing each marker in a sentinel pair, cutting the bracketed regions out, and then
+       removing the spent sentinels. A tree needs none of it: the footnote is a node, so the two
+       strings are two folds of the same tree.
+       [`fold_reference_text`](../../parser/src/content/inline_builder/fold.rs) skips each
+       [`Footnote`](../../parser/src/inlines/footnote.rs) node wherever it sits, and a differential
+       test pins the equivalence from both ends over a corpus of titles. See the step's own
+       "landed as" note above, which also records what the experiment says about the cutover's
+       remaining blast radius.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -36,7 +36,61 @@ pub(crate) fn fold_html(
     parser: &Parser,
 ) -> String {
     let mut out = String::new();
-    fold_into_html(nodes, renderer, parser, &mut out);
+    fold_into_html(nodes, renderer, parser, Footnotes::Marked, &mut out);
+    out
+}
+
+/// Whether a fold writes a [`Footnote`](InlineNode::Footnote)'s in-flow
+/// marker.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Footnotes {
+    /// Write it: the ordinary fold, which is what the flow of a block shows.
+    Marked,
+
+    /// Omit it, marker and all, leaving the surrounding text as though the
+    /// footnote had not been written — see [`fold_reference_text`].
+    Stripped,
+}
+
+/// The fold a **section title** contributes as its reference text and as the
+/// source of its auto-generated id: [`fold_html`] with each footnote's in-flow
+/// marker omitted.
+///
+/// A footnote in a heading is a real, document-order footnote — it is numbered
+/// and it renders in the heading itself — but its marker must not appear in
+/// the text a cross-reference to that heading shows, nor in the id derived
+/// from that text (issue #594). The string pipeline reaches the same answer by
+/// rendering the title **once** with the footnote renderer bracketing each
+/// marker in a pair of sentinels
+/// ([`FOOTNOTE_MARKER_START`](crate::content::FOOTNOTE_MARKER_START) …
+/// [`FOOTNOTE_MARKER_END`](crate::content::FOOTNOTE_MARKER_END), enabled for
+/// that one render by `Parser::mark_footnote_spans`), cutting the bracketed
+/// regions out
+/// ([`strip_footnote_marker_spans`](crate::content::strip_footnote_marker_spans)),
+/// and then removing the now-spent sentinels from the title's own rendering
+/// and from its deferred cross-reference template
+/// (`Content::remove_footnote_marker_sentinels`). Rendering once is what keeps
+/// counters and attribute-expanded footnotes from being processed twice, and
+/// the sentinels are what make one render yield two strings.
+///
+/// A tree needs none of it. The footnote is a node, so the two strings are two
+/// folds of the same tree, and "which regions were footnote markers" is a
+/// question about node kinds rather than about bytes. This is therefore the
+/// **first of the three sentinel systems** design §4.2 names to lose its
+/// reason to exist; deleting it is the cutover's own job (§5.2 Phase 4, step
+/// 6), and until then this is staged and unwired, like every other piece of
+/// that step.
+///
+/// The strip recurses, exactly as the byte-level one does over the whole
+/// rendered string: a footnote nested inside a rendered span, or inside a
+/// cross-reference's own display text, is omitted there too.
+pub(crate) fn fold_reference_text(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+) -> String {
+    let mut out = String::new();
+    fold_into_html(nodes, renderer, parser, Footnotes::Stripped, &mut out);
     out
 }
 
@@ -46,11 +100,14 @@ pub(crate) fn fold_html(
 /// `parser` is threaded through because rendering some nodes — an
 /// [`Image`](InlineNode::Image), whose `render_image`/`render_icon` reads the
 /// document's safe mode, `data-uri`, and `icons`/`icontype` attributes — is a
-/// function of document context, not of the node alone.
+/// function of document context, not of the node alone. `footnotes` is
+/// threaded through because a heading's own reference text omits its footnote
+/// markers wherever they sit — see [`fold_reference_text`].
 fn fold_into_html(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
+    footnotes: Footnotes,
     out: &mut String,
 ) {
     for node in nodes {
@@ -117,23 +174,30 @@ fn fold_into_html(
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Link => {
-                fold_link(reference, renderer, parser, out);
+                fold_link(reference, renderer, parser, footnotes, out);
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => {
-                fold_xref(reference, renderer, parser, out);
+                fold_xref(reference, renderer, parser, footnotes, out);
             }
 
             InlineNode::Anchor(anchor) => {
-                fold_anchor(anchor, renderer, parser, out);
+                fold_anchor(anchor, renderer, parser, footnotes, out);
             }
 
             InlineNode::IndexTerm(index_term) => {
-                fold_index_term(index_term, renderer, parser, out);
+                fold_index_term(index_term, renderer, parser, footnotes, out);
             }
 
             InlineNode::Footnote(footnote) => {
-                fold_footnote(footnote, renderer, out);
+                // A heading's own reference text omits the marker entirely —
+                // the node is skipped rather than folded to nothing, since
+                // `render_footnote` is a backend's to define and a backend
+                // that emitted anything would leak it (see
+                // [`fold_reference_text`]).
+                if footnotes == Footnotes::Marked {
+                    fold_footnote(footnote, renderer, out);
+                }
             }
 
             InlineNode::Callout(callout) => {
@@ -149,7 +213,7 @@ fn fold_into_html(
                 // string pipeline's quotes step did: the same `QuoteType`,
                 // attribute list, and id it recognized, so the bytes match.
                 let mut body = String::new();
-                fold_into_html(&styled.children, renderer, parser, &mut body);
+                fold_into_html(&styled.children, renderer, parser, footnotes, &mut body);
 
                 let scope = match styled.form {
                     SpanForm::Constrained => QuoteScope::Constrained,
@@ -323,10 +387,17 @@ fn fold_link(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
+    footnotes: Footnotes,
     out: &mut String,
 ) {
     let mut link_text = String::new();
-    fold_into_html(&reference.children, renderer, parser, &mut link_text);
+    fold_into_html(
+        &reference.children,
+        renderer,
+        parser,
+        footnotes,
+        &mut link_text,
+    );
 
     // Sliced (empty) from the node's own location so its lifetime matches when
     // no attribute list was parsed.
@@ -384,10 +455,17 @@ fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
+    footnotes: Footnotes,
     out: &mut String,
 ) {
     let mut provided = String::new();
-    fold_into_html(&reference.children, renderer, parser, &mut provided);
+    fold_into_html(
+        &reference.children,
+        renderer,
+        parser,
+        footnotes,
+        &mut provided,
+    );
 
     // Whether a display text was *provided* is the presence of a child, not
     // what that child folds to: the `<<id,>>` shorthand records a
@@ -448,6 +526,7 @@ fn fold_anchor(
     anchor: &Anchor<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
+    footnotes: Footnotes,
     out: &mut String,
 ) {
     let reftext = if anchor.is_bibliography {
@@ -455,7 +534,7 @@ fn fold_anchor(
     } else {
         anchor.reftext.as_ref().map(|children| {
             let mut s = String::new();
-            fold_into_html(children, renderer, parser, &mut s);
+            fold_into_html(children, renderer, parser, footnotes, &mut s);
             s
         })
     };
@@ -494,6 +573,7 @@ fn fold_index_term(
     index_term: &IndexTerm<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     parser: &Parser,
+    footnotes: Footnotes,
     out: &mut String,
 ) {
     let mut folded_children = String::new();
@@ -502,7 +582,13 @@ fn fold_index_term(
         if index_term.children.is_empty() {
             Some(index_term.terms.first().map_or("", CowStr::as_ref))
         } else {
-            fold_into_html(&index_term.children, renderer, parser, &mut folded_children);
+            fold_into_html(
+                &index_term.children,
+                renderer,
+                parser,
+                footnotes,
+                &mut folded_children,
+            );
             Some(folded_children.as_str())
         }
     } else {
@@ -637,6 +723,94 @@ mod tests {
         },
         strings::CowStr,
     };
+
+    /// The string pipeline's own two answers for a section title: the
+    /// rendering the heading shows, and the footnote-free text its reference
+    /// and auto-generated id are derived from.
+    ///
+    /// This is exactly what `Section::parse` does — render the title once with
+    /// `mark_footnote_spans` on, cut the bracketed regions out, then strip the
+    /// spent sentinels from the rendering itself.
+    fn golden_title(source: &str, parser: &Parser) -> (String, String) {
+        use crate::content::{Content, SubstitutionGroup, strip_footnote_marker_spans};
+
+        let mut content = Content::from(Span::new(source));
+
+        parser.mark_footnote_spans.set(true);
+        SubstitutionGroup::Title.apply(&mut content, parser, None);
+        parser.mark_footnote_spans.set(false);
+
+        let reftext = strip_footnote_marker_spans(content.rendered_html());
+        content.remove_footnote_marker_sentinels();
+
+        (content.rendered_html().to_string(), reftext)
+    }
+
+    #[test]
+    fn fold_reference_text_matches_the_sentinel_strip() {
+        // The tree's answer to the footnote-marker sentinel system: the two
+        // strings the string pipeline gets from one marked render plus a
+        // byte-level cut are two *folds of the same tree*, and "which regions
+        // were footnote markers" is a question about node kinds rather than
+        // about bytes.
+        //
+        // Every fixture is checked from both ends: `fold_html` reproduces the
+        // heading's own rendering (sentinels removed), and
+        // `fold_reference_text` reproduces the footnote-free text the
+        // reference and the auto-generated id are derived from.
+        let fixtures = [
+            // No footnote at all: the two strings are the same, and the strip
+            // is a no-op on both sides.
+            "Plain title",
+            "A *bold* title",
+            "Tom & Jerry",
+            // The shape that names this: a footnote in a heading.
+            "Section 2footnote:[second footnote]",
+            "footnote:[leading] Section",
+            "Section footnote:[middle] title",
+            "A footnote:[one] and footnote:[two] title",
+            // A named footnote, and a bare reference to one.
+            "Named.footnote:disc[a discussion]",
+            // The marker nested inside constructs the strip has to recurse
+            // through: a rendered span, and a cross-reference's display text.
+            "A *bold footnote:[inside a span] title*",
+            "See xref:sec[the footnote:[inside a text] steps] here",
+            // Beside the other constructs a title can carry, so the strip is
+            // shown to remove the marker and nothing else.
+            "A footnote:[note] and image:x.png[Alt] and `code`",
+            "A footnote:[note] and a (C) and an -- em dash",
+            "A footnote:[note] and a +++<b>raw</b>+++ passthrough",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            // Two independent parsers, since a footnote's number is document
+            // state: one for each side of the comparison (design §5.3).
+            let (rendered, reftext) = golden_title(fixture, &Parser::default());
+
+            let built_parser = Parser::default();
+            let nodes = crate::content::inline_builder::build_for_group(
+                &crate::content::SubstitutionGroup::Title,
+                CowStr::from(fixture),
+                Span::new(fixture),
+                &built_parser,
+                None,
+            );
+
+            assert_eq!(
+                fold_html_with_parser(&nodes, &renderer, &built_parser),
+                rendered,
+                "the heading's own rendering diverged for {fixture:?}"
+            );
+
+            assert_eq!(
+                super::fold_reference_text(&nodes, &renderer, &built_parser),
+                reftext,
+                "the footnote-free reference text diverged for {fixture:?}"
+            );
+        }
+    }
 
     #[test]
     fn fold_emits_raw_verbatim() {

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -308,6 +308,18 @@
 //!   analogous `pass:c,q[…]` form (see [`apply_passthroughs`]'s doc comment),
 //!   except a `Stem` node already has a single `value` field to hold the
 //!   result, so no richer subtree is needed.
+//! [`fold_html`] folds a finished tree back to output bytes; a section title
+//! also needs the **footnote-free** reading its cross-reference text and its
+//! auto-generated id are derived from, which
+//! [`fold_reference_text`] gives by skipping each
+//! [`Footnote`](InlineNode::Footnote) node wherever it sits. That is the
+//! tree's answer to the first of the three sentinel systems design §4.2 names:
+//! the string pipeline renders the title **once** with the footnote renderer
+//! bracketing each marker in a sentinel pair, cuts the bracketed regions out,
+//! and then removes the spent sentinels — one render yielding two strings,
+//! where a tree simply folds twice. Deleting the sentinels is the cutover's
+//! own job; this is staged and unwired like every other piece of that step.
+//!
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf. Under the block-wide
 //!   `hardbreaks` option — the enclosing block's own `attrlist`, or the
@@ -407,7 +419,7 @@ use char_replacements::apply_character_replacements;
 // Consumed only by `cfg(test)` callers and future external callers until the
 // authoritative-fold half of the cutover wires it into `Content`.
 #[allow(unused_imports)]
-pub(crate) use fold::fold_html;
+pub(crate) use fold::{fold_html, fold_reference_text};
 use footnotes::apply_footnotes;
 // Staged for the eventual authoritative-fold half of the cutover (see this
 // module's own doc comment); not yet called from any real parse path, so —


### PR DESCRIPTION
> Stacked on #1244 → #1243 → #1242 → #1241; the base retargets as each merges. The diff shown here is this increment alone.

The **first of the three sentinel systems** design §4.2 names to lose its reason to exist.

## How this one was found

The increments before it were all found by asking the corpus-wide fold-parity audit *what still diverges*. This one came from asking a different question — **what breaks if `rendered_html()` becomes the fold today?** — run as a throwaway experiment over the whole suite. The largest single cluster of failures has one root cause: a footnote in a section heading.

## The boundary

A footnote in a heading is a real, document-order footnote — it is numbered, and the heading renders its marker — but that marker must not appear in the text a cross-reference to the heading shows, nor in the id auto-generated from that text (#594).

The string pipeline needs two strings out of one title and cannot afford two renders (counters and attribute-expanded footnotes would advance twice). So it renders **once** with the footnote renderer bracketing each marker in a sentinel pair (`FOOTNOTE_MARKER_START` … `FOOTNOTE_MARKER_END`, enabled for that render alone by `Parser::mark_footnote_spans`), cuts the bracketed regions out (`strip_footnote_marker_spans`), and then removes the spent sentinels from the title's own rendering *and* from its deferred cross-reference template (`Content::remove_footnote_marker_sentinels`).

## The lift

A tree needs none of it. The footnote is a **node**, so the two strings are two folds of the same tree, and *"which regions were footnote markers"* is a question about node kinds rather than about bytes.

`fold_reference_text` is `fold_html` with each footnote's in-flow marker omitted — the node **skipped** rather than folded to nothing, since `render_footnote` is a backend's to define and one that emitted anything would leak it. The omission recurses exactly as the byte-level cut does over the whole rendered string, so a footnote inside a rendered span or inside a cross-reference's own display text is omitted there too. Nothing else about the fold changes: a `Footnotes` parameter threads down the recursion with `Marked` at every existing call site.

Deleting the sentinels — along with `mark_footnote_spans`, `strip_footnote_marker_spans`, and `remove_footnote_marker_sentinels` — is the cutover's own job. This is staged and unwired like every other piece of step 6.

## Tests

A differential test pins the equivalence from **both** ends, over a corpus of titles: for each, `fold_html` reproduces the heading's own rendering (sentinels removed) and `fold_reference_text` reproduces the footnote-free text, each against the string pipeline's own two answers computed the way `Section::parse` computes them. Two independent parsers per fixture, since a footnote's number is document state.

The corpus covers a title with no footnote at all (where the two strings coincide and the strip is a no-op on both sides), a footnote at either edge and in the middle, two in one title, a named footnote, a marker nested inside a rendered span and inside a cross-reference's display text, and a footnote beside each other construct a title can carry.

## What the experiment says about what is left

Forcing the tree on for every parse and making `rendered` the fold leaves **15** of ~5,370 tests failing, in three clusters:

- this footnote cluster (5) — closed by the mechanism above;
- documented keeps whose golden output the cutover deliberately changes for the better (~5), each already carrying its own divergence test;
- tests of the opt-in flag and of the Strategy-A recorder harness that retire with the flag itself (~5).

That is a far smaller blast radius than "several sessions" suggested when step 6 was written — the prep work has done its job. The experiment is deliberately crude, though (it neither calls the staged side effects nor sequences the fold against resolution), so the cutover's own ordering work is not measured by it. Both the number and that caveat are recorded in the design-doc note.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — **unchanged**, as it must be for an unwired prep
- Coverage — diff-neutral (3 uncovered regions in `fold.rs` before and after, all the pre-existing defensive `debug_assert!(false)` arm)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_