### PR TITLE
feat: Resolve a cross-reference's effective `xrefstyle` into its node (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6133,6 +6133,37 @@ Each phase is a reviewable unit with a clear exit gate.
 
   Coverage is diff-neutral (`substitution_group.rs` stays at 100%).
 
+  *Step 6 landed as (a cross-reference's effective `xrefstyle`, resolved into the node):* the
+  first prep for the deferred-cross-reference retirement, and one the fold-parity audit cannot
+  see. [`Ref::xrefstyle`](../../parser/src/inlines/ref_node.rs) held the macro's own
+  `xrefstyle=` **override**, and
+  [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) supplied the fallback itself
+  (`reference.xrefstyle.or_else(|| document_xrefstyle(parser))`). That is fine only while the fold
+  runs in the same pass as the parse. The effective style is a *document-order* fact — a
+  `:xrefstyle:` line rebinds it for everything after it — so a fold running **later** than the
+  parse reads whatever the last such line left set, and silently re-styles a reference the string
+  pipeline had already styled. A re-fold at reference-resolution time is exactly that later fold,
+  which is what the retirement below needs.
+
+  So the field becomes the **effective** style, resolved at build time by whichever builder makes
+  the node ([`build_xref_node`](../../parser/src/content/inline_builder/macros/xref.rs) for the
+  macro form, [`build_xref_shorthand_node`](../../parser/src/content/inline_builder/macros/xref.rs)
+  for `<<id>>`), which is the same `document_xrefstyle` reading `InlineXrefReplacer` makes, in the
+  same pass. `None` now means *no style* rather than *ask the document*, and the fold consults no
+  document state for it — §3.3.1 point 1, applied to one more order-dependent fact.
+
+  What pins it is not the audit, which compares `apply`'s own fold against `run_pipeline` in the
+  same parse and therefore reads the same attribute on both sides (0 new, 0 closed — correctly).
+  It is the whole-document harness
+  ([`inline_builder_document_parity`](../../parser/src/tests/inline_builder_document_parity.rs)),
+  whose fold runs after resolution with a *fresh* `Parser` for render context: four fixtures with
+  `:sectnums:` and a document-wide `:xrefstyle:` — set at the top, rebound midway, rebound to a
+  different value, and overridden per-macro — all of which **fail on the base branch** (`Install`
+  where the string pipeline says `Section 1, &#8220;Install&#8221;`) and pass here. That the
+  harness's own `fold_parser` is a default one is what made the gap visible at all.
+
+  Coverage is diff-neutral (`fold.rs` 3/3, `xref.rs` 16/7, `ref_node.rs` 0/0 — identical to base).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7326,6 +7357,20 @@ Each phase is a reviewable unit with a clear exit gate.
        better (`#`CB###2`#`, whose mis-nested `<mark>`/`<code>` was an artifact of substituting
        over rendered markup). Audit: production divergences 18 → 9, none new, all nine accounted
        for. See the step's own "landed as" note above.
+
+     - ✅ **prep (a cross-reference's effective `xrefstyle`, resolved into the node).** The first
+       prep for the retirement below, and the first found by asking *what does a fold that runs
+       later than its parse read differently?* [`Ref::xrefstyle`](../../parser/src/inlines/ref_node.rs)
+       held only the macro's `xrefstyle=` override, with
+       [`fold_xref`](../../parser/src/content/inline_builder/fold.rs) supplying the document-wide
+       fallback at fold time. The effective style is a document-order fact — a `:xrefstyle:` line
+       rebinds it for everything after it — so a re-fold at reference-resolution time would read
+       the *end-of-parse* value and re-style a reference the string pipeline had already styled.
+       The field becomes the effective style, resolved at build time by the same
+       `document_xrefstyle` call `InlineXrefReplacer` makes in the same pass; `None` now means *no
+       style* rather than *ask the document*. Pinned by four whole-document fixtures that fail on
+       base, not by the audit, which cannot see this class. See the step's own "landed as" note
+       above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -4,7 +4,6 @@ use super::{callouts::replacement_type_of, quotes::quote_type_of};
 use crate::{
     Parser,
     attributes::{Attrlist, AttrlistContext},
-    content::document_xrefstyle,
     inlines::{
         Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm,
         Ref, RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
@@ -466,12 +465,11 @@ fn fold_link(
 /// `None` here) and a target that carries its own destination without a
 /// catalog (`derived`, populated at build time — see the `Ref::derived` field
 /// docs): an inter-document target, and the empty target naming the current
-/// document as a whole. The effective `xrefstyle` is the node's own
-/// macro-level override if present, otherwise the document-wide `xrefstyle`
-/// attribute in effect for this reference — mirroring `InlineXrefReplacer`'s
-/// own `xrefstyle_override.or_else(|| document_xrefstyle(parser))` exactly
-/// (see the `Ref::xrefstyle` field docs); the cutover (design §5.2 Phase 4,
-/// step 6) wires catalog resolution to the tree.
+/// document as a whole. The `xrefstyle` is taken straight off the node, which
+/// carries the **effective** style resolved at build time (see the
+/// `Ref::xrefstyle` field docs), so this fold consults no document state for
+/// it; the cutover (design §5.2 Phase 4, step 6) wires catalog resolution to
+/// the tree.
 fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -505,14 +503,18 @@ fn fold_xref(
     // materialized into a `String` vector for the borrow.
     let roles: Vec<String> = reference.roles.iter().map(|r| r.to_string()).collect();
 
-    let xrefstyle = reference.xrefstyle.or_else(|| document_xrefstyle(parser));
-
     let params = XrefRenderParams {
         target: reference.target.as_ref(),
         provided_text,
         window: reference.window.as_deref(),
         roles: &roles,
-        xrefstyle,
+
+        // Taken straight off the node: the *effective* style is resolved into
+        // it at build time (see [`Ref::xrefstyle`]), so this fold consults no
+        // document state and stays a pure function of the tree — which is what
+        // lets it run at reference-resolution time, long after the parse whose
+        // `xrefstyle` was in effect.
+        xrefstyle: reference.xrefstyle,
         derived: reference.derived.as_ref(),
         resolved: reference.resolved.as_ref(),
     };
@@ -953,36 +955,49 @@ mod tests {
     }
 
     #[test]
-    fn fold_xref_falls_back_to_the_document_wide_xrefstyle() {
-        // A node with no macro-level `xrefstyle` override still picks up the
-        // document-wide `xrefstyle` attribute in effect for the reference,
-        // mirroring `InlineXrefReplacer`'s own
-        // `xrefstyle_override.or_else(|| document_xrefstyle(parser))` (see the
-        // `Ref::xrefstyle` field docs) — this is the document-wide default a
-        // hand-built node with no override still observes.
+    fn fold_xref_reads_the_effective_xrefstyle_off_the_node() {
+        // The fold consults **no** document state for `xrefstyle`: the
+        // effective style is resolved into the node at build time (see the
+        // `Ref::xrefstyle` field docs), so the same node folds the same way
+        // whatever the parser it is handed says.
+        //
+        // That is the property the deferred-cross-reference retirement needs.
+        // A re-fold runs at reference-resolution time, and the document-wide
+        // `xrefstyle` in effect *there* is whatever the last `:xrefstyle:` line
+        // in the document left set — not what was in effect where the
+        // reference was written. Reading it at fold time would therefore
+        // silently re-style a reference the string pipeline had already styled.
         let renderer = HtmlSubstitutionRenderer {};
-        let nodes = [resolved_xref_with_signifier(None)];
 
-        // With no document-wide `xrefstyle` set, the target's reference text
-        // (here `None`, so the bracketed fallback) is used verbatim.
-        let unstyled = fold_html_with_parser(&nodes, &renderer, &Parser::default());
-        assert!(!unstyled.contains("Section 2"), "folded: {unstyled}");
-
-        let parser = Parser::default().with_intrinsic_attribute(
+        // A parser whose document-wide `xrefstyle` says `full`, which the
+        // fold must ignore in both directions.
+        let full = Parser::default().with_intrinsic_attribute(
             "xrefstyle",
             "full",
             ModificationContext::Anywhere,
         );
 
-        let styled = fold_html_with_parser(&nodes, &renderer, &parser);
+        // `None` on the node means "no style", not "ask the document".
+        let unstyled =
+            fold_html_with_parser(&[resolved_xref_with_signifier(None)], &renderer, &full);
+
+        assert!(!unstyled.contains("Section 2"), "folded: {unstyled}");
+
+        // And a node carrying a style is honored even by a parser that has
+        // none set.
+        let styled = fold_html_with_parser(
+            &[resolved_xref_with_signifier(Some(XrefStyle::Full))],
+            &renderer,
+            &Parser::default(),
+        );
+
         assert!(styled.contains("Section 2, &#8220;"), "folded: {styled}");
     }
 
     #[test]
-    fn fold_xref_macro_level_xrefstyle_overrides_the_document_wide_default() {
-        // A macro-level `xrefstyle=` override (`Ref::xrefstyle`) wins over the
-        // document-wide `xrefstyle` attribute, exactly as
-        // `InlineXrefReplacer`'s own `xrefstyle_override` takes precedence.
+    fn fold_xref_honors_each_style_the_node_can_carry() {
+        // The complement of the test above: a node carrying `Short` folds as
+        // `Short`, with the document-wide `full` again ignored.
         let renderer = HtmlSubstitutionRenderer {};
         let nodes = [resolved_xref_with_signifier(Some(XrefStyle::Short))];
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -14,7 +14,7 @@ use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{
-        INLINE_XREF,
+        INLINE_XREF, document_xrefstyle,
         inline_builder::{
             quotes::{LevelContext, Piece, build_match_string, source_slice},
             special_chars::Masked,
@@ -478,7 +478,14 @@ fn build_xref_node<'src>(
         window,
         resolved: None,
         derived,
-        xrefstyle,
+
+        // The *effective* style, not the macro's override: an
+        // `xrefstyle=` on the macro wins, and otherwise the document-wide
+        // `xrefstyle` **in effect at this point in the document** is resolved
+        // into the node here — the same reading, at the same moment, the string
+        // replacer makes (design §3.3.1 point 1: every order-dependent fact is
+        // resolved into node values at build time, so the fold is pure).
+        xrefstyle: xrefstyle.or_else(|| document_xrefstyle(parser)),
         attrs: None,
         location,
     })
@@ -733,7 +740,11 @@ fn build_xref_shorthand_node<'src>(
         window: None,
         resolved: None,
         derived,
-        xrefstyle: None,
+
+        // The shorthand carries no attribute list, so its effective style is
+        // the document-wide one, resolved here for the same reason the macro
+        // form resolves it here.
+        xrefstyle: document_xrefstyle(parser),
         attrs: None,
         location,
     })
@@ -745,8 +756,11 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::super::super::test_support::{
-        assert_entity, assert_styled, assert_text, build_src, fold_html, link_text_of,
+    use super::super::super::{
+        build,
+        test_support::{
+            assert_entity, assert_styled, assert_text, build_src, fold_html, link_text_of,
+        },
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -2040,15 +2054,104 @@ mod tests {
     }
 
     #[test]
-    fn an_xref_shorthand_never_carries_an_xrefstyle_override() {
-        // The `<<id>>` shorthand has no attribute-list text of its own (see the
-        // `Ref::xrefstyle` field docs): its node's `xrefstyle` override is
-        // always `None`, even though the document-wide default can still apply
-        // at fold time.
+    fn an_xref_shorthand_has_no_style_of_its_own() {
+        // The `<<id>>` shorthand has no attribute-list text to carry an
+        // override (see the `Ref::xrefstyle` field docs), so its effective
+        // style is whatever the document says — `None` under a parser with no
+        // `xrefstyle` set.
         let nodes = build_src(Span::new("<<install,Install Now>>"));
 
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.xrefstyle, None);
+    }
+
+    /// A parser whose document-wide `xrefstyle` attribute is `value`.
+    fn parser_with_xrefstyle(value: &str) -> Parser {
+        Parser::default().with_intrinsic_attribute(
+            "xrefstyle",
+            value,
+            crate::parser::ModificationContext::Anywhere,
+        )
+    }
+
+    #[test]
+    fn a_node_carries_the_effective_xrefstyle_not_the_override() {
+        // `Ref::xrefstyle` is the style **in effect where the reference was
+        // written**, resolved at build time. That is what makes the fold a pure
+        // function of the tree, which in turn is what lets it run at
+        // reference-resolution time — long after the parse, when the
+        // document-wide `xrefstyle` may have been rebound by a later
+        // `:xrefstyle:` line. See
+        // `fold_xref_reads_the_effective_xrefstyle_off_the_node`, and the
+        // whole-document fixtures in `inline_builder_document_parity`, which
+        // fail without this.
+        let parser = parser_with_xrefstyle("full");
+
+        // Both spellings pick the document-wide style up.
+        for source in ["<<install>>", "xref:install[]", "xref:install[Install Now]"] {
+            let nodes = build(Span::new(source), &parser, None);
+            let reference = assert_xref(&nodes[0]);
+
+            assert_eq!(
+                reference.xrefstyle,
+                Some(XrefStyle::Full),
+                "no document-wide style on the node for {source:?}"
+            );
+        }
+
+        // A macro-level `xrefstyle=` still wins over it.
+        let nodes = build(
+            Span::new("xref:install[Install,xrefstyle=short]"),
+            &parser,
+            None,
+        );
+        assert_eq!(assert_xref(&nodes[0]).xrefstyle, Some(XrefStyle::Short));
+
+        // And the *bare* `:xrefstyle:` spelling, which `document_xrefstyle`
+        // reads as `Basic` rather than parsing a value.
+        let set = Parser::default().with_intrinsic_attribute_bool(
+            "xrefstyle",
+            true,
+            crate::parser::ModificationContext::Anywhere,
+        );
+
+        let nodes = build(Span::new("<<install>>"), &set, None);
+        assert_eq!(assert_xref(&nodes[0]).xrefstyle, Some(XrefStyle::Basic));
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_under_a_document_wide_xrefstyle() {
+        // The differential corpus for the reading above: with the style
+        // resolved into the node rather than read at fold time, the fold still
+        // reproduces the string pipeline's bytes — the string replacer making
+        // the very same `document_xrefstyle` call in the very same pass.
+        //
+        // These fold to the *unresolved* fallback (a bare `Content` has no
+        // catalog), which is the shape both sides agree on here; the resolved
+        // shape, where `xrefstyle` actually changes the bytes, is pinned over
+        // whole documents in `inline_builder_document_parity`.
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for style in ["full", "short", "basic"] {
+            let parser = parser_with_xrefstyle(style);
+
+            for fixture in [
+                "<<install>>",
+                "<<install,Install Now>>",
+                "xref:install[]",
+                "xref:install[Install Now]",
+                "xref:install[Install,xrefstyle=short]",
+                "See <<install>> and xref:other.adoc#frag[] now.",
+            ] {
+                let folded = fold_html(&build(Span::new(fixture), &parser, None), &renderer);
+
+                assert_eq!(
+                    folded,
+                    golden_xref_with(fixture, &parser),
+                    "fold diverged from the string pipeline for {fixture:?} under xrefstyle={style:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -66,15 +66,28 @@ pub struct Ref<'src> {
     /// `None` for a [`Link`](RefVariant::Link).
     pub derived: Option<DerivedReference>,
 
-    /// For a cross-reference, the `xrefstyle=` override supplied via the
-    /// macro's own attribute-list text (`xref:id[text,xrefstyle=full]`).
-    /// `None` when the macro carries no such override — which does *not*
-    /// mean the target's reference text is used verbatim: the fold still
-    /// falls back to the document-wide `xrefstyle` attribute in effect for
-    /// this reference, mirroring `InlineXrefReplacer`'s own
-    /// `xrefstyle_override.or_else(|| document_xrefstyle(parser))`. Always
-    /// `None` for a [`Link`](RefVariant::Link) and for the `<<id>>` shorthand,
-    /// which has no attribute-list text of its own.
+    /// For a cross-reference, the **effective** `xrefstyle`: the
+    /// `xrefstyle=` override supplied via the macro's own attribute-list text
+    /// (`xref:id[text,xrefstyle=full]`) when there is one, and otherwise the
+    /// document-wide `xrefstyle` attribute **in effect at this point in the
+    /// document**. `None` means no style at all — the target's reference text
+    /// is used verbatim — rather than "ask the document". Always `None` for a
+    /// [`Link`](RefVariant::Link).
+    ///
+    /// It is resolved here, at build time, rather than read when the node is
+    /// folded, because the effective style is a *document-order* fact: a
+    /// `:xrefstyle:` line rebinds it for everything that follows, so the value
+    /// in effect where the reference was written is not generally the value in
+    /// effect at the end of the parse. Reading it at fold time would therefore
+    /// re-style a reference whenever the fold runs later than the parse — which
+    /// is precisely what a re-fold at reference-resolution time does. Resolving
+    /// it into the node is design §3.3.1 point 1 (rendering is a pure fold,
+    /// with every order-dependent fact already resolved into node values),
+    /// and it is the same reading `InlineXrefReplacer` makes, in the same
+    /// pass.
+    ///
+    /// The `<<id>>` shorthand carries no attribute-list text, so its effective
+    /// style is always the document-wide one.
     pub xrefstyle: Option<XrefStyle>,
 
     /// For a [`Link`](RefVariant::Link) whose display text carried its own

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -277,6 +277,18 @@ fn fold_matches_the_rendered_string_after_resolution() {
         "[[a]]A.\n\n[[b]]B.\n\nSee <<a>>.footnote:[and also <<b>>] and <<b>>.",
         // A footnote in a heading, beside a reference to that heading.
         "[#sect]\n== Section footnote:[a note]\n\nSee <<sect>>.",
+        // Document-wide `xrefstyle`, which only shows on a reference whose
+        // target carries a signifier (hence `:sectnums:`). The effective style
+        // is a *document-order* fact — a `:xrefstyle:` line rebinds it for
+        // everything after it — so these are what pin that the node carries the
+        // style in effect where the reference was written rather than the fold
+        // asking the document for it. Both spellings, and both the set and the
+        // rebound state.
+        ":sectnums:\n:xrefstyle: full\n\n== Install\n\nSee <<_install>> and xref:_install[].",
+        ":sectnums:\n\n== Install\n\nSee <<_install>>.\n\n:xrefstyle: full\n\nAgain <<_install>>.",
+        ":sectnums:\n:xrefstyle: full\n\n== Install\n\nSee <<_install>>.\n\n:xrefstyle: short\n\nAgain <<_install>>.",
+        // A macro-level `xrefstyle=` beside a document-wide one it overrides.
+        ":sectnums:\n:xrefstyle: full\n\n== Install\n\nSee xref:_install[xrefstyle=short].",
         // A footnote nested in a child that falls between two of its level's
         // own: the catalog's footnote list is in document order, so this
         // fixture fails on the *subtree-to-text* pairing — not only on the


### PR DESCRIPTION
**Stacked on #1258 → #1257 → #1255.** Retarget down the stack as each merges.

The first prep for the **deferred-cross-reference sentinel retirement** (§4.2's second), and the first one found by asking a question the fold-parity audit structurally cannot answer: *what does a fold that runs later than its parse read differently?*

## The defect

`Ref::xrefstyle` held the macro's own `xrefstyle=` **override**, and `fold_xref` supplied the document-wide fallback itself:

```rust
let xrefstyle = reference.xrefstyle.or_else(|| document_xrefstyle(parser));
```

That is correct only while the fold runs in the same pass as the parse. The effective style is a **document-order fact** — a `:xrefstyle:` line rebinds it for everything after it:

```asciidoc
:sectnums:

== Install

See <<_install>>.          // → Install

:xrefstyle: full

Again <<_install>>.        // → Section 1, “Install”
```

A fold running *later* than the parse reads whatever the last such line left set, so both references become `full`. A re-fold at reference-resolution time is exactly that later fold — which is what the retirement needs.

## The change

The field becomes the **effective** style, resolved at build time by whichever builder makes the node (`build_xref_node` for the macro form, `build_xref_shorthand_node` for `<<id>>`). That is the same `document_xrefstyle` reading `InlineXrefReplacer` makes, in the same pass, so the two pipelines still agree by construction.

`None` now means *no style* rather than *ask the document*, and the fold consults no document state for it — §3.3.1 point 1 ("every order-dependent fact already resolved into node values"), applied to one more fact.

## What pins it — and what doesn't

**Not the corpus-wide audit.** It compares `apply`'s own fold against `run_pipeline` within one parse, so it reads the same attribute on both sides: **0 new, 0 closed**, correctly. This whole class is invisible to it, which is worth recording — it is the second time a cutover prerequisite has been found by a different question than the audit asks.

**The whole-document harness.** `inline_builder_document_parity` folds *after* resolution with a fresh `Parser` for render context — and that detail, which looked incidental, is what makes the gap visible. Four fixtures added: `:xrefstyle:` set at the top, rebound midway, rebound to a different value, and overridden per-macro, each with `:sectnums:` so the style actually changes bytes. All four **fail on the base branch**:

```
< See <a href="#_install">Install</a> and <a href="#_install">Install</a>.
> See <a href="#_install">Section 1, &#8220;Install&#8221;</a> and …
```

Plus builder-level tests (`a_node_carries_the_effective_xrefstyle_not_the_override`, covering both spellings, the macro override, and the bare `:xrefstyle:` → `Basic` form) and a differential corpus under three document-wide styles. The two fold tests that asserted the old fallback are rewritten to assert its opposite: the same node folds the same way whatever parser it is handed.

## Verification

- `cargo test --workspace`: **5420 pass, 0 fail**.
- Fold-parity audit: **0 new, 0 closed** (and see above for why that is the expected reading).
- Coverage diff-neutral: `fold.rs` 3/3, `xref.rs` 16/7, `ref_node.rs` 0/0 — identical to base; total missed unchanged at 575/323.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_