### PR TITLE
test: Add a corpus-wide side-effect parity harness, and walk an index term's children (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5456,6 +5456,63 @@ Each phase is a reviewable unit with a clear exit gate.
   gives the same bytes. This is test-only: nothing is wired in, and the corpus-wide fold-parity
   audit is unchanged.
 
+  *Step 6 prep landed as (a corpus-wide side-effect parity harness, and the index term it found):*
+  the increment above closed one half of what the blast-radius experiment left unmeasured — it
+  "neither calls the staged side effects nor sequences the fold against resolution". This one
+  closes the other half, and unlike its sibling it does **not** pass as written.
+
+  Recognizing a construct is not only about the bytes it renders. Four passes of the string
+  pipeline also write down what they saw — an image's target and a link's in the asset catalog, an
+  inline anchor's and a bibliography entry's id in the reference catalog, and a dangerous `link=`
+  scheme in the shared warnings list — and step 6 has to replay all four from the tree, exactly
+  once per parse and in the string pipeline's own pass order. That is what
+  [`apply_macro_side_effects`](../../parser/src/content/inline_builder/macros/mod.rs) is staged to
+  do, and until now it was pinned only by hand-written fixtures inside its own module, one per
+  ordering rule it has to honor.
+
+  [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+  drives a corpus through both sides on two independently-configured parsers (§5.3's discipline —
+  each side registers into the parser it is given, so a shared one would see every entry twice and
+  fire every duplicate-id warning spuriously) and compares *everything either side wrote down*:
+  catalog entries in registration order, ids with their reftext and kind, and warnings in the
+  order the one shared list received them. The corpus covers each family alone and in company, the
+  link family's three-pass order (which fills the catalog in *pass* rather than document order),
+  an `imagesdir` in force, a registration reached from inside another construct's subtree, ids
+  duplicated across two families, and — the shapes most likely to over-register — an escaped
+  macro, one sealed in a passthrough, and one in monospace, each beside a live twin so an
+  over-eager replay shows up as a length mismatch rather than as two empty lists. Three guards
+  keep it honest: the corpus as a whole must write something, each of the four lists must be
+  reached, and the fixtures that write *nothing* are named rather than counted — `icon:` among
+  them, which shares the image family's pass and node kind but is not an asset.
+
+  What it found is one root cause with two faces. [`IndexTerm`](../../parser/src/inlines/index_term.rs)
+  is the **fourth** node kind carrying `children` — added by the visible-term increment above, after
+  all three side-effect walks were written — and none of the three descended into it, so an image,
+  link, or anchor a visible term encloses was recognized, rendered, and then registered nowhere.
+  The walks now recurse into it, and their doc comments say why four is the whole list: a fifth
+  child-bearing kind would be a new place a macro node can hide, and this sweep is what catches one.
+
+  The other face is a **recognition** gap the same fixtures expose, and it is not this increment's
+  to close. The string pipeline replaces a visible term with its shown text and nothing else, so
+  that text goes on sitting in the one flat haystack every later pass scans: a `link:` macro, a
+  bare URL, an anchor, or a cross-reference written inside `((…))` is recognized by the pass that
+  runs *after* the index-term pass, exactly as if the parentheses were not there. A tree cannot do
+  that with the shown text it currently keeps — a plain visible term's is an already-substituted
+  *string* in `terms`, not a subtree — so the families after this one have no nodes to descend
+  into. (The families *before* it are unaffected, which is why the image half of the sweep passes:
+  their construct is already a node when the term encloses it, and rides along in `children`. So
+  is a construct inside a rendered span the term encloses, whose children this step resolves in
+  full before any of this level's families run.) Closing it needs a visible term's shown text to be
+  nodes in **every** case, not only when it encloses a rendered span, *and* the families after this
+  one to descend into them — a change to what the node carries, so it is its own increment.
+  Deferred and pinned by a divergence test, with its parity complement beside it.
+
+  This is the first divergence found by asking about side effects rather than about bytes, and it
+  was invisible to the fold-parity audit for a reason worth recording: the audit's corpus had no
+  fixture putting a later family inside a visible term, so the *rendering* half of the same root
+  cause had gone unseen too. Re-running the audit shows no change to the divergence set, since the
+  shapes that expose it are new here. Coverage is diff-neutral; nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6461,6 +6518,22 @@ Each phase is a reviewable unit with a clear exit gate.
        rather than by variant — paragraphs, admonitions, and the raw-delimited family — plus
        section titles, table cells, and footnote subtrees, with guards against vacuity and against
        the walk narrowing. It passes as written. See the step's own "landed as" note above.
+
+     - ✅ **prep (a corpus-wide side-effect parity harness).** The other half of what the
+       blast-radius measurement left unmeasured: it "neither calls the staged side effects nor
+       sequences the fold against resolution", and the harness above closed only the second
+       clause. `apply_macro_side_effects` — the replay of the four registrations the string
+       pipeline performs at recognition time — was pinned only by hand-written fixtures inside its
+       own module.
+       [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+       drives a corpus through both sides on two independent parsers and compares every catalog
+       entry, id, and warning either wrote, in order. Unlike its sibling it does **not** pass as
+       written: `IndexTerm` is the fourth node kind carrying `children`, added after all three
+       side-effect walks were written, and none descended into it. The walks now do. The same
+       fixtures expose a *recognition* gap with the same root cause — the families that run after
+       the index-term pass cannot reach a plain visible term's shown text, which is a string
+       rather than a subtree — deferred to its own increment and pinned by a divergence test with
+       its parity complement beside it. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -491,9 +491,15 @@ fn build_anchor_reftext<'src>(
 /// Every other caller passes `false`.
 ///
 /// Recurses into every container an id-bearing node can be nested inside —
-/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref), and
-/// [`Footnote`](InlineNode::Footnote) children — mirroring exactly where the
+/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),
+/// [`Footnote`](InlineNode::Footnote), and
+/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where the
 /// image and link increments' own side-effect functions recurse.
+///
+/// The four containers are exactly the four node kinds that carry
+/// `children` — a fifth would be a new place a macro node can hide, and the
+/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
+/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
 pub(crate) fn apply_ref_side_effects(
     nodes: &[InlineNode<'_>],
     parser: &Parser,
@@ -543,6 +549,15 @@ pub(crate) fn apply_ref_side_effects(
             InlineNode::Footnote(footnote) => {
                 apply_ref_side_effects(
                     &footnote.children,
+                    parser,
+                    source,
+                    leading_anchor_registered,
+                );
+            }
+
+            InlineNode::IndexTerm(index_term) => {
+                apply_ref_side_effects(
+                    &index_term.children,
                     parser,
                     source,
                     leading_anchor_registered,

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1038,10 +1038,20 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 /// tests, against their own `Parser`.
 ///
 /// Recurses into every container an `Image` node can be nested inside —
-/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref), and
-/// [`Footnote`](InlineNode::Footnote) children — mirroring exactly where
+/// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),
+/// [`Footnote`](InlineNode::Footnote), and
+/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where
 /// [`apply_macros`](super::apply_macros) and the footnote increment's own
-/// `emit_range` can place one.
+/// `emit_range` can place one. A visible index term's shown text is the
+/// newest of the four: it holds `children` only when the term encloses a
+/// construct the image pass already recognized
+/// (`((a term with an image:t.png[T] inside))`), which is precisely when a
+/// registration can hide there.
+///
+/// The four containers are exactly the four node kinds that carry
+/// `children` — a fifth would be a new place a macro node can hide, and the
+/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
+/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
 pub(crate) fn apply_image_side_effects(
     nodes: &[InlineNode<'_>],
     parser: &Parser,
@@ -1078,6 +1088,10 @@ pub(crate) fn apply_image_side_effects(
 
             InlineNode::Footnote(footnote) => {
                 apply_image_side_effects(&footnote.children, parser, source);
+            }
+
+            InlineNode::IndexTerm(index_term) => {
+                apply_image_side_effects(&index_term.children, parser, source);
             }
 
             _ => {}

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -172,6 +172,17 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// design §4.4's coarse fallback. This is the same lift the anchor and
 /// bare-e-mail families already made, for the same reason.
 ///
+/// What a visible term's shown text *encloses* is recognized only by the
+/// families that run **before** this one (image/icon), or by a rendered span
+/// the quotes step wrote earlier, whose own children this step resolves in
+/// full first — either way the construct is already a node, carried in
+/// [`children`](crate::inlines::IndexTerm::children). The families that run
+/// **after** (the three link spellings, anchors, cross-references) do not
+/// reach it: a plain visible term's shown text is an already-substituted
+/// *string* in [`terms`](crate::inlines::IndexTerm::terms), and the string
+/// pipeline goes on scanning that text in its one flat haystack where a tree
+/// has no nodes to descend into. Deferred, pinned by a divergence test.
+///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect; the string replacer records nothing in a catalog either (the HTML
 /// backend generates no index), so there is none to skip here.
@@ -1408,6 +1419,83 @@ mod tests {
         let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
         assert!(folded.contains("indexterm2:["));
         assert_eq!(golden_macros(source), "<strong>bold</strong> term");
+    }
+
+    #[test]
+    fn a_later_family_inside_a_visible_terms_shown_text_is_a_documented_divergence() {
+        // Found by the corpus-wide side-effect sweep
+        // (`tests::inline_builder_side_effect_parity`), and a *recognition*
+        // gap rather than a replay one — the same root cause seen from both
+        // sides.
+        //
+        // The string pipeline replaces a visible term with its shown text and
+        // nothing else, so that text goes on sitting in the one flat haystack
+        // every later pass scans: a `link:`/`mailto:` macro, a bare URL or
+        // address, an inline anchor, or a cross-reference written inside
+        // `((…))` is recognized by the pass that runs after this one, exactly
+        // as if the parentheses were not there.
+        //
+        // A tree cannot do that with the shown text it currently keeps. This
+        // family runs where the string step runs it — after image/icon, before
+        // the link families — and the shown text of a *plain* visible term is
+        // an already-substituted **string** in
+        // [`terms`](crate::inlines::IndexTerm::terms), not a subtree, so the
+        // families that follow have no nodes to descend into. (The families
+        // that run *before* this one are unaffected: their construct is
+        // already a node when the term encloses it, which is what
+        // [`children`](crate::inlines::IndexTerm::children) carries — see the
+        // parity test below for `image:`, and the side-effect sweep's own
+        // index-term test for a nested rendered span, whose children this step
+        // resolves in full before any of this level's families run.)
+        //
+        // Closing it needs a visible term's shown text to be nodes in every
+        // case, not only when it encloses a rendered span, *and* the families
+        // after this one to descend into them — a change to what the node
+        // carries, so it is its own increment rather than this one's.
+        for source in [
+            "((a term with a link:t.html[T] inside)) end",
+            "((a term with https://t.example inside)) end",
+            "((a term with an [[t]] anchor inside)) end",
+            "((a term with xref:s[X] inside)) end",
+            "indexterm2:[a term with a link:t.html[T] inside] end",
+        ] {
+            let nodes = build_src(Span::new(source));
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+            assert_ne!(
+                folded,
+                golden_macros(source),
+                "expected a divergence for {source:?}"
+            );
+
+            // The term itself *is* recognized — only what its shown text
+            // encloses is left as literal source.
+            assert!(
+                nodes.iter().any(|n| matches!(n, InlineNode::IndexTerm(_))),
+                "expected the term to be recognized for {source:?}: {nodes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_earlier_family_inside_a_visible_terms_shown_text_is_parity() {
+        // The complement of the divergence above, and the reason it is drawn
+        // where it is: `image:`/`icon:` runs *before* this family, so an image
+        // a visible term encloses is already an [`Image`](InlineNode::Image)
+        // node when the term is built, and rides along in the term's own
+        // `children`.
+        for source in [
+            "((a term with an image:t.png[T] inside)) end",
+            "indexterm2:[a term with an image:t.png[T] inside] end",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "expected parity for {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2049,13 +2049,21 @@ fn build_email_node<'src>(
 ///
 /// Recurses into every container a `Ref` node can be nested inside —
 /// [`Styled`](InlineNode::Styled), another [`Ref`](InlineNode::Ref) (a link's
-/// own display children, or a cross-reference's), and
-/// [`Footnote`](InlineNode::Footnote) children — mirroring exactly where
+/// own display children, or a cross-reference's),
+/// [`Footnote`](InlineNode::Footnote), and
+/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where
 /// [`apply_macros`](super::apply_macros) and the footnote increment's own
 /// `emit_range` can place one. A cross-reference node itself is not
 /// registered — only a [`Link`](RefVariant::Link) has an asset-catalog entry —
 /// but its children are still walked, since a formatted cross-reference text
-/// could itself carry a nested link.
+/// could itself carry a nested link. A visible index term's shown text is the
+/// newest of the four, and carries every link spelling: all three of this
+/// family's passes descend into it.
+///
+/// The four containers are exactly the four node kinds that carry
+/// `children` — a fifth would be a new place a macro node can hide, and the
+/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
+/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
 pub(crate) fn apply_link_side_effects(nodes: &[InlineNode<'_>], parser: &Parser) {
     register_links_of_form(nodes, parser, LinkForm::AutoOrFormal);
     register_links_of_form(nodes, parser, LinkForm::Macro);
@@ -2081,6 +2089,10 @@ fn register_links_of_form(nodes: &[InlineNode<'_>], parser: &Parser, form: LinkF
 
             InlineNode::Footnote(footnote) => {
                 register_links_of_form(&footnote.children, parser, form);
+            }
+
+            InlineNode::IndexTerm(index_term) => {
+                register_links_of_form(&index_term.children, parser, form);
             }
 
             _ => {}

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -1,0 +1,445 @@
+//! A corpus-wide differential harness for the builder's recognition **side
+//! effects**.
+//!
+//! Recognizing a construct is not only about the bytes it renders. Four
+//! passes of the string pipeline also *write down* what they saw: an
+//! `image:` macro records its target in the asset catalog, a `link:`/`mailto:`
+//! macro and every auto-linked URL or address record theirs, an inline anchor
+//! (and a bibliography entry) registers its id in the reference catalog, and
+//! an image whose `link=` names a dangerous scheme records a warning. Design
+//! §5.2's step 6 has to replay all four from the tree, exactly once per parse
+//! and in the string pipeline's own pass order, which is what
+//! [`apply_macro_side_effects`](crate::content::inline_builder::apply_macro_side_effects)
+//! is staged to do.
+//!
+//! Until now it was pinned only by hand-written fixtures inside its own
+//! module — one per ordering rule it has to honor. The blast-radius
+//! experiment recorded in the design doc (what breaks if `rendered_html()`
+//! becomes the fold today?) says so in as many words: it "neither calls the
+//! staged side effects nor sequences the fold against resolution". The
+//! sibling harness
+//! [`inline_builder_document_parity`](super::inline_builder_document_parity)
+//! closed the second half of that sentence. This one closes the first.
+//!
+//! The discipline is design §5.3's: two independently-configured parsers see
+//! the same fixture, one through the real
+//! [`SubstitutionGroup::Normal`](crate::content::SubstitutionGroup) pipeline
+//! and one through [`build`](crate::content::inline_builder::build) plus the
+//! staged replay, and everything either side wrote down must match — the
+//! catalog entries, in registration order, and the warnings, in the order one
+//! shared list received them.
+
+use crate::{
+    Parser, Span,
+    content::{
+        Content, SubstitutionGroup,
+        inline_builder::{apply_macro_side_effects, build},
+    },
+    document::RefType,
+    parser::ModificationContext,
+    warnings::WarningType,
+};
+
+/// Everything a recognition pass writes down *besides* the rendered string.
+#[derive(Debug, Eq, PartialEq)]
+struct SideEffects {
+    /// Image targets with the `imagesdir` in force, in document order.
+    images: Vec<(String, Option<String>)>,
+
+    /// Link targets, in the string pipeline's three-pass order.
+    links: Vec<String>,
+
+    /// Registered ids with their reftext and kind, sorted by id (the
+    /// reference catalog's own deterministic order).
+    refs: Vec<(String, Option<String>, RefType)>,
+
+    /// Substitution warnings, in the order the one shared list received them.
+    warnings: Vec<WarningType>,
+}
+
+/// Snapshots everything `parser` has had written into it, draining the
+/// warnings so the snapshot is total rather than incremental.
+fn snapshot(parser: &Parser) -> SideEffects {
+    // The two borrows are of different `RefCell`s (the catalog and the
+    // warnings buffer), so they do not conflict; the catalog's is scoped
+    // anyway, since its `Ref` outliving the read would be a hazard for any
+    // later caller.
+    let (images, links, refs) = {
+        let catalog = parser.catalog();
+
+        (
+            catalog
+                .images()
+                .iter()
+                .map(|image| (image.target.clone(), image.imagesdir.clone()))
+                .collect(),
+            catalog.links().to_vec(),
+            catalog
+                .entries()
+                .map(|(id, entry)| {
+                    (
+                        id.to_string(),
+                        entry.reftext.clone(),
+                        entry.ref_type.clone(),
+                    )
+                })
+                .collect(),
+        )
+    };
+
+    SideEffects {
+        images,
+        links,
+        refs,
+        warnings: parser
+            .drain_substitution_warnings_since(0)
+            .into_iter()
+            .map(|warning| warning.warning)
+            .collect(),
+    }
+}
+
+/// The parser both sides of a comparison are built from, one instance each.
+///
+/// Asset cataloging is on: `register_image` and `register_link` are no-ops
+/// without it, so a run that left it off would compare two empty lists and
+/// pass for the wrong reason. The three attributes are what the corpus's
+/// expanded-target fixtures reference; without them those fixtures would
+/// leave an unexpanded `{...}` behind and register nothing, passing for the
+/// same wrong reason.
+fn corpus_parser() -> Parser {
+    Parser::default()
+        .with_catalog_assets(true)
+        .with_intrinsic_attribute("logo", "logo.png", ModificationContext::Anywhere)
+        .with_intrinsic_attribute(
+            "url",
+            "https://example.org/docs",
+            ModificationContext::Anywhere,
+        )
+        .with_intrinsic_attribute(
+            "link-macro",
+            "link:index.html[Docs]",
+            ModificationContext::Anywhere,
+        )
+}
+
+/// Runs `source` through the real pipeline and through the builder's staged
+/// replay, on two independent parsers, and returns what each wrote down.
+///
+/// `configure` is called once per side rather than sharing one `Parser`: both
+/// sides register into the parser they are given, so a shared one would see
+/// every entry twice and every duplicate-id warning fire spuriously. The same
+/// two-independent-parsers discipline design §5.3 establishes for the fold's
+/// own corpora.
+fn side_effects_with(source: &str, configure: impl Fn() -> Parser) -> (SideEffects, SideEffects) {
+    let golden_parser = configure();
+    let mut content = Content::from(Span::new(source));
+    SubstitutionGroup::Normal.apply(&mut content, &golden_parser, None);
+
+    let builder_parser = configure();
+    let nodes = build(Span::new(source), &builder_parser, None);
+    apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
+
+    (snapshot(&golden_parser), snapshot(&builder_parser))
+}
+
+fn side_effects(source: &str) -> (SideEffects, SideEffects) {
+    side_effects_with(source, corpus_parser)
+}
+
+impl SideEffects {
+    /// `true` when this fixture wrote nothing at all — the shape that would
+    /// make a comparison pass vacuously.
+    fn is_empty(&self) -> bool {
+        self.images.is_empty()
+            && self.links.is_empty()
+            && self.refs.is_empty()
+            && self.warnings.is_empty()
+    }
+}
+
+/// Every fixture the sweep drives. Each is a *single* content: the harness
+/// compares one `Content`'s worth of registrations, so a fixture's own
+/// left-to-right order is the only ordering under test.
+const CORPUS: &[&str] = &[
+    // Nothing to register at all — the negative controls for the sweep's own
+    // non-vacuity guard, which requires the corpus *as a whole* to register
+    // something, not every fixture in it. `icon:` is the interesting one: it
+    // shares the image family's pass (and its node kind) but is *not* an
+    // asset, so a replay that registered one would be caught here rather than
+    // by a comparison, since the golden side registers nothing either.
+    "plain text with no constructs",
+    "*bold* and _em_ and `code`",
+    "an icon:home[] icon",
+    //
+    // The image family, alone and in company.
+    "an image:photo.png[Alt Text] inline",
+    "image:a.png[] and image:b.png[] and image:c.png[]",
+    "image:a&b.png[Query] with a special in the target",
+    "image:{logo}[Logo] from an expanded target",
+    "image:x.png[alt,link=https://example.org] with a safe link",
+    "image:x.png[alt,link=javascript:alert(1)] with a dangerous one",
+    "image:x.png[alt,link=self] with the self form",
+    //
+    // The link family's three passes. The catalog fills in *pass* order
+    // (auto/formal, then explicit macro, then bare address), not document
+    // order, which is the whole reason the replay walks the tree three times.
+    "A link:https://example.org[example] link.",
+    "See https://example.org for details.",
+    "write to doc@example.org today",
+    "Visit https://example.org or link:docs.html[the docs], or write to doc@example.org.",
+    "mailto:a@b.com[email me] and link:c.html[c] and https://d.example and e@f.example",
+    "An angle-bracketed <https://example.org> link.",
+    "link:{url}[Docs] from an expanded target",
+    "{link-macro} wholly from one expansion",
+    "a https://example.org[] bare-macro link",
+    "visit https://example.org/path?q=1 now",
+    "link:https://example.org[Example,role=external,window=_blank]",
+    //
+    // Anchors and bibliography entries.
+    "[[the-anchor]]Anchored paragraph.",
+    "[[a,Reftext A]] and [[b]] and [[c,Reftext C]]",
+    "text before anchor:named[Ref Text] and after",
+    "[[mid-anchor]] after the anchor",
+    "[#only-id]#text#",
+    "[.role1.role2#the-id]#decorated#",
+    "[#anchor]#anchored#",
+    "[[dup]] and [[dup]] twice",
+    //
+    // More than one family in one content, where the pass order is what the
+    // shared lists actually record.
+    "image:a.png[] link:b.html[B] https://c.example [[anchor-id]] xref:anchor-id[]",
+    "[[id]]An image:x.png[X] and a link:y.html[Y] and a bare z@example.org.",
+    "image:x.png[alt,link=javascript:alert(1)] then [[dup]] and [[dup]]",
+    "A footnote:[a note with image:f.png[F] and link:g.html[G] inside]",
+    "a ((term)) beside image:t.png[T] and link:u.html[U]",
+    "See xref:sec[the steps] and image:v.png[V] and https://w.example here.",
+    "A #span with an image:s.png[S] and a link:t.html[T]# inside.",
+    "[[outer]]A *bold image:b.png[B]* and a _link:l.html[L]_ run.",
+    //
+    // Nothing recognized is nothing registered: an escaped macro, and one
+    // sealed inside a passthrough, must leave both catalogs alone. These are
+    // not negative controls — each fixture also carries a live construct, so
+    // an over-eager replay shows up as a length mismatch rather than as two
+    // empty lists.
+    "an escaped \\image:x.png[X] beside a live image:y.png[Y]",
+    "an escaped \\link:x.html[X] beside a live link:y.html[Y]",
+    "+++image:x.png[X]+++ sealed beside a live image:y.png[Y]",
+    "+++link:x.html[X]+++ sealed beside a live link:y.html[Y]",
+    "`image:x.png[X]` in monospace beside image:y.png[Y]",
+    "pass:[image:x.png[X\\]] beside image:y.png[Y]",
+    "an escaped \\[[x]] anchor beside a live [[y]] one",
+    //
+    // The three-pass link order again, this time with a macro that reaches
+    // the pipeline only through an expansion — the form #1242 lifted — sitting
+    // between the two spellings whose passes run before and after its own.
+    "https://a.example then {link-macro} then b@example.org",
+    "{link-macro} first, then https://a.example, then b@example.org",
+    //
+    // An `imagesdir` in force is part of what an image registration records.
+    "{set:imagesdir:img}image:a.png[A] and image:b.png[B]",
+    //
+    // A registration reached from inside another construct's subtree.
+    "link:outer.html[a label with an image:inner.png[I] in it]",
+    "A footnote:[see link:f.html[F]] and a live link:g.html[G].",
+    "((a term with an image:t.png[T] inside)) and image:u.png[U]",
+    "((a term with a *link:t.html[T]* inside)) and link:u.html[U]",
+    "((a term with an *[[t]]* anchor inside)) and [[u]] here",
+    "((a term with *https://t.example* inside)) and https://u.example here",
+    "((a term with an *image:t.png[T]* inside)) and image:u.png[U]",
+    "indexterm2:[a term with an image:t.png[T] inside] and image:u.png[U]",
+    "See xref:sec[a label with image:x.png[X]] here.",
+    //
+    // Duplicate ids across two families, and a reftext that fills the
+    // catalog's reverse index as well as its forward one.
+    "[[dup,Reftext]] and anchor:dup[Other Reftext]",
+    "[[a,Alpha]] and [[b,Beta]] and a link:c.html[C]",
+];
+
+/// A bibliography entry is not a plain fixture: the string pipeline recognizes
+/// `[[[id]]]` only inside a bibliography list item, which is parser state
+/// rather than source text. It gets its own configured pair.
+fn bibliography_side_effects(source: &str) -> (SideEffects, SideEffects) {
+    side_effects_with(source, || {
+        let parser = corpus_parser();
+        parser.in_bibliography_list_item.set(true);
+        parser
+    })
+}
+
+#[test]
+fn the_staged_replay_writes_what_the_string_pipeline_writes() {
+    let mut wrote_nothing: Vec<&str> = vec![];
+
+    for source in CORPUS {
+        let (golden, builder) = side_effects(source);
+
+        assert_eq!(
+            golden, builder,
+            "staged side effects diverged from the real pipeline for {source:?}"
+        );
+
+        if golden.is_empty() {
+            wrote_nothing.push(*source);
+        }
+    }
+
+    // Non-vacuity: a corpus whose fixtures all registered nothing would
+    // compare empty against empty and pass without exercising the replay at
+    // all. Naming the negative controls rather than counting them means a
+    // fixture that *silently stops* registering — an expansion that no longer
+    // reaches its macro, say — fails here instead of being absorbed.
+    assert_eq!(
+        wrote_nothing,
+        [
+            "plain text with no constructs",
+            "*bold* and _em_ and `code`",
+            "an icon:home[] icon",
+        ]
+    );
+}
+
+#[test]
+fn the_sweep_reaches_every_list_a_recognition_pass_writes_to() {
+    // The guard above only asks that *something* was written. This one pins
+    // that each of the four lists `apply_macro_side_effects` composes is
+    // actually reached, so dropping a whole family from the corpus would fail
+    // here rather than quietly narrow the sweep.
+    let (images, links, refs, warnings) = CORPUS.iter().fold(
+        (0usize, 0usize, 0usize, 0usize),
+        |(images, links, refs, warnings), source| {
+            let (golden, _) = side_effects(source);
+
+            (
+                images + golden.images.len(),
+                links + golden.links.len(),
+                refs + golden.refs.len(),
+                warnings + golden.warnings.len(),
+            )
+        },
+    );
+
+    assert!(images > 0, "no fixture registered an image");
+    assert!(links > 0, "no fixture registered a link");
+    assert!(refs > 0, "no fixture registered an id");
+    assert!(warnings > 0, "no fixture recorded a warning");
+}
+
+#[test]
+fn a_bibliography_entry_registers_the_same_way() {
+    for source in [
+        "[[[gof]]] Gamma, Erich et al. _Design Patterns_.",
+        "[[[gof,GoF]]] Gamma, Erich et al. _Design Patterns_.",
+        "[[[gof]]] An entry with an https://example.org link.",
+        "[[[gof]]] An entry with an image:cover.png[Cover].",
+    ] {
+        let (golden, builder) = bibliography_side_effects(source);
+
+        assert_eq!(
+            golden, builder,
+            "staged bibliography side effects diverged for {source:?}"
+        );
+
+        assert!(
+            golden
+                .refs
+                .iter()
+                .any(|(_, _, ref_type)| *ref_type == RefType::Bibliography),
+            "expected a bibliography entry for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn a_visible_index_terms_shown_text_is_walked_for_every_family() {
+    // The gap this harness found, asserted positively rather than only as an
+    // equality: a construct enclosed by a *visible* index term's shown text
+    // lives in the term's own `children` subtree
+    // ([`IndexTerm::children`](crate::inlines::IndexTerm::children)), which is
+    // the newest of the four child-bearing node kinds and the one the three
+    // side-effect walks did not descend into.
+    //
+    // The image family reaches such a child directly, since its own pass runs
+    // *before* the index-term pass. The other families run after it, so they
+    // reach one only through a rendered span the quotes step wrote earlier —
+    // whose children this step resolves in full before any of this level's
+    // families run. Both routes are exercised, because both are how a
+    // registration can end up inside a term.
+    //
+    // The bare-address pass has no row of its own: it shares this walk with
+    // the other two link spellings, and the one shape that would put it
+    // inside a term — `((a term with *t@example.org* inside))` — is not an
+    // address on *either* side, since the `>` closing `<strong>` is one of
+    // `INLINE_EMAIL`'s own mismatch characters (see `apply_macro_families`'s
+    // doc comment, which uses this very shape as its example).
+    for (source, expected) in [
+        (
+            "((a term with an image:t.png[T] inside)) and image:u.png[U]",
+            (vec!["t.png", "u.png"], vec![], vec![]),
+        ),
+        (
+            "((a term with an *image:t.png[T]* inside)) and image:u.png[U]",
+            (vec!["t.png", "u.png"], vec![], vec![]),
+        ),
+        (
+            "((a term with a *link:t.html[T]* inside)) and link:u.html[U]",
+            (vec![], vec!["t.html", "u.html"], vec![]),
+        ),
+        (
+            "((a term with *https://t.example* inside)) and https://u.example here",
+            (
+                vec![],
+                vec!["https://t.example", "https://u.example"],
+                vec![],
+            ),
+        ),
+        (
+            "((a term with an *[[t]]* anchor inside)) and [[u]] here",
+            (vec![], vec![], vec!["t", "u"]),
+        ),
+    ] {
+        let (_, builder) = side_effects(source);
+        let (images, links, refs) = expected;
+
+        assert_eq!(
+            builder
+                .images
+                .iter()
+                .map(|(target, _)| target.as_str())
+                .collect::<Vec<_>>(),
+            images,
+            "images for {source:?}"
+        );
+        assert_eq!(builder.links, links, "links for {source:?}");
+        assert_eq!(
+            builder
+                .refs
+                .iter()
+                .map(|(id, _, _)| id.as_str())
+                .collect::<Vec<_>>(),
+            refs,
+            "ids for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn the_replay_is_not_a_no_op_for_any_family() {
+    // The comparison above would also be satisfied by a replay that wrote
+    // *nothing* if the golden side happened to write nothing either. Assert
+    // the builder side positively, family by family, on one fixture that
+    // exercises all four at once.
+    let (_, builder) =
+        side_effects("image:x.png[alt,link=javascript:alert(1)] link:y.html[Y] [[dup]] [[dup]]");
+
+    assert_eq!(builder.images, [("x.png".to_string(), None)]);
+    assert_eq!(builder.links, ["y.html"]);
+    assert_eq!(builder.refs, [("dup".to_string(), None, RefType::Anchor)]);
+    assert_eq!(
+        builder.warnings,
+        [
+            WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
+            WarningType::DuplicateId("dup".to_string()),
+        ]
+    );
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod fixtures;
 mod hash;
 mod inline_builder_document_parity;
 mod inline_builder_recorder_parity;
+mod inline_builder_side_effect_parity;
 mod inline_recorder;
 mod inline_substitution_renderer;
 mod origin;


### PR DESCRIPTION
> Stacked on #1246 → #1245 → #1244 → #1243; the base retargets as each merges. The diff shown here is this increment alone.

The blast-radius experiment in #1245 says what it does *not* measure: it "neither calls the staged side effects nor sequences the fold against resolution". #1246 closed the second clause. This one closes the first — and unlike its sibling, **it does not pass as written**.

## The gap

Recognizing a construct is not only about the bytes it renders. Four passes of the string pipeline also *write down* what they saw:

- an `image:` macro records its target in the asset catalog;
- a `link:`/`mailto:` macro and every auto-linked URL or address record theirs;
- an inline anchor (and a bibliography entry) registers its id in the reference catalog;
- an image whose `link=` names a dangerous scheme records a warning.

Step 6 has to replay all four from the tree, **exactly once per parse** and in the string pipeline's own pass order, which is what `apply_macro_side_effects` is staged to do. Until now it was pinned only by hand-written fixtures inside its own module — one per ordering rule it has to honor.

## The harness

`inline_builder_side_effect_parity` drives a corpus through both sides on two independently-configured parsers (§5.3's discipline — each side registers into the parser it is given, so a shared one would see every entry twice and fire every duplicate-id warning spuriously) and compares *everything either side wrote down*: catalog entries in registration order, ids with their reftext and kind, and warnings in the order the one shared list received them.

The corpus covers each family alone and in company, the link family's **three-pass order** (which fills the catalog in *pass* rather than document order), an `imagesdir` in force, a registration reached from inside another construct's subtree, ids duplicated across two families, and — the shapes most likely to *over*-register — an escaped macro, one sealed in a passthrough, and one in monospace, each beside a live twin so an over-eager replay shows up as a length mismatch rather than as two empty lists.

Three guards keep it honest: the corpus as a whole must write something; each of the four lists must be reached; and the fixtures that write *nothing* are **named rather than counted** — `icon:` among them, which shares the image family's pass and node kind but is not an asset.

## What it found

One root cause with two faces.

**The replay half.** `IndexTerm` is the **fourth** node kind carrying `children` — added by #1240, after all three side-effect walks were written — and none of the three descended into it. So an image, link, or anchor a visible term encloses was recognized, rendered, and then registered nowhere:

```
((a term with an image:t.png[T] inside)) and image:u.png[U]
   string pipeline → [t.png, u.png]
   staged replay   → [u.png]
```

The walks now recurse into it, and their doc comments say why four is the whole list: a fifth child-bearing kind would be a new place a macro node can hide, and this sweep is what catches one.

**The recognition half**, which is *not* this increment's to close. The string pipeline replaces a visible term with its shown text and nothing else, so that text goes on sitting in the one flat haystack every later pass scans: a `link:` macro, a bare URL, an anchor, or a cross-reference written inside `((…))` is recognized by the pass that runs *after* the index-term pass, exactly as if the parentheses were not there. A tree cannot do that with the shown text it currently keeps — a plain visible term's is an already-substituted **string** in `terms`, not a subtree — so the families after this one have no nodes to descend into.

The families *before* it are unaffected, which is why the image half of the sweep passes: their construct is already a node when the term encloses it, and rides along in `children`. So is a construct inside a rendered span the term encloses, whose children this step resolves in full before any of this level's families run.

Closing it needs a visible term's shown text to be nodes in **every** case, not only when it encloses a rendered span, *and* the families after this one to descend into them — a change to what the node carries, so it is its own increment. Deferred and pinned by a divergence test, with its parity complement beside it.

This is the first divergence found by asking about **side effects** rather than about bytes, and it was invisible to the fold-parity audit for a reason worth recording: the audit's corpus had no fixture putting a later family inside a visible term, so the *rendering* half of the same root cause had gone unseen too.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — **unchanged** (30 records before and after, identical sources); the shapes that expose this are new here
- Coverage — diff-neutral; no added line in a changed production file is uncovered

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_