### PR TITLE
fix: Treat a specialcharacters passthrough body as literal text (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5908,6 +5908,61 @@ Each phase is a reviewable unit with a clear exit gate.
   probe happens to perturb them; a gross sabotage breaks so much through the golden assertions
   that it understates the loss, which is the point of having the corpora at all.
 
+  *Step 6 landed as (a passthrough body is literal text, not raw output):* the cutover blocker
+  review found on the always-on increment, and a conflation in §3.4's trichotomy that had been
+  there since the passthrough step landed.
+
+  [`Raw`](../../parser/src/inlines/inline_node.rs) was documented as "verbatim, un-escaped output
+  … `+++…+++`, `pass:[…]`, `$$…$$`". The first two are that. `$$…$$` and `++…++` are **not**:
+  their substitution group applies special characters, so their body is the author's *literal
+  text*, and something has to escape it. The builder did — at build time, through whichever
+  renderer the `Parser` happened to carry — and froze the result into the node. Two things
+  followed, and the review caught the second:
+
+  1. Folding that tree through a *different* renderer emitted the parse-time renderer's escaping
+     instead, which is precisely what `render_with` exists to not do. Measured with a
+     non-HTML backend: the string pipeline produced `a [LT] b` while the fold produced
+     `a &lt; b`.
+  2. Building the tree **invoked** the document's renderer for a value nothing reads. With the
+     tree built for every parse, a renderer carrying state saw extra calls and a *later block's*
+     authoritative output shifted under it — a real regression, and one no test paired a stateful
+     renderer with a passthrough to catch.
+
+  The obvious fix — hand the builder's parser clone a built-in renderer so it cannot touch the
+  document's — is wrong, and measurably so: it makes (2) go away by making (1) worse, silently
+  HTML-escaping a custom backend's passthrough body. What the two failures share is the *freezing*,
+  not the renderer.
+
+  So `Raw` gains a [`form`](../../parser/src/inlines/inline_node.rs): `AsIs`, whose value already
+  is the bytes to emit, and `Escaped`, whose value is logical text the fold escapes exactly as it
+  escapes a [`Text`](../../parser/src/inlines/inline_node.rs) run. Both stay **opaque** — no
+  transducer step matches inside either, which is what keeps them one node kind rather than two —
+  and the escaping moves to the one place a renderer is chosen. The `Escaped` sites also stop
+  allocating, since they now borrow the author's bytes instead of owning an escaped copy.
+
+  Opacity is why the obvious alternative does not work: a `++…++` body is *semantically* a `Text`
+  run, and folds identically to one, but
+  [`build_match_string`](../../parser/src/content/inline_builder/quotes.rs) decides atomicity by
+  node **kind** — a `Text` piece is splittable, so later steps would match into a passthrough body.
+  The node has to stay `Raw`; only its escaping moves.
+
+  The whole suite passes with **no expectation changed**. That is the claim worth making: the
+  observable bytes are identical, which a change to *where* escaping happens should be, and the
+  corpus-wide fold-parity audit agrees — the divergence set is byte-identical, 235 rows before and
+  after, none added and none closed. `assert_raw` now asserts a node's **fold** rather than its
+  `value` field, because "this passthrough contributes these bytes" is the same question for both
+  forms where reading the field is only the same question for one; that is what let ~25 existing
+  expectations stand unchanged. The Strategy-A cross-check needed the mirror of that:
+  [`raw_rendered`](../../parser/src/tests/inline_builder_recorder_parity.rs) renders a `Raw` leaf
+  before matching it against the recorder's own bytes, exactly as `char_ref_rendered` has always
+  had to.
+
+  What still freezes a value, each for its own reason: a `pass:c,q[…]` body (its explicit
+  substitution list runs a whole pipeline, the deferral 5d part 3 documents for itself), a bare
+  `+…+` body enclosing an already-extracted passthrough (its value interleaves escaped text with
+  another node's fold bytes, so no single form describes it), and a `Stem` body. Each is a narrow
+  form, and each owes the same debt to `render_with` that every frozen value on this branch does.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7041,6 +7096,19 @@ Each phase is a reviewable unit with a clear exit gate.
        test edited** and both recordings unchanged. The ~277 golden-HTML assertions keep `apply`
        deliberately — their subject is `rendered_html()` itself. See the step's own "landed as"
        note above.
+
+     - ✅ **prep (a passthrough body is literal text, not raw output).** The blocker review found
+       on the always-on increment, and a conflation in §3.4's trichotomy: `++…++` / `$$…$$` apply
+       special characters, so their body is the author's *literal text*, not raw output — and the
+       builder was escaping it at build time through whichever renderer the parse carried. That
+       both broke a custom backend's fold (measured: `a &lt; b` where the pipeline gives
+       `a [LT] b`) and made building the tree *invoke* the document's renderer, shifting a later
+       block's output for a stateful one. [`Raw`](../../parser/src/inlines/inline_node.rs) gains a
+       [`form`](../../parser/src/inlines/inline_node.rs) (`AsIs` / `Escaped`); both stay opaque —
+       which they must, since `build_match_string` decides atomicity by node *kind* — and the
+       escaping moves to the fold. No expectation changed, and the audit's divergence set is
+       byte-identical. See the step's own "landed as" note above. **This unblocks the always-on
+       increment.**
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -11,7 +11,7 @@ use crate::{
     Parser, Span,
     content::{ATTRIBUTE_REFERENCE, AttributeMissing},
     document::InterpretedValue,
-    inlines::InlineNode,
+    inlines::{InlineNode, RawForm},
     parser::attribute_lookup_name,
     strings::CowStr,
 };
@@ -1019,6 +1019,7 @@ fn split_attribute_value<'src>(
 
         out.push(InlineNode::Raw {
             value: CowStr::from(ch.to_string()),
+            form: RawForm::AsIs,
             location,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -6,8 +6,8 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::document_xrefstyle,
     inlines::{
-        Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
-        RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
+        Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm,
+        Ref, RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
     },
     parser::{
         CalloutGuard as ParserCalloutGuard, CalloutRenderParams, FootnoteRenderParams,
@@ -122,8 +122,25 @@ fn fold_into_html(
                 }
             }
 
-            InlineNode::Raw { value, .. } => {
+            InlineNode::Raw {
+                value,
+                form: RawForm::AsIs,
+                ..
+            } => {
                 out.push_str(value);
+            }
+
+            // Literal text that later steps could not see into, but which is
+            // not raw output: the fold escapes it exactly as it escapes a
+            // `Text` run, with whatever renderer *this* fold was given.
+            InlineNode::Raw {
+                value,
+                form: RawForm::Escaped,
+                ..
+            } => {
+                for ch in value.chars() {
+                    render_char(ch, renderer, out);
+                }
             }
 
             InlineNode::CharRef {
@@ -254,7 +271,7 @@ fn fold_into_html(
 /// Appends `ch` to `out`, routing the three special characters through
 /// `renderer` (so a custom renderer's escaping is honored) and pushing any
 /// other character verbatim.
-fn render_char(ch: char, renderer: &dyn InlineSubstitutionRenderer, out: &mut String) {
+pub(super) fn render_char(ch: char, renderer: &dyn InlineSubstitutionRenderer, out: &mut String) {
     let type_ = match ch {
         '<' => SpecialCharacter::Lt,
         '>' => SpecialCharacter::Gt,
@@ -716,7 +733,7 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{CharRef, Image, InlineNode, Ref, RefVariant},
+        inlines::{CharRef, Image, InlineNode, RawForm, Ref, RefVariant},
         parser::{
             HtmlSubstitutionRenderer, ModificationContext, ResolvedReference, XrefSignifier,
             XrefStyle,
@@ -820,6 +837,7 @@ mod tests {
 
         let raw = InlineNode::Raw {
             value: CowStr::from(location.data()),
+            form: RawForm::AsIs,
             location,
         };
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -12,7 +12,7 @@ use crate::{
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
-            fold::{fold_html, fold_stem},
+            fold::{fold_html, fold_stem, render_char},
             quotes::{
                 LevelContext, Piece, build_match_string, charref_entity, source_slice, text_slice,
             },
@@ -20,7 +20,7 @@ use crate::{
         },
         normalize_text_lf_escaped_bracket,
     },
-    inlines::{Image, InlineNode},
+    inlines::{Image, InlineNode, RawForm},
     parser::{
         InlineSubstitutionRenderer, has_dangerous_scheme, has_dangerous_self_href, is_uri_ish,
     },
@@ -440,7 +440,29 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
     renderer: &dyn InlineSubstitutionRenderer,
 ) -> Option<Cow<'a, str>> {
     match node {
-        InlineNode::Raw { value, .. } => Some(Cow::Borrowed(value.as_ref())),
+        InlineNode::Raw {
+            value,
+            form: RawForm::AsIs,
+            ..
+        } => Some(Cow::Borrowed(value.as_ref())),
+
+        // An escaped-form body carries the author's logical text, so the bytes
+        // the string pipeline splices over its own sentinel are that text
+        // *escaped* — the same bytes this node's own fold emits, which is the
+        // invariant this function exists to hold (see `node_is_restorable`).
+        InlineNode::Raw {
+            value,
+            form: RawForm::Escaped,
+            ..
+        } => {
+            let mut out = String::with_capacity(value.len());
+
+            for ch in value.chars() {
+                render_char(ch, renderer, &mut out);
+            }
+
+            Some(Cow::Owned(out))
+        }
 
         InlineNode::Stem(stem) => {
             let mut out = String::new();
@@ -1229,7 +1251,7 @@ mod tests {
             build, char_replacements::apply_character_replacements, macros::apply_macros,
             special_chars::Masked,
         },
-        inlines::{CharRef, Image, InlineNode, SpanForm, StyleVariant},
+        inlines::{CharRef, Image, InlineNode, RawForm, SpanForm, StyleVariant},
         parser::{DefaultPathResolver, HtmlSubstitutionRenderer},
         strings::CowStr,
     };
@@ -2551,6 +2573,7 @@ mod tests {
         let restorable = [
             InlineNode::Raw {
                 value: CowStr::from("raw"),
+                form: RawForm::AsIs,
                 location: root,
             },
             InlineNode::Stem(crate::inlines::Stem {

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     Parser, Span,
     content::{Content, INLINE_PASS, INLINE_PASS_MACRO, SubstitutionGroup},
-    inlines::{InlineNode, SpanForm, StyleVariant, Styled},
+    inlines::{InlineNode, RawForm, SpanForm, StyleVariant, Styled},
     strings::CowStr,
 };
 
@@ -661,6 +661,7 @@ fn build_bare_unconstrained_match<'src>(
             consumed,
             node: Box::new(InlineNode::Raw {
                 value: CowStr::from(value),
+                form: RawForm::AsIs,
                 location,
             }),
         },
@@ -763,20 +764,25 @@ fn build_passthrough_node<'src>(
 
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
+            form: RawForm::AsIs,
             location,
         };
     }
 
     if let Some(m) = caps.get(8).or_else(|| caps.get(11)) {
         // `++text++` / `$$text$$`: `SubstitutionGroup::Verbatim` applies only
-        // special characters. Computed through the real substitution
-        // pipeline (rather than hand-escaping `<`/`>`/`&`) so a custom
-        // `InlineSubstitutionRenderer`'s escaping is honored.
+        // special characters — so the body is the author's *literal text*,
+        // not raw output, and the fold is what escapes it
+        // ([`RawForm::Escaped`]). Rendering it here instead would freeze it
+        // against whichever renderer the parse carried, which is a different
+        // renderer from the one a later `render_with` fold is handed, and
+        // (while the string pipeline still runs) invokes that renderer a
+        // second time for a value nothing reads.
         let content = source_slice(pieces, m.start()..m.end(), root);
-        let value = passthrough_text(content.data(), &SubstitutionGroup::Verbatim, parser);
 
         return InlineNode::Raw {
-            value: CowStr::from(value),
+            value: CowStr::from(content.data()),
+            form: RawForm::Escaped,
             location,
         };
     }
@@ -810,7 +816,15 @@ fn build_passthrough_node<'src>(
         CowStr::from(raw)
     };
 
-    InlineNode::Raw { value, location }
+    // Either the body under `SubstitutionGroup::None` (nothing applied, so the
+    // author's bytes are the output bytes) or a value already rendered through
+    // an explicit substitution list — which stays a frozen value, the deferral
+    // `build_pass_macro_subs_value` documents for itself. Both are `AsIs`.
+    InlineNode::Raw {
+        value,
+        form: RawForm::AsIs,
+        location,
+    }
 }
 
 /// Computes the rendered `value` for a `pass:` macro carrying an **explicit
@@ -920,16 +934,18 @@ fn build_attrlisted_passthrough_node<'src>(
     let children = if old_behavior {
         apply_normal_subs(body_span, parser)
     } else {
-        let subs = if boundary == "+++" {
-            SubstitutionGroup::None
+        // `+++` applies nothing, so its body is raw output; `++`/`$$` apply
+        // special characters, so theirs is literal text the fold escapes. Both
+        // carry the author's bytes unchanged — only the form differs.
+        let form = if boundary == "+++" {
+            RawForm::AsIs
         } else {
-            SubstitutionGroup::Verbatim
+            RawForm::Escaped
         };
 
-        let value = passthrough_text(body_span.data(), &subs, parser);
-
         vec![InlineNode::Raw {
-            value: CowStr::from(value),
+            value: CowStr::from(body_span.data()),
+            form,
             location: body_span,
         }]
     };
@@ -1007,10 +1023,11 @@ fn build_bare_attrlisted_passthrough_node<'src>(
     let children = if old_behavior && !is_backtick {
         apply_normal_subs(body_span, parser)
     } else {
-        let value = passthrough_text(body_span.data(), &SubstitutionGroup::Verbatim, parser);
-
+        // Always `SubstitutionGroup::Verbatim` here (see this function's own
+        // doc comment), so the body is literal text the fold escapes.
         vec![InlineNode::Raw {
-            value: CowStr::from(value),
+            value: CowStr::from(body_span.data()),
+            form: RawForm::Escaped,
             location: body_span,
         }]
     };
@@ -1287,6 +1304,144 @@ mod tests {
         );
 
         assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "pass:[x]");
+    }
+
+    #[test]
+    fn a_specialcharacters_body_is_literal_text_the_fold_escapes() {
+        use super::super::test_support::assert_raw_form;
+        use crate::inlines::RawForm;
+
+        // The shape this increment exists for. `SubstitutionGroup` decides
+        // which form a passthrough body takes, and the two are not the same
+        // thing wearing different labels:
+        //
+        //   - `+++…+++` and bare `pass:[…]` apply *nothing*, so the author's bytes are
+        //     the output bytes — raw output by design.
+        //   - `++…++` and `$$…$$` apply special characters and nothing else, so the
+        //     body is the author's *literal text*. Escaping it is the fold's job, with
+        //     whatever renderer the fold is given.
+        //
+        // Both stay opaque to every later step — that is what keeps them one
+        // node kind — so this pins the distinction the kind alone cannot.
+        let nodes = build_src(Span::new("+++<b>+++"));
+        assert_raw_form(&nodes[0], RawForm::AsIs, "<b>");
+
+        let nodes = build_src(Span::new("pass:[<b>]"));
+        assert_raw_form(&nodes[0], RawForm::AsIs, "<b>");
+
+        let nodes = build_src(Span::new("++<b>++"));
+        assert_raw_form(&nodes[0], RawForm::Escaped, "<b>");
+
+        let nodes = build_src(Span::new("$$<b>$$"));
+        assert_raw_form(&nodes[0], RawForm::Escaped, "<b>");
+
+        // The attribute-listed forms carry theirs as the `Styled` wrapper's
+        // one child, and split the same way.
+        let nodes = build_src(Span::new("[.role]+++<b>+++"));
+        let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
+        assert_raw_form(&children[0], RawForm::AsIs, "<b>");
+
+        let nodes = build_src(Span::new("[.role]++<b>++"));
+        let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
+        assert_raw_form(&children[0], RawForm::Escaped, "<b>");
+    }
+
+    #[test]
+    fn a_passthrough_body_honors_the_renderer_the_fold_is_given() {
+        // The defect this closes. A `++…++` body used to be escaped at *build*
+        // time, through whichever renderer the `Parser` carried, and frozen
+        // into the node. Two things followed, and both are wrong:
+        //
+        //   1. folding the tree with a *different* renderer — which is the whole point
+        //      of `render_with` — silently emitted the parse-time renderer's escaping
+        //      instead;
+        //   2. building the tree *invoked* the document's renderer for a value nothing
+        //      reads, so a renderer with state saw extra calls and a later block's
+        //      authoritative output shifted under it.
+        //
+        // Folding the same tree through two different backends is the sharpest
+        // statement of the fix: one tree, two renderings, neither frozen.
+        #[derive(Debug)]
+        struct BracketRenderer;
+
+        impl crate::parser::InlineSubstitutionRenderer for BracketRenderer {
+            fn render_special_character(
+                &self,
+                type_: crate::parser::SpecialCharacter,
+                dest: &mut String,
+            ) {
+                dest.push_str(match type_ {
+                    crate::parser::SpecialCharacter::Lt => "[LT]",
+                    crate::parser::SpecialCharacter::Gt => "[GT]",
+                    crate::parser::SpecialCharacter::Ampersand => "[AMP]",
+                });
+            }
+        }
+
+        let parser = Parser::default();
+        let nodes = build_src(Span::new("++a < b > c & d++"));
+
+        assert_eq!(
+            super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            "a &lt; b &gt; c &amp; d"
+        );
+
+        assert_eq!(
+            super::super::fold_html(&nodes, &BracketRenderer, &parser),
+            "a [LT] b [GT] c [AMP] d"
+        );
+
+        // A genuinely raw body is not escaped by either backend — the other
+        // half of the distinction, which a single-renderer test cannot show.
+        let raw = build_src(Span::new("+++a < b+++"));
+
+        assert_eq!(
+            super::super::fold_html(&raw, &BracketRenderer, &parser),
+            "a < b"
+        );
+    }
+
+    #[test]
+    fn building_a_passthrough_does_not_invoke_the_documents_renderer() {
+        // The second half of the defect above, pinned directly: a renderer with
+        // state must not advance while the *tree* is built, because the tree is
+        // derived and its build must not be observable. Before the fix,
+        // `passthrough_text` ran the real substitution pipeline here and this
+        // counter reached 1.
+        // The counter has to be *observable in the output*, since a renderer
+        // behind an `Rc<dyn …>` cannot be downcast to read a field: each call
+        // emits its own ordinal, so probing afterwards reports how many calls
+        // came before it.
+        #[derive(Debug, Default)]
+        struct OrdinalRenderer {
+            calls: std::cell::Cell<usize>,
+        }
+
+        impl crate::parser::InlineSubstitutionRenderer for OrdinalRenderer {
+            fn render_special_character(
+                &self,
+                _type_: crate::parser::SpecialCharacter,
+                dest: &mut String,
+            ) {
+                self.calls.set(self.calls.get() + 1);
+                dest.push_str(&format!("[{}]", self.calls.get()));
+            }
+        }
+
+        let parser =
+            Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
+
+        let _ = super::super::build(Span::new("++a < b++"), &parser, None);
+
+        let mut probe = String::new();
+        parser
+            .renderer
+            .render_special_character(crate::parser::SpecialCharacter::Lt, &mut probe);
+
+        assert_eq!(
+            probe, "[1]",
+            "building the tree must not invoke the document's renderer; the probe is call one"
+        );
     }
 
     #[test]
@@ -2275,7 +2430,9 @@ mod tests {
         assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "a text b");
 
         match &nodes[1] {
-            InlineNode::Raw { value, location } => {
+            InlineNode::Raw {
+                value, location, ..
+            } => {
                 assert_eq!(value.as_ref(), "text");
                 assert_eq!(location.data(), "+text+");
             }

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -10,7 +10,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{QuoteSub, maybe_has_quotes, quote_subs},
-    inlines::{CharRef, InlineNode, SpanForm, StyleVariant, Styled},
+    inlines::{CharRef, InlineNode, RawForm, SpanForm, StyleVariant, Styled},
     parser::{HtmlSubstitutionRenderer, InlineSubstitutionRenderer, QuoteScope, QuoteType},
     strings::CowStr,
 };
@@ -1553,6 +1553,7 @@ pub(super) fn emit_range<'src>(
 
             out.push(InlineNode::Raw {
                 value: CowStr::from(sliced.to_string()),
+                form: RawForm::AsIs,
                 location: node.span(),
             });
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -5,7 +5,7 @@
 use super::{fold_html, passthrough_step::is_special};
 use crate::{
     HasSpan, Parser, Span,
-    inlines::{CharRef, InlineNode, RefVariant},
+    inlines::{CharRef, InlineNode, RawForm, RefVariant},
     parser::InlineSubstitutionRenderer,
     strings::CowStr,
 };
@@ -248,6 +248,7 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
 
             SpecialLeaf::Raw => InlineNode::Raw {
                 value: CowStr::from(ch_span.data()),
+                form: RawForm::AsIs,
                 location: ch_span,
             },
         });
@@ -344,7 +345,11 @@ pub(super) fn flatten_prior_markup<'src>(
 /// the break `post_replacements` wrote — so only `Text` needs the rewrite.
 fn as_pre_escape<'src>(node: InlineNode<'src>) -> InlineNode<'src> {
     match node {
-        InlineNode::Text { value, location } => InlineNode::Raw { value, location },
+        InlineNode::Text { value, location } => InlineNode::Raw {
+            value,
+            form: RawForm::AsIs,
+            location,
+        },
 
         InlineNode::Styled(mut styled) => {
             styled.children = styled.children.into_iter().map(as_pre_escape).collect();
@@ -538,6 +543,7 @@ fn split_synthesized<'src>(
 
             SpecialLeaf::Raw => InlineNode::Raw {
                 value: CowStr::from(ch.to_string()),
+                form: RawForm::AsIs,
                 location,
             },
         });
@@ -568,7 +574,8 @@ mod tests {
         Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Footnote, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled,
+            Anchor, CharRef, Footnote, InlineNode, RawForm, Ref, RefVariant, SpanForm,
+            StyleVariant, Styled,
         },
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -815,7 +822,9 @@ mod tests {
     /// located at `col` on line 1 with `offset`.
     fn assert_raw_special(node: &InlineNode<'_>, ch: char, col: usize, offset: usize) {
         match node {
-            InlineNode::Raw { value, location } => {
+            InlineNode::Raw {
+                value, location, ..
+            } => {
                 assert_eq!(value.as_ref(), ch.to_string());
                 assert_eq!(location.data(), ch.to_string());
                 assert_eq!(location.col(), col, "col for {ch:?}");
@@ -889,6 +898,7 @@ mod tests {
                 InlineNode::Raw {
                     value: special,
                     location: special_loc,
+                    ..
                 },
                 InlineNode::Text {
                     value: trailing,
@@ -1002,6 +1012,7 @@ mod tests {
             InlineNode::LineBreak { location },
             InlineNode::Raw {
                 value: CowStr::from(location.data()),
+                form: RawForm::AsIs,
                 location,
             },
         ]);

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -119,20 +119,53 @@ pub(super) fn assert_entity<'src>(node: &InlineNode<'src>, entity: &str) -> Span
     location
 }
 
-/// Asserts that `node` is a [`Raw`](InlineNode::Raw) with the given
+/// Asserts that `node` is a [`Raw`](InlineNode::Raw) leaf whose **fold** is
 /// `value`, returning its `location`.
+///
+/// The assertion is on the folded bytes rather than on the node's `value`
+/// field, because a `Raw` node carries one of two
+/// [`form`](crate::inlines::RawForm)s: `AsIs`, whose value already *is* those
+/// bytes, and `Escaped`, whose value is the author's logical text that the fold
+/// escapes. What every caller here means is "this passthrough contributes these
+/// bytes", and that is the same question for both forms — where reading the
+/// field is only the same question for one of them.
 pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'src> {
     match node {
-        InlineNode::Raw {
-            value: got,
-            location,
-        } => {
-            assert_eq!(got.as_ref(), value);
+        InlineNode::Raw { location, .. } => {
+            assert_eq!(
+                fold_html(std::slice::from_ref(node), &HtmlSubstitutionRenderer {}),
+                value
+            );
+
             *location
         }
 
         other => panic!("expected Raw({value:?}), got {other:?}"),
     }
+}
+
+/// Asserts that `node` is a [`Raw`](InlineNode::Raw) leaf of exactly `form`,
+/// carrying exactly `value` — the field-level assertion
+/// [`assert_raw`] deliberately does not make.
+///
+/// Used where the *shape* is the subject: that a `+++…+++` body is `AsIs`
+/// output while a `++…++` body is `Escaped` logical text, which is what keeps
+/// a passthrough's escaping a property of the fold's renderer rather than of
+/// the parse's.
+pub(super) fn assert_raw_form(node: &InlineNode<'_>, form: crate::inlines::RawForm, value: &str) {
+    // Compared as a whole node rather than by matching out the two fields,
+    // which keeps this free of a fallback arm only a failing test could reach.
+    // `location` is taken from `node` itself, so it is deliberately not part of
+    // the assertion — this helper's subject is the form and the value, and
+    // [`assert_raw`] already hands a caller the location to check.
+    assert_eq!(
+        node,
+        &InlineNode::Raw {
+            value: CowStr::from(value),
+            form,
+            location: node.span(),
+        }
+    );
 }
 
 /// Asserts that `node` is a [`Styled`](crate::inlines::Styled) span of

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -48,14 +48,26 @@ pub enum InlineNode<'src> {
         location: Span<'src>,
     },
 
-    /// Verbatim, un-escaped output: passthrough content (`+++…+++`,
-    /// `pass:[…]`, `$$…$$`) and any literal special character of an attribute
-    /// expansion that the effective substitution order left unescaped. This
-    /// node is the model's record of the language's "emit raw HTML by design"
-    /// behavior. ASG: `inlineLiteral` with `name="raw"`.
+    /// Content that later substitution steps must not see inside — passthrough
+    /// content (`+++…+++`, `pass:[…]`, `++…++`, `$$…$$`), a masked STEM body,
+    /// and any literal special character of an attribute expansion that the
+    /// effective substitution order left unescaped. This node is the model's
+    /// record of the language's "this text is off limits" behavior. ASG:
+    /// `inlineLiteral` with `name="raw"`.
+    ///
+    /// [`form`](RawForm) says whether `value` is already output bytes or
+    /// logical text the fold escapes. Both are opaque to the transducer steps —
+    /// that is what makes them one node kind rather than two — but only one is
+    /// "raw HTML by design", and conflating them made a passthrough's escaping
+    /// a function of whichever renderer the *parse* carried rather than of the
+    /// one the fold is given.
     Raw {
-        /// The content to emit verbatim, without HTML-escaping.
+        /// The content this node contributes, in the shape [`form`](Self::Raw)
+        /// names.
         value: CowStr<'src>,
+
+        /// Whether the fold emits [`value`](Self::Raw) as-is or escapes it.
+        form: RawForm,
 
         /// The source location this content derives from.
         location: Span<'src>,
@@ -124,8 +136,9 @@ mod tests {
     use crate::{
         HasSpan, Span,
         inlines::{
-            Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref,
-            RefVariant, SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
+            Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode,
+            RawForm, Ref, RefVariant, SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui,
+            UiKind,
         },
         strings::CowStr,
     };
@@ -145,6 +158,7 @@ mod tests {
             },
             InlineNode::Raw {
                 value: CowStr::from("<b>"),
+                form: RawForm::AsIs,
                 location,
             },
             InlineNode::Styled(Styled {
@@ -288,4 +302,34 @@ mod tests {
         assert_eq!(ui_kinds.len(), 3);
         assert_eq!(callout_guards.len(), 2);
     }
+}
+
+/// How a [`Raw`](InlineNode::Raw) node's value reaches the output.
+///
+/// Both forms are **opaque**: no transducer step matches inside a `Raw` node,
+/// whichever form it carries. What differs is only what the fold does with the
+/// bytes — and, because the fold is where a renderer is chosen, that is exactly
+/// the difference between a value that honors the renderer it is folded with
+/// and one frozen against whatever renderer happened to be configured at parse
+/// time.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RawForm {
+    /// `value` is already the bytes to emit, and the fold emits them unchanged.
+    ///
+    /// This is "raw output by design": a `+++…+++` or bare `pass:[…]` body
+    /// (whose substitution group is [`None`], so nothing was applied), an
+    /// entity's own bytes, or a literal special an effective order never
+    /// escaped.
+    ///
+    /// [`None`]: crate::content::SubstitutionGroup
+    AsIs,
+
+    /// `value` is the author's *logical* text, and the fold escapes it exactly
+    /// as it escapes a [`Text`](InlineNode::Text) node's.
+    ///
+    /// This is a body whose substitution group applies special characters and
+    /// nothing else (`++…++`, `$$…$$`) — literal text that must not be
+    /// *matched into* by a later step, but which is not raw output and must be
+    /// escaped by whichever renderer the fold is given.
+    Escaped,
 }

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -50,7 +50,7 @@ mod index_term;
 pub use index_term::IndexTerm;
 
 mod inline_node;
-pub use inline_node::InlineNode;
+pub use inline_node::{InlineNode, RawForm};
 
 mod ref_node;
 pub use ref_node::{LinkForm, Ref, RefVariant};

--- a/parser/src/tests/inline_builder_recorder_parity.rs
+++ b/parser/src/tests/inline_builder_recorder_parity.rs
@@ -181,7 +181,7 @@ use crate::{
             classify_entity,
         },
     },
-    inlines::{CharRef, InlineNode, RefVariant},
+    inlines::{CharRef, InlineNode, RawForm, RefVariant},
     parser::{HtmlSubstitutionRenderer, ModificationContext},
     strings::CowStr,
 };
@@ -294,8 +294,8 @@ fn assert_trees_equivalent(recorder: &[InlineNode<'_>], builder: &[InlineNode<'_
             InlineNode::Text { value, .. } => {
                 Some((Cow::Borrowed(value.as_ref()), LeafKinds::TextOnly))
             }
-            InlineNode::Raw { value, .. } => {
-                Some((Cow::Borrowed(value.as_ref()), LeafKinds::Mixed))
+            InlineNode::Raw { value, form, .. } => {
+                Some((raw_rendered(value, *form), LeafKinds::Mixed))
             }
             InlineNode::CharRef { value, .. } => {
                 Some((char_ref_rendered(value), LeafKinds::CharRefOnly))
@@ -390,6 +390,33 @@ fn recorder_entity_table_matches_production_classify_entity() {
 /// the recorder recovers it as several adjacent leaves, one per character;
 /// it is rendered by looking up each character individually and
 /// concatenating, mirroring that recovery exactly.
+/// The bytes a [`Raw`](InlineNode::Raw) leaf contributes to the rendered
+/// output, which is what the recorder recovered its own nodes from.
+///
+/// An [`AsIs`](RawForm::AsIs) value already *is* those bytes. An
+/// [`Escaped`](RawForm::Escaped) one is the author's logical text that the fold
+/// escapes — a `++<b>++` body is `<b>` on the node and `&lt;b&gt;` in the
+/// output — so comparing the field directly would ask the recorder for bytes no
+/// pipeline ever produced. This mirrors [`char_ref_rendered`], which has always
+/// had to render its leaf for the same reason.
+fn raw_rendered<'a>(value: &'a CowStr<'_>, form: RawForm) -> Cow<'a, str> {
+    match form {
+        RawForm::AsIs => Cow::Borrowed(value.as_ref()),
+
+        RawForm::Escaped => Cow::Owned(
+            value
+                .chars()
+                .map(|c| match c {
+                    '<' => "&lt;".to_owned(),
+                    '>' => "&gt;".to_owned(),
+                    '&' => "&amp;".to_owned(),
+                    other => other.to_string(),
+                })
+                .collect(),
+        ),
+    }
+}
+
 fn char_ref_rendered<'a>(value: &'a CharRef<'_>) -> Cow<'a, str> {
     if let Some((entity, _)) = RECORDER_ENTITY_TABLE.iter().find(|(_, cr)| cr == value) {
         return Cow::Borrowed(entity);


### PR DESCRIPTION
This is option **(b)**. It **unblocks #1255**.

Branches from `inline-ast`, independent of the cutover stack.

## The conflation

`Raw` is documented as "verbatim, un-escaped output … `+++…+++`, `pass:[…]`, `$$…$$`". The first two are that. `$$…$$` and `++…++` are **not** — their substitution group applies special characters, so their body is the author's *literal text*, and something has to escape it.

The builder did, at build time, through whichever renderer the `Parser` happened to carry, and froze the result into the node. Two things followed:

1. **Folding through a different renderer emitted the parse-time renderer's escaping** — precisely what `render_with` exists not to do. Measured with a non-HTML backend: the string pipeline gives `a [LT] b`, the fold gave `a &lt; b`.
2. **Building the tree invoked the document's renderer** for a value nothing reads. With the tree built on every parse (#1255), a stateful renderer saw extra calls and a *later block's* authoritative output shifted under it. That's the defect Greptile flagged, and nothing in the suite paired a stateful renderer with a passthrough to catch it.

The obvious fix — give the builder's parser clone a built-in renderer — is wrong, and measurably: it makes (2) go away by making (1) worse, silently HTML-escaping a custom backend's passthrough body. What the two failures share is the **freezing**, not the renderer.

## The change

`Raw` gains a `form`:

- **`AsIs`** — the value already *is* the bytes to emit (`+++…+++`, bare `pass:[…]`, an entity's own bytes, a special an effective order never escaped).
- **`Escaped`** — the value is the author's logical text, and the fold escapes it exactly as it escapes a `Text` run.

Both stay **opaque**: no transducer step matches inside either, which is what keeps them one node kind rather than two. Only the escaping moves — to the one place a renderer is actually chosen.

The `Escaped` sites also stop allocating: they borrow the author's bytes instead of owning an escaped copy.

**Why not just use `Text`?** A `++…++` body is semantically a `Text` run and folds identically to one — but `build_match_string` decides atomicity by node **kind**, and a `Text` piece is splittable. Later steps would match into a passthrough body. The node has to stay `Raw`.

## Result

```
                          before          after
stateful renderer      c [3] d         c [2] d    ← matches pre-change baseline
custom-backend fold    a &lt; b        a [LT] b   ← honors the renderer
```

## Verification

- `cargo test --workspace`: **5417 pass, 0 fail**, with **no expectation changed**. That's the claim worth making — the observable bytes are identical, as a change to *where* escaping happens should be.
- Corpus-wide fold-parity audit: divergence set **byte-identical**, 235 rows before and after, none added and none closed.
- Coverage **diff-neutral**: 575 missed regions / 323 missed lines, exactly the baseline. (One gap I'd introduced — an unexercised `>` arm in a test renderer — is now covered; one fallback arm was removed rather than left untested.)
- Preflight clean: fmt, clippy, doc.

Three new tests, **each checked against the old behaviour first** so none is vacuous: the form split itself, one tree folded through two backends, and a build that leaves an ordinal-emitting renderer un-advanced.

## Two things that made this cheap

`assert_raw` now asserts a node's **fold** rather than its `value` field — "this passthrough contributes these bytes" is the same question for both forms, where reading the field is only the same question for one. That let ~25 existing expectations stand unchanged.

The Strategy-A cross-check needed the mirror: `raw_rendered` renders a `Raw` leaf before matching it against the recorder's own bytes, exactly as `char_ref_rendered` has always had to. That harness compares against *rendered* output, so a logical-text field was the wrong thing to hand it.

## What still freezes a value

Each for its own reason, and each owing the same debt to `render_with` that every frozen value on this branch does:

- a `pass:c,q[…]` body — its explicit substitution list runs a whole pipeline (the deferral 5d part 3 documents for itself);
- a bare `+…+` body enclosing an already-extracted passthrough — its value interleaves escaped text with another node's fold bytes, so no single form describes it;
- a `Stem` body.