### PR TITLE
feat: Carry an anchor's reference text structurally, and walk it (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5579,6 +5579,53 @@ Each phase is a reviewable unit with a clear exit gate.
   Re-running the corpus-wide fold-parity audit shows no change to the divergence set; coverage is
   diff-neutral, and nothing further is wired in.
 
+  *Step 6 prep landed as (an anchor's reference text — the fifth nested node list):*
+  the side-effect sweep's own doc comment claimed the walks reach "exactly the four node kinds that
+  carry `children`". Asking that claim the sweep's own question — *is there a fifth?* — turns up one
+  immediately, and it is the one a walk written by matching on `children` is bound to miss:
+  [`Anchor::reftext`](../../parser/src/inlines/anchor.rs) is a nested node list that is not named
+  like one.
+
+  Adding a corpus row for it exposed **two** divergences at once, on every anchor spelling
+  (`[[id,…]]`, `anchor:id[…]`, `[[[label]]]`). A construct the reference text encloses
+  (`[[a,see image:t.png[T]]]`) was not registered — the walks did not descend there — and the
+  registered **reference text itself** differed: the string replacer catalogs the text it has
+  already rendered (`see <span class="image">…`), where the builder catalogued nothing at all.
+
+  Both come from one place.
+  [`build_anchor_reftext`](../../parser/src/content/inline_builder/macros/anchors.rs) deferred a
+  reference text crossing an atomic piece, leaving the field `None` — the same class every sibling
+  family has closed in turn, and closed the same way here: the text is carried **structurally**, as
+  the nodes the range covers, which is what the field's own `Vec<InlineNode<'src>>` type has always
+  allowed. The two byte rewrites the verbatim path performs with `str` methods become ranges (a
+  shorthand's `trim_end` narrows the range, since trailing whitespace is ordinary text and never a
+  placeholder; a macro's escaped `\]` drops its backslash as a gap between two emitted ranges, the
+  same structural unescape the reference-bearing families already use), and the verbatim path keeps
+  its exact prior shape, including its precisely-sliced `location`.
+
+  With nodes there, the registered string is a **mixed** fold, and the mix is the interesting part:
+  a reference text's own `Text` runs carry the level's *match-string* bytes — already substituted,
+  since a reference text is read after the escaping and quotes steps have run — so folding one would
+  escape it a second time (`[&#169; 1995]` → `[&amp;#169; 1995]`). Those contribute their value as
+  it stands, exactly as the field's original single-`Text` reader gave it; only an enclosed
+  construct, whose bytes exist nowhere until the tree is folded, is folded, through the parser's own
+  renderer. That trade is safe for the same reason it is in the link families: the bytes go into the
+  **catalog** rather than straight to output, and a cross-reference reaching them is rendered by
+  this same renderer.
+
+  Nothing about an anchor's *rendering* changes — `render_anchor` emits the id and nothing else, so
+  the fold-parity audit could never have seen any of this. What changes is what a **cross-reference
+  to the anchor** shows, which a whole-document test now drives end to end. The formerly pinned
+  divergence (`[[id,*bold*]]` leaves `reftext` unpopulated) becomes a structural parity test.
+
+  One shape was checked and deliberately left alone: the footnote pass does **not** descend into a
+  reference text, and must not — the anchor replacer consumes that text rather than emitting it, so
+  a `footnote:[…]` written there never reaches the string pipeline's footnote pass either, and both
+  sides agree that nothing is numbered.
+
+  Re-running the corpus-wide fold-parity audit shows no change to the divergence set; coverage is
+  diff-neutral, and nothing further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6615,6 +6662,20 @@ Each phase is a reviewable unit with a clear exit gate.
        The macro spellings still defer, since an attribute list's shown term is not a range of the
        match string; pinned by their own divergence test. See the step's own "landed as" note
        above.
+
+     - ✅ **prep (an anchor's reference text, the fifth nested node list).** The side-effect sweep's
+       own claim that the walks reach "exactly the four node kinds that carry `children`" asked of
+       itself turns up a fifth immediately: `Anchor::reftext` is a nested node list not named like
+       one, and so the one a walk written by matching on `children` is bound to miss. A corpus row
+       for it exposed two divergences on every anchor spelling — a construct the reference text
+       encloses went unregistered, and the registered reference *text* differed, since
+       `build_anchor_reftext` deferred a text crossing an atomic piece and left the field `None`.
+       The text is now carried structurally (the same close every sibling family made for its own
+       display text), the three walks descend into it, and the registered string is a mixed fold:
+       a `Text` run contributes its already-substituted match-string bytes unchanged, an enclosed
+       construct is folded through the parser's own renderer. An anchor's rendering does not change
+       — which is why the fold-parity audit could never have seen this — but what a cross-reference
+       to it shows does, pinned end to end. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -3,13 +3,15 @@
 //! item.
 
 use super::{
-    MacroMatch, MacroMatchKind, image::range_is_verbatim_or_synthesized, rebuild_macro_level,
+    MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
+    image::range_is_verbatim_or_synthesized, rebuild_macro_level,
 };
 use crate::{
     Parser, Span,
     content::{
         INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR,
         inline_builder::{
+            fold_html,
             quotes::{
                 LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
                 range_overlaps_synthesized, source_slice, text_slice,
@@ -364,8 +366,16 @@ fn build_anchor_node<'src>(
 
     let id = text_slice(nodes, pieces, id_range)?;
 
-    let reftext = reftext_match
-        .and_then(|m| build_anchor_reftext(m.start()..m.end(), pieces, root, nodes, is_shorthand));
+    let reftext = reftext_match.and_then(|m| {
+        build_anchor_reftext(
+            m.as_str(),
+            m.start()..m.end(),
+            pieces,
+            root,
+            nodes,
+            is_shorthand,
+        )
+    });
 
     Some(InlineNode::Anchor(Anchor {
         id,
@@ -395,6 +405,7 @@ fn build_anchor_node<'src>(
 /// counterpart of their own, the same policy
 /// [`emit_range`] already applies to every fragment of an expanded value.
 fn build_anchor_reftext<'src>(
+    raw_text: &str,
     range: std::ops::Range<usize>,
     pieces: &[Piece],
     root: Span<'src>,
@@ -402,7 +413,7 @@ fn build_anchor_reftext<'src>(
     shorthand: bool,
 ) -> Option<Vec<InlineNode<'src>>> {
     if !range_is_verbatim_or_synthesized(pieces, &range) {
-        return None;
+        return structural_anchor_reftext(raw_text, range, pieces, nodes, shorthand);
     }
 
     let synthesized = range_overlaps_synthesized(pieces, &range);
@@ -445,6 +456,60 @@ fn build_anchor_reftext<'src>(
     };
 
     Some(vec![child])
+}
+
+/// An anchor's reference text that crosses an **atomic** piece — an
+/// earlier-recognized construct the reference text encloses
+/// (`[[id,see image:t.png[T]]]`), carried here as one
+/// [`SPAN_PLACEHOLDER`] rather than as the bytes it renders to.
+///
+/// No string built now can spell such a text: the construct's markup exists
+/// only at fold time. So it is carried **structurally**, as the nodes the
+/// range covers, which is what the field's own type has always allowed and
+/// what the sibling families already do for a display text
+/// ([`IndexTerm::children`](crate::inlines::IndexTerm), a link's or a
+/// cross-reference's own children). Nothing about the anchor's *rendering*
+/// changes — `render_anchor` emits the id and nothing else — but the reference
+/// text is what a cross-reference to this anchor shows, and what the
+/// registration walk descends into to find a construct hiding there.
+///
+/// The two byte rewrites the verbatim path performs with `str` methods are
+/// performed as ranges instead: a shorthand's `trim_end` narrows the range
+/// (trailing whitespace is ordinary text, never a placeholder), and a macro's
+/// escaped `\]` drops its backslash as a *gap* between two emitted ranges —
+/// the same structural unescape
+/// [`emit_range_unescaping_brackets`] performs for the reference-bearing
+/// families.
+fn structural_anchor_reftext<'src>(
+    raw_text: &str,
+    range: std::ops::Range<usize>,
+    pieces: &[Piece],
+    nodes: &[InlineNode<'src>],
+    shorthand: bool,
+) -> Option<Vec<InlineNode<'src>>> {
+    let mut out = Vec::new();
+
+    if shorthand {
+        // Trailing whitespace is ordinary text, never a placeholder, so
+        // trimming it off the *text* trims exactly the same bytes off the
+        // range. It cannot trim the range away entirely: this path is reached
+        // only for a text crossing an **atomic** piece, which is not
+        // whitespace — so the emptiness the verbatim path has to guard
+        // against is unreachable here, and the `is_empty` check below covers
+        // it anyway without a branch of its own.
+        let trimmed = raw_text.trim_end();
+
+        emit_range(
+            nodes,
+            pieces,
+            range.start..(range.start + trimmed.len()),
+            &mut out,
+        );
+    } else {
+        emit_range_unescaping_brackets(raw_text, range, nodes, pieces, &mut out);
+    }
+
+    (!out.is_empty()).then_some(out)
 }
 
 /// Performs the recognition side effects the string pipeline attaches to an
@@ -493,13 +558,16 @@ fn build_anchor_reftext<'src>(
 /// Recurses into every container an id-bearing node can be nested inside —
 /// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),
 /// [`Footnote`](InlineNode::Footnote), and
-/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where the
+/// [`IndexTerm`](InlineNode::IndexTerm) children, and an
+/// [`Anchor`](InlineNode::Anchor)'s own `reftext` — mirroring exactly where the
 /// image and link increments' own side-effect functions recurse.
 ///
-/// The four containers are exactly the four node kinds that carry
-/// `children` — a fifth would be a new place a macro node can hide, and the
-/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
-/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
+/// The five are every nested node list an [`InlineNode`] holds: the four
+/// `children` fields, and an [`Anchor`](InlineNode::Anchor)'s `reftext`, which
+/// is one despite not being named like one. A sixth would be a new place a
+/// macro node can hide, and the corpus-wide side-effect sweep
+/// (`tests::inline_builder_side_effect_parity`) is what would catch one going
+/// unwalked, as it caught `IndexTerm` and `reftext` in turn.
 pub(crate) fn apply_ref_side_effects(
     nodes: &[InlineNode<'_>],
     parser: &Parser,
@@ -513,10 +581,10 @@ pub(crate) fn apply_ref_side_effects(
                 // from its own earlier pass (see
                 // [`apply_biblio_side_effects`]), so it is skipped here.
                 if !anchor.is_bibliography && !is_bibliography_inner(anchor, source) {
-                    let reftext = anchor_reftext_str(anchor);
+                    let reftext = anchor_reftext_string(anchor, parser);
 
                     if parser
-                        .register_ref(&anchor.id, reftext, RefType::Anchor)
+                        .register_ref(&anchor.id, reftext.as_deref(), RefType::Anchor)
                         .is_err()
                         && !(leading_anchor_registered
                             && anchor.location.byte_offset() == source.byte_offset())
@@ -526,6 +594,10 @@ pub(crate) fn apply_ref_side_effects(
                             WarningType::DuplicateId(anchor.id.to_string()),
                         );
                     }
+                }
+
+                if let Some(reftext) = &anchor.reftext {
+                    apply_ref_side_effects(reftext, parser, source, leading_anchor_registered);
                 }
             }
 
@@ -610,7 +682,7 @@ pub(crate) fn apply_biblio_side_effects(
     if parser
         .register_ref(
             &anchor.id,
-            anchor_reftext_str(anchor),
+            anchor_reftext_string(anchor, parser).as_deref(),
             RefType::Bibliography,
         )
         .is_err()
@@ -619,15 +691,51 @@ pub(crate) fn apply_biblio_side_effects(
     }
 }
 
-/// The reference text `str` a built [`Anchor`] node's `reftext` carries, when
-/// it is populated (a single verbatim [`Text`](InlineNode::Text) child — see
-/// [`build_anchor_reftext`]), mirroring the `Option<&str>`
-/// [`register_ref`](Parser::register_ref) itself expects.
-fn anchor_reftext_str<'a>(anchor: &'a Anchor<'_>) -> Option<&'a str> {
-    match anchor.reftext.as_deref() {
-        Some([InlineNode::Text { value, .. }]) => Some(value.as_ref()),
-        _ => None,
+/// The reference text a built [`Anchor`] node's `reftext` carries, as the
+/// **string** [`register_ref`](Parser::register_ref) takes.
+///
+/// A cross-reference to this anchor shows what the catalog holds, so the
+/// registered text has to be the reference text's *rendering* — which is what
+/// the string replacer registers, having rendered it already by the time it
+/// catalogs the id.
+///
+/// A reference text of a single verbatim [`Text`](InlineNode::Text) run — the
+/// overwhelmingly common case — is that rendering already, and contributes its
+/// bytes unchanged, exactly as the field's original single-`Text` reader gave
+/// them. A construct the reference text **encloses**
+/// ([`structural_anchor_reftext`]) has no such bytes until the tree is folded,
+/// so it is folded here, through the parser's own renderer: the same trade
+/// [`restorable_body`](super::image::restorable_body) makes for a `Stem`, and
+/// the same one the link families' own attribute lists make for a rendered
+/// span. Folding is faithful because these bytes go into the catalog rather
+/// than straight to output, and a cross-reference reaching them is rendered by
+/// this same renderer.
+fn anchor_reftext_string(anchor: &Anchor<'_>, parser: &Parser) -> Option<String> {
+    let reftext = anchor.reftext.as_deref()?;
+    let mut out = String::new();
+
+    for node in reftext {
+        match node {
+            // A reference text's own [`Text`](InlineNode::Text) runs carry the
+            // level's **match-string** bytes — already substituted, since a
+            // reference text is read after the escaping and quotes steps have
+            // run over the content. Folding one would escape it a second time
+            // (`[&#169; 1995]` → `[&amp;#169; 1995]`), so it contributes its
+            // value as it stands, exactly as the field's original single-`Text`
+            // reader did.
+            InlineNode::Text { value, .. } => out.push_str(value.as_ref()),
+
+            // Everything else is an earlier-recognized construct the reference
+            // text encloses, whose bytes exist only at fold time.
+            other => out.push_str(&fold_html(
+                std::slice::from_ref(other),
+                parser.renderer.as_ref(),
+                parser,
+            )),
+        }
     }
+
+    Some(out)
 }
 
 /// Mirrors `InlineAnchorReplacer`'s own `is_bibliography_inner` check: a
@@ -928,23 +1036,77 @@ mod tests {
     }
 
     #[test]
-    fn an_anchor_reference_text_over_a_span_is_consumed() {
-        // A reference text that is a rendered span (`[[id,*bold*]]`) does not
-        // reach the flow: the anchor is still recognized (its id alone renders),
-        // the span is consumed with the match, and the node's `reftext` is left
-        // `None` (a non-verbatim reference text the builder does not slice from
-        // `'src`). The fold still matches the string pipeline byte-for-byte.
+    fn a_cross_reference_shows_a_structural_reference_text_in_a_real_document() {
+        // What the reference text is *for*, end to end: a cross-reference to
+        // the anchor shows what the catalog holds for it, so a reference text
+        // enclosing an earlier-recognized construct has to reach the catalog
+        // with that construct's own rendering in it. Driven through the real
+        // parse path, where the registration and the resolution both happen.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        // The heading carries no content of its own, so the walk below also
+        // reaches its `None` arm.
+        let doc = crate::Parser::default()
+            .with_inline_tree(true)
+            .parse(concat!(
+                "== A heading\n",
+                "\n",
+                "[[tgt,see image:t.png[T] there]]The target.\n",
+                "\n",
+                "Back to <<tgt>>.\n",
+            ));
+
+        let mut checked = 0;
+
+        for block in doc.descendant_blocks() {
+            let (Some(rendered), Some(inlines)) = (block.rendered_html_content(), block.inlines())
+            else {
+                continue;
+            };
+
+            assert_eq!(
+                crate::content::inline_builder::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &crate::Parser::default()
+                ),
+                rendered,
+                "fold diverged from the rendered string for {inlines:?}"
+            );
+
+            checked += 1;
+        }
+
+        assert_eq!(checked, 2, "expected both paragraphs to carry a tree");
+
+        // The reference text the catalog holds carries the image's own
+        // rendering, and that is what the cross-reference shows.
+        assert_eq!(
+            doc.catalog().get_ref("tgt").and_then(|e| e.reftext.clone()),
+            Some(r##"see <span class="image"><img src="t.png" alt="T"></span> there"##.to_string())
+        );
+    }
+
+    #[test]
+    fn an_anchor_reference_text_over_a_span_is_carried_structurally() {
+        // A reference text enclosing a rendered span (`[[id,*bold*]]`) does not
+        // reach the flow — the anchor's id alone renders, and the span is
+        // consumed with the match — but it *is* what a cross-reference to this
+        // anchor shows, so the node carries it: as the nodes the range covers,
+        // since no string built at parse time can spell the span's markup.
         let source = "[[id,*bold*]]";
         let nodes = build_src(Span::new(source));
 
         assert_eq!(nodes.len(), 1);
         let anchor = assert_anchor(&nodes[0]);
         assert_eq!(anchor.id.as_ref(), "id");
-        assert!(
-            anchor.reftext.is_none(),
-            "a non-verbatim reference text is left unpopulated"
-        );
         assert_eq!(anchor.location.data(), "[[id,*bold*]]");
+
+        match anchor.reftext.as_deref() {
+            Some([InlineNode::Styled(_)]) => {}
+
+            other => panic!("expected a reference text of the span itself, got {other:?}"),
+        }
 
         let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
         assert_eq!(folded, golden_macros(source));

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1040,18 +1040,21 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 /// Recurses into every container an `Image` node can be nested inside —
 /// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),
 /// [`Footnote`](InlineNode::Footnote), and
-/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where
+/// [`IndexTerm`](InlineNode::IndexTerm) children, and an
+/// [`Anchor`](InlineNode::Anchor)'s `reftext` — mirroring exactly where
 /// [`apply_macros`](super::apply_macros) and the footnote increment's own
-/// `emit_range` can place one. A visible index term's shown text is the
-/// newest of the four: it holds `children` only when the term encloses a
-/// construct the image pass already recognized
-/// (`((a term with an image:t.png[T] inside))`), which is precisely when a
-/// registration can hide there.
+/// `emit_range` can place one. Both of the last two hold an image the image
+/// pass had already recognized when the enclosing node was built
+/// (`((a term with an image:t.png[T] inside))`,
+/// `[[id,see image:t.png[T]]]`), which is precisely when a registration can
+/// hide there.
 ///
-/// The four containers are exactly the four node kinds that carry
-/// `children` — a fifth would be a new place a macro node can hide, and the
-/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
-/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
+/// The five are every nested node list an [`InlineNode`] holds: the four
+/// `children` fields, and an [`Anchor`](InlineNode::Anchor)'s `reftext`, which
+/// is one despite not being named like one. A sixth would be a new place a
+/// macro node can hide, and the corpus-wide side-effect sweep
+/// (`tests::inline_builder_side_effect_parity`) is what would catch one going
+/// unwalked, as it caught `IndexTerm` and `reftext` in turn.
 pub(crate) fn apply_image_side_effects(
     nodes: &[InlineNode<'_>],
     parser: &Parser,
@@ -1092,6 +1095,12 @@ pub(crate) fn apply_image_side_effects(
 
             InlineNode::IndexTerm(index_term) => {
                 apply_image_side_effects(&index_term.children, parser, source);
+            }
+
+            InlineNode::Anchor(anchor) => {
+                if let Some(reftext) = &anchor.reftext {
+                    apply_image_side_effects(reftext, parser, source);
+                }
             }
 
             _ => {}

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2051,19 +2051,22 @@ fn build_email_node<'src>(
 /// [`Styled`](InlineNode::Styled), another [`Ref`](InlineNode::Ref) (a link's
 /// own display children, or a cross-reference's),
 /// [`Footnote`](InlineNode::Footnote), and
-/// [`IndexTerm`](InlineNode::IndexTerm) children — mirroring exactly where
+/// [`IndexTerm`](InlineNode::IndexTerm) children, and an
+/// [`Anchor`](InlineNode::Anchor)'s `reftext` — mirroring exactly where
 /// [`apply_macros`](super::apply_macros) and the footnote increment's own
 /// `emit_range` can place one. A cross-reference node itself is not
 /// registered — only a [`Link`](RefVariant::Link) has an asset-catalog entry —
 /// but its children are still walked, since a formatted cross-reference text
-/// could itself carry a nested link. A visible index term's shown text is the
-/// newest of the four, and carries every link spelling: all three of this
-/// family's passes descend into it.
+/// could itself carry a nested link. A visible index term's shown text and an
+/// anchor's reference text both carry every link spelling: all three of this
+/// family's passes descend into them.
 ///
-/// The four containers are exactly the four node kinds that carry
-/// `children` — a fifth would be a new place a macro node can hide, and the
-/// corpus-wide side-effect sweep (`tests::inline_builder_side_effect_parity`)
-/// is what would catch one going unwalked, as it caught `IndexTerm` itself.
+/// The five are every nested node list an [`InlineNode`] holds: the four
+/// `children` fields, and an [`Anchor`](InlineNode::Anchor)'s `reftext`, which
+/// is one despite not being named like one. A sixth would be a new place a
+/// macro node can hide, and the corpus-wide side-effect sweep
+/// (`tests::inline_builder_side_effect_parity`) is what would catch one going
+/// unwalked, as it caught `IndexTerm` and `reftext` in turn.
 pub(crate) fn apply_link_side_effects(nodes: &[InlineNode<'_>], parser: &Parser) {
     register_links_of_form(nodes, parser, LinkForm::AutoOrFormal);
     register_links_of_form(nodes, parser, LinkForm::Macro);
@@ -2093,6 +2096,12 @@ fn register_links_of_form(nodes: &[InlineNode<'_>], parser: &Parser, form: LinkF
 
             InlineNode::IndexTerm(index_term) => {
                 register_links_of_form(&index_term.children, parser, form);
+            }
+
+            InlineNode::Anchor(anchor) => {
+                if let Some(reftext) = &anchor.reftext {
+                    register_links_of_form(reftext, parser, form);
+                }
             }
 
             _ => {}

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -258,6 +258,20 @@ const CORPUS: &[&str] = &[
     // catalog's reverse index as well as its forward one.
     "[[dup,Reftext]] and anchor:dup[Other Reftext]",
     "[[a,Alpha]] and [[b,Beta]] and a link:c.html[C]",
+    //
+    // An anchor's *reference text* is the fifth nested node list an
+    // `InlineNode` holds — the one not named `children` — and a construct
+    // enclosed by it hides there just as one enclosed by a visible index term
+    // does. Every anchor spelling, and every family whose pass runs before the
+    // anchor pass.
+    "[[a,see image:t.png[T]]] and image:u.png[U]",
+    "[[a,see link:t.html[T]]] and link:u.html[U]",
+    "[[a,see https://t.example]] and https://u.example here",
+    "[[a,see t@example.org]] and u@example.org here",
+    "[[a,see *bold* text]] and image:u.png[U]",
+    "anchor:a[see image:t.png[T]] and image:u.png[U]",
+    "anchor:a[see link:t.html[T]] and link:u.html[U]",
+    "[[[b,see image:t.png[T]]]] and image:u.png[U]",
 ];
 
 /// A bibliography entry is not a plain fixture: the string pipeline recognizes
@@ -447,6 +461,66 @@ fn a_visible_index_terms_shown_text_is_walked_for_every_family() {
                 .collect::<Vec<_>>(),
             refs,
             "ids for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn an_anchors_reference_text_is_walked_and_registered() {
+    // The reference text is the fifth nested node list an `InlineNode` holds,
+    // and the only one not named `children` — so it is the one a walk written
+    // by matching on `children` misses. Two things ride on it: a construct it
+    // encloses must be registered like any other, and the *text itself* is
+    // what the catalog holds for a cross-reference to this anchor to show, so
+    // it must be the same string the string replacer registered.
+    for (source, links, images, reftext) in [
+        (
+            "[[a,see link:t.html[T]]] and link:u.html[U]",
+            vec!["t.html", "u.html"],
+            vec![],
+            r##"see <a href="t.html">T</a>"##,
+        ),
+        (
+            "anchor:a[see link:t.html[T]] and link:u.html[U]",
+            vec!["t.html", "u.html"],
+            vec![],
+            r##"see <a href="t.html">T</a>"##,
+        ),
+        (
+            "[[a,see image:t.png[T]]] and image:u.png[U]",
+            vec![],
+            vec!["t.png", "u.png"],
+            r##"see <span class="image"><img src="t.png" alt="T"></span>"##,
+        ),
+        // A reference text with nothing enclosed, so the common single-`Text`
+        // shape is pinned beside the structural one: its bytes go into the
+        // catalog exactly as they stand, never folded a second time.
+        ("[[a,plain text]] here", vec![], vec![], "plain text"),
+        ("[[a,A & B]] here", vec![], vec![], "A &amp; B"),
+        ("[[a,(C) 1995]] here", vec![], vec![], "&#169; 1995"),
+    ] {
+        let (golden, builder) = side_effects(source);
+
+        assert_eq!(golden, builder, "side effects diverged for {source:?}");
+
+        assert_eq!(builder.links, links, "links for {source:?}");
+        assert_eq!(
+            builder
+                .images
+                .iter()
+                .map(|(target, _)| target.as_str())
+                .collect::<Vec<_>>(),
+            images,
+            "images for {source:?}"
+        );
+        assert_eq!(
+            builder
+                .refs
+                .iter()
+                .map(|(id, text, _)| (id.as_str(), text.as_deref()))
+                .collect::<Vec<_>>(),
+            [("a", Some(reftext))],
+            "registered reference for {source:?}"
         );
     }
 }


### PR DESCRIPTION
> Stacked on #1248 → #1247 → #1246 → #1245; the base retargets as each merges. The diff shown here is this increment alone.

#1247's own doc comment claimed the side-effect walks reach *"exactly the four node kinds that carry `children`"*. Asking that claim the sweep's own question — **is there a fifth?** — turns one up immediately, and it is the one a walk written by matching on `children` is bound to miss: `Anchor::reftext` is a nested node list that is **not named like one**.

## Two divergences, one place

Adding a corpus row for it exposed two at once, on every anchor spelling (`[[id,…]]`, `anchor:id[…]`, `[[[label]]]`):

```
[[a,see image:t.png[T]]] and image:u.png[U]
   string pipeline → images [t.png, u.png]   reftext Some("see <span class=\"image\">…")
   staged replay   → images [u.png]          reftext None
```

A construct the reference text encloses went unregistered — the walks did not descend there — and the registered **reference text itself** differed: the string replacer catalogs the text it has already rendered, where the builder catalogued nothing at all.

Both come from one place. `build_anchor_reftext` **deferred** a reference text crossing an atomic piece, leaving the field `None`.

## The lift

The same class every sibling family has closed in turn, closed the same way: the text is carried **structurally**, as the nodes the range covers — which is what the field's own `Vec<InlineNode<'src>>` type has always allowed. The two byte rewrites the verbatim path performs with `str` methods become ranges instead (a shorthand's `trim_end` narrows the range, since trailing whitespace is ordinary text and never a placeholder; a macro's escaped `\]` drops its backslash as a gap between two emitted ranges, the same structural unescape the reference-bearing families already use). The verbatim path keeps its exact prior shape, including its precisely-sliced `location`.

With nodes there, the registered string is a **mixed** fold, and the mix is the interesting part:

- a reference text's own `Text` runs carry the level's **match-string** bytes — already substituted, since a reference text is read after the escaping and quotes steps have run — so folding one would escape it a second time (`[&#169; 1995]` → `[&amp;#169; 1995]`). They contribute their value as it stands, exactly as the field's original single-`Text` reader gave it.
- only an **enclosed construct**, whose bytes exist nowhere until the tree is folded, is folded, through the parser's own renderer.

That trade is safe for the same reason it is in the link families (#1244): the bytes go into the **catalog** rather than straight to output, and a cross-reference reaching them is rendered by this same renderer.

## Why the audit never saw it

Nothing about an anchor's *rendering* changes — `render_anchor` emits the id and nothing else — so no fold of any block could differ. What changes is what a **cross-reference to the anchor** shows, which is a document-level fact. A whole-document test now drives it end to end, asserting both the catalog entry and the fold.

## One shape deliberately left alone

The footnote pass does **not** descend into a reference text, and must not: the anchor replacer *consumes* that text rather than emitting it, so a `footnote:[…]` written there never reaches the string pipeline's footnote pass either, and both sides agree that nothing is numbered.

## Tests

The formerly pinned divergence (`[[id,*bold*]]` leaves `reftext` unpopulated) becomes a structural parity test. The side-effect corpus gains every anchor spelling crossed with every family whose pass runs before the anchor pass, plus the common single-`Text` shapes — plain, an escaped `&`, a character replacement — so the mixed fold is pinned from both sides.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — **unchanged**, as it must be for a change no fold can observe
- Coverage — diff-neutral

Nothing further is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_