### PR TITLE
fix: Don't panic on an inline image macro with no target

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -225,6 +225,23 @@ fn apply_macros_internal(
     content.set_deferred_xrefs(xrefs);
 }
 
+/// Matches an [inline image] (`image:target[…]`) or [inline icon]
+/// (`icon:target[…]`) macro.
+///
+/// ## Examples
+///
+/// * `image:sunset.jpg[]`
+/// * `image:sunset.jpg[Sunset,300,200]`
+/// * `icon:tags[]`
+/// * `icon:t[]` — a single-character target
+///
+/// The target is required; only its trailing portion is optional, so a
+/// one-character target matches but an empty one does not. A macro written
+/// without a target (`image:[]`) is thus left as literal text, matching
+/// Asciidoctor's `InlineImageMacroRx`.
+///
+/// [inline image]: https://docs.asciidoctor.org/asciidoc/latest/macros/images/
+/// [inline icon]: https://docs.asciidoctor.org/asciidoc/latest/macros/icons/
 static INLINE_IMAGE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
@@ -232,11 +249,14 @@ static INLINE_IMAGE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
             \\?                         # Optional escape: literal backslash
             i(?:mage|con):              # 'image:' or 'icon:' prefix
 
-            (                           # Group 1: the target
+            (                           # Group 1: the target (required)
                 [^:\s\[\n]                  # First char: not colon, whitespace, [, or newline
-                [^\[\n]*?                   # Middle chars: any except [ or newline, lazily
-                [^\s\[\n]                   # Last char: not whitespace, [, or newline
-            )?                          # Entire target group is optional
+                (?:                         # Remainder is optional: a target
+                                            # may be a single character
+                    [^\[\n]*?                   # Middle chars: any except [ or newline, lazily
+                    [^\s\[\n]                   # Last char: not whitespace, [, or newline
+                )?
+            )
 
             \[                          # Opening square bracket
 
@@ -2091,6 +2111,59 @@ mod tests {
         #[test]
         fn leaves_select_non_word_characters_unencoded() {
             assert_eq!(encode_uri_component("-.~"), "-.~");
+        }
+    }
+
+    mod inline_image_macro {
+        use crate::{
+            content::{Content, SubstitutionStep},
+            strings::CowStr,
+            tests::prelude::*,
+        };
+
+        fn apply_macros(source: &'static str) -> Content<'static> {
+            let mut content = Content::from(crate::Span::new(source));
+            SubstitutionStep::Macros.apply(&mut content, &Parser::default(), None);
+            content
+        }
+
+        // An `image:`/`icon:` macro written without a target is not an image
+        // macro (Asciidoctor's `InlineImageMacroRx` requires one), so the text
+        // is left exactly as the author typed it. This used to panic: the
+        // target capture group was optional but indexed unconditionally.
+        #[test]
+        fn image_macro_without_target_is_left_literal() {
+            let content = apply_macros("image:[]");
+            assert_eq!(content.rendered, CowStr::Borrowed("image:[]"));
+        }
+
+        #[test]
+        fn icon_macro_without_target_is_left_literal() {
+            let content = apply_macros("icon:[]");
+            assert_eq!(content.rendered, CowStr::Borrowed("icon:[]"));
+        }
+
+        // Same, with alt text in the brackets and surrounding text: the macro
+        // is not recognized, and no part of the line is consumed.
+        #[test]
+        fn image_macro_without_target_but_with_alt_text_is_left_literal() {
+            let content = apply_macros("See image:[alt] here.");
+            assert_eq!(content.rendered, CowStr::Borrowed("See image:[alt] here."));
+        }
+
+        // Only the *trailing* portion of the target is optional, so a
+        // one-character target is a valid macro.
+        #[test]
+        fn single_character_target_is_an_image() {
+            let content = apply_macros("image:a[Alt]");
+            assert_eq!(
+                content.rendered,
+                CowStr::Boxed(
+                    r#"<span class="image"><img src="a" alt="Alt"></span>"#
+                        .to_string()
+                        .into_boxed_str()
+                )
+            );
         }
     }
 


### PR DESCRIPTION
Fixes #1236.

## Problem

`Parser::default().parse("image:[]")` panicked inside `regex`:

```
panicked at regex-1.13.1/src/regex/string.rs:2073:32:
no group at index '1'
```

`INLINE_IMAGE_MACRO` in `parser/src/content/macros.rs` marked the *entire* target group optional:

```
(
    [^:\s\[\n]
    [^\[\n]*?
    [^\s\[\n]
)?      # <- entire target group optional
```

while `InlineImageMacroReplacer::replace_append` indexed it unconditionally (`&caps[1]`). `Captures::index` panics when the group did not participate, so any `image:[]` / `icon:[]` — a plausible typo for `image:target[alt]` — brought the parser down.

## Fix

Asciidoctor's `InlineImageMacroRx` requires a target and makes only its *trailing* portion optional:

```ruby
([^:\s\[](?:[^\n\[]*[^\s\[])?)
```

This PR translates that faithfully — group 1 becomes mandatory, with an optional remainder — so `caps[1]` always participates and the indexing is sound.

Two behavior consequences, both matching Asciidoctor:

- `image:[]` / `icon:[]` is no longer a macro match, so the text is left exactly as the author typed it (no panic, and the author's text stays on the page).
- A one-character target such as `image:a[]` now renders as an image. The old pattern required at least two characters in the target and — because the group was optional and the following `[` then failed to line up — silently left such macros as literal text.

## Tests

New `inline_image_macro` module in `parser/src/content/macros.rs`, exercising the macros substitution step directly:

- `image_macro_without_target_is_left_literal` — the regression from #1236
- `icon_macro_without_target_is_left_literal`
- `image_macro_without_target_but_with_alt_text_is_left_literal` — `See image:[alt] here.` is untouched, and no surrounding text is consumed
- `single_character_target_is_an_image` — `image:a[Alt]` renders as ``'&lt;img src="a" alt="Alt"&gt;'``

Verified locally on this branch: `cargo test --all` (4725 passed, 0 failed), `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo +nightly fmt --all -- --check`, and `cargo +nightly doc --no-deps --document-private-items` all clean. The existing ported Asciidoctor cases around inline image targets (space in target, newline in target, leading/trailing space, `image::` found inline) continue to pass unchanged.

Opened as a draft: the single-character-target change is a real (if small) behavior change beyond the panic fix, so flagging it for a maintainer call before this is ready to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Np7T5apbxVjHGMZu8Jnsgx)_