### PR TITLE
perf: Share a snapshot's counter table by `Arc` rather than copying it

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -235,7 +235,7 @@ pub struct Parser {
     ///
     /// [counter]: https://docs.asciidoctor.org/asciidoc/latest/attributes/counters/
     /// [`attribute_value()`]: Self::attribute_value
-    pub(crate) counter_values: RefCell<HashMap<String, String>>,
+    pub(crate) counter_values: RefCell<Arc<HashMap<String, String>>>,
 
     /// Running state for inline `{counter:…}` / `{counter2:…}` counters whose
     /// target attribute is *locked* (API-set or a locked built-in).
@@ -576,7 +576,7 @@ impl Default for Parser {
             in_bibliography_list_item: Cell::new(false),
             mark_footnote_spans: Cell::new(false),
             pending_block_title: None,
-            counter_values: RefCell::new(HashMap::new()),
+            counter_values: RefCell::new(Arc::new(HashMap::new())),
             locked_counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,
@@ -770,7 +770,7 @@ impl Parser {
         self.pending_block_title = None;
 
         // Reset counter (and captioned-block) numbering for each new document.
-        self.counter_values.borrow_mut().clear();
+        Arc::make_mut(&mut self.counter_values.borrow_mut()).clear();
         self.locked_counter_values.borrow_mut().clear();
 
         // Start each parse at the outermost block-nesting level. The counter is
@@ -1373,7 +1373,7 @@ impl Parser {
         ResolvedAttributes::new(
             Arc::clone(&self.attribute_values),
             Arc::clone(&self.default_attribute_values),
-            self.counter_values.borrow().clone(),
+            Arc::clone(&self.counter_values.borrow()),
             self.safe,
             self.reference_time.clone(),
             self.input_mtime.clone(),
@@ -1510,7 +1510,7 @@ impl Parser {
 
         // Either way the partner supersedes (and resets) any counter of the
         // same name, mirroring a direct assignment.
-        self.counter_values.borrow_mut().remove(partner);
+        Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(partner);
 
         if let InterpretedValue::Unset = value {
             // The toggle is off, so the partner turns on. This mirroring
@@ -2668,7 +2668,7 @@ impl Parser {
 
         // An explicit assignment supersedes (and resets) any counter of the same
         // name.
-        self.counter_values.borrow_mut().remove(&attr_name);
+        Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(&attr_name);
 
         // The derived `backend-html5-doctype-*` attribute tracks `doctype`
         // automatically (it is synthesized on lookup), so no refresh is needed.
@@ -2693,7 +2693,7 @@ impl Parser {
             value: InterpretedValue::Value(value.as_ref().to_owned()),
         };
 
-        self.counter_values.borrow_mut().remove(&attr_name);
+        Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(&attr_name);
         Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
     }
 
@@ -2877,7 +2877,7 @@ impl Parser {
 
         // An explicit assignment supersedes (and resets) any counter of the same
         // name. This is what lets `:!name:` reset a counter.
-        self.counter_values.borrow_mut().remove(&attr_name);
+        Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(&attr_name);
 
         // The derived `backend-html5-doctype-*` attribute tracks `doctype`
         // automatically (it is synthesized on lookup), so no refresh is needed.
@@ -3042,8 +3042,7 @@ impl Parser {
                 .borrow_mut()
                 .insert(name.to_string(), next.clone());
         } else {
-            self.counter_values
-                .borrow_mut()
+            Arc::make_mut(&mut self.counter_values.borrow_mut())
                 .insert(name.to_string(), next.clone());
         }
 

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -63,7 +63,14 @@ pub(crate) struct ResolvedAttributes {
 
     /// Current value of each counter as of the end of parsing. A counter value
     /// supersedes any like-named attribute.
-    counter_values: HashMap<String, String>,
+    ///
+    /// Shared with the parser via [`Arc`], on the same copy-on-write terms as
+    /// the two tables above: every parser-side mutation goes through
+    /// [`Arc::make_mut`], so a snapshot taken here is frozen at the moment it
+    /// was taken and taking one allocates nothing. That matters because a
+    /// snapshot is no longer only an end-of-parse artifact — it is taken often
+    /// enough that a per-snapshot `HashMap` clone would show.
+    counter_values: Arc<HashMap<String, String>>,
 
     /// The safe mode the parser ran under. It is not stored in any attribute
     /// table, so the snapshot captures it here to resolve the mode-aware
@@ -136,7 +143,7 @@ impl ResolvedAttributes {
     pub(crate) fn new(
         attribute_values: Arc<HashMap<String, AttributeValue>>,
         default_attribute_values: Arc<HashMap<String, String>>,
-        counter_values: HashMap<String, String>,
+        counter_values: Arc<HashMap<String, String>>,
         safe: SafeMode,
         reference_time: Option<ReferenceTime>,
         input_mtime: Option<ReferenceTime>,
@@ -509,11 +516,70 @@ mod tests {
         ResolvedAttributes::new(
             Arc::new(attribute_values),
             Arc::new(default_attribute_values),
-            counter_values,
+            Arc::new(counter_values),
             SafeMode::Secure,
             None,
             None,
         )
+    }
+
+    #[test]
+    fn a_snapshots_counters_are_frozen_against_the_parser() {
+        // The copy-on-write property the `Arc` exists for, and the reason the
+        // counter table is shared rather than copied: a snapshot must keep
+        // reading the values that were current when it was taken, however the
+        // parser advances afterwards.
+        //
+        // The two attribute tables have always been shared this way; the
+        // counters were copied instead, which was affordable only while a
+        // snapshot was an end-of-parse artifact taken once per document.
+        //
+        // Asserted through `Parser`, not by hand, because the property is a
+        // claim about `Arc::make_mut` at the parser's own mutation sites — a
+        // hand-built `Arc` would hold no matter what those sites did.
+        let parser = crate::Parser::default();
+
+        assert_eq!(parser.counter("chapter", None), "1");
+
+        let snapshot = parser.snapshot_attributes();
+
+        assert_eq!(parser.counter("chapter", None), "2");
+        assert_eq!(parser.counter("figure", None), "1");
+
+        // The snapshot still reads `1`, and has not gained the counter that
+        // was created after it was taken.
+        assert_eq!(
+            snapshot.attribute_value("chapter"),
+            InterpretedValue::Value("1".to_string())
+        );
+
+        assert_eq!(snapshot.attribute_value("figure"), InterpretedValue::Unset);
+
+        // And a snapshot taken now sees the advanced values, so the freeze is
+        // per-snapshot rather than a table that stopped tracking.
+        let later = parser.snapshot_attributes();
+
+        assert_eq!(
+            later.attribute_value("chapter"),
+            InterpretedValue::Value("2".to_string())
+        );
+
+        // That much was already true when the table was copied: a copy is
+        // frozen too. What is new is *how* — the snapshot shares the parser's
+        // table rather than copying it, which is the whole point and the only
+        // part a test can distinguish. `later` was taken with no mutation
+        // since, so it must still be the very same allocation the parser
+        // holds; `snapshot` must not be, the parser having detached from it
+        // through `Arc::make_mut` on the next advance.
+        assert!(Arc::ptr_eq(
+            &later.counter_values,
+            &parser.counter_values.borrow()
+        ));
+
+        assert!(!Arc::ptr_eq(
+            &snapshot.counter_values,
+            &parser.counter_values.borrow()
+        ));
     }
 
     #[test]
@@ -598,7 +664,7 @@ mod tests {
         let attrs = ResolvedAttributes::new(
             Arc::new(attribute_values),
             Arc::new(HashMap::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             SafeMode::Server,
             None,
             None,
@@ -626,7 +692,7 @@ mod tests {
         let attrs = ResolvedAttributes::new(
             Arc::new(HashMap::new()),
             Arc::new(HashMap::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             SafeMode::Server,
             None,
             None,
@@ -650,7 +716,7 @@ mod tests {
         let attrs = ResolvedAttributes::new(
             Arc::new(attribute_values),
             Arc::new(HashMap::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             SafeMode::Server,
             None,
             None,
@@ -671,7 +737,7 @@ mod tests {
         let attrs = ResolvedAttributes::new(
             Arc::new(attribute_values),
             Arc::new(HashMap::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             SafeMode::Safe,
             None,
             None,
@@ -709,7 +775,7 @@ mod tests {
             ResolvedAttributes::new(
                 Arc::new(attribute_values),
                 Arc::new(HashMap::new()),
-                HashMap::new(),
+                Arc::new(HashMap::new()),
                 SafeMode::Secure,
                 None,
                 None,


### PR DESCRIPTION
**Against `main`.** First of two; the follow-on introduces `RenderContext` and is the reason this one exists.

`ResolvedAttributes` already shares the parser's two attribute tables by `Arc`, on copy-on-write terms — every parser-side mutation goes through `Arc::make_mut`, so a snapshot is frozen at the moment it was taken and taking one allocates nothing. The counter table was the exception: it was deep-copied. That was affordable only while a snapshot was an end-of-parse artifact taken once per document.

It is about to stop being that. The render context a renderer will be handed in place of the live `Parser` is built on this snapshot, so one gets taken often enough that a per-snapshot `HashMap` clone shows up.

## The change

`Parser::counter_values` becomes `RefCell<Arc<HashMap<..>>>`, its five mutation sites go through `Arc::make_mut` (which is what keeps the freeze honest), and `snapshot_attributes` shares it like the other two.

## The measurement

100,000 snapshots, release build, varying how many counters the document has advanced:

| counters | before | after | |
|---:|---:|---:|---|
| 0 | 9.9 ms | 9.6 ms | — |
| 8 | 60.0 ms | 11.1 ms | **5.4×** |
| 64 | 600.2 ms | 10.7 ms | **56×** |

Before is linear in the counter count. After is flat.

## On testing this

There is no behavioral surface here, so the suite staying green is the gate — and I want to be straight about what the new test does and does not do. `a_snapshots_counters_are_frozen_against_the_parser` **passes on `main` too**, because a copy is frozen as well; it is not a regression test for this change.

What it pins is the part a test *can* distinguish: that the snapshot now **shares** the parser's table rather than copying it (`Arc::ptr_eq`), and that it detaches on the next advance. That guards the representation against a future "optimization" to shared interior mutability, which would silently break the freeze. It drives a real `Parser` rather than a hand-built `Arc`, since the claim is about `Arc::make_mut` at the parser's own mutation sites — a hand-built `Arc` would hold no matter what those sites did.

## Verification

- `cargo test --workspace`: **4717 pass, 0 fail**.
- Coverage diff-neutral: `parser.rs` 87/73, `resolved_attributes.rs` 3/3, total 360/229 — identical to base.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_