### PR TITLE
chore: Sweep every construct in every container (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5678,6 +5678,54 @@ Each phase is a reviewable unit with a clear exit gate.
   Re-running the corpus-wide fold-parity audit shows no change to the divergence set; coverage is
   diff-neutral, and nothing further is wired in.
 
+  *Step 6 prep landed as (a cross-product sweep: every construct in every container):* the three
+  increments above each closed a walk that failed to descend into a container — a visible index
+  term's shown text, an anchor's reference text, a footnote nested in a child — and in each case
+  the reason no corpus caught it was the same. **The construct and the container were each covered,
+  but never crossed.** Every corpus on this branch is a list of fixtures someone thought to write
+  down, and what was broken was what nobody thought to write down.
+
+  This one is generated instead. `fold_matches_the_real_pipeline_for_every_construct_in_every_container`
+  takes a list of the nested node lists a tree can hold a construct in — a rendered span, a
+  smart-quoted span, each of the three display texts a `Ref` carries, a visible index term's shown
+  text, a footnote's text, an anchor's reference text — crossed with a list of every construct this
+  module recognizes, and asserts fold parity for the whole product. Adding either extends the sweep
+  by a **row or a column** rather than by one case.
+
+  The pairs that diverge are pinned as a *set* rather than skipped, so a pair joining it — or
+  leaving it, which a fix does — fails the sweep either way. There are three, and both root causes
+  were new:
+
+  *A later family matching across an earlier family's own markup.* The string pipeline runs its
+  macro families as passes over one flat string, so by the time the cross-reference and footnote
+  passes run, that string already holds the `</a>` the link pass wrote — and their patterns match
+  straight through it. `link:t.html[pre xref:tgt[T] post]` renders an `<a>` **nested inside an
+  `<a>`**, because the cross-reference's own bracketed text is `T</a> post`. A tree has no tags to
+  match through: the link's display text is a subtree, so a bracket cannot span the boundary at all.
+  This is the same class as
+  [`flatten_prior_markup`](../../parser/src/content/inline_builder/special_chars.rs)'s own, one
+  level finer — not a later *step* reading an earlier step's tags, but a later *family of this same
+  step* reading an earlier family's — and a **keep**: the tree's answer is the well-formed one.
+
+  *A post-replacement inside a cross-reference's display text.* A link's display text and a
+  cross-reference's sit in the same position in the source, and the post-replacements step treats
+  them alike. The string pipeline cannot: by then a link has been rendered inline into the one flat
+  string that step scans, so its text gets its `<br>`, while a **deferred** cross-reference has been
+  replaced by a sentinel pair whose text lives in a *template* the step never sees. The same bytes
+  in the same place get a line break in one and not in the other, decided by nothing the author
+  wrote. A tree has one answer for both, which is what §4.2's retirement of the
+  deferred-cross-reference sentinel makes true for real — so this is a keep that **closes at the
+  cutover**, and a third piece of evidence for that retirement, after the corpus in the
+  document-parity harness and the fold's own `resolved` handling.
+
+  Both are driven through a real document where it matters (a bare `Content` has no catalog, so
+  every cross-reference is left as its sentinel there and would differ for a second, unrelated
+  reason). The sweep itself is test-only. Re-running the corpus-wide fold-parity audit picks up
+  exactly the three fixtures the two divergence tests add and nothing else — which is what a
+  documented keep looks like in that log, and the first time this branch has *added* to it on
+  purpose. No content that passed before diverges now. Coverage is diff-neutral, and nothing
+  further is wired in.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6740,6 +6788,18 @@ Each phase is a reviewable unit with a clear exit gate.
        walk reaches it. The same pass gains `IndexTerm` (a visible term's shown text reaches the
        flow) and deliberately still skips an anchor's `reftext` (which the anchor replacer
        consumes). See the step's own "landed as" note above.
+
+     - ✅ **prep (a cross-product sweep).** The three increments above each closed a walk that
+       failed to descend into a container, and each time the reason no corpus caught it was that
+       the construct and the container were covered separately but never crossed. This sweep is
+       **generated** rather than listed: every nested node list a tree can hold a construct in,
+       crossed with every construct the module recognizes, with the diverging pairs pinned as a set
+       so one joining or leaving it fails either way. Three pairs diverge, on two root causes both
+       new — a later macro family matching *across* the markup an earlier family of the same step
+       emitted (a keep: the tree's answer is the well-formed one), and a post-replacement inside a
+       cross-reference's display text, which the string pipeline never scans because a deferred
+       cross-reference's text lives in a template (a keep that closes at the cutover, and a third
+       piece of evidence for retiring that sentinel). See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1508,6 +1508,66 @@ mod tests {
     }
 
     #[test]
+    fn a_family_matching_across_an_earlier_familys_markup_is_a_documented_divergence() {
+        // Found by the cross-product sweep in this module's parent
+        // (`fold_matches_the_real_pipeline_for_every_construct_in_every_container`),
+        // and the same class as
+        // [`flatten_prior_markup`](super::super::special_chars::flatten_prior_markup)'s
+        // own — a step acting on another step's *emitted markup* — one level
+        // finer: not a later **step** reading an earlier step's tags, but a
+        // later **family of this same step** reading an earlier family's.
+        //
+        // The string pipeline runs its macro families as passes over one flat
+        // string, so by the time the cross-reference and footnote passes run,
+        // that string already holds the `</a>` the link pass wrote. Their
+        // patterns match straight through it, and the bracket a family reads
+        // as its own can begin inside one link's display text and end outside
+        // it: `link:t.html[pre xref:tgt[T] post]` renders an `<a>` nested
+        // inside an `<a>`, because the cross-reference's own bracketed text is
+        // `T</a> post`.
+        //
+        // A tree has no tags to match through. The link's display text is a
+        // subtree, and every family that runs after the link pass sees nodes,
+        // so a bracket cannot span the boundary at all — the construct stays
+        // where it was written, and the link keeps the text it was given.
+        //
+        // This is a **keep**: the tree's answer is the well-formed one, and
+        // the string pipeline's is markup no backend would choose to emit.
+        let parser = Parser::default();
+
+        for (source, golden_html, folded_html) in [
+            (
+                "x link:t.html[pre xref:tgt[T] post] y",
+                r##"x <a href="t.html">pre <a href="#tgt">T</a> post</a> y"##,
+                r##"x <a href="t.html">pre xref:tgt[T</a> post] y"##,
+            ),
+            (
+                "x link:t.html[pre footnote:[n] post] y",
+                concat!(
+                    r##"x <a href="t.html">pre <sup class="footnote">[<a id="_footnoteref_1" "##,
+                    r##"class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]"##,
+                    r##"</sup> y"##,
+                ),
+                r##"x <a href="t.html">pre footnote:[n</a> post] y"##,
+            ),
+        ] {
+            let mut content = Content::from(Span::new(source));
+            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+            assert_eq!(content.rendered_str(), golden_html);
+
+            assert_eq!(
+                fold_html(
+                    &build(Span::new(source), &Parser::default(), None),
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default(),
+                ),
+                folded_html,
+            );
+        }
+    }
+
+    #[test]
     fn registers_every_family_from_a_single_call() {
         let source =
             "image:a.png[] link:b.html[B] https://c.example [[anchor-id]] xref:anchor-id[]";

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -778,6 +778,125 @@ mod tests {
         assert_parity_with(source, Parser::default);
     }
 
+    /// Every construct this module recognizes, written inside every nested
+    /// node list a tree can hold one in.
+    ///
+    /// The sweeps beside this one are corpora of *fixtures* — shapes someone
+    /// thought to write down. This one is a **cross-product**, generated from
+    /// two lists, and it exists because the shapes that turned out to be
+    /// broken were the ones nobody thought to write down. Three separate
+    /// increments of step 6 closed a walk that failed to descend into a
+    /// container (a visible index term's shown text, an anchor's reference
+    /// text, a footnote nested in a child), and in each case the reason no
+    /// corpus caught it was the same: the construct and the container were
+    /// each covered, but never crossed.
+    ///
+    /// Generating the cross-product makes "covered" mean something a fixture
+    /// list cannot. Adding a construct or a container extends the sweep by a
+    /// whole row or column rather than by one case, and a pair that starts
+    /// diverging fails here even when nobody had that pair in mind.
+    ///
+    /// The pairs that *do* diverge are pinned as a **set**, not skipped: each
+    /// is a documented keep with its own test (see
+    /// [`DIVERGING_PAIRS`]), and a pair leaving or joining that set is a
+    /// result either way.
+    const CONTAINERS: &[(&str, &str, &str)] = &[
+        // A rendered span: the container every other one nests inside too.
+        ("styled", "x *pre ", " post* y"),
+        // A smart-quoted span, which renders its own markup around a body
+        // this level's later steps still scan.
+        ("quoted", "x \"`pre ", " post`\" y"),
+        // The three display texts a `Ref` node carries.
+        ("link text", "x link:t.html[pre ", " post] y"),
+        ("xref text", "x xref:tgt[pre ", " post] y"),
+        // A visible index term's shown text, which reaches the flow.
+        ("index term", "x ((pre ", " post)) y"),
+        // A footnote's text, which reaches the catalog rather than the flow —
+        // so the *marker* is all the fold emits, and parity here is about the
+        // number and the marker, not about the text's own rendering.
+        ("footnote text", "x footnote:[pre ", " post] y"),
+        // An anchor's reference text, which reaches neither: the anchor
+        // replacer consumes it. Parity is therefore expected to be trivial,
+        // and that is the point — it pins that nothing the reference text
+        // encloses leaks into the flow.
+        ("anchor reftext", "x [[an,pre ", " post]] y"),
+    ];
+
+    /// Every construct the cross-product above writes into each container.
+    const CONSTRUCTS: &[(&str, &str)] = &[
+        ("bold", "*b*"),
+        ("subscript", "~s~"),
+        ("replacement", "(C)"),
+        ("line break", "z +\nw"),
+        ("image", "image:i.png[A]"),
+        ("icon", "icon:home[]"),
+        ("link macro", "link:l.html[L]"),
+        ("auto link", "https://e.example"),
+        ("email", "a@e.example"),
+        ("anchor", "[[an2]]"),
+        ("xref", "xref:tgt[T]"),
+        ("index term", "((t))"),
+        ("footnote", "footnote:[n]"),
+        ("passthrough", "+++<i>r</i>+++"),
+        ("stem", "stem:[x^2]"),
+        ("kbd", "kbd:[C]"),
+        ("attribute", "{product}"),
+    ];
+
+    /// The `(container, construct)` pairs the cross-product finds divergent,
+    /// each a documented keep carrying its own test. Named as a set so that a
+    /// pair joining it — or leaving it, which a fix does — fails the sweep.
+    const DIVERGING_PAIRS: &[(&str, &str)] = &[
+        // A later macro family matching **across** the markup an earlier
+        // family of the same step already emitted: the string pipeline's
+        // cross-reference and footnote passes scan a flat string that by then
+        // holds the link pass's own `</a>`, and match through it. See
+        // `a_family_matching_across_an_earlier_familys_markup_is_a_documented_divergence`
+        // in `macros/mod.rs`.
+        ("link text", "xref"),
+        ("link text", "footnote"),
+        // A post-replacement inside a **cross-reference's** display text. The
+        // string pipeline never scans that text: a deferred cross-reference
+        // holds it in a template, not in the flat string the post-replacement
+        // step runs over — where a *link's* display text, in the same
+        // position, is scanned and does get its `<br>`. The tree treats the
+        // two alike, which is what §4.2's retirement of the
+        // deferred-cross-reference sentinel makes true for real. See
+        // `a_post_replacement_in_a_cross_reference_text_is_a_documented_divergence`
+        // in `post_replacements.rs`.
+        ("xref text", "line break"),
+    ];
+
+    /// A parser for the cross-product: `experimental` for the UI macros, and
+    /// the one attribute its `{product}` construct references.
+    fn cross_product_parser() -> Parser {
+        Parser::default()
+            .with_intrinsic_attribute("experimental", "", ModificationContext::Anywhere)
+            .with_intrinsic_attribute("product", "Widget", ModificationContext::Anywhere)
+    }
+
+    #[test]
+    fn fold_matches_the_real_pipeline_for_every_construct_in_every_container() {
+        let mut diverged: Vec<(&str, &str)> = vec![];
+
+        for (container, prefix, suffix) in CONTAINERS {
+            for (construct, body) in CONSTRUCTS {
+                let source = format!("{prefix}{body}{suffix}");
+
+                if golden(&source, &cross_product_parser())
+                    != built(&source, &cross_product_parser())
+                {
+                    diverged.push((container, construct));
+                }
+            }
+        }
+
+        assert_eq!(
+            diverged, DIVERGING_PAIRS,
+            "the set of diverging (container, construct) pairs changed"
+        );
+    }
+
     /// A broad, general-purpose sweep of inline fixtures — reusing the shape
     /// of the Phase 1 byte-parity corpus
     /// ([`NORMAL_CORPUS`](crate::tests::inline_recorder)) that pins the

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -189,6 +189,82 @@ mod tests {
     };
 
     #[test]
+    fn a_post_replacement_in_a_cross_reference_text_is_a_documented_divergence() {
+        // Found by the cross-product sweep
+        // (`fold_matches_the_real_pipeline_for_every_construct_in_every_container`
+        // in the parent module), and it is the **deferred-cross-reference
+        // sentinel system** (design §4.2) showing through.
+        //
+        // A link's display text and a cross-reference's sit in the same
+        // position in the source, and this step treats them alike. The string
+        // pipeline cannot: by the time it runs, a *link* has been rendered
+        // inline into the one flat string this step scans, so its display text
+        // gets its `<br>` — while a deferred cross-reference has been replaced
+        // by a sentinel pair whose text lives in a **template**, which this
+        // step never sees at all. So the same bytes in the same place get a
+        // line break in one and not in the other, decided by nothing the
+        // author wrote.
+        //
+        // A tree has one answer for both, because a display text is a subtree
+        // either way and this step walks subtrees. That is what §4.2's
+        // retirement of the sentinel system makes true for real, so this is a
+        // **keep**: the divergence closes when the cutover deletes the
+        // template, not before.
+        //
+        // Driven through a real document, where the cross-reference resolves —
+        // a bare `Content` has no catalog, so *every* cross-reference is left
+        // as the sentinel there and the two would differ for a second,
+        // unrelated reason.
+        use crate::blocks::{FindBlocks, IsBlock};
+
+        let doc = crate::Parser::default()
+            .with_inline_tree(true)
+            .parse(concat!(
+                "[[tgt]]Target.\n",
+                "\n",
+                "x xref:tgt[pre z +\nw post] y\n",
+                "\n",
+                "x link:l.html[pre z +\nw post] y\n",
+            ));
+
+        let folds: Vec<(String, String)> = doc
+            .descendant_blocks()
+            .filter_map(|block| {
+                let (rendered, inlines) = (block.rendered_html_content()?, block.inlines()?);
+
+                Some((
+                    rendered.to_string(),
+                    fold_html(inlines, &HtmlSubstitutionRenderer {}),
+                ))
+            })
+            .collect();
+
+        assert_eq!(
+            folds,
+            [
+                // The anchor, unaffected and at parity.
+                (
+                    r##"<a id="tgt"></a>Target."##.to_string(),
+                    r##"<a id="tgt"></a>Target."##.to_string()
+                ),
+                // The cross-reference: the string pipeline never scanned its
+                // display text, the tree did.
+                (
+                    "x <a href=\"#tgt\">pre z +\nw post</a> y".to_string(),
+                    "x <a href=\"#tgt\">pre z<br>\nw post</a> y".to_string()
+                ),
+                // The link, in the same position, at parity on both sides —
+                // which is what makes the line above an asymmetry rather than
+                // a rule.
+                (
+                    "x <a href=\"l.html\">pre z<br>\nw post</a> y".to_string(),
+                    "x <a href=\"l.html\">pre z<br>\nw post</a> y".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn a_hard_line_break_becomes_a_line_break_leaf() {
         // A line ending in ` +` yields a `LineBreak` leaf in place of the ` +`;
         // the newline and following line stay as text.


### PR DESCRIPTION
> Stacked on #1250 → #1249 → #1248 → #1247; the base retargets as each merges. The diff shown here is this increment alone.

## Why generate a corpus instead of writing one

#1248, #1249 and #1250 each closed a walk that failed to descend into a container — a visible index term's shown text, an anchor's reference text, a footnote nested in a child. In each case the reason no corpus caught it was **the same**:

> The construct and the container were each covered, but never crossed.

Every corpus on this branch is a list of fixtures someone thought to write down, and what was broken was what nobody thought to write down. Three times running is a pattern, not a coincidence.

## The sweep

`fold_matches_the_real_pipeline_for_every_construct_in_every_container` takes two lists —

- **containers**: every nested node list a tree can hold a construct in (a rendered span, a smart-quoted span, each of the three display texts a `Ref` carries, a visible index term's shown text, a footnote's text, an anchor's reference text);
- **constructs**: every construct the module recognizes (17 of them);

— and asserts fold parity for the whole product. Adding either extends the sweep by a **row or a column** rather than by one case.

The pairs that diverge are pinned as a **set** rather than skipped, so a pair joining it — or *leaving* it, which a fix does — fails the sweep either way.

## What it found

Three pairs, on two root causes, both new.

### A later family matching across an earlier family's own markup

The string pipeline runs its macro families as passes over one flat string, so by the time the cross-reference and footnote passes run, that string already holds the `</a>` the link pass wrote — and their patterns match straight through it:

```
x link:t.html[pre xref:tgt[T] post] y
  string pipeline → x <a href="t.html">pre <a href="#tgt">T</a> post</a> y
  tree            → x <a href="t.html">pre xref:tgt[T</a> post] y
```

The `<a>` is nested inside an `<a>` because the cross-reference's own bracketed text is `T</a> post`. A tree has no tags to match through: the link's display text is a subtree, so a bracket cannot span the boundary at all.

Same class as `flatten_prior_markup`'s own, one level finer — not a later *step* reading an earlier step's tags, but a later *family of this same step* reading an earlier family's. A **keep**: the tree's answer is the well-formed one, and the string pipeline's is markup no backend would choose to emit.

### A post-replacement inside a cross-reference's display text

A link's display text and a cross-reference's sit in the same position in the source, and the post-replacements step treats them alike. The string pipeline cannot:

| | string pipeline | tree |
|---|---|---|
| `link:l.html[pre z +⏎w post]` | `pre z<br>⏎w post` | `pre z<br>⏎w post` |
| `xref:tgt[pre z +⏎w post]` | `pre z +⏎w post` | `pre z<br>⏎w post` |

By the time that step runs, a *link* has been rendered inline into the one flat string it scans — while a **deferred** cross-reference has been replaced by a sentinel pair whose text lives in a *template* the step never sees. The same bytes in the same place get a line break in one and not the other, decided by nothing the author wrote.

A tree has one answer for both, which is what §4.2's retirement of the deferred-cross-reference sentinel makes true for real. So this is a keep that **closes at the cutover** — and a third piece of evidence for that retirement, after the corpus in #1246 and the fold's own `resolved` handling.

Both are driven through a real document where it matters: a bare `Content` has no catalog, so every cross-reference is left as its sentinel there and would differ for a second, unrelated reason.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Corpus-wide fold-parity audit — picks up **exactly the three fixtures the two divergence tests add**, and nothing else. That is what a documented keep looks like in that log, and it is the first time this branch has added to it on purpose; no content that passed before diverges now.
- Coverage — test-only; `parser/src/tests/` and `cfg(test)` modules add no production lines

Nothing is wired in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdi1qsiWFrPBtqiSgT8pj1)_