### PR TITLE
feat: Make rendered_html() an authoritative fold (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6077,6 +6077,62 @@ Each phase is a reviewable unit with a clear exit gate.
   `MARK_OPEN`/`MARK_CLOSE` fixture, which had appeared in both a with- and a without-sentinel
   form and now appears once. Coverage is diff-neutral.
 
+  *Step 6 landed as (`rendered_html()` as an authoritative fold):* the cutover's third piece, and
+  the one the whole branch has been building toward. `SubstitutionGroup::apply` now sets
+  `content.rendered` from [`fold_html`](../../parser/src/content/inline_builder/fold.rs), so what
+  `rendered_html()` returns *is* the tree — the string pipeline still runs (it produces the
+  deferred cross-reference segments and fills the catalogs), but its output is no longer what a
+  caller reads.
+
+  Content carrying a **deferred cross-reference** is the one exception, and it is temporary. Such
+  a content's rendered string is rebuilt from a placeholder template every time resolution runs,
+  so making the fold authoritative there means teaching resolution to *re-fold* instead — which
+  is the deferred-cross-reference sentinel system's own retirement (§4.2's second), and its own
+  increment. Rather than interleave the two mechanisms, such a content keeps the template path end
+  to end and the fold takes everything else. The predicate is one line
+  (`content.deferred_parts().is_none()`) and the increment below deletes it.
+
+  The interesting work here was not the fold. It was that **every differential corpus on this
+  branch was about to become tautological.** A parity test takes its golden by running
+  `SubstitutionGroup::apply` and reading `rendered` — which is now the fold, so the test would
+  have been comparing the fold against itself and passing for that reason. Twenty-one call sites
+  across twelve files were in that shape, and nothing about a green suite would have said so. A
+  new test-only [`apply_string_pipeline`](../../parser/src/content/substitution_group.rs) exposes
+  `run_pipeline` on its own — the §5.3 oracle as a callable — and every golden-producing site now
+  goes through it. The sites that drive individual `SubstitutionStep`s by hand were already
+  building no tree and are untouched, as are the ~277 golden assertions, which read
+  `rendered_html()` as the *subject* rather than as a differential golden and are precisely what
+  the fold now has to satisfy.
+
+  Four of the six tests the cutover experiment predicted would fail were that shape and are fixed
+  by the rewiring alone. Of the two that remain, one is
+  `inline_tree_build_tolerates_a_stateful_renderer`, whose renderer emits different bytes on each
+  call: it is now invoked twice per parse (once by the string pipeline, once by the fold), so the
+  rendered string shows the *second* invocation. That is the interim double render, not a property
+  of the fold, and it is pinned exactly — `[second]` rather than loosely — so that it shows up as
+  a signal when the string pipeline stops being run for output.
+
+  The other is the **one golden output the cutover changes**, and it changes for the better.
+  `#`CB###2`#` — an `asciidoc-lang` fixture whose own prose calls the result "a scrambled mess" —
+  rendered a `<mark>` opened inside a `<code>` and closed outside it, because the string
+  pipeline's highlight sub matched across the markup its monospace sub had already written. A
+  tree has no tags to match through, so the extra `#`s stay literal and the nesting is
+  well-formed. This is the same class as the keep the cross-product sweep documents for the macro
+  families, reached one step out; the golden is updated with that reasoning written beside it.
+
+  Re-running the corpus-wide fold-parity audit needs its own adjustment for the same reason the
+  corpora did — the probe has to log *before* the fold overwrites `rendered`, or it compares the
+  fold against itself. So adjusted, the production divergence set goes 18 → 9 with **no new
+  divergence**. The nine that remain are fully accounted for: one is the changed golden above,
+  four are custom-renderer tests (the audit's probe folds with the built-in renderer by
+  construction, so it disagrees with a `[LT]`/`[first]`/`<figure>` backend — pre-existing, and
+  not a divergence), and four are deferred-cross-reference content, which the increment below
+  closes. The nine that *left* the log are the documented keeps, and they left because their
+  tests now drive the string pipeline directly rather than because anything was fixed — worth
+  saying plainly, since the audit can no longer see a fixture whose test bypasses `apply`.
+
+  Coverage is diff-neutral (`substitution_group.rs` stays at 100%).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7257,6 +7313,19 @@ Each phase is a reviewable unit with a clear exit gate.
        corpus-wide before the swap — both answers computed for every section title in the suite,
        **zero** disagreements — rather than on the staged fixture corpus alone; the audit's
        divergence set shrinks by 16. See the step's own "landed as" note above.
+
+     - ✅ **`rendered_html()` as an authoritative fold.** `SubstitutionGroup::apply` sets
+       `content.rendered` from [`fold_html`](../../parser/src/content/inline_builder/fold.rs), so
+       what a caller reads *is* the tree. Content carrying a deferred cross-reference keeps the
+       template path for now (its rendered string is rebuilt on every resolution, so the fold
+       there is the second sentinel system's own retirement) — one predicate, deleted by the next
+       increment. The substantive work was that every differential corpus was about to become
+       **tautological**, taking its golden from `apply` + `rendered`; a test-only
+       [`apply_string_pipeline`](../../parser/src/content/substitution_group.rs) exposes
+       `run_pipeline` alone and 21 sites across 12 files now use it. One golden changes, for the
+       better (`#`CB###2`#`, whose mis-nested `<mark>`/`<code>` was an artifact of substituting
+       over rendered markup). Audit: production divergences 18 → 9, none new, all nine accounted
+       for. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -261,6 +261,26 @@ impl SubstitutionGroup {
                 attrlist,
             );
 
+            // The tree is now **authoritative** for the rendered string: what
+            // `rendered_html()` returns is a fold of it, not the string
+            // pipeline's own output (design §5.2 Phase 4, step 6).
+            //
+            // Content carrying a *deferred cross-reference* is the one
+            // exception, and it is temporary. Such a content's rendered string
+            // is rebuilt from a placeholder template each time resolution runs
+            // (`Content::rebuild_rendered`), so making the fold authoritative
+            // there means teaching resolution to re-fold instead — which is the
+            // deferred-cross-reference sentinel system's own retirement (§4.2's
+            // second), and its own increment. Until then such a content keeps
+            // the template path end to end rather than having the two
+            // mechanisms interleave.
+            if content.deferred_parts().is_none() {
+                let folded =
+                    crate::content::inline_builder::fold_html(&tree, &*parser.renderer, parser);
+
+                content.rendered = crate::strings::CowStr::from(folded);
+            }
+
             content.set_inlines(tree);
         }
     }
@@ -278,11 +298,13 @@ impl SubstitutionGroup {
     /// [`snapshot`](crate::content::inline_builder) for the demonstration.
     ///
     /// So the corpora take their golden from here instead, and go on
-    /// differentiating for real. Today this is byte-identical to `apply`: the
-    /// tree is still additive, so the only difference is work the golden never
-    /// reads. Landing it *before* the cutover is what keeps that equivalence
-    /// checkable — the whole suite has to stay green across this change, which
-    /// is a claim the cutover itself could no longer make.
+    /// differentiating for real. It was landed one increment *before* the
+    /// cutover, while it was still byte-identical to `apply` — the tree being
+    /// additive then, the only difference was work the golden never reads — so
+    /// that the rewiring could be checked by the whole suite staying green,
+    /// which is a claim the cutover itself could no longer make. As of this
+    /// increment the two genuinely differ, and this is the only remaining way
+    /// to reach the string pipeline's own output.
     ///
     /// The ~277 golden-HTML assertions deliberately do **not** take it: their
     /// subject is `rendered_html()` itself, so they must go on exercising the

--- a/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
+++ b/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
@@ -445,9 +445,33 @@ The mix of constrained and unconstrained formatting marks in the line is ambiguo
             panic!("Unexpected block type: {block2:?}");
         };
 
+        // NOTE: this is the **one golden output the inline-AST cutover changes**
+        // (design §5.2 Phase 4, step 6), and it changes for the better.
+        //
+        // The string pipeline ran its quoted-text subs as passes over one flat
+        // string, so the `#`-delimited highlight pass matched across the markup
+        // the monospace pass had already written, and emitted a `<mark>` opened
+        // inside a `<code>` and closed outside it — markup no backend would
+        // choose to produce, and not well-formed HTML:
+        //
+        //     <mark><code>CB<mark>#2</code></mark> and
+        // <mark><code>CB</mark>#3</code></mark>
+        //
+        // A tree has no tags to match through: the monospace span's content is
+        // a subtree, so a later sub's delimiter cannot span its boundary. The
+        // extra `#`s stay literal inside the span, and the nesting is
+        // well-formed. This is the same class as the keep the cross-product
+        // sweep documents for the macro families (a later family matching
+        // across an earlier family's markup), reached one step out.
+        //
+        // The prose this test quotes still holds in substance — the mix of
+        // constrained and unconstrained marks is ambiguous, and neither
+        // pipeline gives you `CB###2` — but the specific scrambling it calls
+        // "a scrambled mess" was an artifact of substituting over rendered
+        // markup, and the tree does not reproduce it.
         assert_eq!(
             sb2.content().rendered_html(),
-            r#"<mark><code>CB<mark>#2</code></mark> and <mark><code>CB</mark>#3</code></mark>"#
+            r#"<mark><code>CB###2</code></mark> and <mark><code>CB###3</code></mark>"#
         );
 
         assert!(blocks.next().is_none());

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1732,8 +1732,15 @@ fn inline_tree_build_tolerates_a_stateful_renderer() {
     };
 
     // The authoritative rendered string reflects the stateful renderer's
-    // (first-invocation) output …
-    assert_eq!(content.rendered_html(), "a [first] b");
+    // output — the *second* invocation's, for now. `rendered_html()` is the
+    // fold of the tree, and the string pipeline still runs ahead of it (it
+    // produces the deferred cross-reference segments and fills the catalogs),
+    // so this renderer is invoked twice per parse and the fold sees the later
+    // state. That is the interim double render, not a property of the fold: it
+    // becomes `[first]` again once the string pipeline stops being run for
+    // output. Pinned exactly rather than loosely so that change shows up here
+    // as a signal.
+    assert_eq!(content.rendered_html(), "a [second] b");
 
     // … while the tree carries the logical special character, unpolluted by
     // the renderer's state.


### PR DESCRIPTION
**Stacked on #1257 → #1255 → #1262.** Retarget down the stack as each merges.

The cutover's third piece, and the one the whole branch has been building toward. `SubstitutionGroup::apply` sets `content.rendered` from `fold_html`, so what `rendered_html()` returns **is** the tree. The string pipeline still runs — it produces the deferred cross-reference segments and fills the catalogs — but its output is no longer what a caller reads.

*Rebased and shrunk.* This PR originally also carried the twenty-one-call-site corpora rewiring onto `apply_string_pipeline`; that turned out to be the more urgent half and landed on its own as #1260, before this. What is left here is the cutover itself: the fold assignment, one golden that changes, one test that changes, and the design note.

## The one exception, and why it's separate

Content carrying a **deferred cross-reference** keeps the template path. Such a content's rendered string is rebuilt from a placeholder template every time resolution runs, so making the fold authoritative there means teaching resolution to *re-fold* instead — which is the deferred-cross-reference sentinel system's own retirement (§4.2's second), and its own increment. Rather than interleave the two mechanisms, such content keeps the template path end to end and the fold takes everything else. The predicate is one line (`content.deferred_parts().is_none()`) and the next increment deletes it.

## The two real changes

**`inline_tree_build_tolerates_a_stateful_renderer`.** Its renderer emits different bytes per call, and it is now invoked twice per parse (string pipeline, then fold), so the rendered string shows the *second* invocation. That is the interim double render, not a property of the fold. Pinned exactly (`[second]`, not loosely) so it surfaces as a signal when the string pipeline stops being run for output.

**One golden output changes, for the better.** `` `#`CB###2`#` `` — an `asciidoc-lang` fixture whose own prose calls the result "a scrambled mess" — rendered a `<mark>` opened inside a `<code>` and closed outside it, because the string pipeline's highlight sub matched across the markup its monospace sub had already written:

```
before:  <code>CB#<mark>2</code> and <code>CB#</mark>3</code>
after:   <code>CB###2</code> and <code>CB###3</code>
```

A tree has no tags to match through, so the extra `#`s stay literal and the nesting is well-formed. Same class as the keeps the cross-product sweep documents for the macro families, reached one step out. The reasoning is written beside the updated golden, including the fact that the quoted prose still holds in substance (neither pipeline gives you `CB###2`) while the specific scrambling it names was an artifact.

## Verification

- `cargo test --workspace`: **5418 pass, 0 fail**.
- Corpus-wide fold-parity audit: production divergences **18 → 9, none new**, and all nine accounted for — one is the changed golden, four are custom-renderer tests the audit's built-in-renderer probe cannot match by construction, four are deferred-cross-reference content the next increment closes.
- Coverage diff-neutral: `substitution_group.rs` stays at 100%.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_