### PR TITLE
feat: Retain each deferred content's own document attributes (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -9,7 +9,7 @@ use crate::{
     inlines::{InlineNode, RefVariant},
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
-        ResolvedReference, XrefRenderParams,
+        ResolvedAttributes, ResolvedReference, XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -102,6 +102,43 @@ pub struct Content<'src> {
     ///
     /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
     inlines: Vec<InlineNode<'src>>,
+
+    /// The document attributes as of the point in the document this content
+    /// was parsed — the *order-dependent* half of what a fold of
+    /// [`inlines`](Self::inlines) needs, and the reason it can be folded
+    /// **later than its parse**.
+    ///
+    /// Retained only for content carrying a deferred cross-reference, which is
+    /// the only content whose rendering is rebuilt after the parse (see
+    /// [`resolve_references`](Self::resolve_references)); `None` for everything
+    /// else, which is nearly everything.
+    ///
+    /// It must be taken *here* rather than read back at resolution time,
+    /// because document attributes are mutable parse state: a `:imagesdir:` or
+    /// `:icons:` line rebinds them for everything after it, so what is in
+    /// effect at the end of a document is not generally what was in effect
+    /// where this content was written.
+    ///
+    /// # Why the attributes and not a whole [`RenderContext`](crate::parser::RenderContext)
+    ///
+    /// A fold also needs the path resolver and the file handlers. Those are
+    /// *parse-wide configuration* rather than document state — they cannot
+    /// change mid-parse — so nothing is lost by not freezing them, and freezing
+    /// them here would cost something real: they are `Rc<dyn …>`, so retaining
+    /// them would make [`Content`], and with it [`Document`](crate::Document),
+    /// no longer [`Send`]/[`Sync`]. A `Document` is both today
+    /// (`document_stays_send_and_sync` pins it), which is worth more than
+    /// saving the caller from supplying the parser it already holds. The
+    /// increment that folds at resolution time assembles a `RenderContext`
+    /// from this plus that configuration.
+    ///
+    /// Boxed for the same reason [`deferred`](Self::deferred) is, and shared
+    /// from the parser by [`Arc`](std::sync::Arc) internally, so retaining one
+    /// allocates nothing beyond the box.
+    ///
+    /// Like [`inlines`](Self::inlines), it is derived rather than identifying,
+    /// so it is excluded from [`PartialEq`]/[`Eq`]/[`Hash`] and from [`Debug`].
+    render_attributes: Option<Box<ResolvedAttributes>>,
 }
 
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
@@ -229,6 +266,13 @@ pub(crate) struct OwnedTitle {
     /// The placeholder template and cross-references, when the title carries
     /// any; `None` for the (overwhelmingly common) cross-reference-free title.
     deferred: Option<(String, Vec<XrefSegment>)>,
+
+    /// The document attributes the title's own content carried, so the rebuilt
+    /// [`Content`] can still be folded later than its parse — see
+    /// [`Content::render_attributes`]. Travels with `deferred`, since the two
+    /// are populated together and a title carrying no deferred
+    /// cross-reference is never re-rendered.
+    render_attributes: Option<Box<ResolvedAttributes>>,
 }
 
 impl<'src> Content<'src> {
@@ -253,7 +297,33 @@ impl<'src> Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            render_attributes: None,
         }
+    }
+
+    /// The document attributes as of this content's own parse, when they were
+    /// retained — see [`render_attributes`](Self::render_attributes) (the
+    /// field).
+    ///
+    /// `Some` exactly for content carrying a deferred cross-reference.
+    // Consumed only by tests until the deferred-cross-reference sentinel
+    // system's retirement (design §4.2's second) folds at resolution time —
+    // the same staging the `inline_builder` module's fold and side effects
+    // are under.
+    #[allow(dead_code)]
+    pub(crate) fn render_attributes(&self) -> Option<&ResolvedAttributes> {
+        self.render_attributes.as_deref()
+    }
+
+    /// Retains `attributes` as this content's document-attribute state, for
+    /// the fold that will run after resolution.
+    ///
+    /// Called once, from
+    /// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup),
+    /// after the pipeline has run and the deferred cross-references (if any)
+    /// are known.
+    pub(crate) fn set_render_attributes(&mut self, attributes: ResolvedAttributes) {
+        self.render_attributes = Some(Box::new(attributes));
     }
 
     /// Returns a fully-owned snapshot of this content's rendered text and
@@ -266,6 +336,7 @@ impl<'src> Content<'src> {
                 .deferred
                 .as_ref()
                 .map(|d| (d.template.clone(), d.xrefs.clone())),
+            render_attributes: self.render_attributes.clone(),
         }
     }
 
@@ -282,6 +353,7 @@ impl<'src> Content<'src> {
                 .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            render_attributes: title.render_attributes,
         }
     }
 
@@ -320,6 +392,7 @@ impl<'src> Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            render_attributes: None,
         }
     }
 
@@ -1086,6 +1159,7 @@ impl<'src> From<Span<'src>> for Content<'src> {
             deferred: None,
             passthroughs: Vec::new(),
             inlines: Vec::new(),
+            render_attributes: None,
         }
     }
 }

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -282,6 +282,22 @@ impl SubstitutionGroup {
             }
 
             content.set_inlines(tree);
+
+            // Content carrying a deferred cross-reference is the only content
+            // whose rendering is rebuilt after the parse, so it is the only
+            // content that will be *folded* after the parse — and a fold needs
+            // the document attributes this content was written under, which by
+            // then the parse has moved on from. Retain them here, where "now"
+            // is still that point in the document.
+            //
+            // Nothing reads them yet: the retirement of the
+            // deferred-cross-reference sentinel system (design §4.2's second)
+            // is the increment that re-folds instead of rebuilding from the
+            // template. Landing the retention first is what keeps that step
+            // checkable — this one changes no output at all.
+            if content.deferred_parts().is_some() {
+                content.set_render_attributes(parser.snapshot_attributes());
+            }
         }
     }
 

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -434,3 +434,99 @@ fn a_stateful_renderer_is_not_required_for_the_fold() {
         );
     }
 }
+
+// The document-attribute state each content retains for the fold that will run
+// *after* resolution — design §4.2's second sentinel system, whose retirement
+// is the increment this one stages.
+
+#[test]
+fn document_stays_send_and_sync() {
+    // Retaining anything from the parser's *configuration* — its renderer,
+    // path resolver, or file handlers, all `Rc<dyn …>` — would take this away,
+    // silently, since nothing else pins it. `Parser` itself is deliberately
+    // neither; a `Document` is both, and a consumer that parses on one thread
+    // and renders on another depends on that.
+    //
+    // This is why a content retains its `ResolvedAttributes` (the
+    // order-dependent half, `Arc`-shared and thread-safe) rather than a whole
+    // `RenderContext`.
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    assert_send::<crate::Document<'static>>();
+    assert_sync::<crate::Document<'static>>();
+}
+
+#[test]
+fn only_deferred_content_retains_its_render_attributes() {
+    use crate::blocks::Block;
+
+    // Retention is deliberately narrow: a context costs a handful of
+    // reference-count bumps, but the overwhelming majority of content is never
+    // re-rendered and so never folded later than its parse.
+    let mut parser = crate::Parser::default();
+
+    let doc = parser.parse("[[tgt]]Plain paragraph.\n\nSee <<tgt>> and <<missing>>.");
+
+    let contexts: Vec<bool> = doc
+        .child_blocks()
+        .filter_map(|block| match block {
+            Block::Simple(simple) => Some(simple.content().render_attributes().is_some()),
+            _ => None,
+        })
+        .collect();
+
+    // The anchor-bearing paragraph carries no cross-reference of its own, so
+    // it needs no context; the one that does, does.
+    assert_eq!(contexts, vec![false, true]);
+
+    // And a block with no cross-references anywhere never gets one.
+    let doc = parser.parse("Just prose with an image:x.png[X].");
+
+    let Some(Block::Simple(simple)) = doc.child_blocks().next() else {
+        panic!("expected a simple block");
+    };
+
+    assert!(simple.content().render_attributes().is_none());
+}
+
+#[test]
+fn each_content_retains_the_attributes_of_its_own_point_in_the_document() {
+    use crate::blocks::Block;
+
+    // The reason the context is taken during the parse rather than
+    // reconstructed at resolution time. Document attributes are mutable parse
+    // state: `:imagesdir:` rebinds for everything after it, so the value in
+    // effect at the *end* of a document is not generally the value in effect
+    // where a given content was written.
+    //
+    // Two cross-reference-bearing paragraphs straddling a `:imagesdir:` line
+    // must therefore disagree about it — which is exactly what a fold running
+    // after resolution has to reproduce, and what a single end-of-parse
+    // snapshot could not.
+    let mut parser = crate::Parser::default();
+
+    let doc = parser.parse(concat!(
+        "[[tgt]]Target.\n\n",
+        "First <<tgt>>.\n\n",
+        ":imagesdir: img\n\n",
+        "Second <<tgt>>.",
+    ));
+
+    let dirs: Vec<String> = doc
+        .child_blocks()
+        .filter_map(|block| match block {
+            Block::Simple(simple) => simple.content().render_attributes(),
+            _ => None,
+        })
+        .map(|attributes| {
+            attributes
+                .attribute_value("imagesdir")
+                .as_maybe_str()
+                .unwrap_or("<unset>")
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(dirs, vec!["<unset>".to_string(), "img".to_string()]);
+}


### PR DESCRIPTION
**Stacked on #1263 → #1258.** Retarget down the stack as each merges.

The first prep for retiring the **deferred-cross-reference sentinel system** (§4.2's second). That increment re-folds at resolution time instead of rebuilding from a placeholder template, and a fold running *later than its parse* needs the document state the content was written under — which by then the parse has moved on from.

So a content carrying a deferred cross-reference now keeps its `ResolvedAttributes`, taken where "now" is still that point in the document. Nothing reads it yet; landing the retention while it is a no-op is what keeps the step that consumes it checkable, the same staging `apply_string_pipeline` (#1260) was landed under.

Retention is narrow on purpose: deferred content is the only content whose rendering is rebuilt after the parse, so it is the only content that will be folded after it. Everything else — nearly everything — keeps `None`.

## Why the attributes rather than a whole `RenderContext`

This was going to retain a `RenderContext`, which is what a fold actually takes. **It can't.** A `RenderContext` holds the path resolver and both file handlers as `Rc<dyn …>`, so retaining one makes `Content` — and with it `Document` — no longer `Send`/`Sync`.

`Document` is both today. I checked rather than assumed:

```
Parser    → not Send   (six Rc<dyn …>: renderer, path resolver, four handlers)
Document  → Send + Sync (holds none of them)
```

So a consumer can parse on one thread and render on another. Nothing pinned that, so the regression would have been silent — the first sign was `clippy::arc_with_non_send_sync` firing on two *pre-existing* `Arc` sites in `quote.rs` and `table.rs`. `document_stays_send_and_sync` now pins it directly.

Splitting the two halves is also just more accurate:

- **Document attributes are order-dependent.** A `:imagesdir:` or `:icons:` line rebinds them for everything after it, so they genuinely must be frozen per content.
- **The resolver and handlers are parse-wide configuration.** They cannot change mid-parse, so freezing them buys nothing.

The increment that folds at resolution time assembles a `RenderContext` from this plus that configuration, which the caller already holds.

Two things fall out nicely: `ResolvedAttributes` is `Arc`-shared internally, so retaining one allocates nothing beyond its box; and it is `Eq`, so `OwnedTitle` — which carries it across a section heading — keeps its derived equality rather than needing a hand-written one.

## Verification

- `cargo test --workspace`: **5430 pass, 0 fail**; no golden changes.
- Corpus-wide fold-parity audit: **54 unique divergences before and after, 0 new, 0 closed** — as a no-op must be.
- Coverage diff-neutral: `content.rs` 21/8, `substitution_group.rs` 0/0, total 575/323 — identical to base.
- `only_deferred_content_retains_its_render_attributes` fails if the retention guard is dropped (`[true, true]` where `[false, true]` is required). `each_content_retains_the_attributes_of_its_own_point_in_the_document` pins two cross-reference-bearing paragraphs straddling a `:imagesdir:` line disagreeing about it — which is the whole reason the snapshot is taken during the parse rather than read back afterwards.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_