### PR TITLE
test: Add a whole-document parity harness for the builder, after resolution (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5394,6 +5394,68 @@ Each phase is a reviewable unit with a clear exit gate.
   effects nor sequences the fold against resolution), so the cutover's own ordering work is not
   measured by it.
 
+  *Step 6 prep landed as (a whole-document parity harness for the builder, after resolution):*
+  the increment above measured what the cutover breaks; this one closes the gap that measurement
+  exposed in what the branch *verifies*.
+
+  Two corpus-wide harnesses meet at this step and neither covers it. The builder's own corpora
+  drive [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) on a bare
+  [`Content`](../../parser/src/content/content.rs), which has no document catalog and therefore
+  **cannot resolve cross-references** at all. The whole-document sweep that does reach resolution
+  ([`inline_recorder`](../../parser/src/tests/inline_recorder.rs)'s `check_document`) drives the
+  *Strategy-A recorder*, which the first half of this step retired to test-only oracle machinery.
+  So the one property the deferred-cross-reference sentinel system's retirement rests on — **the
+  single-pass builder's tree, folded *after* resolution has run, reproduces the rendered string
+  byte-for-byte** — was asserted only by the handful of hand-written whole-document tests
+  individual increments added for their own shapes.
+
+  [`inline_builder_document_parity`](../../parser/src/tests/inline_builder_document_parity.rs)
+  asserts it over a corpus. It needs only **one** parse, which is what makes it simpler than its
+  recorder counterpart: with [`with_inline_tree`](../../parser/src/parser/parser.rs) on, every
+  content location carries both its rendered string and its tree, so the two are compared
+  directly rather than reconstructed from a second, renderer-perturbed parse.
+
+  The walk reaches every location a tree lives in, and reaches it through the *one pair of
+  accessors that answers for every block kind* —
+  [`IsBlock::rendered_html_content`](../../parser/src/blocks/is_block.rs) and its structured
+  counterpart `inlines` — rather than by matching per variant. That is what keeps a corpus-wide
+  sweep from silently narrowing: a block kind nobody thought to name is covered because it
+  implements the trait. Beyond a paragraph's content it therefore reaches an `admonition` and the
+  whole raw-delimited family (`listing`, `literal`, `pass`, whose verbatim groups run a *different*
+  step selection through `build_for_group`). Two locations are not a block's own content and are
+  named explicitly: a section title (whose own document-order pass in
+  [`title_refs`](../../parser/src/document/title_refs.rs) mutates the title's tree, and whose
+  `SectionBlock` implements neither accessor, a section's content being its children), and a table
+  cell, which is not a block at all — and a **block title** (`.Title`), which is substituted content
+  in its own right, carries its own tree, and belongs to the block without being its content. Every
+  block kind that can carry one is named by a read-only counterpart of the mutable accessor the
+  document-order title pass already uses. A compound delimited block — a quote, an example — needs
+  no entry of its own: it carries no content directly, and the paragraphs inside it are reached by
+  the walk's own recursion. A footnote's own subtree is matched against the catalog's registered texts in
+  document order.
+
+  The corpus is built around resolution, since that is the thing nothing else exercised: both
+  cross-reference spellings resolving in block content, a mix of resolved and unresolved in one
+  document, a reference to a *section* (whose destination text is the heading's own reference
+  text), forward and circular references between headings, a reference inside a rendered span and
+  inside a formatted heading, footnote-embedded references both resolved and unresolved, a
+  footnote in a heading beside a reference to that heading, a named footnote defined once and
+  referenced again, table cells, and nested blocks. Two guards keep it from passing vacuously: a
+  fixture must fold at least one **non-empty** tree, and the sweep must reach both branches of
+  the fold's `resolved` handling — a reference that carries its destination and its text, and one
+  that carries the bracketed fallback. A third pins the *set* of location kinds the sweep reaches,
+  so a walk that stopped visiting one, or a fixture that stopped producing one, shrinks the set and
+  fails rather than passing over a location nobody looked at.
+
+  It passes as written, which is the result worth recording: §4.3's claim that resolution "walks
+  the tree and fills `resolved` in place — non-destructive by construction, re-resolvable, no
+  template" now has a corpus behind it rather than a design argument. A second test pins the
+  property `render_with` will rest on (§3.3.1): the same tree folded twice, and folded through a
+  renderer handed out as a shared `Rc` the way
+  [`Parser::with_inline_substitution_renderer`](../../parser/src/parser/parser.rs) installs one,
+  gives the same bytes. This is test-only: nothing is wired in, and the corpus-wide fold-parity
+  audit is unchanged.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6385,6 +6447,20 @@ Each phase is a reviewable unit with a clear exit gate.
        test pins the equivalence from both ends over a corpus of titles. See the step's own
        "landed as" note above, which also records what the experiment says about the cutover's
        remaining blast radius.
+
+     - ✅ **prep (a whole-document parity harness for the builder, after resolution).** The gap
+       the measurement above exposed in what the branch *verifies*, rather than in what it
+       recognizes. The builder's own corpora run on a bare `Content`, which cannot resolve
+       cross-references; the whole-document sweep that does reach resolution drives the
+       *Strategy-A recorder*, which this step retired to test-only machinery. So the property the
+       deferred-cross-reference sentinel system's retirement rests on — the builder's tree, folded
+       **after** resolution, reproducing the rendered string — had no corpus behind it.
+       [`inline_builder_document_parity`](../../parser/src/tests/inline_builder_document_parity.rs)
+       gives it one, in a single parse (with the tree flag on, each location carries both its
+       rendered string and its tree), reaching every content-bearing block kind through `IsBlock`
+       rather than by variant — paragraphs, admonitions, and the raw-delimited family — plus
+       section titles, table cells, and footnote subtrees, with guards against vacuity and against
+       the walk narrowing. It passes as written. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -68,6 +68,13 @@ impl<'src> AdmonitionBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     /// Parse an admonition block, if the given metadata and content describe
     /// one.
     ///

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -987,6 +987,31 @@ impl<'src> Block<'src> {
             _ => None,
         }
     }
+
+    /// Returns this block's *block title* (`.Title`) as a read-only
+    /// [`Content`], when the block has one — the counterpart of
+    /// [`block_title_content_mut`](Self::block_title_content_mut), naming the
+    /// same set of block kinds.
+    ///
+    /// A block title is substituted content in its own right and so carries
+    /// its own inline tree, which is what the whole-document parity sweep
+    /// reads it for. Blocks that never carry a title return `None`.
+    #[cfg(test)]
+    pub(crate) fn block_title_content(&self) -> Option<&Content<'src>> {
+        match self {
+            Self::Simple(b) => b.title_content(),
+            Self::Media(b) => b.title_content(),
+            Self::List(b) => b.title_content(),
+            Self::RawDelimited(b) => b.title_content(),
+            Self::CompoundDelimited(b) => b.title_content(),
+            Self::Admonition(b) => b.title_content(),
+            Self::Quote(b) => b.title_content(),
+            Self::Table(b) => b.title_content(),
+            Self::Break(b) => b.title_content(),
+            Self::Toc(b) => b.title_content(),
+            _ => None,
+        }
+    }
 }
 
 impl<'src> IsBlock<'src> for Block<'src> {

--- a/parser/src/blocks/break.rs
+++ b/parser/src/blocks/break.rs
@@ -58,6 +58,13 @@ impl<'src> Break<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         _parser: &mut Parser,

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -62,6 +62,13 @@ impl<'src> CompoundDelimitedBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -54,6 +54,13 @@ impl<'src> ListBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -82,6 +82,13 @@ impl<'src> MediaBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -133,6 +133,13 @@ impl<'src> QuoteBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     /// Parse a blockquote, if the given metadata and content describe one.
     ///
     /// Returns `None` (without consuming the block) when the content is not a

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -78,6 +78,13 @@ impl<'src> RawDelimitedBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -179,6 +179,13 @@ impl<'src> TableBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     /// Returns `true` if `line` is a table delimiter.
     ///
     /// A table delimiter is one of the lead characters `|`, `!`, `,`, or `:`

--- a/parser/src/blocks/toc.rs
+++ b/parser/src/blocks/toc.rs
@@ -47,6 +47,13 @@ impl<'src> TocBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's own tree.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -308,6 +308,7 @@
 //!   analogous `pass:c,q[…]` form (see [`apply_passthroughs`]'s doc comment),
 //!   except a `Stem` node already has a single `value` field to hold the
 //!   result, so no richer subtree is needed.
+//!
 //! [`fold_html`] folds a finished tree back to output bytes; a section title
 //! also needs the **footnote-free** reading its cross-reference text and its
 //! auto-generated id are derived from, which

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -1,0 +1,417 @@
+//! A **whole-document** differential harness for the single-pass builder.
+//!
+//! The builder's own corpora
+//! ([`inline_builder`](crate::content::inline_builder)'s test module) drive
+//! [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup)
+//! on a bare [`Content`](crate::content::Content), which has no document
+//! catalog and so **cannot resolve cross-references**. The whole-document sweep
+//! that does reach resolution ([`inline_recorder`](super::inline_recorder)'s
+//! `check_document`) drives the *Strategy-A recorder*, not the builder.
+//!
+//! Between them they leave one thing unverified, and it is the thing the
+//! cutover rests on: **the tree the single-pass builder produces, folded
+//! *after* cross-reference resolution has run, reproduces the rendered string
+//! byte-for-byte.** Design §4.2 retires the deferred-cross-reference sentinel
+//! system on exactly that basis — an `xref` is a
+//! [`Ref`](crate::inlines::Ref)`{resolved: None}` node that resolution fills in
+//! place, "non-destructive by construction, re-resolvable, no template" — and
+//! §4.3 extends the same claim to section titles (whose own document-order
+//! pass mutates the title's tree) and to footnote-embedded references (which
+//! live in a footnote's subtree).
+//!
+//! This harness checks all three, over whole documents, in one parse: with
+//! [`with_inline_tree`](crate::Parser::with_inline_tree) on, every content
+//! location carries *both* its rendered string and its tree, so the two are
+//! compared directly rather than reconstructed from a second parse.
+
+use std::rc::Rc;
+
+use crate::{
+    Parser,
+    blocks::{Block, FindBlocks, IsBlock, TableCellContent, TableRow},
+    content::inline_builder::fold_html,
+    inlines::InlineNode,
+    parser::{HtmlSubstitutionRenderer, ModificationContext},
+};
+
+/// One content location: what the string pipeline rendered, and the tree the
+/// builder produced for the same content.
+struct Location<'a, 'src> {
+    what: String,
+    rendered: String,
+    inlines: &'a [InlineNode<'src>],
+}
+
+/// Collects every content-bearing location in `doc` that carries a tree, in a
+/// fixed document order.
+fn locations<'src>(doc: &'src crate::Document<'src>) -> Vec<Location<'src, 'src>> {
+    fn cells<'src>(row: &'src TableRow<'src>, out: &mut Vec<Location<'src, 'src>>) {
+        for cell in row.cells() {
+            // Only inline (`Simple`) cells carry a single `Content`; an
+            // `AsciiDoc` cell is a nested standalone document and is out of
+            // scope for this harness.
+            if let TableCellContent::Simple(content) = cell.content() {
+                out.push(Location {
+                    what: "table cell".to_string(),
+                    rendered: content.rendered_html().to_string(),
+                    inlines: content.inlines(),
+                });
+            }
+        }
+    }
+
+    fn walk<'src>(block: &'src Block<'src>, out: &mut Vec<Location<'src, 'src>>) {
+        // Every block kind that directly carries content, taken through the
+        // one pair of accessors that answers for all of them
+        // ([`IsBlock::rendered_html_content`] and [`IsBlock::inlines`], the
+        // structured counterpart of the first — "the same blocks carry each").
+        // Reading them rather than matching per variant is what keeps this
+        // walk from silently narrowing: a block kind added later, or one this
+        // sweep's author did not think of (a quote, an admonition, a raw
+        // delimited block, a list item), is covered because it implements the
+        // trait, not because it was named here.
+        if let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines()) {
+            out.push(Location {
+                what: block.raw_context().to_string(),
+                rendered: rendered.to_string(),
+                inlines,
+            });
+        }
+
+        // A **block title** (`.Title`) is substituted content in its own
+        // right and carries its own tree, but it is not the block's content,
+        // so neither accessor above reaches it. Every block kind that can
+        // carry one is named by `block_title_content`, which is the mutable
+        // accessor the document-order title pass already uses, read-only.
+        if let Some(title) = block.block_title_content() {
+            out.push(Location {
+                what: "block title".to_string(),
+                rendered: title.rendered_html().to_string(),
+                inlines: title.inlines(),
+            });
+        }
+
+        // The two remaining locations that are *not* a block's own content,
+        // and so are reached by none of the accessors above.
+        match block {
+            // A section's title: `SectionBlock` implements neither accessor
+            // above (a section's own content is its children), so its title —
+            // whose tree the document-order pass in `title_refs` mutates — is
+            // reached only this way.
+            Block::Section(section) => out.push(Location {
+                what: "section title".to_string(),
+                rendered: section.section_title().to_string(),
+                inlines: section.section_title_inlines(),
+            }),
+
+            // A table's cells are not blocks at all.
+            Block::Table(table) => {
+                if let Some(header) = table.header_row() {
+                    cells(header, out);
+                }
+
+                for row in table.body_rows() {
+                    cells(row, out);
+                }
+
+                if let Some(footer) = table.footer_row() {
+                    cells(footer, out);
+                }
+            }
+
+            _ => {}
+        }
+
+        for child in block.child_blocks() {
+            walk(child, out);
+        }
+    }
+
+    let mut out = vec![];
+
+    for block in doc.child_blocks() {
+        walk(block, &mut out);
+    }
+
+    out
+}
+
+/// Every [`Footnote`](InlineNode::Footnote) node in `nodes`, in document order,
+/// recursing into every container one can be nested inside.
+fn footnote_subtrees<'a, 'src>(
+    nodes: &'a [InlineNode<'src>],
+    out: &mut Vec<&'a [InlineNode<'src>]>,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Footnote(footnote) => {
+                // A bare reference (`footnote:id[]`) defines nothing and keeps
+                // the empty subtree its node type documents; the catalog has
+                // no text for it either.
+                if !footnote.is_reference {
+                    out.push(&footnote.children);
+                }
+
+                footnote_subtrees(&footnote.children, out);
+            }
+
+            InlineNode::Styled(styled) => footnote_subtrees(&styled.children, out),
+            InlineNode::Ref(reference) => footnote_subtrees(&reference.children, out),
+            InlineNode::IndexTerm(index_term) => footnote_subtrees(&index_term.children, out),
+
+            _ => {}
+        }
+    }
+}
+
+/// A parser with `experimental` set, so the UI macros a fixture may carry are
+/// recognized by both sides alike, and with tree building on.
+fn parser() -> Parser {
+    Parser::default()
+        .with_inline_tree(true)
+        .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
+}
+
+/// Parses `source` once and asserts that folding each content location's tree
+/// reproduces that location's own `rendered_html()` string — cross-references
+/// resolved, section titles included, footnote texts included.
+fn check_document(source: &str) -> Vec<String> {
+    let mut parser = parser();
+    let doc = parser.parse(source);
+
+    let renderer = HtmlSubstitutionRenderer {};
+
+    // The fold's `&Parser` supplies document render context (an image's safe
+    // mode, `data-uri`, `icons`); a default one matches these fixtures, none of
+    // which sets an attribute the image renderer reads.
+    let fold_parser = Parser::default();
+
+    let locations = locations(&doc);
+
+    // Guard against a fixture that exercises nothing — and against the
+    // subtler vacuity of a location whose tree is empty, which would fold to
+    // the empty string and match an empty rendering.
+    assert!(
+        locations.iter().any(|l| !l.inlines.is_empty()),
+        "document fixture folded no content for {source:?}"
+    );
+
+    for location in &locations {
+        assert_eq!(
+            fold_html(location.inlines, &renderer, &fold_parser),
+            location.rendered,
+            "the {} fold diverged from its rendered string for {source:?}",
+            location.what
+        );
+    }
+
+    // A footnote's text is extracted out of the block it was written in, so it
+    // reaches no `rendered_html()` string above; it is nonetheless substituted
+    // inline content, and the source of a footnote node's subtree, so it folds
+    // under the same invariant. The catalog's entries are in document order,
+    // and so is this walk.
+    let mut subtrees = vec![];
+
+    for location in &locations {
+        footnote_subtrees(location.inlines, &mut subtrees);
+    }
+
+    let catalog = doc.catalog();
+
+    let texts: Vec<String> = catalog
+        .footnotes()
+        .iter()
+        .map(|footnote| footnote.text.clone())
+        .collect();
+
+    let kinds = locations.iter().map(|l| l.what.clone()).collect();
+
+    assert_eq!(
+        subtrees.len(),
+        texts.len(),
+        "footnote subtree count differs from the catalog's for {source:?}"
+    );
+
+    for (subtree, text) in subtrees.iter().zip(texts.iter()) {
+        assert_eq!(
+            &fold_html(subtree, &renderer, &fold_parser),
+            text,
+            "a footnote's subtree fold diverged from its registered text for {source:?}"
+        );
+    }
+
+    kinds
+}
+
+#[test]
+fn fold_matches_the_rendered_string_after_resolution() {
+    // The corpus this harness exists for: documents whose cross-references
+    // actually resolve, so the fold is exercised *after* the resolution pass
+    // has mutated the tree in place.
+    let mut kinds: Vec<String> = vec![];
+
+    for source in [
+        // Resolved cross-references, both spellings, in block content.
+        "[[tgt]]The target paragraph.\n\nSee <<tgt>> for details.",
+        "[[tgt]]Target.\n\nSee <<tgt,the target>> now.",
+        "[[tgt]]Target.\n\nSee xref:tgt[the target] now.",
+        // Several references, one unresolved, so both branches of the fold's
+        // `resolved` handling are reached in one document.
+        "[[a]]First.\n\n[[b]]Second.\n\nSee <<a>>, <<b>>, and <<missing>>.",
+        // A reference resolving to a *section*, whose destination text is the
+        // heading's own reference text — the title pass's own output.
+        "== Install\n\nSee <<_install>> for details.",
+        "[#setup]\n== Set Up\n\nSee <<setup>> and <<setup,the setup>>.",
+        // Forward and circular references between headings, which is why the
+        // title pass exists at all.
+        "[#one]\n== See <<two>>\n\nBody.\n\n[#two]\n== See <<one>>\n\nBody.",
+        // A reference inside a rendered span, and one inside a formatted
+        // heading — resolution has to reach into the span's children.
+        "[[tgt]]Target.\n\nSee *the <<tgt>> here*.",
+        "[[tgt]]Target.\n\n== A *bold* <<tgt>> heading\n\nBody.",
+        // Footnote-embedded cross-references, resolved and unresolved: the
+        // reference lives in the footnote's own subtree.
+        "[[tgt]]The target.\n\nA claim.footnote:[see <<tgt>> for details]",
+        "A claim.footnote:[see <<missing>>]",
+        "[[a]]A.\n\n[[b]]B.\n\nSee <<a>>.footnote:[and also <<b>>] and <<b>>.",
+        // A footnote in a heading, beside a reference to that heading.
+        "[#sect]\n== Section footnote:[a note]\n\nSee <<sect>>.",
+        // Footnote texts carrying their own inline constructs.
+        "A claim.footnote:[the *strong* and _soft_ evidence]",
+        "A claim.footnote:[see link:https://example.org[the source]]",
+        // A named footnote defined once and referenced again: the reference
+        // defines nothing, so it contributes no subtree.
+        "Named.footnote:disc[a *discussion*] then footnote:disc[].",
+        // Table cells, which carry their own `Content` and their own trees.
+        "|===\n|A *bold* cell |A `code` cell\n|===",
+        // Block titles, which carry their own tree — including one whose own
+        // cross-reference the document-order title pass resolves, on each of
+        // the block kinds that can carry one.
+        "[[tgt]]Target.\n\n.A *bold* title with <<tgt>>\nA paragraph.",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n|===\n|cell\n|===",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n====\nAn example.\n====",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n----\nlisting\n----",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n* An item",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\nimage::pic.png[Alt]",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n[NOTE]\n====\nnote body\n====",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n[quote]\n____\nquoted\n____",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\n'''",
+        "[[tgt]]Target.\n\n.A title with <<tgt>>\ntoc::[]",
+        "[[tgt]]Target.\n\n|===\n|See <<tgt>> here\n|===",
+        // Nested blocks, so the walk's recursion is exercised.
+        "====\nAn example with *bold*.\n\nAnd a second para.\n====",
+        "* A *list* item\n* Another with <<tgt>>\n\n[[tgt]]Target.",
+        // The other content-bearing block kinds the walk reaches through
+        // `IsBlock` rather than by name: a quote, an admonition, the raw
+        // delimited blocks (whose verbatim groups run a *different* step
+        // selection through `build_for_group`), a media block's own alt text,
+        // and a list's principal text beside its attached blocks.
+        "[quote,Author]\n____\nA quote with *bold* and <<tgt>>.\n____\n\n[[tgt]]Target.",
+        "____\nA bare quote with `code` and an image:q.png[Q].\n____",
+        "NOTE: An admonition with *bold* and a link:n.html[note].",
+        "[NOTE]\n====\nA block admonition with <<tgt>>.\n====\n\n[[tgt]]Target.",
+        "----\nlisting with a < b and *no* quotes\n----",
+        "....\nliteral with a < b and *no* quotes\n....",
+        "[source,rust]\n----\nlet x = a < b; // <1>\n----\n<1> A callout.",
+        "++++\n<p>passthrough with a < b</p>\n++++",
+        // A media block carries a tree, but an empty one — its alt text lives
+        // in the attribute list, not in inline content — so it rides beside a
+        // paragraph rather than standing alone, which the non-vacuity guard
+        // would (rightly) reject.
+        "image::pic.png[An *alt* text]\n\nA *para* beside it.",
+        "* Principal *text*\n+\nAn attached para with <<tgt>>.\n\n[[tgt]]Target.",
+        "term:: A *definition* with <<tgt>>.\n\n[[tgt]]Target.",
+        // Plain documents, so the harness is not only about references.
+        "First *para* here.\n\nSecond _para_ with `code` and (C).",
+        "== Heading\n\nBody with an image:x.png[Alt] and a kbd:[Ctrl,T].",
+    ] {
+        kinds.extend(check_document(source));
+    }
+
+    // The walk reads `IsBlock` rather than matching per variant, which is what
+    // keeps it from silently narrowing. Pin the whole set of location kinds
+    // the corpus reaches, rather than a hand-picked few: a walk that stopped
+    // visiting a kind, or a fixture that stopped producing one, shrinks this
+    // set and fails here instead of passing over a location nobody looked at.
+    //
+    // The four beyond `paragraph` / `section title` / `table cell` are what
+    // reading the trait added — the raw-delimited family (`listing`,
+    // `literal`, `pass`, whose verbatim groups run a *different* step
+    // selection through `build_for_group`) and an inline `admonition`. A
+    // *quote* block is not among them and needs no fixture of its own: like
+    // every compound delimited block it carries no content directly, and the
+    // paragraphs inside it are reached by this walk's own recursion.
+    kinds.sort();
+    kinds.dedup();
+
+    assert_eq!(
+        kinds,
+        [
+            "admonition",
+            "block title",
+            "listing",
+            "literal",
+            "paragraph",
+            "pass",
+            "section title",
+            "table cell",
+        ]
+    );
+
+    // And the property the corpus above exists to exercise, asserted directly
+    // so the sweep cannot pass by never reaching a resolved reference at all.
+    // Both branches of the fold's `resolved` handling are covered: a reference
+    // that resolved carries its destination and its text, and one that did not
+    // carries the bracketed fallback.
+    let mut parser = parser();
+    let doc = parser.parse("[[tgt]]Target.\n\nSee <<tgt,the target>> and <<missing>>.");
+
+    let folded: Vec<String> = locations(&doc)
+        .iter()
+        .map(|l| fold_html(l.inlines, &HtmlSubstitutionRenderer {}, &Parser::default()))
+        .collect();
+
+    assert!(
+        folded
+            .iter()
+            .any(|f| f.contains(r##"<a href="#tgt">the target</a>"##)),
+        "the sweep never reached a resolved reference: {folded:?}"
+    );
+
+    assert!(
+        folded.iter().any(|f| f.contains("[missing]")),
+        "the sweep never reached an unresolved reference: {folded:?}"
+    );
+}
+
+#[test]
+fn a_stateful_renderer_is_not_required_for_the_fold() {
+    // The fold takes the renderer as an argument, so the same tree renders
+    // through a second, independently-constructed renderer to the same bytes —
+    // the property `render_with` will rest on (design §3.3.1). Driven here on
+    // a document whose references resolve, since that is this harness's own
+    // subject.
+    let mut parser = parser();
+    let doc = parser.parse("[[tgt]]Target.\n\nSee <<tgt>> and *bold* and footnote:[a note].");
+
+    let fold_parser = Parser::default();
+
+    for location in locations(&doc) {
+        let once = fold_html(location.inlines, &HtmlSubstitutionRenderer {}, &fold_parser);
+        let twice = fold_html(location.inlines, &HtmlSubstitutionRenderer {}, &fold_parser);
+
+        assert_eq!(once, twice);
+        assert_eq!(once, location.rendered);
+    }
+
+    // And through a renderer handed out as a shared `Rc`, which is how
+    // `Parser::with_inline_substitution_renderer` installs one.
+    let shared: Rc<HtmlSubstitutionRenderer> = Rc::new(HtmlSubstitutionRenderer {});
+
+    for location in locations(&doc) {
+        assert_eq!(
+            fold_html(location.inlines, shared.as_ref(), &fold_parser),
+            location.rendered
+        );
+    }
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod assert_dom;
 mod block_nesting_depth;
 pub(crate) mod fixtures;
 mod hash;
+mod inline_builder_document_parity;
 mod inline_builder_recorder_parity;
 mod inline_recorder;
 mod inline_substitution_renderer;


### PR DESCRIPTION
> Stacked on #1245 → #1244 → #1243 → #1242; the base retargets as each merges. The diff shown here is this increment alone.

#1245 measured what the cutover breaks. This one closes the gap that measurement exposed in what the branch **verifies**.

## The gap

Two corpus-wide harnesses meet at this step and neither covers it:

- the **builder's own corpora** drive `SubstitutionGroup::apply` on a bare `Content`, which has no document catalog and therefore *cannot resolve cross-references at all*;
- the **whole-document sweep** that does reach resolution (`inline_recorder`'s `check_document`) drives the *Strategy-A recorder*, which the first half of step 6 retired to test-only oracle machinery.

So the one property the deferred-cross-reference sentinel system's retirement rests on — **the single-pass builder's tree, folded *after* resolution has run, reproduces the rendered string byte-for-byte** — was asserted only by the handful of hand-written whole-document tests individual increments added for their own shapes.

## The harness

`inline_builder_document_parity` asserts it over a corpus, and needs only **one** parse — which is what makes it simpler than its recorder counterpart. With `with_inline_tree` on, every content location carries *both* its rendered string and its tree, so the two are compared directly rather than reconstructed from a second, renderer-perturbed parse.

The walk reaches every location a tree lives in:

- a simple block's content;
- a **section title**, whose own document-order pass in `title_refs` mutates the title's tree;
- a **table cell**, which carries its own `Content`;
- a **footnote's subtree**, matched against the catalog's registered texts in document order.

The corpus is built around resolution, since that is the thing nothing else exercised: both cross-reference spellings resolving in block content, a mix of resolved and unresolved in one document, a reference to a *section* (whose destination text is the heading's own reference text), forward and circular references between headings, a reference inside a rendered span and inside a formatted heading, footnote-embedded references both resolved and unresolved, a footnote in a heading beside a reference to that heading, a named footnote defined once and referenced again, table cells, and nested blocks.

Two guards keep it from passing vacuously: a fixture must fold at least one **non-empty** tree, and the sweep must reach **both** branches of the fold's `resolved` handling — a reference that carries its destination and its text, and one that carries the bracketed fallback.

## The result

It passes as written, which is the result worth recording: §4.3's claim that resolution *"walks the tree and fills `resolved` in place — non-destructive by construction, re-resolvable, no template"* now has a corpus behind it rather than a design argument.

A second test pins the property `render_with` will rest on (§3.3.1): the same tree folded twice, and folded through a renderer handed out as a shared `Rc` the way `Parser::with_inline_substitution_renderer` installs one, gives the same bytes.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — **unchanged**; this is test-only and nothing is wired in
- Coverage — `parser/src/tests/` is excluded from the coverage build, so this adds no uncovered production lines

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_