### PR TITLE
feat: Fold through a `RenderContext` rather than a `Parser` (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -307,6 +307,27 @@ impl<'src> Attrlist<'src> {
     /// language via [`nth_attribute(2)`](Self::nth_attribute) — without
     /// this parser performing any syntax highlighting itself.
     ///
+    /// An attribute list with no attributes, located at `source`.
+    ///
+    /// For an inline node that carries no attribute list of its own but folds
+    /// through one anyway (a hand-built [`Image`](crate::inlines::Image), which
+    /// the builder never produces without its list). `source` should be a
+    /// zero-length slice of the node's own location, so the empty list's
+    /// lifetime and position match the node a consumer reached it from.
+    ///
+    /// This exists so the fold need not *parse* an empty span — which would
+    /// cost an attribute-reference substitution pass and, more to the point,
+    /// require a [`Parser`] at a place that has only the
+    /// document state a render needs.
+    pub(crate) fn empty(source: Span<'src>) -> Self {
+        Self {
+            attributes: vec![],
+            anchor: None,
+            source,
+            source_text: None,
+        }
+    }
+
     /// The `source` span is set to the language span, since that is the only
     /// portion of the synthesized list that appears in the document source.
     pub(crate) fn source_with_language(language: Span<'src>) -> Self {

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -264,7 +264,11 @@ impl<'src> SectionBlock<'src> {
 
         // The footnote-free rendering of the title, for the reference text and
         // auto-generated ID.
-        let title_reftext = fold_reference_text(section_title.inlines(), &*parser.renderer, parser);
+        let title_reftext = fold_reference_text(
+            section_title.inlines(),
+            &*parser.renderer,
+            &parser.render_context(),
+        );
 
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1888,7 +1888,11 @@ mod tests {
         assert_eq!(rendered, "First line.\nThird line.");
 
         assert_eq!(
-            super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+            super::super::fold_html(
+                inlines,
+                &HtmlSubstitutionRenderer {},
+                &Parser::default().render_context()
+            ),
             rendered,
             "fold diverged from the rendered string for {inlines:?}"
         );
@@ -1919,7 +1923,11 @@ mod tests {
         assert_eq!(rendered, "MyApp&lt;sup&gt;2&lt;/sup&gt;");
 
         assert_eq!(
-            super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+            super::super::fold_html(
+                inlines,
+                &HtmlSubstitutionRenderer {},
+                &Parser::default().render_context()
+            ),
             rendered,
             "fold diverged from the rendered string for {inlines:?}"
         );

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -456,7 +456,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build_verbatim(Span::new(fixture), parser, None),
                 &HtmlSubstitutionRenderer {},
-                parser,
+                &parser.render_context(),
             );
 
             assert_eq!(

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -2,8 +2,7 @@
 
 use super::{callouts::replacement_type_of, quotes::quote_type_of};
 use crate::{
-    Parser,
-    attributes::{Attrlist, AttrlistContext},
+    attributes::Attrlist,
     inlines::{
         Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm,
         Ref, RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
@@ -11,7 +10,7 @@ use crate::{
     parser::{
         CalloutGuard as ParserCalloutGuard, CalloutRenderParams, FootnoteRenderParams,
         IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer,
-        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, SpecialCharacter,
+        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, RenderContext, SpecialCharacter,
         XrefRenderParams,
     },
     strings::CowStr,
@@ -29,13 +28,21 @@ use crate::{
 /// [`Stem`](InlineNode::Stem), and [`LineBreak`](InlineNode::LineBreak), plus
 /// the design-legal [`Raw`](InlineNode::Raw) leaf; a later increment extends
 /// it as the transducer grows new kinds.
+///
+/// `context` is the document state this fold renders under — see
+/// [`RenderContext`]. It is taken as a parameter rather than derived from a
+/// [`Parser`](crate::Parser) here because a fold does not necessarily run
+/// during the parse that produced the tree: content carrying a deferred
+/// cross-reference is folded again after resolution, under the attributes that
+/// were in effect where it was *written* rather than wherever the parse ended
+/// up.
 pub(crate) fn fold_html(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
 ) -> String {
     let mut out = String::new();
-    fold_into_html(nodes, renderer, parser, Footnotes::Marked, &mut out);
+    fold_into_html(nodes, renderer, context, Footnotes::Marked, &mut out);
     out
 }
 
@@ -82,26 +89,26 @@ pub(crate) enum Footnotes {
 pub(crate) fn fold_reference_text(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
 ) -> String {
     let mut out = String::new();
-    fold_into_html(nodes, renderer, parser, Footnotes::Stripped, &mut out);
+    fold_into_html(nodes, renderer, context, Footnotes::Stripped, &mut out);
     out
 }
 
 /// Appends the fold of `nodes` to `out` (the recursive worker for
 /// [`fold_html`]).
 ///
-/// `parser` is threaded through because rendering some nodes — an
+/// `context` is threaded through because rendering some nodes — an
 /// [`Image`](InlineNode::Image), whose `render_image`/`render_icon` reads the
 /// document's safe mode, `data-uri`, and `icons`/`icontype` attributes — is a
-/// function of document context, not of the node alone. `footnotes` is
+/// function of document state, not of the node alone. `footnotes` is
 /// threaded through because a heading's own reference text omits its footnote
 /// markers wherever they sit — see [`fold_reference_text`].
 fn fold_into_html(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     footnotes: Footnotes,
     out: &mut String,
 ) {
@@ -178,27 +185,27 @@ fn fold_into_html(
             }
 
             InlineNode::Image(image) => {
-                fold_image(image, renderer, parser, out);
+                fold_image(image, renderer, context, out);
             }
 
             InlineNode::Ui(ui) => {
-                fold_ui(ui, renderer, parser, out);
+                fold_ui(ui, renderer, context, out);
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Link => {
-                fold_link(reference, renderer, parser, footnotes, out);
+                fold_link(reference, renderer, context, footnotes, out);
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => {
-                fold_xref(reference, renderer, parser, footnotes, out);
+                fold_xref(reference, renderer, context, footnotes, out);
             }
 
             InlineNode::Anchor(anchor) => {
-                fold_anchor(anchor, renderer, parser, footnotes, out);
+                fold_anchor(anchor, renderer, context, footnotes, out);
             }
 
             InlineNode::IndexTerm(index_term) => {
-                fold_index_term(index_term, renderer, parser, footnotes, out);
+                fold_index_term(index_term, renderer, context, footnotes, out);
             }
 
             InlineNode::Footnote(footnote) => {
@@ -213,7 +220,7 @@ fn fold_into_html(
             }
 
             InlineNode::Callout(callout) => {
-                fold_callout(callout, renderer, parser, out);
+                fold_callout(callout, renderer, context, out);
             }
 
             InlineNode::Stem(stem) => {
@@ -225,7 +232,7 @@ fn fold_into_html(
                 // string pipeline's quotes step did: the same `QuoteType`,
                 // attribute list, and id it recognized, so the bytes match.
                 let mut body = String::new();
-                fold_into_html(&styled.children, renderer, parser, footnotes, &mut body);
+                fold_into_html(&styled.children, renderer, context, footnotes, &mut body);
 
                 let scope = match styled.form {
                     SpanForm::Constrained => QuoteScope::Constrained,
@@ -292,7 +299,7 @@ pub(super) fn render_char(ch: char, renderer: &dyn InlineSubstitutionRenderer, o
 fn fold_image(
     image: &Image<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     out: &mut String,
 ) {
     // A macro-built image always carries its attribute list; a node hand-built
@@ -303,9 +310,7 @@ fn fold_image(
         Some(attrlist) => attrlist,
 
         None => {
-            empty = Attrlist::parse(image.location.slice(0..0), parser, AttrlistContext::Inline)
-                .item
-                .item;
+            empty = Attrlist::empty(image.location.slice(0..0));
 
             &empty
         }
@@ -318,8 +323,6 @@ fn fold_image(
         .unwrap_or_default();
 
     if image.is_icon {
-        let context = parser.render_context();
-
         let params = IconRenderParams {
             target: image.target.as_ref(),
             restored_target_ranges: &image.restored_target_ranges,
@@ -328,13 +331,11 @@ fn fold_image(
                 .named_or_positional_attribute("size", 1)
                 .map(|a| a.value()),
             attrlist,
-            context: &context,
+            context,
         };
 
         renderer.render_icon(&params, out);
     } else {
-        let context = parser.render_context();
-
         let params = ImageRenderParams {
             target: image.target.as_ref(),
             restored_target_ranges: &image.restored_target_ranges,
@@ -342,7 +343,7 @@ fn fold_image(
             width: image.width.as_deref(),
             height: image.height.as_deref(),
             attrlist,
-            context: &context,
+            context,
         };
 
         renderer.render_image(&params, out);
@@ -353,12 +354,12 @@ fn fold_image(
 /// `render_keyboard`/`render_button`/`render_menu` the string pipeline's macros
 /// step calls, reconstructing the render parameters from the keys / label /
 /// menu path the macro step captured, so the output is byte-for-byte identical.
-/// `parser` is threaded through because rendering a menu reads the document's
+/// `context` is threaded through because rendering a menu reads the document's
 /// `icons` attribute to choose the caret between menu levels.
 fn fold_ui(
     ui: &Ui<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     out: &mut String,
 ) {
     match &ui.kind {
@@ -378,13 +379,11 @@ fn fold_ui(
         } => {
             let submenus: Vec<String> = submenus.iter().map(|s| s.to_string()).collect();
 
-            let context = parser.render_context();
-
             let params = MenuRenderParams {
                 menu: menu.as_ref(),
                 submenus: &submenus,
                 menuitem: item.as_deref(),
-                context: &context,
+                context,
             };
 
             renderer.render_menu(&params, out);
@@ -404,7 +403,7 @@ fn fold_ui(
 fn fold_link(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     footnotes: Footnotes,
     out: &mut String,
 ) {
@@ -412,7 +411,7 @@ fn fold_link(
     fold_into_html(
         &reference.children,
         renderer,
-        parser,
+        context,
         footnotes,
         &mut link_text,
     );
@@ -425,13 +424,7 @@ fn fold_link(
         Some(attrs) => attrs,
 
         None => {
-            empty_attrlist = Attrlist::parse(
-                reference.location.slice(0..0),
-                parser,
-                AttrlistContext::Inline,
-            )
-            .item
-            .item;
+            empty_attrlist = Attrlist::empty(reference.location.slice(0..0));
 
             &empty_attrlist
         }
@@ -439,15 +432,13 @@ fn fold_link(
 
     let extra_roles: Vec<&str> = reference.roles.iter().map(|r| r.as_ref()).collect();
 
-    let context = parser.render_context();
-
     let params = LinkRenderParams {
         target: reference.target.to_string(),
         link_text,
         extra_roles,
         window: reference.window.as_deref(),
         attrlist,
-        context: &context,
+        context,
     };
 
     renderer.render_link(&params, out);
@@ -473,7 +464,7 @@ fn fold_link(
 fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     footnotes: Footnotes,
     out: &mut String,
 ) {
@@ -481,7 +472,7 @@ fn fold_xref(
     fold_into_html(
         &reference.children,
         renderer,
-        parser,
+        context,
         footnotes,
         &mut provided,
     );
@@ -548,7 +539,7 @@ fn fold_xref(
 fn fold_anchor(
     anchor: &Anchor<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     footnotes: Footnotes,
     out: &mut String,
 ) {
@@ -557,7 +548,7 @@ fn fold_anchor(
     } else {
         anchor.reftext.as_ref().map(|children| {
             let mut s = String::new();
-            fold_into_html(children, renderer, parser, footnotes, &mut s);
+            fold_into_html(children, renderer, context, footnotes, &mut s);
             s
         })
     };
@@ -595,7 +586,7 @@ fn fold_anchor(
 fn fold_index_term(
     index_term: &IndexTerm<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     footnotes: Footnotes,
     out: &mut String,
 ) {
@@ -608,7 +599,7 @@ fn fold_index_term(
             fold_into_html(
                 &index_term.children,
                 renderer,
-                parser,
+                context,
                 footnotes,
                 &mut folded_children,
             );
@@ -675,7 +666,7 @@ fn fold_footnote(
 fn fold_callout(
     callout: &Callout<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
-    parser: &Parser,
+    context: &RenderContext,
     out: &mut String,
 ) {
     let guard = match &callout.guard {
@@ -683,13 +674,11 @@ fn fold_callout(
         CalloutGuard::Xml => ParserCalloutGuard::Xml,
     };
 
-    let context = parser.render_context();
-
     renderer.render_callout(
         &CalloutRenderParams {
             number: callout.number.as_ref(),
             guard,
-            context: &context,
+            context,
         },
         out,
     );
@@ -737,7 +726,7 @@ mod tests {
 
     use super::{
         super::test_support::{build_src, fold_html},
-        fold_html as fold_html_with_parser,
+        fold_html as fold_html_with_context,
     };
     use crate::{
         Parser, Span,
@@ -822,13 +811,13 @@ mod tests {
             );
 
             assert_eq!(
-                fold_html_with_parser(&nodes, &renderer, &built_parser),
+                fold_html_with_context(&nodes, &renderer, &built_parser.render_context()),
                 golden.rendered_html(),
                 "the heading's own rendering diverged for {fixture:?}"
             );
 
             assert_eq!(
-                super::fold_reference_text(&nodes, &renderer, &built_parser),
+                super::fold_reference_text(&nodes, &renderer, &built_parser.render_context()),
                 expected_reftext,
                 "the footnote-free reference text diverged for {fixture:?}"
             );
@@ -978,17 +967,20 @@ mod tests {
         );
 
         // `None` on the node means "no style", not "ask the document".
-        let unstyled =
-            fold_html_with_parser(&[resolved_xref_with_signifier(None)], &renderer, &full);
+        let unstyled = fold_html_with_context(
+            &[resolved_xref_with_signifier(None)],
+            &renderer,
+            &full.render_context(),
+        );
 
         assert!(!unstyled.contains("Section 2"), "folded: {unstyled}");
 
         // And a node carrying a style is honored even by a parser that has
         // none set.
-        let styled = fold_html_with_parser(
+        let styled = fold_html_with_context(
             &[resolved_xref_with_signifier(Some(XrefStyle::Full))],
             &renderer,
-            &Parser::default(),
+            &Parser::default().render_context(),
         );
 
         assert!(styled.contains("Section 2, &#8220;"), "folded: {styled}");
@@ -1007,7 +999,7 @@ mod tests {
             ModificationContext::Anywhere,
         );
 
-        let folded = fold_html_with_parser(&nodes, &renderer, &parser);
+        let folded = fold_html_with_context(&nodes, &renderer, &parser.render_context());
 
         // `Short` shows only the signifier label, with none of `Full`'s
         // quoted-title suffix.

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1524,7 +1524,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     &nodes,
                     &HtmlSubstitutionRenderer {},
-                    &expanding_parser()
+                    &expanding_parser().render_context()
                 ),
                 golden_normal(source, &expanding_parser()),
                 "fold diverged from the string pipeline for {source:?}"
@@ -1691,7 +1691,7 @@ and another.footnote:[note two]",
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -730,7 +730,7 @@ fn anchor_reftext_string(anchor: &Anchor<'_>, parser: &Parser) -> Option<String>
             other => out.push_str(&fold_html(
                 std::slice::from_ref(other),
                 parser.renderer.as_ref(),
-                parser,
+                &parser.render_context(),
             )),
         }
     }
@@ -1066,7 +1066,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -1179,7 +1179,7 @@ mod tests {
         let folded = crate::content::inline_builder::fold_html(
             &nodes,
             &HtmlSubstitutionRenderer {},
-            &parser,
+            &parser.render_context(),
         );
 
         assert_eq!(folded, golden, "fold diverged from the string pipeline");
@@ -1227,7 +1227,7 @@ mod tests {
         let folded = crate::content::inline_builder::fold_html(
             &nodes,
             &HtmlSubstitutionRenderer {},
-            &parser,
+            &parser.render_context(),
         );
         assert_eq!(folded, golden, "fold diverged from the real pipeline");
     }
@@ -1275,7 +1275,7 @@ mod tests {
         let folded = crate::content::inline_builder::fold_html(
             &nodes,
             &HtmlSubstitutionRenderer {},
-            &parser,
+            &parser.render_context(),
         );
         assert_eq!(folded, golden, "fold diverged from the string pipeline");
     }
@@ -1604,7 +1604,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build_with(Span::new(fixture), &parser),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -1718,7 +1718,7 @@ mod tests {
         let folded = crate::content::inline_builder::fold_html(
             &nodes,
             &HtmlSubstitutionRenderer {},
-            &parser,
+            &parser.render_context(),
         );
 
         assert_eq!(folded, golden_attributes_with(source, &parser));
@@ -1751,7 +1751,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &nodes,
                 &HtmlSubstitutionRenderer {},
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(folded, golden_passthroughs_with(source, &parser));
@@ -1799,7 +1799,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &nodes,
                 &HtmlSubstitutionRenderer {},
-                &parser,
+                &parser.render_context(),
             );
 
             assert_ne!(folded, golden_passthroughs_with(source, &parser));
@@ -1961,7 +1961,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default(),
+                    &Parser::default().render_context(),
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1077,7 +1077,11 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
 
                 Some(MaskedPiece {
                     node,
-                    body: Cow::Owned(fold_html(std::slice::from_ref(node), renderer, parser)),
+                    body: Cow::Owned(fold_html(
+                        std::slice::from_ref(node),
+                        renderer,
+                        &parser.render_context(),
+                    )),
                     rendered: true,
                 })
             });
@@ -1341,7 +1345,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -2387,7 +2391,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -2509,7 +2513,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build_with(Span::new(fixture), &parser),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -2549,7 +2553,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     &build_with(Span::new(source), parser),
                     &renderer,
-                    parser,
+                    &parser.render_context(),
                 )
             };
 
@@ -3040,7 +3044,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -3140,7 +3144,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1378,7 +1378,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -1405,7 +1405,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     section.section_title_inlines(),
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 section.section_title(),
                 "fold diverged from the rendered section title"
@@ -1526,7 +1526,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -1656,7 +1656,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     &nodes,
                     &HtmlSubstitutionRenderer {},
-                    &parser
+                    &parser.render_context()
                 ),
                 golden.rendered_str(),
                 "fold diverged from the string pipeline for {source:?}"
@@ -1822,7 +1822,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -1846,7 +1846,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     section.section_title_inlines(),
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 section.section_title(),
                 "fold diverged from the rendered section title"
@@ -1892,7 +1892,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -1919,7 +1919,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     section.section_title_inlines(),
                     &HtmlSubstitutionRenderer {},
-                    &crate::Parser::default()
+                    &crate::Parser::default().render_context()
                 ),
                 section.section_title(),
                 "fold diverged from the rendered section title"

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2283,7 +2283,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -2386,7 +2386,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -2561,7 +2561,7 @@ mod tests {
                 let folded = crate::content::inline_builder::fold_html(
                     &build_with(Span::new(fixture), &parser),
                     &renderer,
-                    &parser,
+                    &parser.render_context(),
                 );
 
                 assert_eq!(
@@ -2622,7 +2622,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -2854,7 +2854,7 @@ mod tests {
             crate::content::inline_builder::fold_html(
                 &nodes,
                 &HtmlSubstitutionRenderer {},
-                &parser
+                &parser.render_context()
             ),
             golden_macros_with(source, &parser)
         );
@@ -3213,7 +3213,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -3337,7 +3337,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -3815,7 +3815,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -3857,7 +3857,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -6020,7 +6020,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -6064,7 +6064,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -6106,7 +6106,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -6150,7 +6150,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -6559,7 +6559,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &HtmlSubstitutionRenderer {},
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -822,8 +822,11 @@ pub(super) fn restored_markup_text(
             continue;
         }
 
-        let markup =
-            super::fold::fold_html(std::slice::from_ref(node), parser.renderer.as_ref(), parser);
+        let markup = super::fold::fold_html(
+            std::slice::from_ref(node),
+            parser.renderer.as_ref(),
+            &parser.render_context(),
+        );
 
         out = out.replace(&format!("\u{96}{n}\u{97}"), &markup);
     }
@@ -1149,7 +1152,11 @@ mod tests {
             // drop. (No `{source:?}` message: a multi-line assertion's message
             // argument is a failure-only region, which the coverage report
             // counts as an uncovered line in a file whose tests it measures.)
-            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+            let folded = fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context(),
+            );
 
             assert_eq!(folded, content.rendered_html());
             assert!(!folded.contains('\\'));
@@ -1248,7 +1255,11 @@ mod tests {
                         None,
                     );
 
-                    let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+                    let folded = fold_html(
+                        &nodes,
+                        &HtmlSubstitutionRenderer {},
+                        &parser.render_context(),
+                    );
 
                     assert_eq!(folded, content.rendered_html(), "{source:?}");
                     assert!(folded.contains(expected), "{source:?}: {folded:?}");
@@ -1288,7 +1299,11 @@ mod tests {
                 None,
             );
 
-            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+            let folded = fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context(),
+            );
 
             assert_eq!(folded, content.rendered_html(), "{source:?}");
             assert!(folded.contains(expected), "{source:?}: {folded:?}");
@@ -1383,7 +1398,11 @@ mod tests {
             );
 
             assert_eq!(
-                fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+                fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &parser.render_context()
+                ),
                 content.rendered_html(),
                 "fold diverged from the string pipeline for {source:?}"
             );
@@ -1435,7 +1454,11 @@ mod tests {
             );
 
             assert_eq!(
-                fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser),
+                fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &built_parser.render_context()
+                ),
                 content.rendered_html(),
                 "fold diverged from the string pipeline for {source:?}"
             );
@@ -1560,7 +1583,7 @@ mod tests {
                 fold_html(
                     &build(Span::new(source), &Parser::default(), None),
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default(),
+                    &Parser::default().render_context(),
                 ),
                 folded_html,
             );

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -492,7 +492,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -649,7 +649,7 @@ mod tests {
             crate::content::inline_builder::fold_html(
                 &nodes,
                 &HtmlSubstitutionRenderer {},
-                &experimental_parser()
+                &experimental_parser().render_context()
             ),
             golden_macros_with("\\kbd:[X]", &experimental_parser())
         );
@@ -793,7 +793,7 @@ mod tests {
             let folded = crate::content::inline_builder::fold_html(
                 &build(Span::new(fixture), &parser, None),
                 &renderer,
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(
@@ -957,7 +957,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     &nodes,
                     &HtmlSubstitutionRenderer {},
-                    &parser
+                    &parser.render_context()
                 ),
                 golden_normal(source, &parser),
                 "fold diverged from the string pipeline for {source:?}"
@@ -1053,7 +1053,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     &nodes,
                     &HtmlSubstitutionRenderer {},
-                    &parser
+                    &parser.render_context()
                 ),
                 golden_normal(filtered, &parser),
                 "fold diverged from the string pipeline for {filtered:?}"
@@ -1090,7 +1090,7 @@ mod tests {
             crate::content::inline_builder::fold_html(
                 inlines,
                 &HtmlSubstitutionRenderer {},
-                &Parser::default()
+                &Parser::default().render_context()
             ),
             rendered,
             "fold diverged from the rendered string for {inlines:?}"
@@ -1131,7 +1131,7 @@ mod tests {
             crate::content::inline_builder::fold_html(
                 inlines,
                 &HtmlSubstitutionRenderer {},
-                &Parser::default()
+                &Parser::default().render_context()
             ),
             rendered,
             "fold diverged from the rendered string for {inlines:?}"

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1276,7 +1276,7 @@ mod tests {
             super::super::super::fold_html(
                 inlines,
                 &HtmlSubstitutionRenderer {},
-                &Parser::default()
+                &Parser::default().render_context()
             ),
             rendered,
             "fold diverged from the rendered string for {inlines:?}"
@@ -2223,7 +2223,11 @@ mod tests {
         assert_eq!(reference.target.as_ref(), "install");
         assert_eq!(reference.derived, None);
 
-        let folded = super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+        let folded = super::super::super::fold_html(
+            &nodes,
+            &HtmlSubstitutionRenderer {},
+            &parser.render_context(),
+        );
         assert!(folded.contains(r##"href="#install""##), "folded: {folded}");
         assert_eq!(folded, golden_xref_with(source, &parser));
     }
@@ -2250,7 +2254,11 @@ mod tests {
             .expect("a fragmentless self-reference carries a derived destination");
         assert_eq!(derived.href, "#");
 
-        let folded = super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser);
+        let folded = super::super::super::fold_html(
+            &nodes,
+            &HtmlSubstitutionRenderer {},
+            &parser.render_context(),
+        );
         assert_eq!(folded, golden_xref_with(source, &parser));
     }
 
@@ -2340,7 +2348,11 @@ mod tests {
             let nodes = super::super::super::build(Span::new(source), &parser, None);
 
             assert_eq!(
-                super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+                super::super::super::fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &parser.render_context()
+                ),
                 golden_normal(source, &parser),
                 "fold diverged from the string pipeline for {source:?}"
             );
@@ -2404,7 +2416,11 @@ mod tests {
         }
 
         assert_eq!(
-            super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            super::super::super::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context()
+            ),
             golden_normal(source, &parser)
         );
     }
@@ -2435,7 +2451,11 @@ mod tests {
         );
 
         assert_eq!(
-            super::super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            super::super::super::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context()
+            ),
             golden_normal(source, &parser)
         );
     }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -753,7 +753,11 @@ mod tests {
     /// a real cutover would call — through the built-in HTML renderer.
     fn built(source: &str, parser: &Parser) -> String {
         let nodes = build(Span::new(source), parser, None);
-        fold_html(&nodes, &HtmlSubstitutionRenderer {}, parser)
+        fold_html(
+            &nodes,
+            &HtmlSubstitutionRenderer {},
+            &parser.render_context(),
+        )
     }
 
     /// Asserts that `source` folds identically whether taken through the real
@@ -1872,7 +1876,11 @@ mod tests {
                 &built_parser,
                 None,
             );
-            let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+            let built = fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &built_parser.render_context(),
+            );
 
             assert_eq!(
                 built, golden,
@@ -1943,7 +1951,11 @@ mod tests {
 
             let built_parser = parser_with_product();
             let nodes = build_group(group, source, &built_parser);
-            let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+            let built = fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &built_parser.render_context(),
+            );
 
             assert_eq!(
                 built, golden,
@@ -2723,7 +2735,11 @@ mod tests {
 
                 let built_parser = parser_with_product();
                 let nodes = build_group(&group, source, &built_parser);
-                let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+                let built = fold_html(
+                    &nodes,
+                    &HtmlSubstitutionRenderer {},
+                    &built_parser.render_context(),
+                );
 
                 assert_ne!(
                     built, golden,
@@ -2777,7 +2793,11 @@ mod tests {
 
             let built_parser = parser_with_product();
             let nodes = build_group(&group, source, &built_parser);
-            let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+            let built = fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &built_parser.render_context(),
+            );
 
             assert_eq!(built, golden);
         }
@@ -2841,7 +2861,11 @@ mod tests {
             &built_parser,
             None,
         );
-        let built = fold_html(&nodes, &HtmlSubstitutionRenderer {}, &built_parser);
+        let built = fold_html(
+            &nodes,
+            &HtmlSubstitutionRenderer {},
+            &built_parser.render_context(),
+        );
 
         assert_eq!(built, golden);
     }

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1386,12 +1386,16 @@ mod tests {
         let nodes = build_src(Span::new("+a < b > c & d+"));
 
         assert_eq!(
-            super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            super::super::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context()
+            ),
             "a &lt; b &gt; c &amp; d"
         );
 
         assert_eq!(
-            super::super::fold_html(&nodes, &BracketRenderer, &parser),
+            super::super::fold_html(&nodes, &BracketRenderer, &parser.render_context()),
             "a [LT] b [GT] c [AMP] d"
         );
     }
@@ -1472,12 +1476,16 @@ mod tests {
         let nodes = build_src(Span::new("++a < b > c & d++"));
 
         assert_eq!(
-            super::super::fold_html(&nodes, &HtmlSubstitutionRenderer {}, &parser),
+            super::super::fold_html(
+                &nodes,
+                &HtmlSubstitutionRenderer {},
+                &parser.render_context()
+            ),
             "a &lt; b &gt; c &amp; d"
         );
 
         assert_eq!(
-            super::super::fold_html(&nodes, &BracketRenderer, &parser),
+            super::super::fold_html(&nodes, &BracketRenderer, &parser.render_context()),
             "a [LT] b [GT] c [AMP] d"
         );
 
@@ -1486,7 +1494,7 @@ mod tests {
         let raw = build_src(Span::new("+++a < b+++"));
 
         assert_eq!(
-            super::super::fold_html(&raw, &BracketRenderer, &parser),
+            super::super::fold_html(&raw, &BracketRenderer, &parser.render_context()),
             "a < b"
         );
     }
@@ -2085,7 +2093,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
@@ -2233,7 +2241,7 @@ mod tests {
                 crate::content::inline_builder::fold_html(
                     inlines,
                     &HtmlSubstitutionRenderer {},
-                    &Parser::default()
+                    &Parser::default().render_context()
                 ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -2620,7 +2620,11 @@ mod tests {
             };
 
             assert_eq!(
-                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                super::super::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default().render_context()
+                ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
             );
@@ -2663,7 +2667,11 @@ mod tests {
             };
 
             assert_eq!(
-                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                super::super::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default().render_context()
+                ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
             );
@@ -2708,7 +2716,11 @@ mod tests {
             };
 
             assert_eq!(
-                super::super::fold_html(inlines, &HtmlSubstitutionRenderer {}, &Parser::default()),
+                super::super::fold_html(
+                    inlines,
+                    &HtmlSubstitutionRenderer {},
+                    &Parser::default().render_context()
+                ),
                 rendered,
                 "fold diverged from the rendered string for {inlines:?}"
             );
@@ -3860,7 +3872,11 @@ mod tests {
             ),
         ] {
             let nodes = build_src(Span::new(source));
-            let folded = super::super::fold_html(&nodes, &renderer, &crate::Parser::default());
+            let folded = super::super::fold_html(
+                &nodes,
+                &renderer,
+                &crate::Parser::default().render_context(),
+            );
             let golden = golden_passthroughs(source);
 
             assert_eq!(golden, golden_html);
@@ -3965,7 +3981,7 @@ mod tests {
             let folded = super::super::fold_html(
                 &super::super::build(Span::new(source), &parser, None),
                 &HtmlSubstitutionRenderer {},
-                &parser,
+                &parser.render_context(),
             );
 
             assert_eq!(folded, content.rendered_str(), "mismatch for {source:?}");
@@ -4017,7 +4033,7 @@ mod tests {
             let folded = super::super::fold_html(
                 &super::super::build(Span::new(source), &parser, None),
                 &HtmlSubstitutionRenderer {},
-                &parser,
+                &parser.render_context(),
             );
 
             assert_ne!(

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -314,7 +314,11 @@ pub(super) fn flatten_prior_markup<'src>(
             }
 
             let location = node.span();
-            let value = fold_html(std::slice::from_ref(&as_pre_escape(node)), renderer, parser);
+            let value = fold_html(
+                std::slice::from_ref(&as_pre_escape(node)),
+                renderer,
+                &parser.render_context(),
+            );
 
             InlineNode::Text {
                 value: CowStr::from(value),

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -22,7 +22,7 @@ use crate::{
 /// `data-uri`, and `icons` attributes); tests that need a non-default
 /// document call [`super::fold_html`] directly with their own parser.
 pub(super) fn fold_html(nodes: &[InlineNode<'_>], renderer: &HtmlSubstitutionRenderer) -> String {
-    super::fold_html(nodes, renderer, &Parser::default())
+    super::fold_html(nodes, renderer, &Parser::default().render_context())
 }
 
 /// Builds the single-pass tree for `source` with a default parser and no

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -275,8 +275,11 @@ impl SubstitutionGroup {
             // the template path end to end rather than having the two
             // mechanisms interleave.
             if content.deferred_parts().is_none() {
-                let folded =
-                    crate::content::inline_builder::fold_html(&tree, &*parser.renderer, parser);
+                let folded = crate::content::inline_builder::fold_html(
+                    &tree,
+                    &*parser.renderer,
+                    &parser.render_context(),
+                );
 
                 content.rendered = crate::strings::CowStr::from(folded);
             }

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -199,7 +199,7 @@ fn check_document(source: &str) -> Vec<String> {
 
     for location in &locations {
         assert_eq!(
-            fold_html(location.inlines, &renderer, &fold_parser),
+            fold_html(location.inlines, &renderer, &fold_parser.render_context()),
             location.rendered,
             "the {} fold diverged from its rendered string for {source:?}",
             location.what
@@ -235,7 +235,7 @@ fn check_document(source: &str) -> Vec<String> {
 
     for (subtree, text) in subtrees.iter().zip(texts.iter()) {
         assert_eq!(
-            &fold_html(subtree, &renderer, &fold_parser),
+            &fold_html(subtree, &renderer, &fold_parser.render_context()),
             text,
             "a footnote's subtree fold diverged from its registered text for {source:?}"
         );
@@ -387,7 +387,13 @@ fn fold_matches_the_rendered_string_after_resolution() {
 
     let folded: Vec<String> = locations(&doc)
         .iter()
-        .map(|l| fold_html(l.inlines, &HtmlSubstitutionRenderer {}, &Parser::default()))
+        .map(|l| {
+            fold_html(
+                l.inlines,
+                &HtmlSubstitutionRenderer {},
+                &Parser::default().render_context(),
+            )
+        })
         .collect();
 
     assert!(
@@ -416,8 +422,16 @@ fn a_stateful_renderer_is_not_required_for_the_fold() {
     let fold_parser = Parser::default();
 
     for location in locations(&doc) {
-        let once = fold_html(location.inlines, &HtmlSubstitutionRenderer {}, &fold_parser);
-        let twice = fold_html(location.inlines, &HtmlSubstitutionRenderer {}, &fold_parser);
+        let once = fold_html(
+            location.inlines,
+            &HtmlSubstitutionRenderer {},
+            &fold_parser.render_context(),
+        );
+        let twice = fold_html(
+            location.inlines,
+            &HtmlSubstitutionRenderer {},
+            &fold_parser.render_context(),
+        );
 
         assert_eq!(once, twice);
         assert_eq!(once, location.rendered);
@@ -429,7 +443,11 @@ fn a_stateful_renderer_is_not_required_for_the_fold() {
 
     for location in locations(&doc) {
         assert_eq!(
-            fold_html(location.inlines, shared.as_ref(), &fold_parser),
+            fold_html(
+                location.inlines,
+                shared.as_ref(),
+                &fold_parser.render_context()
+            ),
             location.rendered
         );
     }


### PR DESCRIPTION
**Stacked on #1267.** Retarget to `inline-ast` once that merges.

The second prep for retiring the **deferred-cross-reference sentinel system** (§4.2's second), and the one that finishes what merging `main` started.

`RenderContext` landed on `main` (#1265) as the document state a renderer reads. The merge wired the string pipeline's own call sites to it but left the fold taking a `&Parser` and **building a context per rendered element** — a faithful merge, but the wrong shape. A fold that runs *later than its parse* cannot derive its context from the live parser, because the document attributes have moved on; content carrying a deferred cross-reference is folded again after resolution, under the attributes in effect where it was *written*.

So the fold takes the context instead, threaded from the one place that starts it. That is also strictly less work: the per-element construction the merge introduced is gone, and with it the ~117 ns per rendered element #1265 measured.

## Two things had to move first

- **`fold_image` and `fold_link` parsed an empty `Attrlist`** for a hand-built node carrying none — and a parse needs a `Parser`. `Attrlist::empty` builds the zero-attribute list directly, keeping the node's own zero-length location so lifetime and position still match. It also removes a whole attribute-reference substitution pass from that path.

- **The builder's own five internal folds** (a masked piece's body, an anchor's reference text, the pre-escape probe, the restored-markup splice, and the title's reference text) each take `parser.render_context()` at their call site, where a parser is in hand.

The remaining ~90 call sites are tests, swept mechanically — I drove the edits from `rustc`'s own error spans rather than by regex, so every one is a site the compiler identified.

## No behavior change

The context a fold now receives is the one it was building for itself.

- `cargo test --workspace`: **5430 pass, 0 fail**; no golden changes.
- Corpus-wide fold-parity audit: **54 unique divergences before and after, 0 new, 0 closed**.
- Coverage diff-neutral: `fold.rs` 3/3, `attrlist.rs` 0/0 (100%), total 575/323 — identical to base.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

I also swept `fold.rs`'s doc comments for references to the parameter this replaces, having been caught by exactly that twice on #1265.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_