### PR TITLE
fix: Read a quoted role from the attribute list's substituted text (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5726,6 +5726,99 @@ Each phase is a reviewable unit with a clear exit gate.
   purpose. No content that passed before diverges now. Coverage is diff-neutral, and nothing
   further is wired in.
 
+  *Step 6 prep landed as (the image family's attribute list):* the increment that opened the
+  rendered-span class for the link families closed it for every family with a display text to carry
+  and left the image family's bracket open — "a value the fold materializes rather than one frozen
+  at build time, which is a shape no increment has needed yet". Re-running the cutover experiment
+  says the cutover cannot wait for it.
+
+  Forcing the tree on for every parse and making `rendered` the fold leaves **18** of ~5,390 tests
+  failing, and every one is accounted for: 5 divergence tests that compare the two paths the cutover
+  leaves only one of, 5 footnote-in-a-heading (which `fold_reference_text` exists to close), 3 tests
+  of the `with_inline_tree` flag, 2 Strategy-A recorder sweeps, and **3 golden fixtures whose output
+  genuinely changes**. Those three split two-one: `` #`CB###2`# `` and its twin get *better*, where
+  the tree emits well-formed markup and the string pipeline interleaves tags;
+  `['{myrole}']++text++` gets worse, which is this branch's own documented attribute-list keep; and
+  `image:pause.png[title=*Pause* and Resume]`, a fixture from the language docs, lost its whole
+  macro — not a keep, but the deferred boundary coming due.
+
+  The image bracket now admits a rendered span, and the argument that kept it out cuts the other way
+  here. The per-slot rule the link families draw — a frozen span must not reach a slot the renderer
+  writes out — defers *every* image bracket, because every value an image's bracket holds is one
+  `render_image` writes out. A link has somewhere else to put a rendered span, since its display
+  text becomes the node's children; an image has no display text at all. So the rule's cost for this
+  family is the macro itself.
+
+  And the frozen bytes are simply the bytes. The string replacer reads its own bracket out of a
+  haystack the quotes step has already rendered with this same renderer, so
+  `title="<strong>Pause</strong> and Resume"` is what it writes too; freezing the span's build-time
+  fold reproduces that exactly rather than approximating it. It is also the same trade
+  `bracket_attrlist`'s masked branch already makes for a `Stem`, whose body is likewise a build-time
+  fold. What a frozen value cannot survive is being folded again through a *different* renderer —
+  `render_with`, which does not exist yet and which every other frozen value on this branch owes the
+  same debt to.
+
+  The one thing a rendered piece must still satisfy is the split: a token carries none of the
+  `,` / `=` / `"` an attribute list splits on and a span's markup may, so the two parses are compared
+  attribute by attribute and a disagreement defers the whole match. The **target** half of the old
+  boundary stays, and now has its own reason rather than sharing the bracket's: a target is resolved
+  as a path, where splicing markup in has no meaning.
+
+  That leaves the cutover **one** golden regression rather than two.
+
+  *Step 6 prep landed as (a quoted role, read from the attribute list's substituted text):* the
+  cutover's last golden regression, and the one the increment above named as "this branch's own
+  documented attribute-list keep". It was not a keep. The keep it was filed under is
+  `flatten_prior_markup`'s category — a later step of the same order rewriting bytes that live only
+  inside markup an earlier step emitted — and three of that keep's four shapes really are that. This
+  one was a *wrong answer* in `Attrlist` itself, which the string pipeline's own later step happened
+  to paper over.
+
+  [`Attrlist::parse`](../../parser/src/attributes/attrlist.rs) expands attribute references over the
+  whole list **before** splitting it, so every *parsed* field a caller reads is already expanded —
+  which is why `[{myrole}]`, `[.{myrole}]`, and `[#{myrole}]` were at parity in the tree all along.
+  [`quoted_text_fallback_role`](../../parser/src/attributes/attrlist.rs) is the one accessor that
+  reads the list's own **text** instead (Asciidoctor's `parse_quoted_text_attributes` takes a
+  quote-delimited first positional verbatim, quote characters included), and `parse` computed that
+  expanded text as `source_cow` and then *threw it away* — leaving that accessor to fall back to the
+  raw `source` span. So `['{myrole}']` yielded the role `'{myrole}'`.
+
+  The string pipeline hid it. Under the *normal* order the attribute-references step runs after
+  quotes, so it rewrote the `{myrole}` sitting inside the `class="'{myrole}'"` the quotes step had
+  just written, and the final bytes came out right — by the same accident this branch's keep
+  describes. The passthrough family has no such accident available, because its extraction pass runs
+  ahead of every step; `PassthroughRestoreReplacer` therefore substitutes the *stored* attrlist body
+  itself, at restore time, and its own comment says why. Two mechanisms, one surface, and the tree
+  reproduced neither.
+
+  The fix is `parse` retaining `source_cow` as [`source_text`](../../parser/src/attributes/attrlist.rs)
+  whenever the substitution changed anything — the field the attributed-span increment added for
+  precisely this accessor — with
+  [`into_owned`](../../parser/src/attributes/attrlist.rs) and `into_owned_restoring` carrying
+  `source_text()` forward instead of re-reading `self.source.data()`, so a list rebuilt from a
+  temporary does not reinstate the `{name}` spelling. That is Asciidoctor's own order:
+  `sub_attributes` over the list, *then* the verbatim first positional. No node field, gate, or
+  signature moves, and the string pipeline's rendered output is unchanged everywhere the later step
+  was already covering for it.
+
+  What lands here is therefore both halves at once. `['{myrole}']*bold*` — the quotes family, and
+  the shape the keep pinned — and `['{myrole}']++text++` — the passthrough family, and the cutover's
+  regression — become one parity corpus,
+  `a_quoted_role_reads_the_attribute_lists_substituted_text`, together with the `+…+` and backtick
+  spellings, a named attribute after the quoted positional, the comma-inside-the-quotes truncation
+  (which runs after the substitution, so an expansion introducing a comma truncates too), a missing
+  attribute under the default `attribute-missing=skip` (a no-op expansion, so the raw text is what
+  the role was already reading), and the three unquoted spellings that never took this path, pinned
+  so they still do not. The keep's own test keeps its other three shapes — a typographic
+  replacement, a restored entity, and a later sub's own span — which are genuinely markup-reading.
+
+  Re-running the corpus-wide fold-parity audit confirms the divergence set strictly **shrank**, by
+  exactly those two fixtures and nothing else. Coverage is diff-neutral (`attrlist.rs` stays at
+  100%), and nothing further is wired in. Re-running the cutover experiment leaves it at **zero**
+  golden regressions: 16 failing tests, all of them the divergence tests, footnote-in-a-heading
+  cases, flag tests, and recorder sweeps the cutover itself resolves, plus the one golden the tree
+  gets *better*.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6816,6 +6909,23 @@ Each phase is a reviewable unit with a clear exit gate.
        and the **target** half of the boundary stays, now on its own reason (a target is resolved as
        a path). That leaves the cutover **one** golden regression rather than two. See the step's
        own "landed as" note above.
+
+     - ✅ **prep (a quoted role, read from the attribute list's substituted text).** The cutover's
+       **last golden regression**, filed as a keep by the increment above and not one: the
+       attribute-references half of `flatten_prior_markup`'s category was a wrong answer in
+       [`Attrlist`](../../parser/src/attributes/attrlist.rs) itself, which the string pipeline's own
+       later step papered over. `parse` expands attribute references over the whole list before
+       splitting it — so every *parsed* field is already expanded — but discarded that expanded text,
+       leaving [`quoted_text_fallback_role`](../../parser/src/attributes/attrlist.rs), the one
+       accessor that reads the list's own text rather than a parsed attribute, on the raw `source`
+       span. `parse` now retains it as
+       [`source_text`](../../parser/src/attributes/attrlist.rs) — the field the attributed-span
+       increment added for exactly this accessor — and `into_owned`/`into_owned_restoring` carry
+       `source_text()` forward, which is Asciidoctor's own `sub_attributes`-then-verbatim order. The
+       quotes family's `['{myrole}']*bold*` and the passthrough family's `['{myrole}']++text++` land
+       together as one parity corpus; the keep's other three shapes (a typographic replacement, a
+       restored entity, a later sub's own span) are genuinely markup-reading and stay. See the step's
+       own "landed as" note above. **The cutover now stands at zero golden regressions.**
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -31,11 +31,18 @@ pub struct Attrlist<'src> {
     source: Span<'src>,
 
     /// The attrlist text this list was parsed from, kept only when `source`'s
-    /// own bytes are *not* that text — which happens exactly when
-    /// [`into_owned`](Self::into_owned) rebuilt the list from a temporary and
-    /// re-tagged it with a coarser source span. `None` for every list parsed
-    /// straight from the source it describes, where `source.data()` already is
-    /// that text.
+    /// own bytes are *not* that text. There are two such cases, and both are
+    /// about the same thing — the bytes the parse actually read:
+    ///
+    ///   - [`parse`](Self::parse) substituted attribute references into the
+    ///     text before splitting it, so what it parsed is the *expanded* text
+    ///     and `source` holds the author's `{name}` spelling.
+    ///   - [`into_owned`](Self::into_owned) rebuilt the list from a temporary
+    ///     and re-tagged it with a coarser source span, so `source` holds
+    ///     whatever that span covers rather than the attrlist text at all.
+    ///
+    /// `None` for every list whose `source.data()` already *is* the text it
+    /// was parsed from — the common case.
     ///
     /// Only [`source_text`](Self::source_text) reads it, for
     /// [`quoted_text_fallback_role`](Self::quoted_text_fallback_role) — the one
@@ -65,7 +72,15 @@ impl<'src> Attrlist<'src> {
     /// `'src` slice reproduces). An owned copy of the text this list was parsed
     /// from therefore rides along in
     /// [`source_text`](Self::source_text), so that accessor goes on reading it.
+    ///
+    /// That copy is taken through [`source_text`](Self::source_text) rather
+    /// than off `self.source` directly, so a list whose own
+    /// [`parse`](Self::parse) already expanded an attribute reference carries
+    /// the *expanded* text forward rather than reinstating the `{name}`
+    /// spelling the re-tag is discarding the span for.
     pub(crate) fn into_owned<'dst>(self, source: Span<'dst>) -> Attrlist<'dst> {
+        let source_text = CowStr::from(self.source_text().to_string());
+
         Attrlist {
             attributes: self
                 .attributes
@@ -74,7 +89,7 @@ impl<'src> Attrlist<'src> {
                 .collect(),
             anchor: self.anchor.map(CowStr::into_owned),
             source,
-            source_text: Some(CowStr::from(self.source.data().to_string())),
+            source_text: Some(source_text),
         }
     }
 
@@ -95,6 +110,8 @@ impl<'src> Attrlist<'src> {
         source: Span<'dst>,
         bodies: &[&str],
     ) -> Attrlist<'dst> {
+        let source_text = CowStr::from(self.source_text().to_string());
+
         Attrlist {
             attributes: self
                 .attributes
@@ -108,12 +125,7 @@ impl<'src> Attrlist<'src> {
             // match at the first `]`, so `[x]` never arrives here intact.
             anchor: self.anchor.map(CowStr::into_owned),
             source,
-            source_text: Some(restore_into(
-                CowStr::from(self.source.data()),
-                bodies,
-                &mut [],
-                &mut Vec::new(),
-            )),
+            source_text: Some(restore_into(source_text, bodies, &mut [], &mut Vec::new())),
         }
     }
 
@@ -139,6 +151,17 @@ impl<'src> Attrlist<'src> {
             CowStr::from(source.data())
         };
 
+        // Every *parsed* field below comes out of `source_cow`, so an attribute
+        // reference in a value is already expanded by the time a caller reads
+        // it. `quoted_text_fallback_role` is the one accessor that reads the
+        // list's own text instead, and it must see the same expanded bytes —
+        // Asciidoctor's `parse_quoted_text_attributes` runs `sub_attributes`
+        // over the list and *then* takes the first positional verbatim. So the
+        // expanded text is retained whenever the substitution changed anything,
+        // and `source.data()` goes on serving the (overwhelmingly common) case
+        // where it did not.
+        let substituted = source_cow.as_ref() != source.data();
+
         if source_cow.starts_with('[') && source_cow.ends_with(']') {
             let anchor = source_cow[1..source_cow.len() - 1].to_owned();
 
@@ -148,7 +171,7 @@ impl<'src> Attrlist<'src> {
                         attributes,
                         anchor: Some(CowStr::from(anchor)),
                         source,
-                        source_text: None,
+                        source_text: substituted.then_some(source_cow),
                     },
                     after: source.discard_all(),
                 },
@@ -264,7 +287,7 @@ impl<'src> Attrlist<'src> {
                     attributes,
                     anchor: None,
                     source,
-                    source_text: None,
+                    source_text: substituted.then_some(source_cow),
                 },
                 after: source.discard_all(),
             },

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -3877,26 +3877,25 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_rewritten_by_a_later_step_is_a_documented_divergence() {
-        // The complement of the boundary above, and not one this step can
-        // draw: under the *normal* order the steps that run **after** quotes
-        // (attribute references, character replacements) go on matching over
-        // the string pipeline's whole rendered string — the markup the quotes
-        // step just wrote included — so they rewrite bytes that live only
-        // inside a rendered `class`/`id` attribute. A later *sub* of this same
-        // step does it too (`[.a~b~c]#y#`, whose subscript sub runs after the
-        // unquoted one that consumed the attribute list). A tree's markup
-        // exists at fold time alone, and its later transducers see the nodes,
-        // not the tags, so an attribute list is whatever the sub that
-        // recognized it parsed, and nothing rewrites it afterwards.
+    fn a_quoted_role_reads_the_attribute_lists_substituted_text() {
+        // A quote-delimited first positional is the one thing an attribute
+        // list yields from its own *text* rather than from a parsed attribute
+        // (`quoted_text_fallback_role`, mirroring the `else` branch of
+        // Asciidoctor's `parse_quoted_text_attributes`, which takes the role
+        // verbatim — quote characters included). `Attrlist::parse` expands
+        // attribute references over the whole list before splitting it, so
+        // that accessor reads the *expanded* text, exactly as
+        // `parse_quoted_text_attributes` reads the string its own
+        // `sub_attributes` returned.
         //
-        // This is the same class as `flatten_prior_markup`'s own (design
-        // §5.2, Phase 4 step 6's late-escaping increment) — a step acting on
-        // another step's emitted markup — seen from the other side, and it
-        // costs four shapes: an attribute reference in a single-quoted role, a
-        // typographic replacement, a *restored* entity (whose escaped
-        // `&amp;amp;` the replacements step unwinds one level in the rendered
-        // markup), and a later sub's own span.
+        // Every family that parses an attribute list therefore agrees on a
+        // quoted role, whichever step recognized it: the quotes step, whose
+        // list is a slice of the buffer (`['{myrole}']*bold*`), and the
+        // passthrough-extraction step, whose list the string pipeline
+        // substitutes at *restore* time instead (`['{myrole}']++text++`, see
+        // `PassthroughRestoreReplacer`). The unquoted spellings — a bare
+        // positional, a shorthand role, an id — never took this path at all,
+        // and are here to pin that they still do not.
         let parser = crate::Parser::default().with_intrinsic_attribute(
             "myrole",
             "highlight",
@@ -3904,10 +3903,104 @@ mod tests {
         );
 
         for (source, golden_html) in [
+            // The quoted positional, in each family that parses a list.
             (
                 "['{myrole}']*bold*",
                 "<strong class=\"'highlight'\">bold</strong>",
             ),
+            (
+                "['{myrole}']#text#",
+                "<span class=\"'highlight'\">text</span>",
+            ),
+            (
+                "['{myrole}']`code`",
+                "<code class=\"'highlight'\">code</code>",
+            ),
+            (
+                "['{myrole}']++text++",
+                "<span class=\"'highlight'\">text</span>",
+            ),
+            (
+                "['{myrole}']+text+",
+                "<span class=\"'highlight'\">text</span>",
+            ),
+            // A named attribute after the quoted positional: the role is the
+            // source up to the first comma, so the tail changes nothing.
+            (
+                "['{myrole}',foo]++text++",
+                "<span class=\"'highlight'\">text</span>",
+            ),
+            // A comma *inside* the quotes still truncates the role there
+            // (Asciidoctor's `str.slice 0, (str.index ',')` runs after the
+            // substitution, so an expansion introducing one truncates too).
+            ("['a,{myrole}']#text#", "<span class=\"'a\">text</span>"),
+            // A missing attribute leaves the reference alone under the default
+            // `attribute-missing=skip`, so the expansion is a no-op and the
+            // raw text is what the role was already reading.
+            (
+                "['{missing}']#text#",
+                "<span class=\"'{missing}'\">text</span>",
+            ),
+            // The unquoted spellings, which read a parsed attribute instead.
+            (
+                "[{myrole}]++text++",
+                "<span class=\"highlight\">text</span>",
+            ),
+            (
+                "[.{myrole}]++text++",
+                "<span class=\"highlight\">text</span>",
+            ),
+            ("[#{myrole}]++text++", "<span id=\"highlight\">text</span>"),
+            (
+                "[{myrole}]*bold*",
+                "<strong class=\"highlight\">bold</strong>",
+            ),
+        ] {
+            let mut content = Content::from(Span::new(source));
+            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+            assert_eq!(content.rendered_str(), golden_html, "golden for {source:?}");
+
+            let folded = super::super::fold_html(
+                &super::super::build(Span::new(source), &parser, None),
+                &HtmlSubstitutionRenderer {},
+                &parser,
+            );
+
+            assert_eq!(folded, content.rendered_str(), "mismatch for {source:?}");
+        }
+    }
+
+    #[test]
+    fn an_attribute_list_rewritten_by_a_later_step_is_a_documented_divergence() {
+        // The complement of the boundary above, and not one this step can
+        // draw: under the *normal* order the steps that run **after** quotes
+        // (character replacements) go on matching over the string pipeline's
+        // whole rendered string — the markup the quotes step just wrote
+        // included — so they rewrite bytes that live only inside a rendered
+        // `class`/`id` attribute. A later *sub* of this same step does it too
+        // (`[.a~b~c]#y#`, whose subscript sub runs after the unquoted one that
+        // consumed the attribute list). A tree's markup exists at fold time
+        // alone, and its later transducers see the nodes, not the tags, so an
+        // attribute list is whatever the sub that recognized it parsed, and
+        // nothing rewrites it afterwards.
+        //
+        // This is the same class as `flatten_prior_markup`'s own (design
+        // §5.2, Phase 4 step 6's late-escaping increment) — a step acting on
+        // another step's emitted markup — seen from the other side, and it
+        // costs three shapes: a typographic replacement, a *restored* entity
+        // (whose escaped `&amp;amp;` the replacements step unwinds one level
+        // in the rendered markup), and a later sub's own span.
+        //
+        // The **attribute-references** step used to cost a fourth
+        // (`['{myrole}']*bold*`), and no longer does: that one was never
+        // really about a later step reading emitted markup, but about
+        // `Attrlist::parse` discarding the substituted text one accessor
+        // needs — see `a_quoted_role_reads_the_attribute_lists_substituted_text`
+        // above. What is left here is genuinely markup-reading.
+        let parser = crate::Parser::default();
+
+        for (source, golden_html) in [
             ("[.a(C)c]#x#", "<span class=\"a&#169;c\">x</span>"),
             (
                 "[.a&amp;b]*bold*",


### PR DESCRIPTION
This is the cutover's last golden regression, and the increment that measured it filed it as "this branch's own documented attribute-list keep". It was not a keep.

The keep it was filed under is `flatten_prior_markup`'s category — a later step of the same order rewriting bytes that live only inside markup an earlier step emitted — and three of that keep's four shapes really are that. This one was a wrong answer in `Attrlist` itself, which the string pipeline's own later step happened to paper over.

## What was actually wrong

`Attrlist::parse` expands attribute references over the whole list *before* splitting it, so every parsed field a caller reads is already expanded. That is why `[{myrole}]`, `[.{myrole}]`, and `[#{myrole}]` were at parity in the tree all along:

```
[{myrole}]++text++    tree = strg = <span class="highlight">
[.{myrole}]++text++   tree = strg = <span class="highlight">
[#{myrole}]++text++   tree = strg = <span id="highlight">
['{myrole}']++text++  tree = <span class="'{myrole}'">   strg = <span class="'highlight'">
```

`quoted_text_fallback_role` is the one accessor that reads the list's own **text** instead — Asciidoctor's `parse_quoted_text_attributes` takes a quote-delimited first positional verbatim, quote characters included — and `parse` computed that expanded text as `source_cow` and then threw it away, leaving the accessor to fall back to the raw `source` span.

The string pipeline hid it. Under the normal order the attribute-references step runs after quotes, so it rewrote the `{myrole}` sitting inside the `class="'{myrole}'"` the quotes step had just written, and the final bytes came out right — by the same accident the keep describes. The passthrough family has no such accident available, since its extraction pass runs ahead of every step; `PassthroughRestoreReplacer` therefore substitutes the stored attrlist body itself, at restore time, and its own comment says why. Two mechanisms, one surface, and the tree reproduced neither.

## The fix

`parse` retains `source_cow` as `source_text` whenever the substitution changed anything — the field the attributed-span increment added for precisely this accessor — and `into_owned`/`into_owned_restoring` carry `source_text()` forward rather than re-reading `self.source.data()`, so a list rebuilt from a temporary does not reinstate the `{name}` spelling. That is Asciidoctor's own order: `sub_attributes` over the list, then the verbatim first positional.

No node field, gate, or signature moves, and the string pipeline's rendered output is unchanged everywhere the later step was already covering for it.

## Corpora

Both halves land at once. `['{myrole}']*bold*` (the quotes family, the shape the keep pinned) and `['{myrole}']++text++` (the passthrough family, the cutover's regression) become one parity corpus, `a_quoted_role_reads_the_attribute_lists_substituted_text`, alongside the `+…+` and backtick spellings, a named attribute after the quoted positional, the comma-inside-the-quotes truncation, a missing attribute under the default `attribute-missing=skip`, and the three unquoted spellings pinned so they still do not take this path.

The keep's own test keeps its other three shapes — a typographic replacement, a restored entity, and a later sub's own span — which are genuinely markup-reading.

## Verification

- Corpus-wide fold-parity audit (both sides, `--test-threads=1`): `comm -13` empty — **no new divergence**. The set strictly shrank, by exactly `['{myrole}']*bold*` and `['{myrole}']++text++` and nothing else.
- Coverage diff-neutral: `attrlist.rs` stays at 100%; `quotes.rs` keeps its 13 missed regions / 4 missed lines, on the same lines.
- Cutover experiment (seed forced on, `rendered` := the fold): 17 → 16 failing, and the one that drops is `passthrough_role_resolves_attribute_reference`. **Zero golden regressions remain** — the only golden left in the set is the one the tree gets *better*.

Also adds the "landed as" narrative note #1252 referenced but did not write.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_