### PR TITLE
feat: Record where a `Raw` node's content came from (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -11,7 +11,7 @@ use crate::{
     Parser, Span,
     content::{ATTRIBUTE_REFERENCE, AttributeMissing},
     document::InterpretedValue,
-    inlines::{InlineNode, RawForm},
+    inlines::{InlineNode, RawForm, RawOrigin},
     parser::attribute_lookup_name,
     strings::CowStr,
 };
@@ -1020,6 +1020,7 @@ fn split_attribute_value<'src>(
         out.push(InlineNode::Raw {
             value: CowStr::from(ch.to_string()),
             form: RawForm::AsIs,
+            origin: RawOrigin::Substitution,
             location,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -730,7 +730,7 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{CharRef, Image, InlineNode, RawForm, Ref, RefVariant},
+        inlines::{CharRef, Image, InlineNode, RawForm, RawOrigin, Ref, RefVariant},
         parser::{
             HtmlSubstitutionRenderer, ModificationContext, ResolvedReference, XrefSignifier,
             XrefStyle,
@@ -833,6 +833,7 @@ mod tests {
         let raw = InlineNode::Raw {
             value: CowStr::from(location.data()),
             form: RawForm::AsIs,
+            origin: RawOrigin::Passthrough,
             location,
         };
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1255,7 +1255,7 @@ mod tests {
             build, char_replacements::apply_character_replacements, macros::apply_macros,
             special_chars::Masked,
         },
-        inlines::{CharRef, Image, InlineNode, RawForm, SpanForm, StyleVariant},
+        inlines::{CharRef, Image, InlineNode, RawForm, RawOrigin, SpanForm, StyleVariant},
         parser::{DefaultPathResolver, HtmlSubstitutionRenderer},
         strings::CowStr,
     };
@@ -2578,6 +2578,7 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from("raw"),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Passthrough,
                 location: root,
             },
             InlineNode::Stem(crate::inlines::Stem {

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -736,9 +736,76 @@ mod tests {
     use crate::{
         Parser, Span,
         content::{Content, SubstitutionGroup, inline_builder::fold_html},
+        inlines::{InlineNode, RawOrigin},
         parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
     };
+
+    #[test]
+    fn a_raw_leafs_origin_says_who_produced_it() {
+        // `RawOrigin` is a property of the *node*, not of the pass that happens
+        // to be looking at it. That is the point: a recognition gate can ask
+        // "would the string replacer have seen these bytes, or a sentinel?"
+        // without knowing whether the extraction pass's identity is in hand —
+        // which is what an earlier attempt at this got wrong, by inferring
+        // provenance from a `Masked` list that is empty on some call paths.
+        let parser = Parser::default();
+
+        let origins = |source: &str| -> Vec<(RawOrigin, String)> {
+            build(Span::new(source), &parser, None)
+                .iter()
+                .filter_map(|node| match node {
+                    InlineNode::Raw { origin, value, .. } => {
+                        Some((*origin, value.as_ref().to_string()))
+                    }
+
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // Every construction is folded into one comparison per group, with the
+        // source carried *in* the compared value rather than in an assertion
+        // message. A message argument on a line of its own is a failure-only
+        // region the coverage report counts as uncovered at every call site —
+        // the same trap `assert_special_char` documents in `test_support`.
+
+        // Every explicit passthrough spelling: the author asked for this text
+        // to be off limits, and the extraction pass is holding it.
+        let by_spelling: Vec<(&str, Vec<RawOrigin>)> =
+            ["+++<b>x</b>+++", "++a < b++", "$$<i>$$", "pass:[<b>]"]
+                .into_iter()
+                .map(|source| {
+                    let found = origins(source).into_iter().map(|(o, _)| o).collect();
+                    (source, found)
+                })
+                .collect();
+
+        assert_eq!(
+            by_spelling,
+            vec![
+                ("+++<b>x</b>+++", vec![RawOrigin::Passthrough]),
+                ("++a < b++", vec![RawOrigin::Passthrough]),
+                ("$$<i>$$", vec![RawOrigin::Passthrough]),
+                ("pass:[<b>]", vec![RawOrigin::Passthrough]),
+            ]
+        );
+
+        // An expanded attribute value's literal `&`, which §3.4.1 leaves
+        // unescaped because the value expands *after* `specialcharacters` ran.
+        // Nothing extracted it and nothing restores it — the string replacer
+        // reads these very bytes. `{cpp}` is `C&#43;&#43;`, so the expansion
+        // leaves one `Raw` per `&`, twice per occurrence.
+        assert_eq!(
+            origins("see xref:{cpp}[{cpp}]."),
+            vec![
+                (RawOrigin::Substitution, "&".to_string()),
+                (RawOrigin::Substitution, "&".to_string()),
+                (RawOrigin::Substitution, "&".to_string()),
+                (RawOrigin::Substitution, "&".to_string()),
+            ]
+        );
+    }
 
     /// Runs `source` through the real, public `SubstitutionGroup::Normal`
     /// pipeline, exactly as a real block's content is substituted in

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     Parser, Span,
     content::{Content, INLINE_PASS, INLINE_PASS_MACRO, SubstitutionGroup},
-    inlines::{InlineNode, RawForm, SpanForm, StyleVariant, Styled},
+    inlines::{InlineNode, RawForm, RawOrigin, SpanForm, StyleVariant, Styled},
     strings::CowStr,
 };
 
@@ -662,6 +662,7 @@ fn build_bare_unconstrained_match<'src>(
             node: Box::new(InlineNode::Raw {
                 value: CowStr::from(value),
                 form,
+                origin: RawOrigin::Passthrough,
                 location,
             }),
         },
@@ -794,6 +795,7 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::AsIs,
+            origin: RawOrigin::Passthrough,
             location,
         };
     }
@@ -812,6 +814,7 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::Escaped,
+            origin: RawOrigin::Passthrough,
             location,
         };
     }
@@ -852,6 +855,7 @@ fn build_passthrough_node<'src>(
     InlineNode::Raw {
         value,
         form: RawForm::AsIs,
+        origin: RawOrigin::Passthrough,
         location,
     }
 }
@@ -975,6 +979,7 @@ fn build_attrlisted_passthrough_node<'src>(
         vec![InlineNode::Raw {
             value: CowStr::from(body_span.data()),
             form,
+            origin: RawOrigin::Passthrough,
             location: body_span,
         }]
     };
@@ -1057,6 +1062,7 @@ fn build_bare_attrlisted_passthrough_node<'src>(
         vec![InlineNode::Raw {
             value: CowStr::from(body_span.data()),
             form: RawForm::Escaped,
+            origin: RawOrigin::Passthrough,
             location: body_span,
         }]
     };
@@ -1338,7 +1344,7 @@ mod tests {
     #[test]
     fn a_bare_plus_body_is_literal_text_unless_it_restores_something() {
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::RawForm;
+        use crate::inlines::{RawForm, RawOrigin};
 
         // A bare `+…+` body is `SubstitutionGroup::Verbatim` like `++…++`, so
         // by rights it is the author's literal text too. It could not say so
@@ -1351,12 +1357,17 @@ mod tests {
         // detected rather than assumed: with nothing restorable inside the
         // body, the value is the author's bytes and the fold escapes them.
         let nodes = build_src(Span::new("+a < b+"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, "a < b");
+        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "a < b");
 
         // The mixture keeps `AsIs`, since part of its value is another node's
         // rendering rather than anything an escape could reproduce.
         let nodes = build_src(Span::new("+a $$<b>$$ c+"));
-        assert_raw_form(&nodes[0], RawForm::AsIs, "a &lt;b&gt; c");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::AsIs,
+            RawOrigin::Passthrough,
+            "a &lt;b&gt; c",
+        );
     }
 
     #[test]
@@ -1403,7 +1414,7 @@ mod tests {
     #[test]
     fn a_specialcharacters_body_is_literal_text_the_fold_escapes() {
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::RawForm;
+        use crate::inlines::{RawForm, RawOrigin};
 
         // The shape this increment exists for. `SubstitutionGroup` decides
         // which form a passthrough body takes, and the two are not the same
@@ -1418,26 +1429,31 @@ mod tests {
         // Both stay opaque to every later step — that is what keeps them one
         // node kind — so this pins the distinction the kind alone cannot.
         let nodes = build_src(Span::new("+++<b>+++"));
-        assert_raw_form(&nodes[0], RawForm::AsIs, "<b>");
+        assert_raw_form(&nodes[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
 
         let nodes = build_src(Span::new("pass:[<b>]"));
-        assert_raw_form(&nodes[0], RawForm::AsIs, "<b>");
+        assert_raw_form(&nodes[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
 
         let nodes = build_src(Span::new("++<b>++"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, "<b>");
+        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "<b>");
 
         let nodes = build_src(Span::new("$$<b>$$"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, "<b>");
+        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "<b>");
 
         // The attribute-listed forms carry theirs as the `Styled` wrapper's
         // one child, and split the same way.
         let nodes = build_src(Span::new("[.role]+++<b>+++"));
         let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
-        assert_raw_form(&children[0], RawForm::AsIs, "<b>");
+        assert_raw_form(&children[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
 
         let nodes = build_src(Span::new("[.role]++<b>++"));
         let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
-        assert_raw_form(&children[0], RawForm::Escaped, "<b>");
+        assert_raw_form(
+            &children[0],
+            RawForm::Escaped,
+            RawOrigin::Passthrough,
+            "<b>",
+        );
     }
 
     #[test]
@@ -1572,7 +1588,7 @@ mod tests {
         }
 
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::RawForm;
+        use crate::inlines::{RawForm, RawOrigin};
 
         let parser =
             Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
@@ -1580,7 +1596,12 @@ mod tests {
         let nodes = super::super::build(Span::new("+a $$b < c$$ d+"), &parser, None);
 
         assert_eq!(nodes.len(), 1);
-        assert_raw_form(&nodes[0], RawForm::AsIs, "a b [1] c d");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::AsIs,
+            RawOrigin::Passthrough,
+            "a b [1] c d",
+        );
         assert_eq!(nodes[0].span().data(), "+a $$b < c$$ d+");
 
         let mut probe = String::new();

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -10,7 +10,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{QuoteSub, maybe_has_quotes, quote_subs},
-    inlines::{CharRef, InlineNode, RawForm, SpanForm, StyleVariant, Styled},
+    inlines::{CharRef, InlineNode, RawForm, RawOrigin, SpanForm, StyleVariant, Styled},
     parser::{HtmlSubstitutionRenderer, InlineSubstitutionRenderer, QuoteScope, QuoteType},
     strings::CowStr,
 };
@@ -1554,6 +1554,7 @@ pub(super) fn emit_range<'src>(
             out.push(InlineNode::Raw {
                 value: CowStr::from(sliced.to_string()),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Substitution,
                 location: node.span(),
             });
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -5,7 +5,7 @@
 use super::{fold_html, passthrough_step::is_special};
 use crate::{
     HasSpan, Parser, Span,
-    inlines::{CharRef, InlineNode, RawForm, RefVariant},
+    inlines::{CharRef, InlineNode, RawForm, RawOrigin, RefVariant},
     parser::InlineSubstitutionRenderer,
     strings::CowStr,
 };
@@ -249,6 +249,7 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
             SpecialLeaf::Raw => InlineNode::Raw {
                 value: CowStr::from(ch_span.data()),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Substitution,
                 location: ch_span,
             },
         });
@@ -352,6 +353,7 @@ fn as_pre_escape<'src>(node: InlineNode<'src>) -> InlineNode<'src> {
         InlineNode::Text { value, location } => InlineNode::Raw {
             value,
             form: RawForm::AsIs,
+            origin: RawOrigin::Substitution,
             location,
         },
 
@@ -548,6 +550,7 @@ fn split_synthesized<'src>(
             SpecialLeaf::Raw => InlineNode::Raw {
                 value: CowStr::from(ch.to_string()),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Substitution,
                 location,
             },
         });
@@ -578,7 +581,7 @@ mod tests {
         Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Footnote, InlineNode, RawForm, Ref, RefVariant, SpanForm,
+            Anchor, CharRef, Footnote, InlineNode, RawForm, RawOrigin, Ref, RefVariant, SpanForm,
             StyleVariant, Styled,
         },
         parser::HtmlSubstitutionRenderer,
@@ -1017,6 +1020,7 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from(location.data()),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Passthrough,
                 location,
             },
         ]);

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -11,7 +11,7 @@ use super::{build, quotes::apply_quotes, special_chars::apply_special_characters
 use crate::{
     HasSpan, Parser, Span,
     content::{Content, Passthroughs, SubstitutionStep},
-    inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
+    inlines::{CharRef, InlineNode, RawOrigin, Ref, RefVariant, SpanForm, StyleVariant},
     parser::HtmlSubstitutionRenderer,
     strings::CowStr,
 };
@@ -124,11 +124,11 @@ pub(super) fn assert_entity<'src>(node: &InlineNode<'src>, entity: &str) -> Span
 ///
 /// The assertion is on the folded bytes rather than on the node's `value`
 /// field, because a `Raw` node carries one of two
-/// [`form`](crate::inlines::RawForm)s: `AsIs`, whose value already *is* those
-/// bytes, and `Escaped`, whose value is the author's logical text that the fold
-/// escapes. What every caller here means is "this passthrough contributes these
-/// bytes", and that is the same question for both forms — where reading the
-/// field is only the same question for one of them.
+/// [`form`](crate::inlines::RawForm)s: `AsIs`, whose value already
+/// *is* those bytes, and `Escaped`, whose value is the author's logical text
+/// that the fold escapes. What every caller here means is "this passthrough
+/// contributes these bytes", and that is the same question for both forms —
+/// where reading the field is only the same question for one of them.
 pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'src> {
     match node {
         InlineNode::Raw { location, .. } => {
@@ -151,8 +151,15 @@ pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'sr
 /// Used where the *shape* is the subject: that a `+++…+++` body is `AsIs`
 /// output while a `++…++` body is `Escaped` logical text, which is what keeps
 /// a passthrough's escaping a property of the fold's renderer rather than of
-/// the parse's.
-pub(super) fn assert_raw_form(node: &InlineNode<'_>, form: crate::inlines::RawForm, value: &str) {
+/// the parse's — and that both are
+/// [`Passthrough`](RawOrigin::Passthrough)-origin, unlike the `Raw` leaves a
+/// substitution leaves behind in place.
+pub(super) fn assert_raw_form(
+    node: &InlineNode<'_>,
+    form: crate::inlines::RawForm,
+    origin: RawOrigin,
+    value: &str,
+) {
     // Compared as a whole node rather than by matching out the two fields,
     // which keeps this free of a fallback arm only a failing test could reach.
     // `location` is taken from `node` itself, so it is deliberately not part of
@@ -163,6 +170,8 @@ pub(super) fn assert_raw_form(node: &InlineNode<'_>, form: crate::inlines::RawFo
         &InlineNode::Raw {
             value: CowStr::from(value),
             form,
+
+            origin,
             location: node.span(),
         }
     );

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -55,12 +55,12 @@ pub enum InlineNode<'src> {
     /// record of the language's "this text is off limits" behavior. ASG:
     /// `inlineLiteral` with `name="raw"`.
     ///
-    /// [`form`](RawForm) says whether `value` is already output bytes or
-    /// logical text the fold escapes. Both are opaque to the transducer steps —
-    /// that is what makes them one node kind rather than two — but only one is
-    /// "raw HTML by design", and conflating them made a passthrough's escaping
-    /// a function of whichever renderer the *parse* carried rather than of the
-    /// one the fold is given.
+    /// [`form`](RawForm) says whether `value` is already output
+    /// bytes or logical text the fold escapes. Both are opaque to the
+    /// transducer steps — that is what makes them one node kind rather than
+    /// two — but only one is "raw HTML by design", and conflating them made
+    /// a passthrough's escaping a function of whichever renderer the
+    /// *parse* carried rather than of the one the fold is given.
     Raw {
         /// The content this node contributes, in the shape [`form`](Self::Raw)
         /// names.
@@ -68,6 +68,9 @@ pub enum InlineNode<'src> {
 
         /// Whether the fold emits [`value`](Self::Raw) as-is or escapes it.
         form: RawForm,
+
+        /// Where this raw output came from — see [`RawOrigin`].
+        origin: RawOrigin,
 
         /// The source location this content derives from.
         location: Span<'src>,
@@ -137,8 +140,8 @@ mod tests {
         HasSpan, Span,
         inlines::{
             Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode,
-            RawForm, Ref, RefVariant, SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui,
-            UiKind,
+            RawForm, RawOrigin, Ref, RefVariant, SpanForm, Stem, StemNotation, StyleVariant,
+            Styled, Ui, UiKind,
         },
         strings::CowStr,
     };
@@ -159,6 +162,7 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from("<b>"),
                 form: RawForm::AsIs,
+                origin: RawOrigin::Substitution,
                 location,
             },
             InlineNode::Styled(Styled {
@@ -302,6 +306,43 @@ mod tests {
         assert_eq!(ui_kinds.len(), 3);
         assert_eq!(callout_guards.len(), 2);
     }
+}
+
+/// Where a [`Raw`](InlineNode::Raw) node's content came from.
+///
+/// Orthogonal to [`RawForm`], which says what the fold *does* with the bytes.
+/// This says who produced them, and it answers two different questions.
+///
+/// For a **consumer**, it sharpens the security story design §3.4 gives this
+/// node kind. "This document emits raw HTML" is visible as `Raw` nodes in the
+/// tree; whether that came from an author writing an explicit passthrough or
+/// from a substitution expanding an attribute value is the difference between a
+/// deliberate escape hatch and a value that may have arrived from elsewhere.
+///
+/// For the **builder**, it is the difference between content the extraction
+/// pass is holding and content that is simply there. The string pipeline's own
+/// haystack carries a sentinel where a [`Passthrough`](Self::Passthrough)
+/// node's text belongs, and splices the real text back only when it rewrites
+/// the rendered string — so a *computed value* that reads those bytes before
+/// the restore (a cross-reference's target, captured into its deferred segment)
+/// sees the sentinel, while one that reads a
+/// [`Substitution`](Self::Substitution) node's bytes sees exactly what the
+/// replacer saw. Recording it on the node is what lets a recognition gate tell
+/// the two apart without having to know which pass it is running in.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RawOrigin {
+    /// An explicit passthrough the extraction pass pulled out before any step
+    /// ran: `+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, or an inline STEM body.
+    ///
+    /// The author asked for this text to be off limits.
+    Passthrough,
+
+    /// Raw output a substitution produced **in place**, with no extraction
+    /// involved: a literal `<`, `>`, or `&` from an expanded attribute value
+    /// (which §3.4.1 leaves unescaped, since the value expands *after*
+    /// `specialcharacters` ran), a special an effective order never escaped, or
+    /// a slice of an entity's own bytes.
+    Substitution,
 }
 
 /// How a [`Raw`](InlineNode::Raw) node's value reaches the output.

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -50,7 +50,7 @@ mod index_term;
 pub use index_term::IndexTerm;
 
 mod inline_node;
-pub use inline_node::{InlineNode, RawForm};
+pub use inline_node::{InlineNode, RawForm, RawOrigin};
 
 mod ref_node;
 pub use ref_node::{LinkForm, Ref, RefVariant};


### PR DESCRIPTION
`InlineNode::Raw` gains `origin: RawOrigin`, orthogonal to `RawForm`:

- **`Passthrough`** — content the extraction pass pulled out before any step ran: `+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, an inline STEM body.
- **`Substitution`** — raw output a substitution produced *in place*: an expanded attribute value's literal special (which §3.4.1 leaves unescaped, the value having expanded *after* `specialcharacters` ran), a special an effective order never escaped, or a slice of an entity's own bytes.

## Why

**For a consumer**, it sharpens the security story §3.4 gives this node kind. "This document emits raw HTML" is visible as `Raw` nodes in the tree; whether that came from an author writing an explicit passthrough or from a substitution expanding an attribute value is the difference between a deliberate escape hatch and a value that may have arrived from elsewhere.

**For the builder**, it is the difference between content the extraction pass is *holding* and content that is simply there — which the next increment needs. A cross-reference's target is captured into its deferred segment *before* the restore pass runs, so a computed value reading a `Passthrough` node's bytes sees the extraction sentinel, while one reading a `Substitution` node's sees exactly what the string replacer saw. That is why

```
xref:{cpp}[{cpp}]     can be recognized   ({cpp} → C&#43;&#43;, whose & leaves are expansion residue)
xref:++someid++[]     must stay deferred  (a documented divergence: the string pipeline's own
                                           href leaks \u{96}n\u{97} there)
```

## Why on the node

This came out of a failed first attempt. I tried inferring the same distinction from the `Masked` list the extraction pass builds, and **it does not work**: that list is keyed by location identity and is empty on call paths where the identity is not in hand, so the same node classified differently depending on which pass was asking. I also got the safety direction backwards on the first pass, because `Masked::covers` answers `false` for an unknown identity — which *admits* where it must defer.

Provenance is a fact about the node, so it belongs on the node. That is the same reasoning that put `form` there.

## No behavior change

Nothing reads `origin` yet.

- `cargo test --workspace`: **5431 pass, 0 fail**.
- Corpus-wide fold-parity audit: **54 unique divergences, 0 new**.
- Coverage diff-neutral: total 575/323, identical to base. (`assert_raw_form` gained an `origin` parameter rather than deriving it from the node — deriving it needed a fallback arm no passing test reaches, which cost a region.)
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

`a_raw_leafs_origin_says_who_produced_it` pins all four passthrough spellings as `Passthrough` and an expanded value's residue as `Substitution`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_