### PR TITLE
fix: Treat a bare `+…+` body as literal text too (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -5963,6 +5963,34 @@ Each phase is a reviewable unit with a clear exit gate.
   another node's fold bytes, so no single form describes it), and a `Stem` body. Each is a narrow
   form, and each owes the same debt to `render_with` that every frozen value on this branch does.
 
+  *Step 6 landed as (the bare `+…+` body, which is literal text too):* the increment above closed
+  the passthrough family's build-time escaping for `++…++` and `$$…$$` and named three shapes that
+  still freeze a value. Sweeping *every* construct with a call-counting renderer — rather than
+  taking that list on trust — confirms exactly three, and one of them is not narrow at all: the
+  **bare `+…+` form**, which is `SubstitutionGroup::Verbatim` like its delimited siblings and is
+  ordinary AsciiDoc.
+
+  It could not say so while one shape stood in the way. A bare body *enclosing a construct the
+  first extraction pass already replaced* (`+a $$b$$ c+`) interleaves escaped text with that
+  node's own **fold** bytes, and no single form describes the mixture. The previous increment read
+  that as "the bare form freezes", when what it actually means is "the *mixture* freezes" — and
+  the mixture is rare where the plain body is not. So
+  [`substitute_and_restore`](../../parser/src/content/inline_builder/passthrough_step.rs) now
+  detects it rather than assuming it: with nothing restorable inside the body, the value is the
+  author's bytes and the fold escapes them
+  ([`Escaped`](../../parser/src/inlines/inline_node.rs)); only the genuine mixture keeps `AsIs`.
+
+  What remains is **three** shapes, and the third is this increment's own leftover rather than a
+  new one: a `pass:c,q[…]` body and a `Stem` body each run an arbitrary substitution list, and the
+  mixture above — a bare body enclosing an already-extracted construct — interleaves escaped text
+  with that construct's fold bytes. None of the three is a *specialcharacters* body, so no
+  `RawForm` describes any of them; all three need the fold-time laziness §3.3.1 will bring, and owe
+  `render_with` the same debt every frozen value on this branch does. Every *other* construct makes
+  **zero** renderer calls while its tree is built, which the increment below pins as a sweep.
+
+  Corpus-wide fold-parity audit: divergence set byte-identical, 60 rows either side. Coverage is
+  diff-neutral.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7096,6 +7124,17 @@ Each phase is a reviewable unit with a clear exit gate.
        test edited** and both recordings unchanged. The ~277 golden-HTML assertions keep `apply`
        deliberately — their subject is `rendered_html()` itself. See the step's own "landed as"
        note above.
+
+     - ✅ **prep (the bare `+…+` body, which is literal text too).** A call-counting sweep over
+       every construct — rather than trusting the previous increment's list — finds exactly three
+       that still invoke the renderer while the tree is built, and the bare `+…+` form is one:
+       ordinary AsciiDoc, and `Verbatim` like its delimited siblings. What actually freezes is the
+       *mixture* a body enclosing an already-extracted construct produces, not the form, so
+       [`substitute_and_restore`](../../parser/src/content/inline_builder/passthrough_step.rs)
+       detects the mixture instead of assuming it. What is left is three shapes — a `pass:c,q[…]`
+       body, a `Stem` body, and the mixture itself — none of them a *specialcharacters* body, all
+       needing fold-time laziness.
+       See the step's own "landed as" note above.
 
      - ✅ **prep (a passthrough body is literal text, not raw output).** The blocker review found
        on the always-on increment, and a conflation in §3.4's trichotomy: `++…++` / `$$…$$` apply

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -654,14 +654,14 @@ fn build_bare_unconstrained_match<'src>(
     let consumed = delim_start..full.end;
     let location = source_slice(pieces, consumed.clone(), root);
 
-    let value = substitute_and_restore(body_m.as_str(), &body, nodes, pieces, parser);
+    let (value, form) = substitute_and_restore(body_m.as_str(), &body, nodes, pieces, parser);
 
     Some(MacroMatch {
         kind: MacroMatchKind::Node {
             consumed,
             node: Box::new(InlineNode::Raw {
                 value: CowStr::from(value),
-                form: RawForm::AsIs,
+                form,
                 location,
             }),
         },
@@ -699,8 +699,30 @@ fn substitute_and_restore(
     nodes: &[InlineNode<'_>],
     pieces: &[Piece],
     parser: &Parser,
-) -> String {
+) -> (String, RawForm) {
     let renderer = parser.renderer.as_ref();
+
+    // The overwhelmingly common case: a `+…+` body with nothing extracted
+    // inside it. Then there is no interleaving to do — the body is one
+    // `Verbatim` run, which is to say the author's literal text — so it takes
+    // the same [`Escaped`](RawForm::Escaped) form every other
+    // specialcharacters-only body does, and the fold escapes it with the
+    // renderer it is given rather than the one this parse happens to carry.
+    if !pieces.iter().any(|piece| {
+        piece.s_start + piece.s_len > range.start
+            && piece.s_start < range.end
+            && nodes
+                .get(piece.node_index)
+                .is_some_and(|node| restorable_body(node, renderer).is_some())
+    }) {
+        return (body_text.to_string(), RawForm::Escaped);
+    }
+
+    // Otherwise the value genuinely interleaves escaped text with another
+    // node's *fold* bytes, and no single form describes it: it is built here
+    // and emitted as-is. That keeps this one frozen against the parse's
+    // renderer, which is the residue this shape owes to `render_with` — the
+    // same debt a `pass:c,q[…]` body and a `Stem` body carry.
     let mut out = String::new();
     let mut cursor = range.start;
 
@@ -742,7 +764,7 @@ fn substitute_and_restore(
         parser,
     ));
 
-    out
+    (out, RawForm::AsIs)
 }
 
 /// Builds one [`Raw`](InlineNode::Raw) node from a verbatim, unescaped
@@ -1304,6 +1326,67 @@ mod tests {
         );
 
         assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "pass:[x]");
+    }
+
+    #[test]
+    fn a_bare_plus_body_is_literal_text_unless_it_restores_something() {
+        use super::super::test_support::assert_raw_form;
+        use crate::inlines::RawForm;
+
+        // A bare `+…+` body is `SubstitutionGroup::Verbatim` like `++…++`, so
+        // by rights it is the author's literal text too. It could not say so
+        // while one shape stood in the way: a body *enclosing a construct the
+        // first extraction pass already replaced* interleaves escaped text with
+        // that node's own **fold** bytes, and no single form describes the
+        // mixture.
+        //
+        // That shape is rare and the plain one is not, so the mixture is
+        // detected rather than assumed: with nothing restorable inside the
+        // body, the value is the author's bytes and the fold escapes them.
+        let nodes = build_src(Span::new("+a < b+"));
+        assert_raw_form(&nodes[0], RawForm::Escaped, "a < b");
+
+        // The mixture keeps `AsIs`, since part of its value is another node's
+        // rendering rather than anything an escape could reproduce.
+        let nodes = build_src(Span::new("+a $$<b>$$ c+"));
+        assert_raw_form(&nodes[0], RawForm::AsIs, "a &lt;b&gt; c");
+    }
+
+    #[test]
+    fn a_bare_plus_body_honors_the_renderer_the_fold_is_given() {
+        // The observable consequence, and the reason this is worth its own
+        // increment rather than a documented deferral: `+…+` is a common
+        // construct, and its body used to be escaped against whichever renderer
+        // the *parse* carried.
+        #[derive(Debug)]
+        struct BracketRenderer;
+
+        impl crate::parser::InlineSubstitutionRenderer for BracketRenderer {
+            fn render_special_character(
+                &self,
+                type_: crate::parser::SpecialCharacter,
+                dest: &mut String,
+            ) {
+                dest.push_str(match type_ {
+                    crate::parser::SpecialCharacter::Lt => "[LT]",
+                    crate::parser::SpecialCharacter::Gt => "[GT]",
+                    crate::parser::SpecialCharacter::Ampersand => "[AMP]",
+                });
+            }
+        }
+
+        let parser = Parser::default();
+        let nodes = build_src(Span::new("+a < b > c & d+"));
+
+        assert_eq!(
+            super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            "a &lt; b &gt; c &amp; d"
+        );
+
+        assert_eq!(
+            super::super::fold_html(&nodes, &BracketRenderer, &parser),
+            "a [LT] b [GT] c [AMP] d"
+        );
     }
 
     #[test]

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -3,7 +3,7 @@
 use super::{
     macros::{
         MacroMatch, MacroMatchKind,
-        image::{range_is_restorable, range_is_verbatim, restorable_body},
+        image::{node_is_restorable, range_is_restorable, range_is_verbatim, restorable_body},
         rebuild_macro_level,
     },
     quotes::{Piece, attributes_of, build_match_string, source_slice},
@@ -708,12 +708,19 @@ fn substitute_and_restore(
     // the same [`Escaped`](RawForm::Escaped) form every other
     // specialcharacters-only body does, and the fold escapes it with the
     // renderer it is given rather than the one this parse happens to carry.
+    //
+    // The test is `node_is_restorable` rather than `restorable_body`, though
+    // the two answer for the same set: this is a *discriminant*, and
+    // `restorable_body` produces bytes — rendering a `Stem` body, escaping an
+    // [`Escaped`](RawForm::Escaped) one — through the parser's renderer. Asking
+    // it here would run those calls a second time for every node the
+    // restoration loop below then renders for real, which a stateful renderer
+    // reports (its second answer is what lands in the value) and a renderer
+    // with side effects performs twice.
     if !pieces.iter().any(|piece| {
         piece.s_start + piece.s_len > range.start
             && piece.s_start < range.end
-            && nodes
-                .get(piece.node_index)
-                .is_some_and(|node| restorable_body(node, renderer).is_some())
+            && nodes.get(piece.node_index).is_some_and(node_is_restorable)
     }) {
         return (body_text.to_string(), RawForm::Escaped);
     }
@@ -1524,6 +1531,58 @@ mod tests {
         assert_eq!(
             probe, "[1]",
             "building the tree must not invoke the document's renderer; the probe is call one"
+        );
+    }
+
+    #[test]
+    fn a_mixed_bare_plus_body_renders_each_nested_node_once() {
+        // A bare `+…+` enclosing an already-extracted node is the one shape
+        // whose value is finished at build time, so it is also the one place
+        // the builder legitimately calls the document's renderer. It must call
+        // it *once* per nested node: the mixture test above it is a
+        // discriminant (`node_is_restorable`), not a second rendering.
+        //
+        // The counter has to be observable in the output, since a renderer
+        // behind an `Rc<dyn …>` cannot be downcast to read a field: each call
+        // emits its own ordinal. Before the fix the detection pass rendered
+        // the `$$…$$` node's `<` first, so the *second* answer (`[2]`) is what
+        // landed in the value and the probe afterwards read `[3]`.
+        #[derive(Debug, Default)]
+        struct OrdinalRenderer {
+            calls: std::cell::Cell<usize>,
+        }
+
+        impl crate::parser::InlineSubstitutionRenderer for OrdinalRenderer {
+            fn render_special_character(
+                &self,
+                _type_: crate::parser::SpecialCharacter,
+                dest: &mut String,
+            ) {
+                self.calls.set(self.calls.get() + 1);
+                dest.push_str(&format!("[{}]", self.calls.get()));
+            }
+        }
+
+        use super::super::test_support::assert_raw_form;
+        use crate::inlines::RawForm;
+
+        let parser =
+            Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
+
+        let nodes = super::super::build(Span::new("+a $$b < c$$ d+"), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+        assert_raw_form(&nodes[0], RawForm::AsIs, "a b [1] c d");
+        assert_eq!(nodes[0].span().data(), "+a $$b < c$$ d+");
+
+        let mut probe = String::new();
+        parser
+            .renderer
+            .render_special_character(crate::parser::SpecialCharacter::Lt, &mut probe);
+
+        assert_eq!(
+            probe, "[2]",
+            "the nested node must be rendered once; the probe is call two"
         );
     }
 


### PR DESCRIPTION
A follow-on to #1261, found by **not trusting my own deferral list**.

#1261 closed the passthrough family's build-time escaping for `++…++` / `$$…$$` and named three shapes that still freeze a value. Before rebasing #1255 on top, I swept *every* construct with a call-counting renderer to check that list rather than assume it. The probe reports its own ordinal, so `[2]` means the string pipeline alone and `[3]` means one extra call during the build:

```
[2]  "a < b"              [2]  "$$a < b$$"          [2]  "image:x.png[a < b]"
[2]  "++a < b++"          [2]  "[.role]#a < b#"     [2]  "link:x.html[a < b]"
[1]  "+++a < b+++"        [2]  "[.a<b]#x#"          [2]  "footnote:[a < b]"
[1]  "pass:[a < b]"       [2]  "[x-]++a < b++"
[3]  "pass:c[a < b]"   ←  explicit subs list (documented)
[3]  "stem:[x < y]"    ←  STEM body (documented)
[3]  "+a < b+"         ←  the bare form — ordinary AsciiDoc, not narrow at all
```

Exactly three, as #1261 said. But one of them is a common construct, and I'd filed it as a narrow deferral.

## What was actually frozen

Not the *form* — the **mixture**. A bare body enclosing a construct the first extraction pass already replaced (`+a $$b$$ c+`) interleaves escaped text with that node's own **fold** bytes, and no single `RawForm` describes it. #1261 read that as "the bare form freezes"; what it means is "the mixture freezes" — and the mixture is rare where the plain body is not.

So `substitute_and_restore` now **detects** the mixture instead of assuming it. With nothing restorable inside the body, the value is the author's bytes and the fold escapes them (`Escaped`); only the genuine mixture keeps `AsIs`.

## What remains, by measurement

A `pass:c,q[…]` body and a `Stem` body each run an *arbitrary* substitution list, so neither is a specialcharacters body and neither can take this form. They're the two shapes that genuinely need the fold-time laziness §3.3.1 will bring, and they owe `render_with` the same debt every frozen value on this branch does.

**Every other construct in the sweep makes zero renderer calls while its tree is built.**

## Verification

- `cargo test --workspace`: **5419 pass, 0 fail**, no expectation changed.
- Corpus-wide fold-parity audit: divergence set **byte-identical**, 60 rows either side.

  (Worth noting: my first run of this showed 235 → 60, which looked like a huge improvement and was pure artifact — the baseline predated #1260, which routed 25 corpora away from `apply` and so out of the audit probe's reach. Re-baselined on the current `inline-ast` before believing it.)
- Coverage **diff-neutral**: 575 missed regions / 323 missed lines.
- Preflight clean: fmt, clippy, doc.

Two tests, both checked against the old behaviour first: the form split (including the mixture keeping `AsIs`), and one tree folded through two backends.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_