### PR TITLE
fix: Terminate the parse for a line holding only a control character

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -737,15 +737,24 @@ impl<'src> Block<'src> {
                     metadata.anchor = None;
                     metadata.attrlist = None;
                     metadata.block_start = metadata.source;
-                } else if !metadata.source.data().is_empty() {
+                } else if metadata.block_start.byte_offset() > source.byte_offset() {
                     // The metadata scan consumed one or more do-nothing lines
                     // (e.g. a lone empty `[[]]` anchor) that produced no title,
                     // anchor, or attribute list, and no block follows them. The
                     // lines are still consumed, so report the source as dropped
                     // (resuming at `block_start`) rather than falling through to
                     // `NoMatch`: a non-blank source left unadvanced would spin
-                    // the block-collection loop. Genuinely empty/blank input
-                    // (nothing consumed) still reaches `NoMatch` below.
+                    // the block-collection loop.
+                    //
+                    // The test is that `block_start` actually moved past the
+                    // `source` this call was given, not merely that the source
+                    // is non-empty. A non-empty source from which the scan
+                    // consumed *nothing* leaves `block_start == source`, so
+                    // reporting it as dropped resumes exactly where this call
+                    // began — the very spin this branch exists to prevent
+                    // (issue #1234). Such a source falls through to `NoMatch`
+                    // below, along with genuinely empty/blank input, and the
+                    // block-collection loops skip its first line.
                     return MatchAndWarnings {
                         item: BlockParseOutcome::Dropped(metadata.block_start),
                         warnings,

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -521,6 +521,16 @@ impl<'src> ListItem<'src> {
             // always a block macro, never `+`-prefixed content, so it can't set
             // `had_content_starting_with_plus`.)
             if let BlockParseOutcome::Dropped(after) = indented_block_maw.item {
+                // Progress guarantee: a dropped block is expected to have
+                // consumed the source it stands for, but this loop is not
+                // otherwise bounded by the source shrinking, so an outcome
+                // reporting no progress would spin here forever (issue #1234).
+                // End the list item instead — truncating is a visible loss;
+                // hanging is not recoverable at all.
+                if after.byte_offset() <= next.byte_offset() {
+                    break;
+                }
+
                 next = after;
                 continuation_active = false;
                 next_block_must_be_indented = true;

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -520,26 +520,24 @@ impl<'src> ListItem<'src> {
             // to be indented or reintroduced with a `+`. (A dropped block is
             // always a block macro, never `+`-prefixed content, so it can't set
             // `had_content_starting_with_plus`.)
-            if let BlockParseOutcome::Dropped(after) = indented_block_maw.item {
-                // Progress guarantee: a dropped block is expected to have
-                // consumed the source it stands for, but this loop is not
-                // otherwise bounded by the source shrinking, so an outcome
-                // reporting no progress would spin here forever (issue #1234).
-                // End the list item instead — truncating is a visible loss;
-                // hanging is not recoverable at all.
-                if after.byte_offset() <= next.byte_offset() {
-                    break;
-                }
-
+            //
+            // Progress guarantee (issue #1234): the drop is only followed when
+            // it actually advanced past `next`. This loop is not otherwise
+            // bounded by the source shrinking, so a `Dropped` reporting no
+            // progress would spin here forever; one that did not advance falls
+            // through to the `break` below instead, ending the list item the
+            // same way an unparseable source does.
+            if let BlockParseOutcome::Dropped(after) = indented_block_maw.item
+                && after.byte_offset() > next.byte_offset()
+            {
                 next = after;
                 continuation_active = false;
                 next_block_must_be_indented = true;
                 continue;
             }
 
-            // `NoMatch` only arises for empty/blank input, which is filtered out
-            // above before we get here; the defensive `break` mirrors the
-            // pre-drop-line code path.
+            // Anything else ends the list item: `NoMatch` (no block could be
+            // made of this source), or the non-advancing `Dropped` above.
             let BlockParseOutcome::Parsed(indented_block_mi) = indented_block_maw.item else {
                 break;
             };

--- a/parser/src/blocks/parse_utils.rs
+++ b/parser/src/blocks/parse_utils.rs
@@ -60,6 +60,9 @@ where
             warnings.append(&mut maw.warnings);
         }
 
+        // Where the outcome says parsing should resume. `NoMatch` consumed
+        // nothing, so it resumes where this iteration began — which the
+        // progress rule below turns into an advance.
         let after = match maw.item {
             BlockParseOutcome::Parsed(mi) => {
                 let after = mi.after;
@@ -67,38 +70,37 @@ where
                 after
             }
 
-            BlockParseOutcome::Dropped(after) => {
-                // A dropped block (`attribute-missing=drop-line`) contributes
-                // no block, but parsing must still advance past its source.
-                after
-            }
+            // A dropped block (`attribute-missing=drop-line`) contributes no
+            // block, but parsing must still advance past its source.
+            BlockParseOutcome::Dropped(after) => after,
 
-            BlockParseOutcome::NoMatch => {
-                // `source` is non-blank by the loop guard and the
-                // `discard_empty_lines` calls, yet no block could be made of
-                // it. That happens when a line is not blank by
-                // `Span::take_empty_line`'s reckoning (space and tab only) but
-                // holds nothing a block can be built from — a lone vertical tab
-                // (U+000B), form feed (U+000C), or carriage return, each of
-                // which the block parsers discard as trailing whitespace
-                // (issue #1234). Consume the line and carry on, exactly as if
-                // it had been blank: leaving it unconsumed would spin this loop
-                // forever, and breaking out of the loop would silently truncate
-                // whatever follows it.
-                source.take_normalized_line().after
-            }
+            BlockParseOutcome::NoMatch => source,
         };
 
-        // Progress guarantee. Every outcome above is expected to advance past
-        // at least one line of `source`, but the loop is bounded on the source
-        // being non-empty, not on it having moved — so an outcome that reports
-        // no progress (a future parser bug, or a case not yet foreseen) would
-        // spin here forever rather than fail visibly. Stop instead: truncating
-        // the parse loses content, but it terminates, and an infinite loop in
-        // a library parsing untrusted input is the worse failure by far.
-        if after.byte_offset() <= source.byte_offset() {
-            break;
-        }
+        // Progress guarantee. This loop is bounded on `source` being non-empty,
+        // not on it having moved, so an outcome that consumed nothing would
+        // spin here forever. Consume a line ourselves instead: whatever the
+        // block parsers could not make a block of is dropped exactly as a blank
+        // line would be, and the loop is guaranteed to advance because
+        // `take_normalized_line` consumes at least one byte of a non-empty
+        // source.
+        //
+        // `NoMatch` on a non-blank source is the case that actually arrives
+        // here (issue #1234). `source` is non-blank by the loop guard and the
+        // `discard_empty_lines` calls, yet no block could be made of it — which
+        // happens for a line that is not blank by `Span::take_empty_line`'s
+        // reckoning (space and tab only) but holds nothing a block can be built
+        // from: a lone vertical tab (U+000B), form feed (U+000C), or carriage
+        // return, each of which the block parsers discard as trailing
+        // whitespace. Dropping just that line, rather than ending the loop,
+        // keeps whatever follows it parsing. A `Parsed` or `Dropped` outcome
+        // that reports no progress is not expected to occur, and takes the same
+        // recovery.
+        let after = if after.byte_offset() > source.byte_offset() {
+            after
+        } else {
+            source.take_normalized_line().after
+        };
 
         source = after.discard_empty_lines();
     }

--- a/parser/src/blocks/parse_utils.rs
+++ b/parser/src/blocks/parse_utils.rs
@@ -60,20 +60,47 @@ where
             warnings.append(&mut maw.warnings);
         }
 
-        if let BlockParseOutcome::Parsed(mi) = maw.item {
-            source = mi.after.discard_empty_lines();
-            blocks.push(mi.item);
-        } else if let BlockParseOutcome::Dropped(after) = maw.item {
-            // A dropped block (`attribute-missing=drop-line`) contributes no
-            // block, but parsing must still advance past its source.
-            source = after.discard_empty_lines();
+        let after = match maw.item {
+            BlockParseOutcome::Parsed(mi) => {
+                let after = mi.after;
+                blocks.push(mi.item);
+                after
+            }
+
+            BlockParseOutcome::Dropped(after) => {
+                // A dropped block (`attribute-missing=drop-line`) contributes
+                // no block, but parsing must still advance past its source.
+                after
+            }
+
+            BlockParseOutcome::NoMatch => {
+                // `source` is non-blank by the loop guard and the
+                // `discard_empty_lines` calls, yet no block could be made of
+                // it. That happens when a line is not blank by
+                // `Span::take_empty_line`'s reckoning (space and tab only) but
+                // holds nothing a block can be built from — a lone vertical tab
+                // (U+000B), form feed (U+000C), or carriage return, each of
+                // which the block parsers discard as trailing whitespace
+                // (issue #1234). Consume the line and carry on, exactly as if
+                // it had been blank: leaving it unconsumed would spin this loop
+                // forever, and breaking out of the loop would silently truncate
+                // whatever follows it.
+                source.take_normalized_line().after
+            }
+        };
+
+        // Progress guarantee. Every outcome above is expected to advance past
+        // at least one line of `source`, but the loop is bounded on the source
+        // being non-empty, not on it having moved — so an outcome that reports
+        // no progress (a future parser bug, or a case not yet foreseen) would
+        // spin here forever rather than fail visibly. Stop instead: truncating
+        // the parse loses content, but it terminates, and an infinite loop in
+        // a library parsing untrusted input is the worse failure by far.
+        if after.byte_offset() <= source.byte_offset() {
+            break;
         }
 
-        // `BlockParseOutcome::NoMatch` is intentionally not handled: it only
-        // arises for empty/blank input, which never reaches here because the
-        // loop guard and the `discard_empty_lines` calls above keep `source`
-        // non-blank. (Matching the behavior before drop-line support, which
-        // likewise only advanced on a successful parse.)
+        source = after.discard_empty_lines();
     }
 
     parser.block_nesting_depth -= 1;

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod fixtures;
 mod hash;
 mod inline_substitution_renderer;
 mod origin;
+mod parse_termination;
 pub(crate) mod prelude;
 pub(crate) mod sdd;
 mod security;

--- a/parser/src/tests/parse_termination.rs
+++ b/parser/src/tests/parse_termination.rs
@@ -1,0 +1,94 @@
+//! Regression coverage for parse termination (issue #1234).
+//!
+//! The block-collection loops advance by consuming the source a parsed block
+//! stands for. They are bounded on the source being *non-empty*, not on it
+//! having *moved*, so an outcome that reports no progress spins forever rather
+//! than failing visibly — an infinite loop inside a library call, which a host
+//! parsing untrusted AsciiDoc cannot defend against with a timeout.
+//!
+//! The inputs below all reach that state through the same door: a line whose
+//! only content is a vertical tab (U+000B), a form feed (U+000C), or carriage
+//! returns. [`Span::take_empty_line`](crate::Span::take_empty_line) counts a
+//! line as blank only when every byte is a space or a tab, so such a line is
+//! never skipped as blank; the block parsers, which trim trailing whitespace by
+//! the Unicode definition, then find nothing in it to build a block from. The
+//! line is not blank enough to skip and not substantial enough to parse.
+//!
+//! Whether such a line *should* count as blank is a language question, and
+//! these tests deliberately do not settle it: they assert only that parsing
+//! terminates, and that content following the offending line still parses.
+
+use std::{sync::mpsc, thread, time::Duration};
+
+use crate::{HasSpan, Parser, blocks::Block};
+
+/// Parses `source` on its own thread and reports whether the call returned.
+///
+/// The parse cannot run on the test thread: before the fix it never returned,
+/// so a direct call would not fail the test — the run would die on a harness
+/// timeout, with no named assertion pointing at the input that hung. Off-thread
+/// the failure is a normal assertion; the spinning thread is leaked, which the
+/// test process cleans up when it exits.
+fn terminates(source: &'static str) -> bool {
+    let (done, finished) = mpsc::channel();
+
+    thread::spawn(move || {
+        let _ = Parser::default().parse(source);
+        let _ = done.send(());
+    });
+
+    finished.recv_timeout(Duration::from_secs(10)).is_ok()
+}
+
+/// The five inputs from the original report, minimised by libFuzzer. The first
+/// is a single byte.
+#[test]
+fn a_line_holding_only_a_control_character_terminates() {
+    for source in [
+        "\u{c}",
+        ";toc::  \u{c}",
+        "\n\r\r\r",
+        "= T\n\n\r\r",
+        "[;;\n\u{b}",
+    ] {
+        assert!(terminates(source), "parse did not terminate on {source:?}");
+    }
+}
+
+/// The same line reached through each block scope that collects child blocks:
+/// the document body, a section body, a compound delimited block, a quote
+/// block, a table cell, and a list item's continuation. Each nests a separate
+/// call to a block-collection loop, so each is a separate way in.
+#[test]
+fn such_a_line_terminates_in_every_block_scope() {
+    for source in [
+        "before\n\n\u{c}\n\nafter",
+        "= T\n\n== S\n\n\u{c}\n\ntext",
+        "====\nx\n\n\u{c}\n\ny\n====",
+        "____\na\n\n\u{c}\n\nb\n____",
+        "|===\n| a\n\n\u{c}\n\n| b\n|===",
+        "* a\n+\n\u{c}\n",
+        "\u{c}\n\u{b}\n\r",
+    ] {
+        assert!(terminates(source), "parse did not terminate on {source:?}");
+    }
+}
+
+/// Terminating by abandoning the rest of the document would satisfy the tests
+/// above while quietly discarding content, so pin down that the offending line
+/// is skipped rather than treated as the end of the input.
+#[test]
+fn content_after_such_a_line_still_parses() {
+    let doc = Parser::default().parse("before\n\n\u{c}\n\nafter");
+
+    let paragraphs: Vec<&str> = doc
+        .top_level_blocks()
+        .iter()
+        .filter_map(|block| match block {
+            Block::Simple(simple) => Some(simple.span().data()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(paragraphs, vec!["before", "after"]);
+}


### PR DESCRIPTION
Fixes #1234.

`Parser::parse` never returned for a document containing a line whose only content is a vertical tab (U+000B), a form feed (U+000C), or carriage returns. One byte (`"\u{c}"`) was enough. The call spun in `parse_blocks_until`, so a host parsing untrusted AsciiDoc could not defend against it with a timeout.

## Why it hung

Such a line falls between two definitions of "blank":

* `Span::take_empty_line` counts a line as blank only when every byte is a space or a tab, so `discard_empty_lines` never skips it.
* The block parsers trim trailing whitespace by the Unicode definition, so they find nothing in it to build a block from.

The line is not blank enough to skip and not substantial enough to parse.

Reaching that state, `Block::parse_internal_inner` reported the source as `Dropped(metadata.block_start)`. That branch exists precisely to keep a consumed-but-blockless source from spinning the block-collection loop, and it assumes the metadata scan consumed something — but for these inputs it consumed nothing, so `block_start` was still the caller's own `source`, and `parse_blocks_until` re-parsed it forever.

## The fix

**`blocks/block.rs` — correct the premise.** Take the `Dropped` branch only when `metadata.block_start` actually moved past the `source` this call was given, rather than merely when the source is non-empty. A scan that consumed nothing now falls through to `NoMatch`.

**`blocks/parse_utils.rs` — give the loop a progress guarantee.** `parse_blocks_until` was bounded on the source being non-empty, not on it having *moved*. It now computes where each outcome says parsing should resume — `NoMatch` resumes where the iteration began, having consumed nothing — and applies a single rule: if that did not advance past `source`, consume a line here instead, exactly as a blank line is consumed. `take_normalized_line` always consumes at least one byte of a non-empty source, so the loop cannot fail to advance.

Ending the loop instead would also have terminated, but it would have silently truncated whatever followed the offending line; dropping just that line keeps the rest of the document parsing. An unforeseen non-advancing `Parsed` or `Dropped` takes the same recovery.

**`blocks/list_item.rs` — the same guarantee in the sibling loop.** A `Dropped` outcome is followed only when it advanced past `next`. One that did not falls through to the `break` that already ends the list item on `NoMatch`.

This deliberately leaves open whether such a line *should* count as blank — as the issue notes, widening `take_empty_line` to Unicode whitespace changes what counts as a paragraph boundary, which is a language decision rather than a bug fix.

## Testing

`parser/src/tests/parse_termination.rs` runs each parse on its own thread, because a test that simply called `parse` would not fail — it would never return, and the run would die on a harness timeout rather than a named assertion. It covers:

* the five minimised inputs from the issue;
* the same line reached through each block scope that collects child blocks — document body, section body, compound delimited block, quote block, table cell, and a list item's continuation. Six of these seven hung before the fix; the list-item and table cases were already reachable through other paths in the report;
* that `"before\n\n\u{c}\n\nafter"` still yields both paragraphs, so terminating by abandoning the rest of the document would not pass.

Beyond the committed tests, I brute-forced all 65,536 four-character inputs over an alphabet of `\n \r \v \f`, space, tab, and the block-significant punctuation (`= [ ] ; : * . | + a`). All terminate with the fix. Against unfixed code the same sweep stalls on its third input, so the sweep is a meaningful check rather than a vacuous one. It is not committed — 65k parses is too slow for the debug-build test suite.

## Coverage

The progress guarantees were first written as defensive `break`s on conditions that cannot occur, which left two lines unreachable from any test — a gap that the guards' own purpose made impossible to close by adding a test case. The second commit folds each into a path that real input already exercises: `NoMatch` fails the progress test and takes the recovery, covering both directions of the rule, and the non-advancing `Dropped` in `ListItem::parse` shares the `break` the suite already covers. Both loops got smaller as a result, and the guarantee is stronger than the original guards, since the unforeseen cases now recover rather than truncating.

Measured with `cargo llvm-cov --workspace --all-features --ignore-filename-regex tests`, the invocation CI uploads to Codecov: the lcov report has no missed line in any file this branch touches. The one remaining missed line in `list_item.rs` predates this branch and lies outside its diff.

## Local verification

`cargo test --workspace` (4,724 pass, 0 fail), `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo +nightly fmt --all -- --check`, and `cargo doc --no-deps --document-private-items` are all clean.

Still a draft pending your read of one judgment call: the progress guarantee in `parse_utils.rs` now recovers by skipping a line rather than ending the parse. That is what keeps content after the offending line, but it does mean the parser silently drops a line it cannot interpret. If you would rather it be visible, a warning type could be added — I left it out because the only content that reaches it is whitespace by the Unicode definition.