### PR TITLE
fix: Expand an attribute reference in a quote-delimited inline role

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -26,6 +26,18 @@ pub struct Attrlist<'src> {
     attributes: Vec<ElementAttribute<'src>>,
     anchor: Option<CowStr<'src>>,
     source: Span<'src>,
+
+    /// The attrlist text this list was parsed from, kept only when `source`'s
+    /// own bytes are *not* that text — which happens exactly when
+    /// [`parse`](Self::parse) substituted an attribute reference into it, so
+    /// what was parsed is the *expanded* text while `source` holds the
+    /// author's `{name}` spelling. `None` otherwise, which is the common case.
+    ///
+    /// Only [`source_text`](Self::source_text) reads it, for
+    /// [`quoted_text_fallback_role`](Self::quoted_text_fallback_role) — the one
+    /// accessor that reads the attrlist's own text rather than a parsed
+    /// attribute.
+    source_text: Option<CowStr<'src>>,
 }
 
 impl<'src> Attrlist<'src> {
@@ -51,6 +63,17 @@ impl<'src> Attrlist<'src> {
             CowStr::from(source.data())
         };
 
+        // Every *parsed* field below comes out of `source_cow`, so an attribute
+        // reference in a value is already expanded by the time a caller reads
+        // it. `quoted_text_fallback_role` is the one accessor that reads the
+        // list's own text instead, and it must see the same expanded bytes —
+        // Asciidoctor's `parse_quoted_text_attributes` runs `sub_attributes`
+        // over the list and *then* takes the first positional verbatim. So the
+        // expanded text is retained whenever the substitution changed anything,
+        // and `source.data()` goes on serving the (overwhelmingly common) case
+        // where it did not.
+        let substituted = source_cow.as_ref() != source.data();
+
         if source_cow.starts_with('[') && source_cow.ends_with(']') {
             let anchor = source_cow[1..source_cow.len() - 1].to_owned();
 
@@ -60,6 +83,7 @@ impl<'src> Attrlist<'src> {
                         attributes,
                         anchor: Some(CowStr::from(anchor)),
                         source,
+                        source_text: substituted.then_some(source_cow),
                     },
                     after: source.discard_all(),
                 },
@@ -175,6 +199,7 @@ impl<'src> Attrlist<'src> {
                     attributes,
                     anchor: None,
                     source,
+                    source_text: substituted.then_some(source_cow),
                 },
                 after: source.discard_all(),
             },
@@ -204,6 +229,10 @@ impl<'src> Attrlist<'src> {
             ],
             anchor: None,
             source: language,
+
+            // A synthesized list has no attrlist text in the document at all
+            // (`source` is the language span), and nothing reads this for it.
+            source_text: None,
         }
     }
 
@@ -280,6 +309,10 @@ impl<'src> Attrlist<'src> {
             attributes: later_attributes,
             anchor: later_anchor,
             source: _,
+
+            // Kept from `self`, like `source` itself: only inline quoted text
+            // reads the list's own text, and an inline list is never merged.
+            source_text: _,
         } = later;
 
         if later_anchor.is_some() {
@@ -567,8 +600,18 @@ impl<'src> Attrlist<'src> {
         // `['a,b']` yields the role `'a`) rather than being treated as quoted
         // content. A quote-delimited first positional always leaves at least its
         // opening quote here, so the slice is never empty.
-        let raw = self.source.data();
+        let raw = self.source_text();
         Some(raw.split_once(',').map_or(raw, |(first, _)| first).trim())
+    }
+
+    /// The text this attribute list was parsed from: the attribute-expanded
+    /// text when [`parse`](Self::parse)'s own substitution changed anything,
+    /// and `source`'s own bytes otherwise.
+    fn source_text(&'src self) -> &'src str {
+        match &self.source_text {
+            Some(text) => text.as_ref(),
+            None => self.source.data(),
+        }
     }
 
     /// Returns any option attributes that were found.
@@ -2470,6 +2513,60 @@ mod tests {
             .unwrap_if_no_warnings();
 
             assert!(mi.item.quoted_text_fallback_role().is_none());
+        }
+
+        #[test]
+        fn quoted_first_positional_reads_the_substituted_text() {
+            // `parse` expands attribute references over the whole list before
+            // splitting it, so every *parsed* field is already expanded. The
+            // verbatim role must come from those same expanded bytes:
+            // Asciidoctor's `parse_quoted_text_attributes` runs
+            // `sub_attributes` over the list and *then* takes the first
+            // positional verbatim, and it does so regardless of the enclosing
+            // block's `subs` list.
+            let p = crate::Parser::default().with_intrinsic_attribute(
+                "myrole",
+                "highlight",
+                crate::parser::ModificationContext::Anywhere,
+            );
+
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'{myrole}'"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'highlight'");
+
+            // The comma boundary is applied *after* the substitution, so an
+            // expansion that introduces one truncates the role there too.
+            let p = crate::Parser::default().with_intrinsic_attribute(
+                "commarole",
+                "a,b",
+                crate::parser::ModificationContext::Anywhere,
+            );
+
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'{commarole}'"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'a");
+
+            // A missing attribute is left alone under the default
+            // `attribute-missing=skip`, so the substitution is a no-op and the
+            // source's own bytes still serve.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'{missing}'"),
+                &crate::Parser::default(),
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'{missing}'");
         }
     }
 

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -9067,6 +9067,71 @@ mod passthroughs {
     }
 
     #[test]
+    fn quoted_role_resolves_attribute_reference_without_the_attributes_sub() {
+        // The quotes family's own half of the test above, and the case that
+        // half was masking. `Attrlist::parse` expands attribute references over
+        // the whole list before splitting it, regardless of the enclosing
+        // block's `subs` — which is what Asciidoctor's
+        // `parse_quoted_text_attributes` does too (it calls `sub_attributes`
+        // unconditionally). A quote-delimited first positional is the one value
+        // that comes from the list's own *text* rather than from a parsed
+        // attribute, so it has to read those same expanded bytes.
+        //
+        // Under the default `subs` the attribute-references step runs after
+        // quotes and rewrites the reference inside the `class` the quotes step
+        // just wrote, so the final bytes came out right either way. Drop that
+        // step from the order and only the expansion at parse time is left.
+        // This is a crate-specific regression test, not a port.
+        let render = |input: &str| {
+            let mut p = Parser::default().with_intrinsic_attribute(
+                "myrole",
+                "highlight",
+                ModificationContext::Anywhere,
+            );
+
+            let maw = crate::blocks::Block::parse(crate::Span::new(input), &mut p);
+
+            let crate::blocks::Block::Simple(block) = maw.item.unwrap().item else {
+                panic!("expected a simple block");
+            };
+
+            block.content().rendered().to_string()
+        };
+
+        // The default order, where the later attribute-references step was
+        // covering for this.
+        assert_eq!(
+            render("['{myrole}']#text#"),
+            r#"<span class="'highlight'">text</span>"#
+        );
+
+        // An order with no attribute-references step at all: the expansion at
+        // parse time is the only one there is.
+        assert_eq!(
+            render("[subs=\"quotes\"]\n['{myrole}']#text#"),
+            r#"<span class="'highlight'">text</span>"#
+        );
+
+        assert_eq!(
+            render("[subs=\"specialcharacters,quotes\"]\n['{myrole}']*bold*"),
+            r#"<strong class="'highlight'">bold</strong>"#
+        );
+
+        // The unquoted spellings read a parsed attribute instead, and were
+        // already expanding under the same order — which is what made the
+        // quoted one's behavior inconsistent rather than merely late.
+        assert_eq!(
+            render("[subs=\"quotes\"]\n[{myrole}]#text#"),
+            r#"<span class="highlight">text</span>"#
+        );
+
+        assert_eq!(
+            render("[subs=\"quotes\"]\n[.{myrole}]#text#"),
+            r#"<span class="highlight">text</span>"#
+        );
+    }
+
+    #[test]
     fn should_allow_inline_double_plus_passthrough_to_be_escaped_using_backslash() {
         verifies!(
             r#"


### PR DESCRIPTION
Found while working the `inline-ast` branch's step 6 cutover, but it is a bug on `main` in its own right and independent of that branch — so it lands here rather than there.

## The bug

`Attrlist::parse` expands attribute references over the whole list *before* splitting it, so every **parsed** field a caller reads is already expanded — and it does that regardless of the enclosing block's `subs`, which is what Asciidoctor's `parse_quoted_text_attributes` does too (it calls `sub_attributes` unconditionally).

`quoted_text_fallback_role` is the one accessor that reads the list's own **text** instead: Asciidoctor treats a quote-delimited first positional as a verbatim role, quote characters included. But `parse` computed that expanded text as `source_cow` and then threw it away, leaving the accessor to fall back to the raw `source` span — so a reference in a quoted role went unexpanded.

Under the default `subs` this is invisible. The attribute-references step runs after quotes, so it rewrites the `{myrole}` sitting inside the `class="'{myrole}'"` the quotes step just wrote, and the final bytes come out right anyway. Drop that step from the order and only the expansion at parse time is left:

```
[subs="quotes"]
['{myrole}']#text#     ->  <span class="'{myrole}'">text</span>     (wrong)
```

while the unquoted spellings, which read a parsed attribute, expand correctly under that same order:

```
[subs="quotes"]
[{myrole}]#text#       ->  <span class="highlight">text</span>      (right)
[.{myrole}]#text#      ->  <span class="highlight">text</span>      (right)
```

That inconsistency within a single parse is the tell. The passthrough family has no later step to cover for it at all, which is why `PassthroughRestoreReplacer` already substitutes its own stored attrlist body by hand at restore time (see its comment there) — two mechanisms papering over the same gap.

## The fix

`parse` retains `source_cow` in a new private `source_text: Option<CowStr<'src>>` field whenever the substitution changed anything, and `quoted_text_fallback_role` reads it through a small `source_text()` accessor that falls back to `source.data()` otherwise. That is Asciidoctor's own order: `sub_attributes` over the list, then the verbatim first positional.

`source_with_language` (a synthesized list with no attrlist text in the document at all) sets it to `None`, and the block-attribute-line merge keeps `self`'s, exactly as it already keeps `self`'s `source` — only inline quoted text reads a list's own text, and an inline list is never merged.

## Verification

- Full workspace suite passes with **no existing test changed** — rendered output is unchanged everywhere the later step was already covering for it.
- Two new tests, both confirmed non-vacuous (they fail with the `parse` change reverted):
  - `quoted_first_positional_reads_the_substituted_text` — the accessor directly, including the comma truncation applying *after* the substitution (so an expansion that introduces a comma truncates too) and a missing attribute under the default `attribute-missing=skip` being a no-op.
  - `quoted_role_resolves_attribute_reference_without_the_attributes_sub` — the rendering, under the default order and under two `subs` lists without the attribute-references step, with the unquoted spellings pinned beside it.
- `attributes/attrlist.rs` stays at 100% region and line coverage.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_