### PR TITLE
feat: Delete the footnote-marker sentinel system (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6038,6 +6038,44 @@ Each phase is a reviewable unit with a clear exit gate.
   than a gap: a `pass:c,q[…]` body, a `Stem` body, and a bare `+…+` body enclosing an
   already-extracted construct. So the honest form of the claim is: **this changes no output for any
   renderer that does not carry state**, and for one that does, only through those three.
+  *Step 6 landed as (the footnote-marker sentinel system, deleted — the first of the three):*
+  the cutover's second piece, and the first §4.2 deletion. `Section::parse` now gets a heading's
+  footnote-free reference text from
+  [`fold_reference_text`](../../parser/src/content/inline_builder/fold.rs) instead of from a
+  byte-level cut, and the whole sentinel apparatus goes with it: `FOOTNOTE_MARKER_START` /
+  `FOOTNOTE_MARKER_END`, `strip_footnote_marker_spans`,
+  `Content::remove_footnote_marker_sentinels`, `Parser::mark_footnote_spans`, and the two
+  `dest.push(…)` calls in [`InlineFootnoteMacroReplacer`](../../parser/src/content/macros.rs)
+  that emitted them.
+
+  The property being traded is worth stating precisely, because it is *not* "the fold is
+  authoritative" — `rendered` is still the string pipeline's here, and stays that way until the
+  next increment. What moves is one derived string: a heading's reference text and the id
+  derived from it. The sentinels existed only to make **one** render yield **two** strings, so
+  that counters and attribute-expanded footnotes were not processed twice. A tree yields two
+  strings from one render for free — they are two folds of it — so the constraint the sentinels
+  bought is satisfied by construction and the mechanism is pure overhead.
+
+  The prep increment that staged `fold_reference_text` pinned the equivalence against a corpus
+  of thirteen titles. That corpus is a list of fixtures someone thought to write down, which is
+  the failure mode the cross-product sweep was built to answer, so the swap was measured
+  corpus-wide first instead: a throwaway patch computed **both** answers for every section title
+  in the suite and logged any disagreement. Across ~5,390 tests there were **zero**. That is the
+  evidence the swap rests on; the fixture corpus survives as its written-down form.
+
+  With the strip gone there is no second implementation left to differentiate the reference text
+  against, so `fold_reference_text_matches_the_sentinel_strip` becomes
+  `fold_reference_text_omits_a_headings_footnote_markers`: the heading's own rendering is still
+  compared against the string pipeline (the §5.3 oracle, which still produces it), while the
+  reference text is compared against a **literal** expected string — the exact bytes the strip
+  produced, captured before it was deleted. The four unit tests of the strip itself go with the
+  function.
+
+  Re-running the corpus-wide fold-parity audit shows the divergence set **shrink by 16**, every
+  one of them a title whose only disagreement was the sentinel pair itself, which neither side
+  now emits. One row is re-spelled rather than added: a recorder test's own
+  `MARK_OPEN`/`MARK_CLOSE` fixture, which had appeared in both a with- and a without-sentinel
+  form and now appears once. Coverage is diff-neutral.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -7207,6 +7245,18 @@ Each phase is a reviewable unit with a clear exit gate.
        tree). See the step's own "landed as" note above. What remains of step 6 is
        `rendered_html()` as the fold, the three sentinel deletions, and the side effects wired
        for real.
+
+     - ✅ **the footnote-marker sentinel system, deleted (the first of the three).**
+       `Section::parse` takes a heading's footnote-free reference text from
+       [`fold_reference_text`](../../parser/src/content/inline_builder/fold.rs) rather than from
+       a byte-level cut, and `FOOTNOTE_MARKER_START`/`_END`, `strip_footnote_marker_spans`,
+       `Content::remove_footnote_marker_sentinels`, `Parser::mark_footnote_spans`, and the
+       replacer's two `dest.push(…)` calls all go. `rendered` is still the string pipeline's:
+       what moves is one *derived* string. The sentinels existed only to make one render yield
+       two strings (so counters ran once), which a tree does by construction. Measured
+       corpus-wide before the swap — both answers computed for every section title in the suite,
+       **zero** disagreements — rather than on the staged fixture corpus alone; the audit's
+       divergence set shrinks by 16. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -10,7 +10,7 @@ use crate::{
         parse_utils::parse_blocks_until,
     },
     content::{
-        Content, SubstitutionGroup, XrefSegment, strip_footnote_marker_spans,
+        Content, SubstitutionGroup, XrefSegment, inline_builder::fold_reference_text,
         substitute_attributes_in_reftext,
     },
     document::{InterpretedValue, RefType},
@@ -251,22 +251,20 @@ impl<'src> SectionBlock<'src> {
         //
         // A footnote in the title is a real, document-order footnote, but its
         // marker must not leak into the section's reference text (an xref's link
-        // text) or auto-generated ID. Marking the title's footnote markers with
-        // sentinels lets those be excised below from a single render — no second
+        // text) or auto-generated ID. The title's tree is what answers that: a
+        // footnote is a node, so the heading's own rendering and its
+        // footnote-free reference text are two folds of one tree
+        // ([`fold_reference_text`]), and "which regions were footnote markers"
+        // is a question about node kinds rather than about bytes. Still a single
         // substitution pass, so counters and attribute-expanded footnotes are
-        // processed exactly once.
+        // processed exactly once — which is what the sentinel pair this replaces
+        // existed to buy (design §4.2's first sentinel system).
         let mut section_title = Content::from(title_span);
-        parser.mark_footnote_spans.set(true);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
-        parser.mark_footnote_spans.set(false);
 
         // The footnote-free rendering of the title, for the reference text and
-        // auto-generated ID; a no-op string copy when the title had no footnote.
-        let title_reftext = strip_footnote_marker_spans(section_title.rendered_html());
-
-        // Strip the now-consumed sentinels from the title itself, keeping the
-        // footnote marker so the heading still renders it.
-        section_title.remove_footnote_marker_sentinels();
+        // auto-generated ID.
+        let title_reftext = fold_reference_text(section_title.inlines(), &*parser.renderer, parser);
 
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -157,47 +157,6 @@ pub(crate) struct XrefSegment {
 const XREF_PLACEHOLDER_START: char = '\u{E000}';
 const XREF_PLACEHOLDER_END: char = '\u{E001}';
 
-/// Sentinel codepoints (Unicode Private Use Area) bracketing a footnote's
-/// rendered inline marker while a section title is being substituted. Like the
-/// cross-reference placeholders above, these cannot collide with user text and
-/// are inert to the remaining substitution steps.
-///
-/// A footnote in a section title is a real, document-order footnote, but its
-/// marker must be kept out of the section's reference text and auto-generated
-/// ID. Marking the marker in a single render (rather than re-rendering the
-/// title with footnotes suppressed) means stateful substitutions — counters,
-/// attribute references that expand into footnotes — run exactly once. See
-/// [`strip_footnote_marker_spans`] and
-/// [`Content::remove_footnote_marker_sentinels`].
-pub(crate) const FOOTNOTE_MARKER_START: char = '\u{E002}';
-pub(crate) const FOOTNOTE_MARKER_END: char = '\u{E003}';
-
-/// Removes each footnote marker span — a [`FOOTNOTE_MARKER_START`] …
-/// [`FOOTNOTE_MARKER_END`] region and everything between, i.e. the sentinels
-/// *and* the marker they bracket — leaving footnote-free text suitable for a
-/// section's reference text and auto-generated ID.
-pub(crate) fn strip_footnote_marker_spans(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-
-    while let Some(start) = rest.find(FOOTNOTE_MARKER_START) {
-        out.push_str(&rest[..start]);
-        rest = &rest[start + FOOTNOTE_MARKER_START.len_utf8()..];
-
-        // Drop through the matching end sentinel (the marker text). A start
-        // without an end cannot occur — the substitution always emits both — but
-        // if it somehow did, drop the remainder rather than reintroduce the
-        // stray sentinel.
-        rest = match rest.find(FOOTNOTE_MARKER_END) {
-            Some(end) => &rest[end + FOOTNOTE_MARKER_END.len_utf8()..],
-            None => "",
-        };
-    }
-
-    out.push_str(rest);
-    out
-}
-
 /// Strips markup down to plain text, mirroring Asciidoctor's
 /// `Document::Title` sanitize option (`XmlSanitizeRx = /<[^>]+>/`): every tag
 /// — opening, closing, or self-contained (e.g. an `<img>` rendered from an
@@ -486,31 +445,6 @@ impl<'src> Content<'src> {
     /// builder (see [`inline_builder`](crate::content::inline_builder)).
     pub(crate) fn set_inlines(&mut self, inlines: Vec<InlineNode<'src>>) {
         self.inlines = inlines;
-    }
-
-    /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
-    /// bracketing each footnote marker, *keeping* the marker itself, so the
-    /// content renders normally. Called after a section title's reference text
-    /// and ID have been derived (via [`strip_footnote_marker_spans`], which
-    /// needs the sentinels to locate the markers). The sentinels are removed
-    /// from the deferred template too, so a later cross-reference resolution
-    /// rebuild does not reintroduce them.
-    pub(crate) fn remove_footnote_marker_sentinels(&mut self) {
-        if !self.rendered.as_ref().contains(FOOTNOTE_MARKER_START) {
-            return;
-        }
-
-        self.rendered = self
-            .rendered
-            .as_ref()
-            .replace([FOOTNOTE_MARKER_START, FOOTNOTE_MARKER_END], "")
-            .into();
-
-        if let Some(deferred) = self.deferred.as_mut() {
-            deferred.template = deferred
-                .template
-                .replace([FOOTNOTE_MARKER_START, FOOTNOTE_MARKER_END], "");
-        }
     }
 
     /// Returns the deferred cross-reference template and segments, if this
@@ -1241,41 +1175,6 @@ mod tests {
 
             assert!(matches!(content.rendered, CowStr::Boxed(_)));
             assert_eq!(content.rendered.as_ref(), "ab");
-        }
-    }
-
-    mod strip_footnote_marker_spans {
-        use super::super::{
-            FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, strip_footnote_marker_spans,
-        };
-
-        fn marked(marker: &str) -> String {
-            format!("{FOOTNOTE_MARKER_START}{marker}{FOOTNOTE_MARKER_END}")
-        }
-
-        #[test]
-        fn leaves_unmarked_text_unchanged() {
-            assert_eq!(strip_footnote_marker_spans("Plain title"), "Plain title");
-        }
-
-        #[test]
-        fn removes_a_marker_span_and_its_sentinels() {
-            let input = format!("Title{}", marked("[1]"));
-            assert_eq!(strip_footnote_marker_spans(&input), "Title");
-        }
-
-        #[test]
-        fn removes_multiple_spans_keeping_surrounding_text() {
-            let input = format!("a{}b{}c", marked("[1]"), marked("[2]"));
-            assert_eq!(strip_footnote_marker_spans(&input), "abc");
-        }
-
-        #[test]
-        fn a_start_without_an_end_drops_the_remainder() {
-            // Defensive: the substitution always emits balanced sentinels, but a
-            // lone start must not leak the sentinel into the output.
-            let input = format!("Title{FOOTNOTE_MARKER_START}dangling");
-            assert_eq!(strip_footnote_marker_spans(&input), "Title");
         }
     }
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -59,27 +59,23 @@ pub(crate) enum Footnotes {
 /// A footnote in a heading is a real, document-order footnote — it is numbered
 /// and it renders in the heading itself — but its marker must not appear in
 /// the text a cross-reference to that heading shows, nor in the id derived
-/// from that text (issue #594). The string pipeline reaches the same answer by
-/// rendering the title **once** with the footnote renderer bracketing each
-/// marker in a pair of sentinels
-/// ([`FOOTNOTE_MARKER_START`](crate::content::FOOTNOTE_MARKER_START) …
-/// [`FOOTNOTE_MARKER_END`](crate::content::FOOTNOTE_MARKER_END), enabled for
-/// that one render by `Parser::mark_footnote_spans`), cutting the bracketed
-/// regions out
-/// ([`strip_footnote_marker_spans`](crate::content::strip_footnote_marker_spans)),
-/// and then removing the now-spent sentinels from the title's own rendering
-/// and from its deferred cross-reference template
-/// (`Content::remove_footnote_marker_sentinels`). Rendering once is what keeps
-/// counters and attribute-expanded footnotes from being processed twice, and
-/// the sentinels are what make one render yield two strings.
+/// from that text (issue #594).
+///
+/// The string pipeline used to reach that answer with a sentinel system: it
+/// rendered the title **once** with the footnote renderer bracketing each
+/// marker in a pair of Private-Use-Area codepoints, cut the bracketed regions
+/// out for the reference text, and then removed the now-spent sentinels from
+/// the title's own rendering and from its deferred cross-reference template.
+/// Rendering once is what kept counters and attribute-expanded footnotes from
+/// being processed twice; the sentinels were what made one render yield two
+/// strings.
 ///
 /// A tree needs none of it. The footnote is a node, so the two strings are two
 /// folds of the same tree, and "which regions were footnote markers" is a
-/// question about node kinds rather than about bytes. This is therefore the
-/// **first of the three sentinel systems** design §4.2 names to lose its
-/// reason to exist; deleting it is the cutover's own job (§5.2 Phase 4, step
-/// 6), and until then this is staged and unwired, like every other piece of
-/// that step.
+/// question about node kinds rather than about bytes — still one substitution
+/// pass, so the counters are still processed once. `Section::parse` calls this
+/// for a heading's reference text, and the whole sentinel system (design
+/// §4.2's **first of three**) is deleted.
 ///
 /// The strip recurses, exactly as the byte-level one does over the whole
 /// rendered string: a footnote nested inside a rendered span, or inside a
@@ -751,70 +747,68 @@ mod tests {
         strings::CowStr,
     };
 
-    /// The string pipeline's own two answers for a section title: the
-    /// rendering the heading shows, and the footnote-free text its reference
-    /// and auto-generated id are derived from.
-    ///
-    /// This is exactly what `Section::parse` does — render the title once with
-    /// `mark_footnote_spans` on, cut the bracketed regions out, then strip the
-    /// spent sentinels from the rendering itself.
-    fn golden_title(source: &str, parser: &Parser) -> (String, String) {
-        use crate::content::{Content, SubstitutionGroup, strip_footnote_marker_spans};
-
-        let mut content = Content::from(Span::new(source));
-
-        parser.mark_footnote_spans.set(true);
-        SubstitutionGroup::Title.apply_string_pipeline(&mut content, parser, None);
-        parser.mark_footnote_spans.set(false);
-
-        let reftext = strip_footnote_marker_spans(content.rendered_html());
-        content.remove_footnote_marker_sentinels();
-
-        (content.rendered_html().to_string(), reftext)
-    }
-
     #[test]
-    fn fold_reference_text_matches_the_sentinel_strip() {
-        // The tree's answer to the footnote-marker sentinel system: the two
-        // strings the string pipeline gets from one marked render plus a
-        // byte-level cut are two *folds of the same tree*, and "which regions
-        // were footnote markers" is a question about node kinds rather than
-        // about bytes.
+    fn fold_reference_text_omits_a_headings_footnote_markers() {
+        // The tree's answer to the footnote-marker sentinel system this
+        // increment deleted: the two strings `Section::parse` needs — the
+        // rendering the heading shows, and the footnote-free text its reference
+        // and auto-generated id are derived from — are two *folds of the same
+        // tree*, and "which regions were footnote markers" is a question about
+        // node kinds rather than about bytes.
         //
-        // Every fixture is checked from both ends: `fold_html` reproduces the
-        // heading's own rendering (sentinels removed), and
-        // `fold_reference_text` reproduces the footnote-free text the
-        // reference and the auto-generated id are derived from.
+        // Every fixture is checked from both ends. The heading's own rendering
+        // is compared against the string pipeline, which still produces it and
+        // is the golden-HTML oracle (§5.3). The footnote-free reference text is
+        // compared against a **literal** expected string: with the sentinel
+        // strip gone there is no second implementation left to differentiate
+        // against, so the expectation is written down instead — these are the
+        // exact bytes that strip produced, captured before it was deleted.
         let fixtures = [
-            // No footnote at all: the two strings are the same, and the strip
-            // is a no-op on both sides.
-            "Plain title",
-            "A *bold* title",
-            "Tom & Jerry",
+            // No footnote at all: the two strings are the same.
+            ("Plain title", "Plain title"),
+            ("A *bold* title", "A <strong>bold</strong> title"),
+            ("Tom & Jerry", "Tom &amp; Jerry"),
             // The shape that names this: a footnote in a heading.
-            "Section 2footnote:[second footnote]",
-            "footnote:[leading] Section",
-            "Section footnote:[middle] title",
-            "A footnote:[one] and footnote:[two] title",
-            // A named footnote, and a bare reference to one.
-            "Named.footnote:disc[a discussion]",
-            // The marker nested inside constructs the strip has to recurse
+            ("Section 2footnote:[second footnote]", "Section 2"),
+            ("footnote:[leading] Section", " Section"),
+            ("Section footnote:[middle] title", "Section  title"),
+            ("A footnote:[one] and footnote:[two] title", "A  and  title"),
+            // A named footnote.
+            ("Named.footnote:disc[a discussion]", "Named."),
+            // The marker nested inside constructs the omission has to recurse
             // through: a rendered span, and a cross-reference's display text.
-            "A *bold footnote:[inside a span] title*",
-            "See xref:sec[the footnote:[inside a text] steps] here",
-            // Beside the other constructs a title can carry, so the strip is
+            (
+                "A *bold footnote:[inside a span] title*",
+                "A <strong>bold  title</strong>",
+            ),
+            (
+                "See xref:sec[the footnote:[inside a text] steps] here",
+                "See <a href=\"#sec\">the footnote:[inside a text</a> steps] here",
+            ),
+            // Beside the other constructs a title can carry, so the omission is
             // shown to remove the marker and nothing else.
-            "A footnote:[note] and image:x.png[Alt] and `code`",
-            "A footnote:[note] and a (C) and an -- em dash",
-            "A footnote:[note] and a +++<b>raw</b>+++ passthrough",
+            (
+                "A footnote:[note] and image:x.png[Alt] and `code`",
+                "A  and <span class=\"image\"><img src=\"x.png\" alt=\"Alt\"></span> and <code>code</code>",
+            ),
+            (
+                "A footnote:[note] and a (C) and an -- em dash",
+                "A  and a &#169; and an&#8201;&#8212;&#8201;em dash",
+            ),
+            (
+                "A footnote:[note] and a +++<b>raw</b>+++ passthrough",
+                "A  and a <b>raw</b> passthrough",
+            ),
         ];
 
         let renderer = HtmlSubstitutionRenderer {};
 
-        for fixture in fixtures {
+        for (fixture, expected_reftext) in fixtures {
             // Two independent parsers, since a footnote's number is document
             // state: one for each side of the comparison (design §5.3).
-            let (rendered, reftext) = golden_title(fixture, &Parser::default());
+            let golden_parser = Parser::default();
+            let mut golden = crate::content::Content::from(Span::new(fixture));
+            crate::content::SubstitutionGroup::Title.apply(&mut golden, &golden_parser, None);
 
             let built_parser = Parser::default();
             let nodes = crate::content::inline_builder::build_for_group(
@@ -827,13 +821,13 @@ mod tests {
 
             assert_eq!(
                 fold_html_with_parser(&nodes, &renderer, &built_parser),
-                rendered,
+                golden.rendered_html(),
                 "the heading's own rendering diverged for {fixture:?}"
             );
 
             assert_eq!(
                 super::fold_reference_text(&nodes, &renderer, &built_parser),
-                reftext,
+                expected_reftext,
                 "the footnote-free reference text diverged for {fixture:?}"
             );
         }

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -2096,17 +2096,6 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
             )
         };
 
-        // While a section title is substituted, bracket a real footnote's marker
-        // with sentinels so it can later be excised from the section's reference
-        // text and auto-generated ID (see `Parser::mark_footnote_spans`). The
-        // footnote is still defined and numbered here, in document order; only
-        // the marker's *placement* is annotated. A bare `footnote:[]` (the
-        // literal-text branch below) is not a footnote and is left unmarked.
-        let mark_span = parser.mark_footnote_spans.get() && (id.is_some() || content.is_some());
-        if mark_span {
-            dest.push(crate::content::FOOTNOTE_MARKER_START);
-        }
-
         // `id` and `content` own their data, so each branch renders its marker
         // before they are dropped (the params borrow them).
         if let Some(id) = id {
@@ -2172,10 +2161,6 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
         } else {
             // `footnote:[]` with neither an ID nor text is not a footnote.
             dest.push_str(&caps[0]);
-        }
-
-        if mark_span {
-            dest.push(crate::content::FOOTNOTE_MARKER_END);
         }
 
         LookaheadResult::Continue

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,9 +6,8 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
-    block_tree_xrefs, footnote_tree_xrefs, rehome_xref_placeholders, render_xref_template,
-    sanitize_title, strip_footnote_marker_spans,
+    FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xrefs, footnote_tree_xrefs,
+    rehome_xref_placeholders, render_xref_template, sanitize_title,
 };
 
 pub(crate) mod inline_builder;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -182,20 +182,6 @@ pub struct Parser {
     /// parser.
     pub(crate) in_bibliography_list_item: Cell<bool>,
 
-    /// True while a section title is being substituted, so each `footnote:[…]`
-    /// macro's rendered marker is bracketed with
-    /// [`FOOTNOTE_MARKER_START`](crate::content::FOOTNOTE_MARKER_START) /
-    /// [`FOOTNOTE_MARKER_END`](crate::content::FOOTNOTE_MARKER_END) sentinels.
-    /// The footnote is still defined and numbered in document order; the
-    /// sentinels merely let the marker be excised from the section's reference
-    /// text and auto-generated ID without a second substitution pass (see
-    /// `SectionBlock::parse`).
-    ///
-    /// Wrapped in a [`Cell`] for the same reason as
-    /// [`in_bibliography_list_item`](Self::in_bibliography_list_item): the
-    /// substitution code paths hold only a shared reference to the parser.
-    pub(crate) mark_footnote_spans: Cell<bool>,
-
     /// A block title carried over from a section heading to the first block
     /// parsed after it.
     ///
@@ -588,7 +574,6 @@ impl Default for Parser {
             parsing_bibliography_section_body: false,
             in_delimited_block: false,
             in_bibliography_list_item: Cell::new(false),
-            mark_footnote_spans: Cell::new(false),
             pending_block_title: None,
             counter_values: RefCell::new(Arc::new(HashMap::new())),
             locked_counter_values: RefCell::new(HashMap::new()),


### PR DESCRIPTION
**Stacked on #1255.** Retarget to `inline-ast` once that merges.

The cutover's second piece, and the **first of the three §4.2 sentinel deletions**.

`Section::parse` now gets a heading's footnote-free reference text from `fold_reference_text` instead of from a byte-level cut, and the whole apparatus goes with it: `FOOTNOTE_MARKER_START` / `FOOTNOTE_MARKER_END`, `strip_footnote_marker_spans`, `Content::remove_footnote_marker_sentinels`, `Parser::mark_footnote_spans`, and the two `dest.push(…)` calls in `InlineFootnoteMacroReplacer` that emitted them.

## What is and isn't being traded

This is **not** "the fold is authoritative" — `rendered` is still the string pipeline's here, and stays that way until the next PR in the stack. What moves is one *derived* string: a heading's reference text and the id derived from it.

The sentinels existed only to make **one** render yield **two** strings, so that counters and attribute-expanded footnotes were not processed twice. A tree yields two strings from one render for free — they are two folds of it — so the constraint the sentinels bought is satisfied by construction, and the mechanism is pure overhead.

## How the swap was verified

The prep increment that staged `fold_reference_text` pinned the equivalence against a corpus of thirteen titles. A corpus is a list of fixtures someone thought to write down — the failure mode the cross-product sweep was built to answer — so the swap was measured corpus-wide first instead: a throwaway patch computed **both** answers for every section title in the suite and logged any disagreement.

**Across ~5,390 tests there were zero.** (Run twice: once with a defensive sentinel-strip on the folded side, once without, to be sure the strip wasn't masking anything.)

That is the evidence this rests on; the fixture corpus survives as its written-down form.

## Tests

With the strip gone there is no second implementation left to differentiate the reference text against, so `fold_reference_text_matches_the_sentinel_strip` becomes `fold_reference_text_omits_a_headings_footnote_markers`:

- the heading's own rendering is still compared against the string pipeline (the §5.3 oracle, which still produces it);
- the reference text is compared against a **literal** expected string — the exact bytes the strip produced, captured before it was deleted.

The four unit tests of the strip itself go with the function.

## Verification

- `cargo test --workspace`: **5389 pass, 0 fail**.
- Corpus-wide fold-parity audit: divergence set **shrinks by 16**, every one a title whose only disagreement was the sentinel pair neither side now emits. One row is re-spelled rather than added — a recorder test's own `MARK_OPEN`/`MARK_CLOSE` fixture that had appeared in both a with- and a without-sentinel form and now appears once.
- Coverage diff-neutral: `section.rs` 40/39, `content.rs` 21/8, `fold.rs` 3/3, `macros.rs` 2/1, `parser.rs` 87/73 — identical to base.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_