### PR TITLE
fix: Report a whitespace-only shorthand name and drop it

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -1612,10 +1612,57 @@ mod tests {
             .filter(|w| w.warning == WarningType::EmptyShorthandName)
             .count();
 
-        assert_eq!(empty_shorthand_name_warnings, 5);
+        // Six delimiters name nothing: the four leading `%`, the `%` followed
+        // only by tabs, and the two `%` after them. (The whitespace-only name
+        // was silently accepted until
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.)
+        assert_eq!(empty_shorthand_name_warnings, 6);
 
         assert!(doc.warnings().all(|w| w.source.data() == "%%%%\t\t%%%f"
             || w.warning == WarningType::MissingBlockAfterTitleOrAttributeList));
+    }
+
+    #[test]
+    fn whitespace_only_shorthand_id_does_not_shadow_a_real_one() {
+        // A shorthand name made only of whitespace was accepted without a
+        // warning and then surfaced as an empty ID. Because `id()` reports the
+        // first shorthand item that starts with `#`, that empty ID hid a real
+        // one declared later in the same attrlist.
+        // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+        let mut p = Parser::default();
+        let doc = p.parse("[x#\t#realid]\nhello");
+
+        assert_eq!(doc.child_blocks().next().unwrap().id().unwrap(), "realid");
+
+        assert_eq!(
+            doc.warnings()
+                .filter(|w| w.warning == WarningType::EmptyShorthandName)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn whitespace_only_shorthand_ids_do_not_collide_in_the_catalog() {
+        // Each whitespace-only ID used to be registered in the ID catalog as
+        // the empty string, so a second one reported `DuplicateId("")`.
+        // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+        let mut p = Parser::default();
+        let doc = p.parse("[x#\t]\nhello\n\n[y#\t]\nworld");
+
+        assert!(doc.child_blocks().all(|b| b.id().is_none()));
+
+        assert!(
+            !doc.warnings()
+                .any(|w| matches!(w.warning, WarningType::DuplicateId(_)))
+        );
+
+        assert_eq!(
+            doc.warnings()
+                .filter(|w| w.warning == WarningType::EmptyShorthandName)
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -258,11 +258,17 @@ impl<'src> ElementAttribute<'src> {
                 &value[*curr..]
             };
 
+            // Trim before testing for a bare delimiter: an item such as `#\t`
+            // carries no name (`parse_shorthand_items` reports it as
+            // `WarningType::EmptyShorthandName`) and must be discarded here
+            // just as `#` is, rather than surfacing as an empty ID, role, or
+            // option — and, in the case of an ID, shadowing a real one
+            // declared later in the same attrlist.
+            next_item = next_item.trim_end();
+
             if next_item == "#" || next_item == "." || next_item == "%" {
                 continue;
             }
-
-            next_item = next_item.trim_end();
 
             if !next_item.is_empty() {
                 result.push(next_item);
@@ -647,30 +653,30 @@ fn parse_shorthand_items(source: &str, warnings: &mut Vec<WarningType>) -> Vec<u
         // Assumption: First character is a delimiter.
         let after_delimiter = span.discard(1);
 
-        match after_delimiter.position(is_shorthand_delimiter) {
-            None => {
-                if after_delimiter.is_empty() {
-                    warnings.push(WarningType::EmptyShorthandName);
-                    shorthand_item_indices.push(span.byte_offset());
-                    span = after_delimiter;
-                } else {
-                    shorthand_item_indices.push(span.byte_offset());
-                    span = span.discard_all();
-                }
-            }
-
-            Some(0) => {
-                shorthand_item_indices.push(span.byte_offset());
-                warnings.push(WarningType::EmptyShorthandName);
-                span = after_delimiter;
-            }
+        // The name runs from the delimiter to the next one, or to the end of
+        // the value if this is the last item.
+        let (name, after) = match after_delimiter.position(is_shorthand_delimiter) {
+            None => (after_delimiter, after_delimiter.discard_all()),
 
             Some(index) => {
-                let mi: MatchedItem<Span> = span.into_parse_result(index + 1);
-                shorthand_item_indices.push(span.byte_offset());
-                span = mi.after;
+                let mi: MatchedItem<Span> = after_delimiter.into_parse_result(index);
+                (mi.item, mi.after)
             }
+        };
+
+        shorthand_item_indices.push(span.byte_offset());
+
+        // Emptiness is decided on the trimmed name, matching what the
+        // shorthand accessors read back: a name made only of whitespace
+        // (`[x#\t]`) names nothing, exactly as a missing one (`[x#]`) does.
+        // Deciding it on the raw text instead would let the whitespace-only
+        // name through unreported and then surface it as an empty ID, role, or
+        // option.
+        if name.data().trim().is_empty() {
+            warnings.push(WarningType::EmptyShorthandName);
         }
+
+        span = after;
     }
 
     shorthand_item_indices
@@ -1552,6 +1558,138 @@ mod tests {
         }
 
         #[test]
+        fn error_whitespace_only_id() {
+            // A name made only of whitespace names nothing, exactly as a
+            // missing name does. It used to be accepted without a warning and
+            // then surface as an empty ID.
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+            let p = Parser::default();
+
+            let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+                &CowStr::from("abc#\t"),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Inline,
+            );
+
+            assert_eq!(
+                element_attr,
+                ElementAttribute {
+                    name: None,
+                    shorthand_items: &["abc"],
+                    value: "abc#\t"
+                }
+            );
+
+            assert_eq!(element_attr.block_style().unwrap(), "abc");
+            assert!(element_attr.id().is_none());
+            assert!(element_attr.roles().is_empty());
+            assert!(element_attr.options().is_empty());
+
+            assert_eq!(offset, 5);
+            assert_eq!(warning_types, vec![WarningType::EmptyShorthandName]);
+        }
+
+        #[test]
+        fn error_whitespace_only_id_does_not_shadow_later_id() {
+            // The empty ID that a whitespace-only name used to yield came
+            // first, so it hid the real ID declared after it.
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+            let p = Parser::default();
+
+            let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+                &CowStr::from("abc#\t#realid"),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Inline,
+            );
+
+            assert_eq!(
+                element_attr,
+                ElementAttribute {
+                    name: None,
+                    shorthand_items: &["abc", "#realid"],
+                    value: "abc#\t#realid"
+                }
+            );
+
+            assert_eq!(element_attr.block_style().unwrap(), "abc");
+            assert_eq!(element_attr.id().unwrap(), "realid");
+            assert!(element_attr.roles().is_empty());
+            assert!(element_attr.options().is_empty());
+
+            assert_eq!(offset, 12);
+            assert_eq!(warning_types, vec![WarningType::EmptyShorthandName]);
+        }
+
+        #[test]
+        fn error_whitespace_only_role() {
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+            let p = Parser::default();
+
+            let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+                &CowStr::from("abc.\t"),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Inline,
+            );
+
+            assert_eq!(
+                element_attr,
+                ElementAttribute {
+                    name: None,
+                    shorthand_items: &["abc"],
+                    value: "abc.\t"
+                }
+            );
+
+            assert_eq!(element_attr.block_style().unwrap(), "abc");
+            assert!(element_attr.id().is_none());
+            assert!(element_attr.roles().is_empty());
+            assert!(element_attr.options().is_empty());
+
+            assert_eq!(offset, 5);
+            assert_eq!(warning_types, vec![WarningType::EmptyShorthandName]);
+        }
+
+        #[test]
+        fn error_whitespace_only_option() {
+            // A non-breaking space is whitespace, too, and (unlike a plain
+            // space) survives the trailing-space trim applied to the attribute
+            // value before the shorthand is parsed.
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+            let p = Parser::default();
+
+            let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+                &CowStr::from("abc%\u{a0}"),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Inline,
+            );
+
+            assert_eq!(
+                element_attr,
+                ElementAttribute {
+                    name: None,
+                    shorthand_items: &["abc"],
+                    value: "abc%\u{a0}"
+                }
+            );
+
+            assert_eq!(element_attr.block_style().unwrap(), "abc");
+            assert!(element_attr.id().is_none());
+            assert!(element_attr.roles().is_empty());
+            assert!(element_attr.options().is_empty());
+
+            assert_eq!(offset, 6);
+            assert_eq!(warning_types, vec![WarningType::EmptyShorthandName]);
+        }
+
+        #[test]
         fn id_only() {
             let p = Parser::default();
 
@@ -1847,7 +1985,10 @@ mod tests {
             let earlier = parse("%%%%\t\t%%%f");
             let later = parse("f");
 
-            assert_eq!(earlier.options(), vec!["", "f"]);
+            // The `%\t\t` run names nothing either, so it never becomes an
+            // option to be merged in the first place.
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/1273.
+            assert_eq!(earlier.options(), vec!["f"]);
 
             let merged =
                 crate::attributes::ElementAttribute::merge_block_style_shorthand(&earlier, &later);


### PR DESCRIPTION
Fixes #1273.

## What was wrong

`parse_shorthand_items` and `shorthand_items_internal` disagreed about what an *empty* shorthand name is. The parser decided emptiness on the untrimmed text; the accessor trimmed the item, but only *after* testing it for a bare delimiter. A name made only of whitespace fell between the two: accepted without a `WarningType::EmptyShorthandName`, then surfaced from the public accessors as an empty string.

The damaging case is an ID, since `id()` reports the first shorthand item beginning with `#`: in `[x#\t#realid]` the whitespace-only one comes first, so `realid` was never reached. Two such blocks also collided in the ID catalog — each registered `""`, and the second drew a spurious `DuplicateId("")`.

Only non-space whitespace reaches the shorthand parser (the attribute value is stripped of trailing *spaces* before it is parsed), which is why `[x% ]` was already handled and `[x%\t]` was not.

## The fix

* `parse_shorthand_items` decides emptiness on the **trimmed** name, so a whitespace-only name raises `EmptyShorthandName` like a missing one. The `None` / `Some(0)` / `Some(index)` arms collapsed into one: each now takes the name up to the next delimiter (or to the end of the value) and tests it the same way. The item offsets it records are unchanged.
* `shorthand_items_internal` trims **before** testing for a bare `#`, `.`, or `%`, so `#\t` is discarded just as `#` is instead of surfacing as an empty ID, role, or option.

The two tests are equivalent by construction — a name is whitespace-only exactly when trimming empties it — so the parser and the accessors can no longer disagree.

## Behavior change

The whole table from the issue now matches the `[x#]` / `[x.]` / `[x%]` rows: `shorthand_items()` is `["x"]`, no empty ID/role/option, and `EmptyShorthandName` reported once. `[x#\t#realid]` resolves the ID to `realid`.

Two existing tests asserted the old behavior for `[%%%%\t\t%%%f]` and were updated: its `%\t\t` item no longer yields an empty option, and the document reports six `EmptyShorthandName` warnings rather than five (the sixth is the whitespace-only name that was silently accepted before).

## Tests

New regression tests:

* `parse_with_shorthand::error_whitespace_only_id`, `…_role`, `…_option` (the last using a non-breaking space, which also survives the trailing-space trim)
* `parse_with_shorthand::error_whitespace_only_id_does_not_shadow_later_id`
* `attrlist::whitespace_only_shorthand_id_does_not_shadow_a_real_one` — the document-level repro from the issue
* `attrlist::whitespace_only_shorthand_ids_do_not_collide_in_the_catalog` — no `DuplicateId("")`

`cargo test`, `cargo clippy --all-features --all-targets -- -Dwarnings`, and `cargo +nightly fmt --check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5BPA1Aum6QLDiAhcCP37Q)_