### PR TITLE
feat: Build the inline tree for every parse (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5990,6 +5990,54 @@ Each phase is a reviewable unit with a clear exit gate.
 
   Corpus-wide fold-parity audit: divergence set byte-identical, 60 rows either side. Coverage is
   diff-neutral.
+  *Step 6 landed as (the tree, built for every parse — the `with_inline_tree` flag retired):*
+  the first piece of the cutover proper, and deliberately the one that changes **no output at
+  all**. Every prior increment measured the cutover by forcing the seed on in a throwaway patch;
+  this makes that half real while leaving `rendered` exactly where it is, so the whole corpus
+  runs against a tree that is built but not yet read.
+
+  That ordering is the point. Turning the builder on for every parse and making the fold
+  authoritative are two independent risks — a builder that panics or mis-recognizes somewhere in
+  ~5,390 tests, and a fold whose bytes differ — and bundling them would report both as one red
+  suite. Split, the first is falsifiable on its own: with `rendered` still the string pipeline's,
+  the tree is purely additive, so the *only* tests that can fail are the ones asserting the tree
+  is absent. Two did, and nothing else moved.
+
+  `Parser::with_inline_tree` is gone from the public API. The `build_inline_tree` field it set
+  stays, defaulting to `true`, because the flag's plumbing was always doing a second job:
+  `SubstitutionGroup::apply` clears it on the counter-safe clone it hands the builder, since
+  building a tree re-enters `apply` for a passthrough body whose own substitution list must run
+  (`passthrough_text`), and that nested content needs no tree. It is now documented as the
+  recursion guard it is, with no public surface.
+
+  The two tests that asserted absence are rewritten rather than deleted. `inline_tree_is_empty_by_default`
+  becomes `inline_tree_is_built_by_default`, its assertion inverted. `is_block_inlines_is_some_but_empty_when_flag_off`
+  keeps the distinction it was really pinning — `Some(&[])` is a content-bearing block, `None` a
+  block with no direct content, and the two are not interchangeable — but reaches `Some(&[])`
+  through content that is *genuinely* empty (`----\n----`) rather than through a flag. Every
+  other call site simply drops a `.with_inline_tree(true)` that is now the default.
+
+  What this costs is performance, and it is the cutover's cost rather than this increment's: a
+  parser clone and a full recognition pass per content, on every parse. It is paid back when the
+  string pipeline stops being run for its output, which is what the increments below do.
+
+  The claim above — "changes no output at all" — needs one qualification, and it is the review
+  finding that sent this increment back the first time. Building the tree is only unobservable if
+  the build does not *call the document's renderer*, and it used to: a passthrough body was escaped
+  at build time, so a renderer carrying state saw extra calls and a **later block's** authoritative
+  output shifted under it. The two increments above closed that for every
+  specialcharacters body, and
+  `building_the_tree_does_not_consult_the_documents_renderer` now sweeps every construct to keep
+  it closed — measured at `build` rather than at `parse`, deliberately, since the string pipeline
+  legitimately calls the renderer and for an unresolved cross-reference calls it five times, with
+  and without a tree alike. Counting a whole parse would pin the string pipeline's own behavior and
+  call it this increment's.
+
+  Three shapes still consult it, each pinned by
+  `the_three_non_specialcharacters_bodies_still_consult_the_renderer` so they are a decision rather
+  than a gap: a `pass:c,q[…]` body, a `Stem` body, and a bare `+…+` body enclosing an
+  already-extracted construct. So the honest form of the claim is: **this changes no output for any
+  renderer that does not carry state**, and for one that does, only through those three.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -7148,6 +7196,17 @@ Each phase is a reviewable unit with a clear exit gate.
        escaping moves to the fold. No expectation changed, and the audit's divergence set is
        byte-identical. See the step's own "landed as" note above. **This unblocks the always-on
        increment.**
+     - ✅ **the flag, retired: the tree is built for every parse.** The cutover's first piece,
+       and deliberately the one that changes no output: `SubstitutionGroup::apply` always takes
+       the tree seed, while `rendered` stays the string pipeline's. Splitting "build it always"
+       from "read it" is what makes each falsifiable alone — with the tree still additive, the
+       only tests that *can* fail are the two asserting its absence, and only those did.
+       `Parser::with_inline_tree` is gone from the public API; the `build_inline_tree` field it
+       set survives as the **recursion guard** its plumbing was always also serving (the clone
+       handed to the builder clears it, so a passthrough body's own re-entrant `apply` seeds no
+       tree). See the step's own "landed as" note above. What remains of step 6 is
+       `rendered_html()` as the fold, the three sentinel deletions, and the side effects wired
+       for real.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -45,11 +45,9 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     /// carry each — so a block with no directly-contained content returns
     /// `None` here too.
     ///
-    /// The tree is populated only when inline-tree building is enabled on the
-    /// [`Parser`](crate::Parser) (see
-    /// [`with_inline_tree`](crate::Parser::with_inline_tree)); a
-    /// content-bearing block parsed without it returns `Some(&[])` (an
-    /// empty tree), not `None`.
+    /// Every parse builds the tree, so `Some(&[])` here means a
+    /// content-bearing block whose content is *empty* — still distinct from the
+    /// `None` a block with no directly-contained content returns.
     /// See [`Content::inlines`](crate::content::Content::inlines) for the
     /// tree's guarantees.
     fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -94,13 +94,11 @@ pub struct Content<'src> {
     /// This is a **derived artifact** — built alongside the rendered content,
     /// which remains the source of truth (making the tree canonical, with
     /// `rendered_html()` a fold of it, is the remaining half of the [inline
-    /// AST architecture] design's step 6). It is populated only when
-    /// inline-tree building is enabled on the [`Parser`](crate::Parser)
-    /// ([`with_inline_tree`](crate::Parser::with_inline_tree)); otherwise it is
-    /// empty and the default parse path is byte- and performance-identical to
-    /// before. Because it is derived, it is deliberately excluded from
-    /// [`PartialEq`]/[`Eq`]/[`Hash`]: two `Content`s with equal rendered text
-    /// compare equal regardless of whether the tree was built.
+    /// AST architecture] design's step 6). Every parse builds it: the
+    /// `with_inline_tree` opt-in that used to gate it is retired. Because it is
+    /// derived, it is deliberately excluded from [`PartialEq`]/[`Eq`]/[`Hash`]:
+    /// two `Content`s with equal rendered text compare equal regardless of
+    /// their trees.
     ///
     /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
     inlines: Vec<InlineNode<'src>>,
@@ -454,10 +452,10 @@ impl<'src> Content<'src> {
     /// Returns the inline AST for this content: the structured, read-only
     /// representation of its inline nodes.
     ///
-    /// This is populated only when inline-tree building is enabled on the
-    /// [`Parser`](crate::Parser) (see
-    /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
-    /// slice otherwise. The tree is built by the single-pass builder
+    /// Every parse builds this — the `with_inline_tree` opt-in that used to
+    /// gate it is retired — so it is an empty slice only for content whose tree
+    /// is genuinely empty (empty content). The tree is built by the single-pass
+    /// builder
     /// (the crate-internal `inline_builder` module) directly from the
     /// pre-substitution source, so each node carries its own precise source
     /// [`Span`] (a node born from a transformation, such as an attribute
@@ -677,9 +675,8 @@ impl<'src> Content<'src> {
     /// [`resolved`](crate::inlines::Ref::resolved) destination the rendered
     /// string reflects.
     ///
-    /// This runs only when an inline tree was built (see
-    /// [`Parser::with_inline_tree`](crate::Parser::with_inline_tree)); it is a
-    /// no-op otherwise. It reuses the results of the deferred-reference
+    /// It is a no-op for a content whose tree holds no cross-reference node.
+    /// It reuses the results of the deferred-reference
     /// resolution above rather than re-invoking the resolver, correlating each
     /// tree node with its *own* segment **positionally**: the tree's
     /// cross-reference nodes, visited in document order, line up one-to-one
@@ -732,8 +729,7 @@ impl<'src> Content<'src> {
     /// tree's footnote subtrees. The two lists partition the deferred segments,
     /// so each is correlated against exactly the nodes it belongs to.
     ///
-    /// It is a no-op when no inline tree was built (see
-    /// [`Parser::with_inline_tree`](crate::Parser::with_inline_tree)),
+    /// It is a no-op for a tree holding no cross-reference node,
     /// non-destructive, and re-resolvable: each call overwrites the tree's
     /// resolved state from `block_ordered` and `footnote_ordered`.
     pub(crate) fn mirror_tree_xref_resolution(

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1877,7 +1877,6 @@ mod tests {
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default()
-            .with_inline_tree(true)
             .parse(":attribute-missing: drop-line\n\nFirst line.\nA {nope} line.\nThird line.\n");
 
         let blocks: Vec<_> = doc.descendant_blocks().collect();
@@ -1907,7 +1906,7 @@ mod tests {
         // oracle — see `attribute_entry_substitutions`).
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(
+        let doc = Parser::default().parse(
             ":app-name: pass:quotes[MyApp^2^]\n\n[subs=attributes+]\n------\n{app-name}\n------\n",
         );
 

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1670,7 +1670,7 @@ and another.footnote:[note two]",
             blocks::{FindBlocks, IsBlock},
         };
 
-        let doc = Parser::default().with_inline_tree(true).parse(
+        let doc = Parser::default().parse(
             ":fn-disclaimer: footnote:disclaimer[Opinions are my own.]\n\n\
              A bold statement!{fn-disclaimer}\n\n\
              Another outrageous statement.{fn-disclaimer}",

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1046,15 +1046,13 @@ mod tests {
 
         // The heading carries no content of its own, so the walk below also
         // reaches its `None` arm.
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "== A heading\n",
-                "\n",
-                "[[tgt,see image:t.png[T] there]]The target.\n",
-                "\n",
-                "Back to <<tgt>>.\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "== A heading\n",
+            "\n",
+            "[[tgt,see image:t.png[T] there]]The target.\n",
+            "\n",
+            "Back to <<tgt>>.\n",
+        ));
 
         let mut checked = 0;
 
@@ -1947,7 +1945,7 @@ mod tests {
         // folds to exactly the rendered string the string pipeline produced.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(
+        let doc = Parser::default().parse(
             "[bibliography]\n* [[[gof,GoF]]] Gamma, Erich et al.\n* [[[pp]]] Hunt, Andrew.\n",
         );
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2364,7 +2364,7 @@ mod tests {
         // regress the moment `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "A sunset: image:++sunset_beach.jpg++[] under a masked name.\n",

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1357,16 +1357,14 @@ mod tests {
         // becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "== A indexterm2:[Coffee,region=Kona] heading\n",
-                "\n",
-                "indexterm2:[Flash,see=HTML 5] has been supplanted by\n",
-                "indexterm2:[HTML 5,see-also=\"CSS 3, SVG\"].\n",
-                "\n",
-                "Only named indexterm2:[see=HTML 5] here.\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "== A indexterm2:[Coffee,region=Kona] heading\n",
+            "\n",
+            "indexterm2:[Flash,see=HTML 5] has been supplanted by\n",
+            "indexterm2:[HTML 5,see-also=\"CSS 3, SVG\"].\n",
+            "\n",
+            "Only named indexterm2:[see=HTML 5] here.\n",
+        ));
 
         let mut folded_blocks = 0;
 
@@ -1502,16 +1500,14 @@ mod tests {
         // title, both of which run this same macros step.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "[[target]]\n",
-                "== The Target\n",
-                "\n",
-                "See ((a term with xref:target[the target] inside)) here.\n",
-                "\n",
-                "And ((a term with <<target,the target>> inside)) too.\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "[[target]]\n",
+            "== The Target\n",
+            "\n",
+            "See ((a term with xref:target[the target] inside)) here.\n",
+            "\n",
+            "And ((a term with <<target,the target>> inside)) too.\n",
+        ));
 
         let mut folded = 0;
 
@@ -1805,14 +1801,12 @@ mod tests {
         // whose `Title` group runs the same macros step.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "== A \\(((Coffee))) heading\n",
-                "\n",
-                "An escaped \\(((Coffee >> Beans))) term keeps its parens,\n",
-                "and \\((()))  shows nothing between them.\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "== A \\(((Coffee))) heading\n",
+            "\n",
+            "An escaped \\(((Coffee >> Beans))) term keeps its parens,\n",
+            "and \\((()))  shows nothing between them.\n",
+        ));
 
         let mut folded_blocks = 0;
 
@@ -1874,14 +1868,12 @@ mod tests {
         // same macros step.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "== The ((*tiger*)) heading\n",
-                "\n",
-                "The ((*tiger*)) (Panthera tigris) is the largest cat species,\n",
-                "and an indexterm2:[_em_ term] shows its span too.\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "== The ((*tiger*)) heading\n",
+            "\n",
+            "The ((*tiger*)) (Panthera tigris) is the largest cat species,\n",
+            "and an indexterm2:[_em_ term] shows its span too.\n",
+        ));
 
         let mut folded_blocks = 0;
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2602,7 +2602,7 @@ mod tests {
         // carries — the `href` and a bare link's shown text alike.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "Read link:https://example.org/stem:[x_i][the paper] today.\n",
@@ -3793,7 +3793,7 @@ mod tests {
         // `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "See link:https://example.org[++the <docs>++,role=hl] today.\n",
@@ -3837,7 +3837,7 @@ mod tests {
         // regress the moment `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "Read https://++example.org/now_this__link_works.html++ today.\n",
@@ -6000,7 +6000,7 @@ mod tests {
         // the moment `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "See https://example.org> for details.\n",
@@ -6042,7 +6042,7 @@ mod tests {
         // fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "This URL has repeating underscores ",
@@ -6086,7 +6086,7 @@ mod tests {
         // `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "See [width=10]##x ##https://example.org and [width=10]##y##https://example.org here.\n",
@@ -6128,7 +6128,7 @@ mod tests {
         // of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "Mail *doc@example.org* or _doc@example.org writes_ here.\n",

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -1070,7 +1070,6 @@ mod tests {
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default()
-            .with_inline_tree(true)
             .parse(":experimental:\n:view: View\n\nChoose menu:{view}[Zoom > Reset].");
 
         let blocks: Vec<_> = doc.descendant_blocks().collect();
@@ -1108,7 +1107,7 @@ mod tests {
         // to.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(
+        let doc = Parser::default().parse(
             ":experimental:\n\nPress kbd:[Ctrl&C] then menu:&#8942;[More Tools, Extensions].",
         );
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1244,9 +1244,7 @@ mod tests {
         // destinations.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default()
-            .with_inline_tree(true)
-            .parse("<<tigers,>>\n\n[#tigers]\n== Tigers");
+        let doc = Parser::default().parse("<<tigers,>>\n\n[#tigers]\n== Tigers");
 
         let blocks: Vec<_> = doc.descendant_blocks().collect();
         let rendered = blocks[0].rendered_html_content().unwrap();
@@ -2348,7 +2346,6 @@ mod tests {
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default()
-            .with_inline_tree(true)
             .parse(":id: install\n\n[#install]\n== Install\n\nSee xref:{id}[the install steps].");
 
         let block = doc
@@ -2382,7 +2379,6 @@ mod tests {
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default()
-            .with_inline_tree(true)
             .parse("[#install]\n== Install\n\nSee xref:install[Tom & Jerry] for details.");
 
         let block = doc
@@ -2416,7 +2412,7 @@ mod tests {
         // runs the same macros step.
         use crate::blocks::{Block, FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "[#install]\n",
             "== See xref:install[the *bold* steps,role=hl]\n",
             "\n",

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -338,8 +338,7 @@
 //! [character replacements]:
 //!     https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
 //!
-//! This module is now **the production tree source**: when inline-tree
-//! building is enabled ([`Parser::with_inline_tree`](crate::Parser)),
+//! This module is now **the production tree source**, for every parse:
 //! `SubstitutionGroup::apply` calls [`build_for_group`] — the group-aware
 //! entry point mirroring its own `run_pipeline` step selection — over the
 //! pre-substitution content value, against a counter-safe clone of the

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -2064,7 +2064,7 @@ mod tests {
         // `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             r"An escaped \[attrs]++<b>*x*</b>++ bracket.",
@@ -2212,7 +2212,7 @@ mod tests {
         // `rendered_html()` becomes a fold of this tree.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "The index:[attrs]+text+ form keeps its bracket, unlike [attrs]+text+.",

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -217,15 +217,13 @@ mod tests {
         // unrelated reason.
         use crate::blocks::{FindBlocks, IsBlock};
 
-        let doc = crate::Parser::default()
-            .with_inline_tree(true)
-            .parse(concat!(
-                "[[tgt]]Target.\n",
-                "\n",
-                "x xref:tgt[pre z +\nw post] y\n",
-                "\n",
-                "x link:l.html[pre z +\nw post] y\n",
-            ));
+        let doc = crate::Parser::default().parse(concat!(
+            "[[tgt]]Target.\n",
+            "\n",
+            "x xref:tgt[pre z +\nw post] y\n",
+            "\n",
+            "x link:l.html[pre z +\nw post] y\n",
+        ));
 
         let folds: Vec<(String, String)> = doc
             .descendant_blocks()

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -2603,7 +2603,7 @@ mod tests {
             blocks::{FindBlocks, IsBlock},
         };
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "That only gives you \"``end points``\".\n",
@@ -2644,7 +2644,7 @@ mod tests {
             blocks::{FindBlocks, IsBlock},
         };
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "She said \"`hello`\"`code` and meant it.\n",
@@ -2689,7 +2689,7 @@ mod tests {
             blocks::{FindBlocks, IsBlock},
         };
 
-        let doc = Parser::default().with_inline_tree(true).parse(concat!(
+        let doc = Parser::default().parse(concat!(
             "== A heading\n",
             "\n",
             "See **bold**https://example.org and __em__https://example.org here.\n",

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -3,7 +3,8 @@
 //! machinery**.
 //!
 //! This module was the production tree source through Phase 2 and Phase 4's
-//! additive increments: when tree building was enabled on the [`Parser`],
+//! additive increments: when tree building was enabled on the [`Parser`] — an
+//! opt-in that has since retired along with it —
 //! `SubstitutionGroup::apply` re-ran the pipeline through the
 //! [`RecordingRenderer`] and parsed the recorded markers into each
 //! [`Content`]'s tree. The Phase 4 single-pass builder
@@ -48,7 +49,6 @@
 //! [`inline_recorder`]: ../../tests/inline_recorder.rs
 //! [`Content`]: crate::content::Content
 //! [`Parser`]: crate::Parser
-//! [`Parser::with_inline_tree`]: crate::Parser::with_inline_tree
 
 // Some node metadata is captured but not yet read by every consumer while the
 // tree is not yet canonical; the tree carries the full structure the public API

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -227,12 +227,16 @@ impl SubstitutionGroup {
         attrlist: Option<&Attrlist<'src>>,
     ) {
         // Snapshot the pre-substitution value and the parser *before* the
-        // authoritative pass runs, when inline-tree building is enabled. The
-        // parser clone captures every document counter (footnote/callout
-        // numbers, `{counter:…}` values) at its pre-substitution value, so the
-        // single-pass builder below numbers constructs exactly as the
-        // authoritative pass does; the clone's mutations are then discarded,
-        // leaving the real parser advanced once.
+        // authoritative pass runs. The parser clone captures every document
+        // counter (footnote/callout numbers, `{counter:…}` values) at its
+        // pre-substitution value, so the single-pass builder below numbers
+        // constructs exactly as the authoritative pass does; the clone's
+        // mutations are then discarded, leaving the real parser advanced once.
+        //
+        // `build_inline_tree` is no longer an opt-in switch — every parse
+        // builds the tree — but it is still the recursion guard the clone
+        // clears below, so a nested `apply` for a passthrough body skips the
+        // snapshot entirely rather than seeding a tree nothing reads.
         let tree_seed = if parser.build_inline_tree {
             Some((content.rendered.clone(), parser.clone()))
         } else {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -477,16 +477,18 @@ pub struct Parser {
     /// with only a shared reference).
     datetime_context: RefCell<Option<DatetimeContext>>,
 
-    /// When `true`, each [`Content`](crate::content::Content) also builds its
-    /// inline AST (an additional, counter-safe single-pass recognition over
-    /// the same source; see `content::inline_builder`) and stores it for
-    /// [`Content::inlines`](crate::content::Content::inlines).
+    /// Whether each [`Content`](crate::content::Content) built with this parser
+    /// also builds its inline AST (see `content::inline_builder`) and stores it
+    /// for [`Content::inlines`](crate::content::Content::inlines).
     ///
-    /// `false` by default, in which case the parse path is byte- and
-    /// performance-identical to before the inline AST existed. Enable it with
-    /// [`with_inline_tree`](Self::with_inline_tree). This is an opt-in switch
-    /// while the inline AST is being brought up (design Phase 4); it will
-    /// eventually become the canonical representation and the flag will retire.
+    /// `true` for every parser a caller can construct — the opt-in
+    /// `with_inline_tree` switch this used to carry is retired, and every parse
+    /// now builds the tree. What survives is the **recursion guard** that
+    /// switch's plumbing also served: `SubstitutionGroup::apply` clears it on
+    /// the clone it hands the builder, because building a tree re-enters
+    /// `apply` for a passthrough body whose own substitution list must run
+    /// (`passthrough_step::passthrough_text`), and that nested content needs no
+    /// tree of its own. Nothing else sets it, and no public API exposes it.
     pub(crate) build_inline_tree: bool,
 }
 
@@ -603,7 +605,7 @@ impl Default for Parser {
             reference_time: None,
             input_mtime: None,
             datetime_context: RefCell::new(None),
-            build_inline_tree: false,
+            build_inline_tree: true,
         }
     }
 }
@@ -2308,39 +2310,6 @@ impl Parser {
         renderer: ISR,
     ) -> Self {
         self.renderer = Rc::new(renderer);
-        self
-    }
-
-    /// Enables (or disables) building the **inline AST** for every
-    /// [`Content`](crate::content::Content) this parser produces.
-    ///
-    /// When enabled, each block's inline content is additionally parsed into a
-    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable from
-    /// its [`Content`](crate::content::Content) via
-    /// [`Content::inlines`](crate::content::Content::inlines) (or, at the block
-    /// level, [`IsBlock::inlines`](crate::blocks::IsBlock::inlines)). The tree
-    /// is built by the single-pass builder
-    /// (`content::inline_builder`) directly from the pre-substitution source,
-    /// so its nodes carry precise source spans and their own parsed attribute
-    /// lists; see
-    /// [`Content::inlines`](crate::content::Content::inlines) for the tree's
-    /// guarantees (including the small set of documented deferred forms).
-    ///
-    /// This is **off by default**. Building the tree costs an additional,
-    /// counter-safe recognition pass per block over the same source, so the
-    /// default parse path is unchanged in both output and performance. The
-    /// switch is expected to retire once the inline AST becomes the canonical
-    /// representation (with `rendered_html()` a fold of it — the remaining
-    /// half of the design's step 6 cutover).
-    ///
-    /// A custom [`InlineSubstitutionRenderer`] is consulted while the tree is
-    /// built only where a node's *value* is defined as already-substituted
-    /// text (a delimited passthrough's or STEM expression's body, whose
-    /// special characters it escapes); it is not otherwise re-run over the
-    /// content, and the registered asset handlers are not re-invoked.
-    #[must_use]
-    pub fn with_inline_tree(mut self, enabled: bool) -> Self {
-        self.build_inline_tree = enabled;
         self
     }
 

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -19,10 +19,9 @@
 //! pass mutates the title's tree) and to footnote-embedded references (which
 //! live in a footnote's subtree).
 //!
-//! This harness checks all three, over whole documents, in one parse: with
-//! [`with_inline_tree`](crate::Parser::with_inline_tree) on, every content
-//! location carries *both* its rendered string and its tree, so the two are
-//! compared directly rather than reconstructed from a second parse.
+//! This harness checks all three, over whole documents, in one parse: every
+//! content location carries *both* its rendered string and its tree, so the two
+//! are compared directly rather than reconstructed from a second parse.
 
 use std::rc::Rc;
 
@@ -167,9 +166,11 @@ fn footnote_subtrees<'a, 'src>(
 /// A parser with `experimental` set, so the UI macros a fixture may carry are
 /// recognized by both sides alike, and with tree building on.
 fn parser() -> Parser {
-    Parser::default()
-        .with_inline_tree(true)
-        .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
+    Parser::default().with_intrinsic_attribute_bool(
+        "experimental",
+        true,
+        ModificationContext::Anywhere,
+    )
 }
 
 /// Parses `source` once and asserts that folding each content location's tree

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -17,10 +17,10 @@
 //!    cross-check) — so the recorder stays honest as the independent
 //!    construction the structural cross-check
 //!    (`tests::inline_builder_recorder_parity`) compares the builder against.
-//! 2. The `with_inline_tree` wiring tests drive the **production** tree path —
-//!    now the single-pass builder — asserting what
-//!    [`Content::inlines`](crate::content::Content) stores for real parsed
-//!    documents, and that enabling the flag never changes rendered output.
+//! 2. The wiring tests drive the **production** tree path — now the single-pass
+//!    builder, run for every parse since the `with_inline_tree` opt-in retired
+//!    — asserting what [`Content::inlines`](crate::content::Content) stores for
+//!    real parsed documents.
 //!
 //! [inline AST architecture]: ../../../docs/design/inline-ast-architecture.md
 
@@ -562,7 +562,7 @@ fn check_inline_tree_flag_parity(source: &str) {
     let mut off = collect_rendered(&off_doc);
     off.extend(collect_footnote_texts(&off_doc));
 
-    let mut on_parser = experimental(Parser::default()).with_inline_tree(true);
+    let mut on_parser = experimental(Parser::default());
     let on_doc = on_parser.parse(source);
 
     let mut on = collect_rendered(&on_doc);
@@ -838,10 +838,9 @@ fn callout_in_verbatim_is_a_callout_node() {
 
 // ─── Wiring: the tree as a live artifact on `Content` ────────────────────────
 //
-// These exercise the Phase 2 wiring: `Parser::with_inline_tree` builds each
-// `Content`'s tree during the parse, so `Content::inlines()` is populated for
-// real blocks (with document counters numbered correctly), and the default
-// (flag-off) path leaves it empty.
+// These exercise the Phase 2 wiring, now unconditional: every parse builds each
+// `Content`'s tree, so `Content::inlines()` is populated for real blocks (with
+// document counters numbered correctly) without a caller opting in.
 
 /// Collects the first simple block's content from a parsed document.
 fn first_simple_inlines<'a>(doc: &'a crate::Document<'a>) -> &'a [InlineNode<'a>] {
@@ -871,20 +870,130 @@ fn first_simple_rendered<'a>(doc: &'a crate::Document<'a>) -> &'a str {
     panic!("no simple block found");
 }
 
+/// Every construct whose tree the builder can produce without consulting a
+/// renderer — which, after the two passthrough-form increments, is everything
+/// except the two shapes that run an arbitrary substitution list.
+const RENDERER_FREE_CONSTRUCTS: &[&str] = &[
+    "a < b",
+    "++a < b++",
+    "+++a < b+++",
+    "$$a < b$$",
+    "+a < b+",
+    "pass:[a < b]",
+    "[.role]#a < b#",
+    "[.a<b]#x#",
+    "[x-]++a < b++",
+    "image:x.png[a < b]",
+    "link:x.html[a < b]",
+    "footnote:[a < b]",
+    "<<tgt,a < b>>",
+    "kbd:[Ctrl+T] and a < b",
+    "a < b -- c (C) d",
+];
+
+/// A renderer that reports, through its own output, how many times it has been
+/// called — the only way to observe an `Rc<dyn InlineSubstitutionRenderer>`,
+/// which cannot be downcast to read a counter field.
+#[derive(Debug, Default)]
+struct OrdinalRenderer {
+    calls: std::cell::Cell<usize>,
+}
+
+impl crate::parser::InlineSubstitutionRenderer for OrdinalRenderer {
+    fn render_special_character(&self, _type_: crate::parser::SpecialCharacter, dest: &mut String) {
+        self.calls.set(self.calls.get() + 1);
+        dest.push_str(&format!("[{}]", self.calls.get()));
+    }
+}
+
+/// Builds `source`'s tree and returns how many times the build consulted
+/// `parser`'s renderer.
+fn renderer_calls_while_building(source: &str) -> usize {
+    let parser = Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
+
+    let _ = crate::content::inline_builder::build(crate::Span::new(source), &parser, None);
+
+    let mut probe = String::new();
+    parser
+        .renderer
+        .render_special_character(crate::parser::SpecialCharacter::Lt, &mut probe);
+
+    // The probe is itself a call, so its ordinal is one more than the build's.
+    probe
+        .trim_matches(|c: char| !c.is_ascii_digit())
+        .parse::<usize>()
+        .expect("the probe reports its own ordinal")
+        - 1
+}
+
 #[test]
-fn inline_tree_is_empty_by_default() {
+fn building_the_tree_does_not_consult_the_documents_renderer() {
+    // The property this increment has to hold, and the one the review of its
+    // first attempt found broken: the tree is a *derived* artifact, so building
+    // it must not be observable. A renderer with state is how "observable" gets
+    // measured — a call the build makes lands between the string pipeline's,
+    // and a *later block's* authoritative output shifts under a renderer that
+    // has done nothing wrong.
+    //
+    // Measured at `build` rather than at `parse`, deliberately. The string
+    // pipeline legitimately calls the renderer, and for some constructs more
+    // than once: an unresolved cross-reference renders its fallback template
+    // repeatedly, so `<<tgt,a < b>>` reaches five calls in a full parse — with
+    // *and without* a tree, checked both ways. Counting a whole parse would
+    // therefore pin the string pipeline's own behavior and call it this
+    // increment's. Counting the build alone asks the one question that matters:
+    // does building add any?
+    for source in RENDERER_FREE_CONSTRUCTS {
+        assert_eq!(
+            renderer_calls_while_building(source),
+            0,
+            "building the tree for {source:?} consulted the renderer"
+        );
+    }
+}
+
+#[test]
+fn the_three_non_specialcharacters_bodies_still_consult_the_renderer() {
+    // The documented complement, pinned so it is a decision rather than a gap.
+    // Three shapes, each for the same underlying reason: their value is not a
+    // *specialcharacters* body, so no `RawForm` describes it and it has to be
+    // computed at build time, against the parse's renderer.
+    //
+    //   - `pass:c,q[…]` and `stem:[…]` each run an **arbitrary substitution list**,
+    //     which is a whole pipeline.
+    //   - a bare `+…+` body enclosing an already-extracted construct interleaves
+    //     escaped text with that construct's own **fold** bytes, which is a mixture
+    //     rather than a form.
+    //
+    // All three owe `render_with` the same debt every frozen value on this
+    // branch does (design §3.3.1), and when that lands this test is what should
+    // start failing.
+    for source in ["pass:c[a < b]", "stem:[x < y]", "+a $$b < c$$ d+"] {
+        let calls = renderer_calls_while_building(source);
+
+        assert!(
+            calls > 0,
+            "expected {source:?} to still consult the renderer while building, got {calls}"
+        );
+    }
+}
+
+#[test]
+fn inline_tree_is_built_by_default() {
+    // The `with_inline_tree` opt-in is retired: a plain `Parser::default()`
+    // builds the tree, where it used to leave `inlines()` empty.
     let mut parser = Parser::default();
     let doc = parser.parse("One *word* is strong.");
 
     assert!(
-        first_simple_inlines(&doc).is_empty(),
-        "the inline tree must be empty when tree building is disabled"
+        !first_simple_inlines(&doc).is_empty(),
+        "every parse must build the inline tree"
     );
 }
 
 #[test]
-fn inline_tree_is_built_when_enabled() {
-    let mut parser = Parser::default().with_inline_tree(true);
+fn inline_tree_is_built_for_a_default_parser() {
+    let mut parser = Parser::default();
     let doc = parser.parse("One *word* is strong.");
 
     let tree = first_simple_inlines(&doc);
@@ -913,7 +1022,7 @@ fn inline_tree_is_built_when_enabled() {
 fn is_block_inlines_exposes_the_content_tree() {
     use crate::blocks::{Block, IsBlock};
 
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("One *word* is strong.");
 
     let block = doc.child_blocks().next().expect("a block");
@@ -930,13 +1039,16 @@ fn is_block_inlines_exposes_the_content_tree() {
 }
 
 #[test]
-fn is_block_inlines_is_some_but_empty_when_flag_off() {
+fn is_block_inlines_is_some_and_empty_for_empty_content() {
     use crate::blocks::IsBlock;
 
-    // A content-bearing block parsed without tree building returns an *empty*
-    // tree, not `None` — the block still has content, the tree is just not built.
+    // `Some(&[])` and `None` mean different things, and the distinction
+    // outlives the retired opt-in: `None` is a block with no direct inline
+    // content at all (the test below), while `Some(&[])` is a block that has
+    // content whose tree is legitimately empty. `build_for_group` returns no
+    // nodes for empty content, which an empty listing block's body is.
     let mut parser = Parser::default();
-    let doc = parser.parse("One *word* is strong.");
+    let doc = parser.parse("----\n----");
 
     let block = doc.child_blocks().next().expect("a block");
 
@@ -949,7 +1061,7 @@ fn is_block_inlines_is_none_for_a_block_without_direct_content() {
 
     // A section is a compound block: its inline content lives in its child
     // blocks, so the section itself has no direct tree.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("== Title\n\nBody.");
 
     let section = doc.child_blocks().next().expect("a section block");
@@ -991,7 +1103,7 @@ fn is_block_inlines_matches_rendered_html_content_across_every_block_kind() {
     // `Section`; the leaf/container blocks cover the rest. Each is walked with
     // the inline-tree flag on so `inlines()` is populated for the
     // content-bearing kinds.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse(concat!(
         "= Doc Title\n\n",
         "Preamble *para*.\n\n",
@@ -1059,7 +1171,7 @@ fn is_block_inlines_carries_a_real_tree_for_each_content_bearing_kind() {
     // Beyond `Some` vs `None`, the override bodies for the content-bearing block
     // kinds must return the *actual* parsed tree — so a formatting construct in
     // each shows up as a `Styled` node, not an empty slice.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse(concat!(
         "NOTE: A _note_.\n\n",
         "[verse]\n____\nA `verse`.\n____\n\n",
@@ -1120,7 +1232,7 @@ fn inline_tree_honors_a_blocks_custom_subs_list() {
     // selection: the tree carries a `Styled` node for `*bold*`, while `<`
     // stays inside a plain `Text` run (no `CharRef` — the special-characters
     // step never ran) exactly as the rendered string leaves it unescaped.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[subs=quotes]\nkeep *bold* and a < b\n");
 
     let tree = first_simple_inlines(&doc);
@@ -1146,7 +1258,7 @@ fn inline_tree_for_none_group_content_is_the_untouched_seed() {
     // run, though: because no `SpecialCharacters` step ever acted on it, each
     // literal `<`/`>`/`&` is a `Raw` leaf the fold emits verbatim rather than
     // a `Text` character the fold would escape (design §3.4.1).
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[pass]\n<b>raw</b> and *not bold*\n");
 
     let tree = first_simple_inlines(&doc);
@@ -1183,7 +1295,7 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
     // callouts), so its tree must carry a `Callout` node for the trailing
     // `<1>` — driving the group-aware builder's `Callouts` dispatch through a
     // real parse.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("----\ncode line <1>\n----\n");
 
     let listing = doc
@@ -1210,7 +1322,7 @@ fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
     // resolution mirror must detect the count mismatch and skip — leaving the
     // tree in its honest unresolved state — rather than assign destinations to
     // the wrong nodes (or panic).
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=*hl*].");
 
     // The rendered output is unaffected (the string pipeline is
@@ -1241,7 +1353,7 @@ fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
     // (The deferred form here is a shorthand whose *id* crosses an opaque
     // piece — a masked passthrough — since a footnote's own bracketed text
     // ends at the first `]`, which rules out the bracket-carrying spellings.)
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse(
         "[[a]]A target.\n\n[[c]]Another.\n\nSee <<c>>.footnote:[see <<a +++b+++ c>> and <<c>>]",
     );
@@ -1315,7 +1427,7 @@ fn inline_tree_numbers_footnotes_in_document_order() {
     // advances the footnote counter, so a footnote in the second paragraph is
     // numbered "2" in its tree — matching `rendered_html()` — rather than
     // restarting at "1" (which a fresh-parser recording pass would produce).
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc =
         parser.parse("Body text.footnote:[the first note]\n\nMore text.footnote:[the second note]");
 
@@ -1383,7 +1495,7 @@ fn inline_tree_xref_is_resolved_after_parse() {
     // The target is anchored in the first paragraph and referenced in the
     // second; after the parse's own-catalog resolution, the tree's xref node
     // carries the resolved `#tgt` destination.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target paragraph.\n\nSee <<tgt>> for details.");
 
     let refs = collect_refs(&doc);
@@ -1404,7 +1516,7 @@ fn inline_tree_xref_is_resolved_after_parse() {
 fn inline_tree_xref_inside_formatting_is_resolved() {
     // The recursion reaches an xref nested inside a formatting span, so a
     // `Ref` node that lives under a `Styled` node is resolved too.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target.\n\nSee *the <<tgt>> link* here.");
 
     let refs = collect_refs(&doc);
@@ -1427,7 +1539,7 @@ fn inline_tree_xref_inside_formatting_is_resolved() {
 fn inline_tree_unresolved_xref_stays_none() {
     // A reference whose target has no catalog entry is left unresolved in the
     // tree, mirroring the unresolved-fallback the rendered string shows.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("See <<missing>> here.");
 
     let refs = collect_refs(&doc);
@@ -1449,7 +1561,7 @@ fn inline_tree_resolution_walks_past_a_footnote_and_a_link() {
     // the walk recurses into the footnote node's (currently empty) subtree
     // without disturbing it, and a link (a `Ref` of variant `Link`) passes
     // through untouched because only an `Xref` has a catalog destination.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser
         .parse("[[tgt]]The target.\n\nSee <<tgt>> and https://example.org[x].footnote:[a note]");
 
@@ -1518,7 +1630,7 @@ fn inline_tree_same_target_refs_keep_per_reference_resolution() {
         }
     }
 
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("See <<tgt,first>> and <<tgt,second>>.");
     doc.resolve_references(&PerTextResolver, &HtmlSubstitutionRenderer {});
 
@@ -1542,7 +1654,7 @@ fn inline_tree_xref_resolution_matches_the_rendered_string() {
     // The tree's resolved destination and the rendered HTML are two projections
     // of the same resolution: the `#tgt` fragment in the resolved node is the
     // same href the rendered `<a>` carries.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target.\n\nSee <<tgt,the target>> now.");
 
     use crate::blocks::Block;
@@ -1609,9 +1721,7 @@ fn inline_tree_build_tolerates_a_stateful_renderer() {
         }
     }
 
-    let mut parser = Parser::default()
-        .with_inline_substitution_renderer(FlipRenderer::default())
-        .with_inline_tree(true);
+    let mut parser = Parser::default().with_inline_substitution_renderer(FlipRenderer::default());
 
     let doc = parser.parse("a < b");
 
@@ -1697,7 +1807,7 @@ fn section_title_forward_xref_is_resolved_in_the_tree() {
     // The first heading forward-references a section defined later. The title
     // pass resolves it in document order and mirrors the destination into the
     // heading's tree, so the title's `Ref` node carries `#the-end`.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("== See <<the-end>>\n\n[#the-end]\n== The End\n");
 
     let refs = collect_section_title_refs(&doc);
@@ -1722,7 +1832,7 @@ fn circular_section_title_xrefs_are_both_resolved_in_the_tree() {
     // rendered link *text*, but each reference still resolves to its target's
     // destination — and both destinations are now mirrored into the two
     // headings' trees.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[#a]\n== See <<b>>\n\n[#b]\n== See <<a>>\n");
 
     let hrefs: Vec<String> = collect_section_title_refs(&doc)
@@ -1744,7 +1854,7 @@ fn circular_section_title_xrefs_are_both_resolved_in_the_tree() {
 fn unresolved_section_title_xref_stays_none_in_the_tree() {
     // A heading whose cross-reference names no catalog entry is left unresolved
     // in the tree, mirroring the unresolved fallback the rendered title shows.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("== See <<missing>>\n");
 
     let refs = collect_section_title_refs(&doc);
@@ -1764,7 +1874,7 @@ fn block_title_xref_is_resolved_in_the_tree() {
     // A block `.Title` carrying a cross-reference is resolved by the same title
     // pass, which mirrors the destination into the block title's tree — a site
     // the per-content pass never resolved at all.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc =
         parser.parse("[[tgt]]The target paragraph.\n\n.See <<tgt>>\nA captioned paragraph.\n");
 
@@ -1837,7 +1947,7 @@ fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
             .map(|resolved| resolved.href.clone())
     }
 
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("== See <<tgt>>\n\n[#tgt]\n== Target\n");
 
     // First pass: the resolver recognizes the target, so the heading's tree xref
@@ -1931,7 +2041,7 @@ fn refs_in<'a>(nodes: &[InlineNode<'a>]) -> Vec<crate::inlines::Ref<'a>> {
 fn footnote_carries_its_text_as_child_nodes() {
     // The footnote's text is a subtree, not an opaque string: the formatting
     // inside it is structure the block's rendered string never carries.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("A claim.footnote:[the *strong* evidence]");
 
     let footnote = first_footnote(&doc);
@@ -1964,7 +2074,7 @@ fn footnote_subtree_carries_a_nested_macro() {
     // A macro substituted before footnotes (here a link) is captured as part of
     // the footnote's text, so it surfaces as a node of the footnote's subtree
     // rather than being absorbed into the block.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("A claim.footnote:[see link:https://example.org[the source]]");
 
     let footnote = first_footnote(&doc);
@@ -1987,7 +2097,7 @@ fn footnote_reference_keeps_an_empty_subtree() {
     // `footnote:id[]` defines nothing — it re-uses an earlier footnote's number —
     // so it consumes no footnote text and keeps the empty subtree its node type
     // documents, while the defining occurrence carries the text.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("Named.footnote:disc[a *discussion*] then footnote:disc[].");
 
     use crate::blocks::Block;
@@ -2023,7 +2133,7 @@ fn footnote_subtrees_track_document_order_across_blocks() {
     // Each block's recording pass picks up only the footnotes *that* block
     // defined (the registry length is snapshotted first), so the second
     // paragraph's footnote gets its own text rather than the first one's.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("One.footnote:[first note]\n\nTwo.footnote:[second note]");
 
     use crate::blocks::Block;
@@ -2062,7 +2172,7 @@ fn footnote_embedded_xref_is_resolved_in_the_tree() {
     // The cross-reference lives in the footnote's subtree, and its destination
     // is mirrored there from the same resolution sweep that resolved the block's
     // own references — so the tree agrees with the rendered footnote text.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target.\n\nA claim.footnote:[see <<tgt>> for details]");
 
     let footnote = first_footnote(&doc);
@@ -2097,7 +2207,7 @@ fn footnote_embedded_xref_does_not_displace_block_xrefs() {
     // must not consume a slot of the block-level list. Were the block walk to
     // descend into the footnote subtree, the reference *after* the footnote
     // would take the footnote's destination.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse(
         "[[one]]First.\n\n[[two]]Second.\n\nSee <<one>>.footnote:[also <<two>>] and <<two>>.",
     );
@@ -2149,7 +2259,7 @@ fn unresolved_footnote_embedded_xref_stays_none() {
     // A footnote-embedded reference whose target has no catalog entry is left
     // unresolved in the subtree, mirroring the unresolved fallback the rendered
     // footnote text shows.
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("A claim.footnote:[see <<missing>>]");
 
     let footnote = first_footnote(&doc);
@@ -2196,7 +2306,7 @@ fn re_resolving_clears_a_now_unresolved_footnote_tree_destination() {
             .map(|resolved| resolved.href)
     }
 
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("A claim.footnote:[see <<tgt>>]");
 
     doc.resolve_references(&FixedResolver(Some("#tgt")), &HtmlSubstitutionRenderer {});
@@ -2217,7 +2327,7 @@ fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
     // footnote-embedded ones into the heading tree's footnote subtree too.
     use crate::blocks::{Block, FindBlocks};
 
-    let mut parser = Parser::default().with_inline_tree(true);
+    let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target.\n\n== A Heading.footnote:[see <<tgt>>]\n\nBody.\n");
 
     fn headings<'a>(


### PR DESCRIPTION
**Targets `inline-ast` directly** now that #1262 has merged. #1257 → #1258 stack on top.

The first piece of the **cutover proper**. `SubstitutionGroup::apply` always takes the tree seed; `rendered` stays the string pipeline's.

## Why this is its own PR

Turning the builder on for every parse and making the fold authoritative are two independent risks — a builder that mis-recognizes somewhere in ~5,400 tests, and a fold whose bytes differ — and bundling them would report both as one red suite. Split, the first is falsifiable alone: with `rendered` still the string pipeline's, the tree is additive, so the only tests that *can* fail are the ones asserting it is absent.

## What changed since the first attempt

The first version of this PR was **wrong**, and the review caught it. Building the tree is only unobservable if the build does not call the document's renderer — and it did: a passthrough body was escaped at build time, so a renderer carrying state saw extra calls and a **later block's** authoritative output shifted under it (`c [2] d` became `c [3] d`).

#1261 and #1262 closed that for every specialcharacters body. This PR carries the sweep that keeps it closed:

- **`building_the_tree_does_not_consult_the_documents_renderer`** — sixteen constructs, each asserting the build makes **zero** renderer calls.
- **`the_three_non_specialcharacters_bodies_still_consult_the_renderer`** — the documented complement, so the remaining three are a decision rather than a gap: a `pass:c,q[…]` body, a `Stem` body, and a bare `+…+` body enclosing an already-extracted construct. None is a specialcharacters body, so no `RawForm` describes it; all three need the fold-time laziness §3.3.1 will bring. When that lands, this test is what should start failing.

**Measured at `build`, not at `parse`, deliberately.** My first attempt at this test counted a whole parse and failed on `&lt;&gt;` at five calls — which turned out to be the string pipeline's own deferred-template machinery, identical with *and without* a tree. Counting a parse pins the string pipeline's behavior and calls it this increment's; counting the build asks the one question that matters.

Writing the sweep also corrected #1262: I had listed two remaining shapes, and the mixture case makes three. Fixed there.

## The honest claim

Not "changes no output at all" — **changes no output for any renderer that does not carry state**, and for one that does, only through those three shapes. The commit message and design note say so.

## What else changed

`Parser::with_inline_tree` is gone from the public API. The `build_inline_tree` field survives as the **recursion guard** its plumbing was always also serving (the clone handed to the builder clears it, so a passthrough body's re-entrant `apply` seeds no tree).

Two tests that asserted absence are rewritten rather than deleted — `inline_tree_is_empty_by_default` inverts, and `is_block_inlines_is_some_but_empty_when_flag_off` keeps the `Some(&[])` / `None` distinction it was really pinning but reaches it through genuinely empty content.

## Cost

**CodSpeed regression, accepted.** A parser clone and a full recognition pass per content, on every parse — measured at ~2.4–3.8× locally, and confirmed reproducible (a re-run gave 50.99% again, so not a runner artifact). It's the cutover's cost, not this increment's, and only shows here: once this lands, later PRs compare against an already-slow base.

## Verification

- `cargo test --workspace`: **5422 pass, 0 fail**.
- Coverage **diff-neutral**: 575 missed regions / 323 missed lines.
- Preflight clean: fmt, clippy, doc.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_