### PR TITLE
chore: Take each corpus's golden from the string pipeline directly (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5875,6 +5875,39 @@ Each phase is a reviewable unit with a clear exit gate.
   the cutover must not land until every corpus it would render tautological is either recorded or
   knowingly exempted.
 
+  *Step 6 landed as (the golden-HTML oracle, as a callable):* the other half of the recording
+  increment's finding, and the half that covers the corpora the recordings do not. A corpus takes
+  its golden by running `SubstitutionGroup::apply` and reading `rendered`; the cutover makes
+  `rendered` a fold, so the corpus compares the fold against itself. Recordings answer that
+  durably, but converting twenty-odd corpora — each with its own parser configuration — is a large
+  change to make *inside* the cutover, where a mistake is indistinguishable from a real divergence.
+
+  A new test-only
+  [`apply_string_pipeline`](../../parser/src/content/substitution_group.rs) answers it cheaply
+  instead: `run_pipeline` on its own, with no tree and no fold. **25 golden-producing call sites
+  across 14 files** now take their golden from it, so every one goes on differentiating against a
+  genuinely independent construction for as long as the string pipeline exists — which is exactly
+  the window the cutover needs. The recordings remain the durable answer for when it does not.
+
+  What makes this landable *now*, ahead of the cutover, is that it is byte-identical today: the
+  tree is still additive, so `apply` and `apply_string_pipeline` differ only in work the golden
+  never reads. The whole suite stays green with **no test edited** and both recordings byte-for-byte
+  unchanged — a claim the cutover itself could no longer make, which is the reason to spend a
+  separate increment on it.
+
+  Two categories deliberately keep `apply`. The ~277 **golden-HTML assertions** (§5.3), whose
+  subject is `rendered_html()` itself: they must go on exercising the production entry point, and
+  after the cutover they are precisely what validates the fold. And
+  [`passthrough_text`](../../parser/src/content/inline_builder/passthrough_step.rs)'s own call,
+  which is production code rather than a golden.
+
+  Measured under a simulated cutover with a deliberately sabotaged fold: six corpora flip from
+  passing to failing that would otherwise have passed — `fold_matches_the_string_pipeline_for_xrefs_inside_expanded_values`,
+  the four `build_for_group` order tests, and the cross-reference family's deferral test. The
+  other nineteen sites are tautological by construction under the cutover whether or not a given
+  probe happens to perturb them; a gross sabotage breaks so much through the golden assertions
+  that it understates the loss, which is the point of having the corpora at all.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -6997,6 +7030,17 @@ Each phase is a reviewable unit with a clear exit gate.
        subject is the diverging *set*). The generator is the string pipeline; Asciidoctor was
        measured (202/259) and deferred as spec-conformance work. See the step's own "landed as"
        note above. The remaining ~20 corpora are the **fold increment's prerequisite list**.
+
+     - ✅ **prep (the golden-HTML oracle, as a callable).** That prerequisite list, discharged.
+       A test-only [`apply_string_pipeline`](../../parser/src/content/substitution_group.rs) runs
+       `run_pipeline` alone, and **25 golden-producing call sites across 14 files** take their
+       golden from it rather than from `apply` — so each goes on differentiating against an
+       independent construction for as long as the string pipeline exists, which is the window the
+       cutover needs (the recordings are the durable answer for after). Landable ahead of the
+       cutover precisely because it is byte-identical today: the whole suite stays green with **no
+       test edited** and both recordings unchanged. The ~277 golden-HTML assertions keep `apply`
+       deliberately — their subject is `rendered_html()` itself. See the step's own "landed as"
+       note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1320,7 +1320,7 @@ mod tests {
         // does — the documented `subs=attributes+` trick for inspecting a
         // stored attribute value.
         let mut content = Content::from(Span::new(source));
-        group.apply(&mut content, &parser_with_attribute("tag", "<b>"), None);
+        group.apply_string_pipeline(&mut content, &parser_with_attribute("tag", "<b>"), None);
 
         assert_eq!(content.rendered_str(), "&lt;b&gt;");
         assert_eq!(

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -737,7 +737,7 @@ mod tests {
         let mut content = Content::from(Span::new(source));
 
         parser.mark_footnote_spans.set(true);
-        SubstitutionGroup::Title.apply(&mut content, parser, None);
+        SubstitutionGroup::Title.apply_string_pipeline(&mut content, parser, None);
         parser.mark_footnote_spans.set(false);
 
         let reftext = strip_footnote_marker_spans(content.rendered_html());

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -809,7 +809,7 @@ mod tests {
         let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
 
         let mut golden = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut golden, &configure(), None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &configure(), None);
 
         assert_eq!(folded, golden.rendered_str(), "{nodes:#?}");
         assert!(folded.contains("Widget"), "{folded:?}");
@@ -1474,7 +1474,7 @@ mod tests {
         use crate::content::{Content, SubstitutionGroup};
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.rendered_str().to_string()
     }
 
@@ -1599,7 +1599,7 @@ and another.footnote:[note two]",
             let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
 
             let mut golden = Content::from(Span::new(filtered));
-            SubstitutionGroup::Normal.apply(&mut golden, &Parser::default(), None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &Parser::default(), None);
 
             assert_eq!(
                 folded,

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2963,7 +2963,7 @@ mod tests {
         use crate::content::{Content, SubstitutionGroup};
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.rendered_str().to_string()
     }
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1654,7 +1654,7 @@ mod tests {
             let nodes = build(Span::new(source), &parser, None);
 
             let mut golden = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut golden, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &parser, None);
 
             assert_eq!(
                 crate::content::inline_builder::fold_html(

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -6493,7 +6493,7 @@ mod tests {
         use crate::content::{Content, SubstitutionGroup};
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.rendered_str().to_string()
     }
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1134,7 +1134,7 @@ mod tests {
             r"<<target,a \{name} b>>",
         ] {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
 
             let nodes = build_for_group(
                 &SubstitutionGroup::Normal,
@@ -1238,7 +1238,7 @@ mod tests {
                     ),
                 ] {
                     let mut content = Content::from(Span::new(&source));
-                    group.apply(&mut content, &parser, None);
+                    group.apply_string_pipeline(&mut content, &parser, None);
 
                     let nodes = build_for_group(
                         group,
@@ -1372,7 +1372,7 @@ mod tests {
             "stem:[a &copy; b]",
         ] {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
 
             let nodes = build_for_group(
                 &SubstitutionGroup::Normal,
@@ -1422,7 +1422,7 @@ mod tests {
 
         let parity = |source: &str| {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &configure(), None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &configure(), None);
 
             let built_parser = configure();
 
@@ -1552,7 +1552,7 @@ mod tests {
             ),
         ] {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
 
             assert_eq!(content.rendered_str(), golden_html);
 

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -917,7 +917,7 @@ mod tests {
         use crate::content::{Content, SubstitutionGroup};
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.rendered_str().to_string()
     }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -2181,7 +2181,7 @@ mod tests {
         use crate::content::SubstitutionGroup;
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.finalize_deferred(&HtmlSubstitutionRenderer {});
         content.rendered_str().to_string()
     }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -746,7 +746,7 @@ mod tests {
     /// production.
     fn golden(source: &str, parser: &Parser) -> String {
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.rendered_str().to_string()
     }
 
@@ -1933,7 +1933,7 @@ mod tests {
         fn golden_for_group(group: &SubstitutionGroup, source: &str) -> String {
             let golden_parser = parser_with_product();
             let mut content = Content::from(Span::new(source));
-            group.apply(&mut content, &golden_parser, None);
+            group.apply_string_pipeline(&mut content, &golden_parser, None);
             content.rendered_str().to_string()
         }
 

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -334,7 +334,7 @@ mod tests {
         let parser = Parser::default();
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
         let golden = content.rendered_str().to_string();
 
         let nodes = super::super::build(Span::new(source), &parser, None);
@@ -437,7 +437,7 @@ mod tests {
         };
 
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply(&mut content, parser, attrlist.as_ref());
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, attrlist.as_ref());
         let golden = content.rendered_str().to_string();
 
         let nodes = super::super::build(Span::new(source), parser, attrlist.as_ref());

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -3957,7 +3957,7 @@ mod tests {
             ),
         ] {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
 
             assert_eq!(content.rendered_str(), golden_html, "golden for {source:?}");
 
@@ -4009,7 +4009,7 @@ mod tests {
             ("[.a~b~c]#y#", "<span class=\"a<sub>b</sub>c\">y</span>"),
         ] {
             let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
 
             assert_eq!(content.rendered_str(), golden_html);
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -261,6 +261,39 @@ impl SubstitutionGroup {
         }
     }
 
+    /// Runs **only** the string pipeline over `content` — no inline tree, no
+    /// fold — which is the golden-HTML oracle (§5.3) as a callable.
+    ///
+    /// Every differential corpus on this branch takes its golden by rendering a
+    /// fixture through the string pipeline and comparing it against the tree's
+    /// fold. Taking that golden from [`apply`](Self::apply) works only while
+    /// `rendered` *is* the string pipeline's output. The step 6 cutover makes
+    /// `rendered` a fold of the tree, at which point such a corpus compares the
+    /// fold against itself and passes for that reason, with nothing failing to
+    /// say so — see
+    /// [`snapshot`](crate::content::inline_builder) for the demonstration.
+    ///
+    /// So the corpora take their golden from here instead, and go on
+    /// differentiating for real. Today this is byte-identical to `apply`: the
+    /// tree is still additive, so the only difference is work the golden never
+    /// reads. Landing it *before* the cutover is what keeps that equivalence
+    /// checkable — the whole suite has to stay green across this change, which
+    /// is a claim the cutover itself could no longer make.
+    ///
+    /// The ~277 golden-HTML assertions deliberately do **not** take it: their
+    /// subject is `rendered_html()` itself, so they must go on exercising the
+    /// production entry point, and after the cutover they are precisely what
+    /// validates the fold.
+    #[cfg(test)]
+    pub(crate) fn apply_string_pipeline<'src>(
+        &self,
+        content: &mut Content<'src>,
+        parser: &Parser,
+        attrlist: Option<&Attrlist<'src>>,
+    ) {
+        self.run_pipeline(content, parser, attrlist);
+    }
+
     /// Runs the substitution pipeline for this group over `content`: extract
     /// passthroughs (when the group includes them), apply each step in order,
     /// restore the passthroughs, and finalize any deferred cross-references.

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -213,7 +213,7 @@ fn assert_shapes_with(source: &str, configure: impl Fn() -> Parser) {
     let footnote_start = recorder_parser.catalog().footnotes.len();
 
     let mut content = Content::from(Span::new(source));
-    SubstitutionGroup::Normal.apply(&mut content, &recorder_parser, None);
+    SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &recorder_parser, None);
 
     let footnote_texts: Vec<String> = recorder_parser
         .catalog()

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -134,7 +134,7 @@ fn corpus_parser() -> Parser {
 fn side_effects_with(source: &str, configure: impl Fn() -> Parser) -> (SideEffects, SideEffects) {
     let golden_parser = configure();
     let mut content = Content::from(Span::new(source));
-    SubstitutionGroup::Normal.apply(&mut content, &golden_parser, None);
+    SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &golden_parser, None);
 
     let builder_parser = configure();
     let nodes = build(Span::new(source), &builder_parser, None);

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -116,7 +116,7 @@ fn oracle<'src>(source: &'src str, group: &SubstitutionGroup) -> Oracle<'src> {
     // Golden pass.
     let golden_parser = experimental(Parser::default());
     let mut golden_content = Content::from(Span::new(source));
-    group.apply(&mut golden_content, &golden_parser, None);
+    group.apply_string_pipeline(&mut golden_content, &golden_parser, None);
     let golden = golden_content.rendered_owned();
 
     // Recording pass, driving the production recorder.
@@ -124,7 +124,7 @@ fn oracle<'src>(source: &'src str, group: &SubstitutionGroup) -> Oracle<'src> {
     let recording_parser =
         experimental(Parser::default()).with_inline_substitution_renderer(recorder);
     let mut recording_content = Content::from(Span::new(source));
-    group.apply(&mut recording_content, &recording_parser, None);
+    group.apply_string_pipeline(&mut recording_content, &recording_parser, None);
     let marked = recording_content.rendered_owned();
 
     let markers = open_marker_count(&marked);


### PR DESCRIPTION
Discharges the prerequisite list #1259 named. Branches from `inline-ast`; independent of the blocked cutover stack.

## The problem, restated

A corpus takes its golden by running `SubstitutionGroup::apply` and reading `rendered`. The cutover makes `rendered` a fold of the tree, so such a corpus compares the fold against itself and passes for that reason.

#1259 answered that durably for two corpora with checked-in recordings. But converting twenty-odd more — each with its own parser configuration — is a large change to make *inside* the cutover, where a mistake looks exactly like a real divergence.

## The cheap answer

A test-only `apply_string_pipeline`: `run_pipeline` on its own, no tree, no fold. **25 golden-producing call sites across 14 files** now take their golden from it, so every one keeps differentiating against a genuinely independent construction for as long as the string pipeline exists — which is precisely the window the cutover needs. The recordings remain the durable answer for when it doesn't.

## Why it lands *before* the cutover

Because today it's byte-identical. The tree is still additive, so `apply` and `apply_string_pipeline` differ only in work the golden never reads:

- whole suite green, **no test edited**;
- both recordings **byte-for-byte unchanged**.

That equivalence is checkable now and would not be after the cutover, which is the whole reason to spend a separate increment on it.

## What deliberately keeps `apply`

- The **~277 golden-HTML assertions** (§5.3). Their subject is `rendered_html()` itself, so they must go on exercising the production entry point — and after the cutover they are exactly what validates the fold. I converted them by accident on the first pass and reverted; worth stating explicitly so nobody "finishes the job" later.
- `passthrough_text`'s own call, which is production code, not a golden.

## Measured

Under a simulated cutover with a deliberately sabotaged fold, six corpora flip from passing to failing that would otherwise have passed:

```
macros::xref::tests::fold_matches_the_string_pipeline_for_xrefs_inside_expanded_values
macros::xref::tests::an_xref_over_a_rendered_span_in_an_expanded_value_is_still_deferred
tests::build_for_group::a_custom_list_including_macros_extracts_passthroughs
tests::build_for_group::a_custom_list_runs_exactly_the_named_steps_in_order
tests::build_for_group::a_group_that_never_escapes_folds_its_specials_verbatim
tests::build_for_group::header_group_extracts_passthroughs_and_expands_attributes
```

The other nineteen sites are tautological *by construction* under the cutover whether or not a given probe perturbs them. A gross sabotage breaks so much through the golden assertions that it understates the loss — which is the point of having the corpora at all, since they exist for the narrow regressions no literal assertion happens to cover.

## Verification

- `cargo test --workspace`: **5414 pass, 0 fail**, no test edited.
- Recordings unchanged (`git diff` on `parser/snapshots/` is empty).
- Coverage diff-neutral: `substitution_group.rs` stays at 100%.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_