### PR TITLE
feat: Hand a visible index term's shown text back to the later macro families (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5513,6 +5513,72 @@ Each phase is a reviewable unit with a clear exit gate.
   cause had gone unseen too. Re-running the audit shows no change to the divergence set, since the
   shapes that expose it are new here. Coverage is diff-neutral; nothing further is wired in.
 
+  *Step 6 prep landed as (a visible index term's shown text, handed back to the later families):*
+  the recognition half the sweep above named, closed for the shorthand spellings.
+
+  A visible term's shown text is not a boundary the other macro families stop at. The string
+  replacer replaces `((term))` with that text and nothing else, so the text goes on sitting in the
+  one flat haystack every later pass scans: a `link:` macro, a bare URL or address, an inline
+  anchor, or a cross-reference written inside `((…))` is recognized by the pass that runs after the
+  index-term pass, exactly as if the parentheses were not there.
+
+  Two things had to change for a tree to say the same. First, what the node **carries**:
+  [`shown_term`](../../parser/src/content/inline_builder/macros/indexterm.rs) built a `children`
+  subtree only when no already-substituted string could express the shown text (a term enclosing a
+  rendered span), and a plain term's text was a string in
+  [`terms`](../../parser/src/inlines/index_term.rs) alone — nothing for a later family to descend
+  into. It now builds **both**, from the same range: `children` is the shown text's authoritative
+  form (a term's text is a region of the document, not an opaque string), and `terms` carries the
+  same text as the single string
+  [`IndexTermRenderParams`](../../parser/src/parser/inline_substitution_renderer.rs) takes whenever
+  one can express it. The two agree by construction —
+  [`shown_term_range`](../../parser/src/content/inline_builder/macros/indexterm.rs) answers the
+  normalization as offsets and `emit_shown_term_range` performs the two remaining rewrites
+  structurally — which is what makes carrying both a widening rather than a choice, and leaves
+  every existing `terms` reader working.
+
+  Second, **who sees them**: the five families that run after this one (the three link spellings,
+  inline anchors, cross-references) move into an
+  [`apply_reference_families`](../../parser/src/content/inline_builder/macros/mod.rs) that
+  [`apply_macro_families`](../../parser/src/content/inline_builder/macros/mod.rs) now calls twice —
+  once for this level, and once per visible term, over the term's own children. Their own level
+  rather than one flat scan, because a term renders its shown text with no markup of its own, so
+  its children read what stands beside the *term* — exactly the transparent case
+  [`LevelContext::child_contexts`](../../parser/src/content/inline_builder/quotes.rs) already
+  answers, and the same treatment a transparent span's children get.
+
+  Making `children` the common case immediately surfaced a **third** face of the sweep's own root
+  cause, in a walk nobody had thought to check:
+  [`classify_unescaped_specials`](../../parser/src/content/inline_builder/special_chars.rs) — which
+  under an order omitting `specialcharacters` turns a literal `<`/`>`/`&` into a `Raw` leaf — also
+  did not descend into `IndexTerm`, so `an escaped \(((a & b))) term` under a `Macros`-only group
+  escaped an ampersand the string pipeline leaves alone. The existing `build_for_group` corpus
+  caught it the moment the term's text became nodes.
+
+  What reaches parity is each later family inside a term (`link:`, `mailto:`, a bare URL, a bare
+  address, `[[id]]`, `anchor:id[…]`), at either edge of the shown text and as the whole of it,
+  twice in one term, two families in one term, beside a twin outside the term so the pass order
+  that fills the asset catalog is exercised from both sides, the two paren-keeping spellings whose
+  shown text is a narrowing, inside a rendered span and with one inside the term, and the nested
+  `((… ((term)) …))` shorthand. A cross-reference cannot be asserted this way — `golden_macros`
+  runs a bare `Content`, which has no catalog, so *every* `xref:`/`<<…>>` is left as the deferred
+  sentinel there — so a whole-document test drives both spellings through the real parse path
+  instead, in block content and in a heading's own title. The side-effect sweep gains the same
+  shapes on its side.
+
+  What still defers is the **macro** spellings (`indexterm:[…]`, `indexterm2:[…]`), which keep
+  their shown text as a string alone: an attribute list's shown term is the value `Attrlist::parse`
+  returns for its first positional attribute, which is not a range of this level's match string, so
+  nodes built from that range would not agree with it — and this family cannot tell that case from
+  the plain one before the list is parsed. Closing it needs the attribute-list narrowing itself
+  expressed as a range of the match string, the way `shown_term_range` already expresses `trim` and
+  the `see` strip; pinned by its own divergence test. The structural recorder sweep's index-term
+  comparison is relaxed to match the widened node: `children` is one-sided richness it never
+  compares, and `terms` is compared wherever the builder computed one.
+
+  Re-running the corpus-wide fold-parity audit shows no change to the divergence set; coverage is
+  diff-neutral, and nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6534,6 +6600,21 @@ Each phase is a reviewable unit with a clear exit gate.
        the index-term pass cannot reach a plain visible term's shown text, which is a string
        rather than a subtree — deferred to its own increment and pinned by a divergence test with
        its parity complement beside it. See the step's own "landed as" note above.
+
+     - ✅ **prep (a visible index term's shown text, handed back to the later families).** The
+       recognition half the sweep above named, closed for the shorthand spellings. A visible term's
+       shown text is not a boundary the other macro families stop at — the string replacer puts it
+       back into the one flat haystack every later pass scans — so `shown_term` now builds the
+       `children` subtree **always**, not only when no string can express the text, and the five
+       families that run after this one move into an `apply_reference_families` that
+       `apply_macro_families` calls once for this level and once per visible term over its own
+       children (their own level, the transparent case `child_contexts` already answers). `terms`
+       goes on carrying the same text as a string wherever one exists, so the node is widened
+       rather than reshaped. Making `children` the common case surfaced a third walk with the same
+       omission — `classify_unescaped_specials` — caught by the existing `build_for_group` corpus.
+       The macro spellings still defer, since an attribute list's shown term is not a range of the
+       match string; pinned by their own divergence test. See the step's own "landed as" note
+       above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -172,16 +172,24 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// design §4.4's coarse fallback. This is the same lift the anchor and
 /// bare-e-mail families already made, for the same reason.
 ///
-/// What a visible term's shown text *encloses* is recognized only by the
-/// families that run **before** this one (image/icon), or by a rendered span
-/// the quotes step wrote earlier, whose own children this step resolves in
-/// full first — either way the construct is already a node, carried in
-/// [`children`](crate::inlines::IndexTerm::children). The families that run
-/// **after** (the three link spellings, anchors, cross-references) do not
-/// reach it: a plain visible term's shown text is an already-substituted
-/// *string* in [`terms`](crate::inlines::IndexTerm::terms), and the string
-/// pipeline goes on scanning that text in its one flat haystack where a tree
-/// has no nodes to descend into. Deferred, pinned by a divergence test.
+/// A visible term's shown text is **not** a boundary the other macro families
+/// stop at, because the string replacer puts that text back into the one flat
+/// haystack every later pass scans. So the shorthand spellings carry it as
+/// nodes in [`children`](crate::inlines::IndexTerm::children) — always, not
+/// only when it encloses a rendered span — and
+/// [`apply_macro_families`](super::apply_macro_families) hands those children
+/// to the families that run after this one, as their own level. The families
+/// that run *before* it need nothing: their construct is already a node when
+/// the term encloses it.
+///
+/// The **macro** spellings (`indexterm:[…]`, `indexterm2:[…]`) keep their shown
+/// text as a string alone. An attribute list's shown term is the value
+/// [`Attrlist::parse`](Attrlist) returns for its first positional attribute,
+/// which is not a range of this level's match string, so nodes built from that
+/// range would not agree with it — and this family cannot tell that case from
+/// the plain one before the list is parsed. What such a term's text encloses
+/// therefore stays unreached by the later families; pinned by a divergence
+/// test.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
 /// effect; the string replacer records nothing in a catalog either (the HTML
@@ -306,16 +314,22 @@ impl TermSource {
     }
 }
 
-/// The shown text of a visible term, in whichever of the two forms an
-/// [`IndexTerm`] node can carry it (see [`IndexTerm::children`]).
-enum ShownTerm<'src> {
-    /// The already-substituted string the string replacer computes, which is
-    /// what every term whose own bytes the match string spells in full becomes.
-    Computed(String),
+/// The shown text of a visible term, in both of the forms an [`IndexTerm`]
+/// node can carry it (see [`IndexTerm::children`]).
+///
+/// The two are built from the *same* range of the level's match string and
+/// agree by construction — [`shown_term_range`] answers the normalization as
+/// offsets, and [`emit_shown_term_range`] performs the two remaining byte
+/// rewrites structurally — so a caller is free to take either or both.
+struct ShownTerm<'src> {
+    /// The already-substituted string the string replacer computes.
+    ///
+    /// `None` when the term crosses a construct whose rendering exists only at
+    /// fold time, which no string built now can spell.
+    computed: Option<String>,
 
-    /// The nodes the term encloses, for a term crossing a construct whose
-    /// rendering exists only at fold time.
-    Children(Vec<InlineNode<'src>>),
+    /// The nodes the term encloses.
+    children: Vec<InlineNode<'src>>,
 }
 
 /// The range of `text` the string replacer *shows*, as a narrowing of the
@@ -417,10 +431,6 @@ fn shown_term<'src>(
         computed = computed.replace("\\]", "]");
     }
 
-    if !computed.contains(SPAN_PLACEHOLDER) {
-        return ShownTerm::Computed(computed);
-    }
-
     let shown_source = source.narrow(&range);
     let mut children = Vec::new();
 
@@ -436,7 +446,10 @@ fn shown_term<'src>(
         );
     }
 
-    ShownTerm::Children(children)
+    ShownTerm {
+        computed: (!computed.contains(SPAN_PLACEHOLDER)).then_some(computed),
+        children,
+    }
 }
 
 /// Emits the nodes one contiguous range of a shown term covers, performing
@@ -549,26 +562,33 @@ fn build_indexterm_macro_match<'src>(
 
         let shown = shown_term(s, &source, false, true, nodes, pieces, root);
 
-        let (terms, children, rendered_nonempty) = match shown {
-            ShownTerm::Computed(term) => {
+        let (terms, children, rendered_nonempty) = match shown.computed {
+            Some(term) => {
                 let term = shown_macro_term(term, parser);
                 let rendered_nonempty = !term.is_empty();
 
+                // The macro spelling keeps its shown text as a **string**
+                // alone. An attribute list's shown term is the value
+                // [`Attrlist::parse`](Attrlist) returns for its first
+                // positional attribute, which is not a range of this level's
+                // match string, so the nodes built from that range would not
+                // agree with it — and this family cannot tell the two cases
+                // apart before the list is parsed. So the later macro families
+                // still do not reach what *this* spelling's shown text
+                // encloses; the shorthand's own note records the boundary.
                 (vec![CowStr::from(term)], vec![], rendered_nonempty)
             }
 
-            ShownTerm::Children(children) => {
-                // An attribute list's shown term is the value
-                // [`Attrlist::parse`](Attrlist) returns for its first
-                // positional attribute, not a range of this level's match
-                // string, so there is nothing to carry structurally and the
-                // macro is deferred — the boundary the increment that read the
-                // list here deliberately did not move.
+            None => {
+                // As above, with nothing to carry as a string either: the term
+                // crosses a construct whose rendering exists only at fold
+                // time, and an attribute list would decide which of its bytes
+                // are shown.
                 if source.text(s).contains('=') {
                     return None;
                 }
 
-                (vec![], children, true)
+                (vec![], shown.children, true)
             }
         };
 
@@ -761,15 +781,15 @@ fn push_indexterm_shorthand_matches<'src>(
         let term_full = (full.start + 1)..full.end;
         let consumed = (term_full.start + 1)..(term_full.end - 1);
 
-        let (terms, children) =
-            match shown_term(s, &encl.narrow(&nested), true, false, nodes, pieces, root) {
-                ShownTerm::Computed(term) => (vec![CowStr::from(term)], vec![]),
-                ShownTerm::Children(children) => (vec![], children),
-            };
+        let shown = shown_term(s, &encl.narrow(&nested), true, false, nodes, pieces, root);
+
+        let terms: Vec<CowStr<'src>> = shown
+            .computed
+            .map_or_else(Vec::new, |term| vec![CowStr::from(term)]);
 
         let node = InlineNode::IndexTerm(IndexTerm {
             terms,
-            children,
+            children: shown.children,
             visible: true,
             location: source_slice(pieces, term_full.clone(), root),
         });
@@ -812,15 +832,13 @@ fn push_indexterm_shorthand_matches<'src>(
     let location = source_slice(pieces, full.clone(), root);
 
     let (node, rendered_nonempty) = if visible {
-        let (terms, children, shown_nonempty) =
-            match shown_term(s, &encl.narrow(&term_sub), true, false, nodes, pieces, root) {
-                ShownTerm::Computed(term) => {
-                    let shown_nonempty = !term.is_empty();
-                    (vec![CowStr::from(term)], vec![], shown_nonempty)
-                }
+        let shown = shown_term(s, &encl.narrow(&term_sub), true, false, nodes, pieces, root);
 
-                ShownTerm::Children(children) => (vec![], children, true),
-            };
+        let shown_nonempty = shown.computed.as_ref().is_none_or(|term| !term.is_empty());
+
+        let terms: Vec<CowStr<'src>> = shown
+            .computed
+            .map_or_else(Vec::new, |term| vec![CowStr::from(term)]);
 
         // The match renders output when it shows a non-empty term or keeps a
         // literal parenthesis beside it.
@@ -829,7 +847,7 @@ fn push_indexterm_shorthand_matches<'src>(
         (
             InlineNode::IndexTerm(IndexTerm {
                 terms,
-                children,
+                children: shown.children,
                 visible: true,
                 location,
             }),
@@ -1422,42 +1440,126 @@ mod tests {
     }
 
     #[test]
-    fn a_later_family_inside_a_visible_terms_shown_text_is_a_documented_divergence() {
-        // Found by the corpus-wide side-effect sweep
-        // (`tests::inline_builder_side_effect_parity`), and a *recognition*
-        // gap rather than a replay one — the same root cause seen from both
-        // sides.
-        //
-        // The string pipeline replaces a visible term with its shown text and
-        // nothing else, so that text goes on sitting in the one flat haystack
-        // every later pass scans: a `link:`/`mailto:` macro, a bare URL or
-        // address, an inline anchor, or a cross-reference written inside
-        // `((…))` is recognized by the pass that runs after this one, exactly
-        // as if the parentheses were not there.
-        //
-        // A tree cannot do that with the shown text it currently keeps. This
-        // family runs where the string step runs it — after image/icon, before
-        // the link families — and the shown text of a *plain* visible term is
-        // an already-substituted **string** in
-        // [`terms`](crate::inlines::IndexTerm::terms), not a subtree, so the
-        // families that follow have no nodes to descend into. (The families
-        // that run *before* this one are unaffected: their construct is
-        // already a node when the term encloses it, which is what
-        // [`children`](crate::inlines::IndexTerm::children) carries — see the
-        // parity test below for `image:`, and the side-effect sweep's own
-        // index-term test for a nested rendered span, whose children this step
-        // resolves in full before any of this level's families run.)
-        //
-        // Closing it needs a visible term's shown text to be nodes in every
-        // case, not only when it encloses a rendered span, *and* the families
-        // after this one to descend into them — a change to what the node
-        // carries, so it is its own increment rather than this one's.
+    fn fold_matches_the_string_pipeline_for_a_later_family_inside_a_visible_term() {
+        // The shorthand half of the boundary the side-effect sweep found, now
+        // closed. The string replacer puts a visible term's shown text back
+        // into the one flat haystack every later pass scans, so a `link:`
+        // macro, a bare URL or address, an inline anchor, or a
+        // cross-reference written inside `((…))` is recognized by the pass
+        // that runs after this one, exactly as if the parentheses were not
+        // there. The tree reaches the same answer by handing the term's own
+        // `children` to those same passes, as their own level.
         for source in [
             "((a term with a link:t.html[T] inside)) end",
+            "((a term with a mailto:t@example.org[T] inside)) end",
             "((a term with https://t.example inside)) end",
             "((a term with an [[t]] anchor inside)) end",
-            "((a term with xref:s[X] inside)) end",
-            "indexterm2:[a term with a link:t.html[T] inside] end",
+            "((a term with an anchor:t[Ref] inside)) end",
+            // A cross-reference is not in this corpus: `golden_macros` runs a
+            // bare `Content`, which has no catalog, so *every* `xref:`/`<<…>>`
+            // is left as the deferred-cross-reference sentinel there whether
+            // or not a term encloses it. The whole-document test below drives
+            // that spelling through the real parse path instead.
+            // At either edge of the shown text, and as the whole of it.
+            "((link:t.html[T] leads)) end",
+            "((trails link:t.html[T])) end",
+            "((link:t.html[T])) end",
+            // Twice in one term, and two families in one term.
+            "((a link:t.html[T] and link:u.html[U] term)) end",
+            "((a link:t.html[T] and https://u.example term)) end",
+            // Beside a twin outside the term, so the pass order that fills
+            // the catalog is exercised from both sides.
+            "((a link:t.html[T] term)) and link:u.html[U] here",
+            "((a https://t.example term)) and https://u.example here",
+            // The paren-keeping spellings, whose shown text is a narrowing of
+            // the enclosed bytes rather than all of them.
+            "(((a link:t.html[T] term)) end",
+            "((a link:t.html[T] term))) end",
+            // Inside a rendered span, and with one inside the term.
+            "*((a link:t.html[T] term))* end",
+            "((a *link:t.html[T]* term)) end",
+            // The nested `((… ((term)) …))` shorthand this family also builds.
+            "a ((((a link:t.html[T] term)))) end",
+            // A term with nothing for the later families to find, unchanged.
+            "((a plain term)) end",
+            "((a *bold* term)) end",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cross_reference_inside_a_visible_term_resolves_in_a_real_document() {
+        // The one later family the byte-parity corpus above cannot reach: a
+        // cross-reference needs a catalog to resolve against, which a bare
+        // `Content` has none of. Driven end to end instead, where the term's
+        // shown text must carry a resolved `<a href="#…">` exactly as the
+        // rendered string does — in block content and in a heading's own
+        // title, both of which run this same macros step.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = crate::Parser::default()
+            .with_inline_tree(true)
+            .parse(concat!(
+                "[[target]]\n",
+                "== The Target\n",
+                "\n",
+                "See ((a term with xref:target[the target] inside)) here.\n",
+                "\n",
+                "And ((a term with <<target,the target>> inside)) too.\n",
+            ));
+
+        let mut folded = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert!(
+                rendered.contains(r##"<a href="#target">the target</a>"##),
+                "expected a resolved cross-reference, got {rendered:?}"
+            );
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            folded += 1;
+        }
+
+        assert_eq!(folded, 2, "expected both paragraphs to carry a tree");
+    }
+
+    #[test]
+    fn a_later_family_inside_a_macro_spelling_term_is_a_documented_divergence() {
+        // The half the shorthand's lift does *not* reach. An
+        // `indexterm2:[…]` argument carrying an `=` shows only what
+        // [`Attrlist::parse`](Attrlist) returns for its first positional
+        // attribute, which is not a range of this level's match string — so
+        // the nodes built from that range would not agree with the shown
+        // string, and this family cannot tell the two cases apart before the
+        // list is parsed. It therefore keeps its shown text as a string alone,
+        // and the families that run after this one have no nodes to descend
+        // into.
+        //
+        // Closing it needs the attribute-list narrowing itself expressed as a
+        // range of the match string, the way [`shown_term_range`] already
+        // expresses `trim` and the `see` strip — its own increment.
+        for source in [
+            r"indexterm2:[a term with a link:t.html[T\] inside] end",
+            "indexterm2:[a term with https://t.example inside] end",
         ] {
             let nodes = build_src(Span::new(source));
             let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
@@ -1468,8 +1570,6 @@ mod tests {
                 "expected a divergence for {source:?}"
             );
 
-            // The term itself *is* recognized — only what its shown text
-            // encloses is left as literal source.
             assert!(
                 nodes.iter().any(|n| matches!(n, InlineNode::IndexTerm(_))),
                 "expected the term to be recognized for {source:?}: {nodes:?}"

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -311,6 +311,84 @@ fn apply_macro_families<'src>(
     // mirroring the string step's order.
     let nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
 
+    // A **visible** term's shown text is not a boundary the later families
+    // stop at. The string replacer puts that text back into the one flat
+    // haystack every later pass scans — `((a term with a link:t.html[T]))`
+    // links exactly as if the parentheses were not there — so the families
+    // below descend into the term's own
+    // [`children`](crate::inlines::IndexTerm::children), which is where this
+    // pass has just put that text. (A *concealed* term shows nothing, so the
+    // replacer leaves no text behind for them to scan and its `children` are
+    // empty.)
+    //
+    // Their own level, rather than one flat scan across the term and its
+    // neighbours: a term renders its shown text with no markup of its own, so
+    // its children read what stands beside the *term*, which is exactly the
+    // transparent case [`LevelContext::child_contexts`] already answers.
+    //
+    // The scan comes first because most levels hold no such term at all, and
+    // `child_contexts` builds a `Vec` (and, for a transparent span, this
+    // level's whole match string) that would then be thrown away.
+    let has_shown_term = nodes
+        .iter()
+        .any(|node| matches!(node, InlineNode::IndexTerm(term) if !term.children.is_empty()));
+
+    let nodes = if has_shown_term {
+        let contexts = LevelContext::child_contexts(&nodes, ctx, masked);
+
+        nodes
+            .into_iter()
+            .zip(contexts)
+            .map(|(node, inner)| match node {
+                InlineNode::IndexTerm(mut index_term) if !index_term.children.is_empty() => {
+                    index_term.children = apply_reference_families(
+                        std::mem::take(&mut index_term.children),
+                        root,
+                        parser,
+                        inner,
+                        masked,
+                        specials,
+                    );
+
+                    InlineNode::IndexTerm(index_term)
+                }
+
+                other => other,
+            })
+            .collect()
+    } else {
+        nodes
+    };
+
+    apply_reference_families(nodes, root, parser, ctx, masked, specials)
+
+    // Footnotes are **not** handled here. Every other family's recognition is
+    // order-independent (no cross-node side effect), so it is safe for them to
+    // run under this function's "resolve a whole subtree's children, then this
+    // level" recursion (see the closure at the top of this function). A
+    // footnote's assigned number is *not* order-independent, so it needs its
+    // own recursive walk that visits nodes in true left-to-right source order
+    // regardless of nesting depth — see [`apply_footnotes`], run once, as its
+    // own step in [`build`], after `apply_macros` has fully resolved every
+    // other family at every level.
+}
+
+/// The macro families that run **after** the index-term pass — the three link
+/// spellings, inline anchors, and cross-references — in the string step's own
+/// order.
+///
+/// Split out of [`apply_macro_families`] because it has two callers rather
+/// than one: this level, and a visible index term's shown text, which the
+/// string replacer hands back to exactly these passes. See the call site for
+/// why the term's children are their own level.
+fn apply_reference_families<'src>(
+    nodes: Vec<InlineNode<'src>>,
+    root: Span<'src>,
+    parser: &Parser,
+    ctx: LevelContext,
+    masked: Masked<'_>,
+    specials: ComputedSpecials,
+) -> Vec<InlineNode<'src>> {
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro, mirroring the string step's
     // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
@@ -337,16 +415,6 @@ fn apply_macro_families<'src>(
     // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
     // string step's order.
     xref_macros_level(nodes, root, parser, ctx, masked, specials)
-
-    // Footnotes are **not** handled here. Every other family's recognition is
-    // order-independent (no cross-node side effect), so it is safe for them to
-    // run under this function's "resolve a whole subtree's children, then this
-    // level" recursion (see the closure at the top of this function). A
-    // footnote's assigned number is *not* order-independent, so it needs its
-    // own recursive walk that visits nodes in true left-to-right source order
-    // regardless of nesting depth — see [`apply_footnotes`], run once, as its
-    // own step in [`build`], after `apply_macros` has fully resolved every
-    // other family at every level.
 }
 
 /// The eventual cutover's single entry point (design §5.2, Phase 4 step 6) for

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -125,6 +125,11 @@ pub(super) fn classify_unescaped_specials<'src>(
                 out.push(InlineNode::Footnote(footnote));
             }
 
+            InlineNode::IndexTerm(mut index_term) => {
+                index_term.children = classify_unescaped_specials(index_term.children);
+                out.push(InlineNode::IndexTerm(index_term));
+            }
+
             other => out.push(other),
         }
     }

--- a/parser/src/inlines/index_term.rs
+++ b/parser/src/inlines/index_term.rs
@@ -9,27 +9,30 @@ use crate::{HasSpan, Span, inlines::InlineNode, strings::CowStr};
 pub struct IndexTerm<'src> {
     /// The term levels, from primary to tertiary.
     ///
-    /// Empty when the shown text is carried by [`children`](Self::children)
-    /// instead.
+    /// Empty when no already-substituted string can express the shown text —
+    /// see [`children`](Self::children).
     pub terms: Vec<CowStr<'src>>,
 
-    /// The shown text of a *visible* term, as child inline nodes — used when
-    /// that text crosses a construct whose own rendering it contains, which an
-    /// already-substituted string cannot express.
+    /// The shown text of a *visible* term, as the child inline nodes it
+    /// encloses.
     ///
-    /// A visible term's text is normally the single already-substituted string
-    /// in [`terms`](Self::terms), because that is what
-    /// [`IndexTermRenderParams`](crate::parser::IndexTermRenderParams) takes
-    /// and what the term's own source spells. But a term may enclose an
-    /// earlier-recognized construct — `((*tiger*))`, whose primary term is a
-    /// bold span — and *that* construct's rendering exists only when the tree
-    /// is folded, so it cannot be baked into a string at parse time. Such a
-    /// term carries its text here instead, as the nodes it encloses, and the
-    /// fold renders them with the same renderer as the surrounding flow.
+    /// This is what the fold renders, and it is the shown text's authoritative
+    /// form: a term's text is a *region of the document*, not an opaque
+    /// string, and anything written inside it — a link, an anchor, a
+    /// cross-reference, an image, a formatted span — is a construct in its own
+    /// right, recognized exactly as it would be outside the parentheses.
     ///
-    /// Empty for a concealed term (which shows nothing) and for every visible
-    /// term whose text [`terms`](Self::terms) already carries; the two are
-    /// never both populated.
+    /// [`terms`](Self::terms) carries the same text as the single
+    /// already-substituted string
+    /// [`IndexTermRenderParams`](crate::parser::IndexTermRenderParams) takes,
+    /// whenever one can express it. One cannot when the term encloses a
+    /// construct whose rendering exists only at fold time — `((*tiger*))`,
+    /// whose primary term is a bold span — and `terms` is then empty. The two
+    /// are built from the same source range and agree by construction, so a
+    /// consumer wanting the plain text may read `terms` and fall back to
+    /// folding these nodes.
+    ///
+    /// Empty for a concealed term, which shows nothing.
     pub children: Vec<InlineNode<'src>>,
 
     /// `true` for a *flow* term (`((term))` / `indexterm2:[…]`), whose primary

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -694,21 +694,19 @@ fn assert_node_equivalent(r: &InlineNode<'_>, b: &InlineNode<'_>, source: &str) 
         }
 
         (InlineNode::IndexTerm(ri), InlineNode::IndexTerm(bi)) => {
-            // A visible term *enclosing* a rendered span is the builder's
-            // one-sided richness, of exactly the kind this sweep already
-            // records elsewhere: the recorder recovers a shown term out of the
-            // finished string, so it can only ever hold that span's markup as
-            // text, where the builder carries the span itself as `children`
-            // and lets the fold render it (see `IndexTerm::children`). Compare
-            // `terms` only where the builder computed one, and compare the
-            // enclosed structure on its own terms below.
-            if bi.children.is_empty() {
+            // A visible term's `children` are the builder's one-sided
+            // richness, of exactly the kind this sweep already records
+            // elsewhere: the recorder recovers a shown term out of the
+            // finished string, so it holds that text — and any span's markup
+            // inside it — as a string alone, where the builder carries the
+            // shown text as nodes and lets the fold render them (see
+            // `IndexTerm::children`). So `children` is not compared, and
+            // `terms` is compared wherever the builder computed one. A term
+            // *enclosing a rendered span* is the case where it could not: its
+            // markup exists only at fold time, so no string built at parse
+            // time can spell it and the builder leaves `terms` empty.
+            if !bi.terms.is_empty() {
                 assert_eq!(ri.terms, bi.terms, "IndexTerm terms differ for {source:?}");
-            } else {
-                assert!(
-                    bi.terms.is_empty(),
-                    "a structural term carries no computed text for {source:?}"
-                );
             }
 
             assert_eq!(

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -247,6 +247,10 @@ const CORPUS: &[&str] = &[
     "((a term with an *[[t]]* anchor inside)) and [[u]] here",
     "((a term with *https://t.example* inside)) and https://u.example here",
     "((a term with an *image:t.png[T]* inside)) and image:u.png[U]",
+    "((a term with a link:t.html[T] inside)) and link:u.html[U]",
+    "((a term with https://t.example inside)) and https://u.example here",
+    "((a term with an [[t]] anchor inside)) and [[u]] here",
+    "((a term with t@example.org inside)) and u@example.org here",
     "indexterm2:[a term with an image:t.png[T] inside] and image:u.png[U]",
     "See xref:sec[a label with image:x.png[X]] here.",
     //
@@ -359,18 +363,18 @@ fn a_visible_index_terms_shown_text_is_walked_for_every_family() {
     // the newest of the four child-bearing node kinds and the one the three
     // side-effect walks did not descend into.
     //
-    // The image family reaches such a child directly, since its own pass runs
-    // *before* the index-term pass. The other families run after it, so they
-    // reach one only through a rendered span the quotes step wrote earlier —
-    // whose children this step resolves in full before any of this level's
-    // families run. Both routes are exercised, because both are how a
+    // Every family reaches such a child: the image pass because it runs
+    // *before* the index-term pass, so its node is already there when the term
+    // is built; the families that run *after* it because `apply_macro_families`
+    // hands them the term's own children as their own level. A construct
+    // inside a rendered span the term encloses is a third route, since this
+    // step resolves a span's children in full before any of this level's
+    // families run. All three are exercised, because all three are how a
     // registration can end up inside a term.
     //
-    // The bare-address pass has no row of its own: it shares this walk with
-    // the other two link spellings, and the one shape that would put it
-    // inside a term — `((a term with *t@example.org* inside))` — is not an
-    // address on *either* side, since the `>` closing `<strong>` is one of
-    // `INLINE_EMAIL`'s own mismatch characters (see `apply_macro_families`'s
+    // A bare address gets no `*…*` row: `((a term with *t@example.org*))` is
+    // not an address on *either* side, since the `>` closing `<strong>` is one
+    // of `INLINE_EMAIL`'s own mismatch characters (see `apply_macro_families`'s
     // doc comment, which uses this very shape as its example).
     for (source, expected) in [
         (
@@ -395,6 +399,30 @@ fn a_visible_index_terms_shown_text_is_walked_for_every_family() {
         ),
         (
             "((a term with an *[[t]]* anchor inside)) and [[u]] here",
+            (vec![], vec![], vec!["t", "u"]),
+        ),
+        (
+            "((a term with a link:t.html[T] inside)) and link:u.html[U]",
+            (vec![], vec!["t.html", "u.html"], vec![]),
+        ),
+        (
+            "((a term with https://t.example inside)) and https://u.example here",
+            (
+                vec![],
+                vec!["https://t.example", "https://u.example"],
+                vec![],
+            ),
+        ),
+        (
+            "((a term with t@example.org inside)) and u@example.org here",
+            (
+                vec![],
+                vec!["mailto:t@example.org", "mailto:u@example.org"],
+                vec![],
+            ),
+        ),
+        (
+            "((a term with an [[t]] anchor inside)) and [[u]] here",
             (vec![], vec![], vec!["t", "u"]),
         ),
     ] {


### PR DESCRIPTION
> Stacked on #1247 → #1246 → #1245 → #1244 → #1243; the base retargets as each merges. The diff shown here is this increment alone.

The **recognition half** the side-effect sweep in #1247 named, closed for the shorthand spellings.

## The boundary

A visible term's shown text is not a boundary the other macro families stop at. The string replacer replaces `((term))` with that text and nothing else, so the text goes on sitting in the one flat haystack every later pass scans — a `link:` macro, a bare URL or address, an inline anchor, or a cross-reference written inside `((…))` is recognized by the pass that runs *after* the index-term pass, exactly as if the parentheses were not there:

```
((a term with a link:t.html[T] inside)) end
   string pipeline → a term with a <a href="t.html">T</a> inside end
   tree (before)   → a term with a link:t.html[T] inside end
```

## The lift

Two things had to change.

**What the node carries.** `shown_term` built a `children` subtree only when *no* already-substituted string could express the shown text (a term enclosing a rendered span, #1240); a plain term's text was a string in `terms` alone — nothing for a later family to descend into. It now builds **both**, from the same range: `children` is the shown text's authoritative form (a term's text is a region of the document, not an opaque string), and `terms` carries the same text as the single string `IndexTermRenderParams` takes whenever one can express it. The two agree by construction — `shown_term_range` answers the normalization as offsets and `emit_shown_term_range` performs the two remaining rewrites structurally — which is what makes carrying both a **widening rather than a choice**, and leaves every existing `terms` reader working.

**Who sees them.** The five families that run after this one (the three link spellings, inline anchors, cross-references) move into an `apply_reference_families` that `apply_macro_families` now calls twice — once for this level, and once per visible term over the term's own children. Their own level rather than one flat scan, because a term renders its shown text with no markup of its own, so its children read what stands beside the *term* — exactly the transparent case `LevelContext::child_contexts` already answers, and the same treatment a transparent span's children get.

## A third face of the same root cause

Making `children` the common case immediately surfaced a **third** walk with the omission #1247 found, in a place nobody had thought to check: `classify_unescaped_specials` — which under an order omitting `specialcharacters` turns a literal `<`/`>`/`&` into a `Raw` leaf — also did not descend into `IndexTerm`. So `an escaped \(((a & b))) term` under a `Macros`-only group escaped an ampersand the string pipeline leaves alone. The existing `build_for_group` corpus caught it the moment the term's text became nodes.

## Tests

Parity reaches each later family inside a term (`link:`, `mailto:`, a bare URL, a bare address, `[[id]]`, `anchor:id[…]`), at either edge of the shown text and as the whole of it, twice in one term, two families in one term, beside a twin outside the term so the pass order that fills the asset catalog is exercised from both sides, the two paren-keeping spellings whose shown text is a narrowing, inside a rendered span and with one inside the term, and the nested `((… ((term)) …))` shorthand.

A cross-reference cannot be asserted that way — `golden_macros` runs a bare `Content`, which has no catalog, so *every* `xref:`/`<<…>>` is left as the deferred sentinel there whether or not a term encloses it — so a whole-document test drives both spellings through the real parse path instead, in block content and in a heading's own title. The side-effect sweep gains the same shapes on its side.

The structural recorder sweep's index-term comparison is relaxed to match the widened node: `children` is one-sided richness it never compares, and `terms` is compared wherever the builder computed one.

## What still defers

The **macro** spellings (`indexterm:[…]`, `indexterm2:[…]`) keep their shown text as a string alone. An attribute list's shown term is the value `Attrlist::parse` returns for its first positional attribute, which is *not* a range of this level's match string — so nodes built from that range would not agree with it, and this family cannot tell that case from the plain one before the list is parsed. Closing it needs the attribute-list narrowing itself expressed as a range of the match string, the way `shown_term_range` already expresses `trim` and the `see` strip. Pinned by its own divergence test.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — **unchanged** (30 records, identical sources)
- Coverage — diff-neutral; no added line in a changed production file is uncovered

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_