### PR TITLE
fix: Escape sentinel codepoints a document types itself

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     content::{
         Content, SubstitutionGroup, XrefSegment, strip_footnote_marker_spans,
-        substitute_attributes_in_reftext,
+        substitute_attributes_in_reftext, unescape_sentinels,
     },
     document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
@@ -255,18 +255,32 @@ impl<'src> SectionBlock<'src> {
         // sentinels lets those be excised below from a single render — no second
         // substitution pass, so counters and attribute-expanded footnotes are
         // processed exactly once.
+        //
+        // The title is substituted in the escaped sentinel form (see
+        // `escape_sentinels`) and left there, so that the marker excision below
+        // reads only the markers this substitution wrote — never a copy of a
+        // marker sentinel the document itself typed.
         let mut section_title = Content::from(title_span);
         parser.mark_footnote_spans.set(true);
-        SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
+        SubstitutionGroup::Title.apply_keeping_sentinels_escaped(
+            &mut section_title,
+            parser,
+            metadata.attrlist.as_ref(),
+        );
         parser.mark_footnote_spans.set(false);
 
         // The footnote-free rendering of the title, for the reference text and
         // auto-generated ID; a no-op string copy when the title had no footnote.
-        let title_reftext = strip_footnote_marker_spans(section_title.rendered());
+        let title_reftext =
+            unescape_sentinels(&strip_footnote_marker_spans(section_title.rendered())).into_owned();
 
         // Strip the now-consumed sentinels from the title itself, keeping the
         // footnote marker so the heading still renders it.
         section_title.remove_footnote_marker_sentinels();
+
+        // Every sentinel-reading pass over the title has now run, so the
+        // document's own sentinel codepoints can be restored.
+        section_title.unescape_sentinels();
 
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -3,6 +3,8 @@
 //!
 //! [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 
+use std::borrow::Cow;
+
 use crate::{
     Span,
     content::Passthrough,
@@ -133,15 +135,22 @@ pub(crate) struct XrefSegment {
 }
 
 /// Sentinel codepoints (Unicode Private Use Area) bracketing a placeholder
-/// index in [`DeferredContent::template`]. These cannot collide with user text
-/// and are inert to the remaining substitution steps.
+/// index in [`DeferredContent::template`].
+///
+/// A document can type these codepoints — they are unassigned by Unicode, but
+/// perfectly valid in a `&str` — so they are *not* self-evidently the parser's
+/// own. What keeps them unambiguous is the escaping pass described on
+/// [`escape_sentinels`]: a document's own copies are replaced before
+/// substitution begins, so every occurrence the readers below see was written
+/// by the substitution pipeline itself.
 const XREF_PLACEHOLDER_START: char = '\u{E000}';
 const XREF_PLACEHOLDER_END: char = '\u{E001}';
 
 /// Sentinel codepoints (Unicode Private Use Area) bracketing a footnote's
 /// rendered inline marker while a section title is being substituted. Like the
-/// cross-reference placeholders above, these cannot collide with user text and
-/// are inert to the remaining substitution steps.
+/// cross-reference placeholders above, they are inert to the remaining
+/// substitution steps, and a document's own copies are escaped out of the way
+/// first (see [`escape_sentinels`]).
 ///
 /// A footnote in a section title is a real, document-order footnote, but its
 /// marker must be kept out of the section's reference text and auto-generated
@@ -152,6 +161,125 @@ const XREF_PLACEHOLDER_END: char = '\u{E001}';
 /// [`Content::remove_footnote_marker_sentinels`].
 pub(crate) const FOOTNOTE_MARKER_START: char = '\u{E002}';
 pub(crate) const FOOTNOTE_MARKER_END: char = '\u{E003}';
+
+/// Sentinel codepoints (C1 control range) bracketing an extracted
+/// passthrough's index while the other substitutions run. Defined here so the
+/// escaping pass below covers them alongside the Private Use Area sentinels;
+/// they are emitted and consumed by
+/// [`passthroughs`](crate::content::passthroughs).
+pub(crate) const PASSTHROUGH_PLACEHOLDER_START: char = '\u{96}';
+pub(crate) const PASSTHROUGH_PLACEHOLDER_END: char = '\u{97}';
+
+/// Introduces the escaped form of a reserved sentinel (see
+/// [`escape_sentinels`]). A document's own copies of this codepoint are
+/// escaped too, so an occurrence in escaped text always introduces an escape.
+const SENTINEL_ESCAPE: char = '\u{E004}';
+
+/// Every codepoint the substitution pipeline reserves as an in-band control
+/// sentinel, paired with the ASCII tag that stands in for it in escaped text.
+///
+/// The tags are arbitrary; all that matters is that each is distinct and that
+/// the escape introducer itself is in the table, so escaping is reversible.
+const RESERVED_SENTINELS: [(char, char); 7] = [
+    (XREF_PLACEHOLDER_START, 'a'),
+    (XREF_PLACEHOLDER_END, 'b'),
+    (FOOTNOTE_MARKER_START, 'c'),
+    (FOOTNOTE_MARKER_END, 'd'),
+    (PASSTHROUGH_PLACEHOLDER_START, 'e'),
+    (PASSTHROUGH_PLACEHOLDER_END, 'f'),
+    (SENTINEL_ESCAPE, 'g'),
+];
+
+/// Replaces each reserved sentinel codepoint a *document* typed with an escaped
+/// form, so that the only unescaped sentinels in the text being substituted are
+/// the ones the substitution pipeline wrote itself.
+///
+/// The sentinels are in-band: they are spliced into the same string as the
+/// document's text, so the passes that read them back — [`render_template`],
+/// [`rehome_xref_placeholders`], [`strip_footnote_marker_spans`], and the
+/// passthrough restore — cannot otherwise tell a sentinel the parser wrote
+/// from one the document did. Without this pass, a document that types
+/// `U+E000 0 U+E001` alongside a real cross-reference has that text read back
+/// as a placeholder, forging a second cross-reference into the output.
+///
+/// Escaped text is an internal representation: every path that hands rendered
+/// text back to a caller reverses it with [`unescape_sentinels`], so a
+/// document's private-use characters survive to the output unchanged. The two
+/// passes are exact inverses, so applying them in matched pairs nests safely
+/// (a passthrough's text, for example, is substituted by a nested
+/// escape/unescape pair while it is itself held in escaped form).
+///
+/// Text with no reserved codepoint — the overwhelming majority — is borrowed
+/// through unchanged.
+pub(crate) fn escape_sentinels(text: &str) -> Cow<'_, str> {
+    if !text.contains(is_reserved_sentinel) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+
+    for c in text.chars() {
+        match RESERVED_SENTINELS
+            .iter()
+            .find(|(sentinel, _)| *sentinel == c)
+        {
+            Some((_, tag)) => {
+                out.push(SENTINEL_ESCAPE);
+                out.push(*tag);
+            }
+            None => out.push(c),
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+/// Restores the document's own sentinel codepoints, reversing
+/// [`escape_sentinels`].
+///
+/// Applied once to each string as it leaves the substitution machinery. A
+/// dangling escape introducer cannot occur in text this pass is given (escaping
+/// always emits a tag), but is passed through literally rather than dropped if
+/// it somehow does.
+pub(crate) fn unescape_sentinels(text: &str) -> Cow<'_, str> {
+    if !text.contains(SENTINEL_ESCAPE) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != SENTINEL_ESCAPE {
+            out.push(c);
+            continue;
+        }
+
+        match chars
+            .peek()
+            .and_then(|tag| RESERVED_SENTINELS.iter().find(|(_, t)| t == tag))
+        {
+            Some((sentinel, _)) => {
+                out.push(*sentinel);
+                chars.next();
+            }
+            None => out.push(SENTINEL_ESCAPE),
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+/// Returns `true` if `c` is one of the codepoints the substitution pipeline
+/// reserves for its own use.
+///
+/// Written as a range test rather than a scan of [`RESERVED_SENTINELS`]: this
+/// runs over every character of every block's content, while the table itself
+/// is only consulted for text that has a sentinel in it. A unit test pins the
+/// two to the same set of codepoints.
+fn is_reserved_sentinel(c: char) -> bool {
+    matches!(c, '\u{96}' | '\u{97}' | '\u{E000}'..='\u{E004}')
+}
 
 /// Removes each footnote marker span — a [`FOOTNOTE_MARKER_START`] …
 /// [`FOOTNOTE_MARKER_END`] region and everything between, i.e. the sentinels
@@ -418,6 +546,31 @@ impl<'src> Content<'src> {
         self.passthroughs = passthroughs;
     }
 
+    /// Escapes the reserved sentinel codepoints this content's *own text*
+    /// contains, so the substitution pipeline can tell its own in-band
+    /// sentinels from the document's text. See [`escape_sentinels`].
+    ///
+    /// Called once, before substitution begins; the matching
+    /// [`unescape_sentinels`](Self::unescape_sentinels) call restores them.
+    pub(crate) fn escape_sentinels(&mut self) {
+        if let Cow::Owned(escaped) = escape_sentinels(self.rendered.as_ref()) {
+            self.rendered = escaped.into();
+        }
+    }
+
+    /// Restores the document's own sentinel codepoints in
+    /// [`rendered`](Self::rendered), reversing
+    /// [`escape_sentinels`](Self::escape_sentinels).
+    ///
+    /// The deferred template is deliberately left escaped: it is an internal
+    /// representation that is re-rendered (through [`render_template`], whose
+    /// callers unescape the result) each time references are resolved.
+    pub(crate) fn unescape_sentinels(&mut self) {
+        if let Cow::Owned(unescaped) = unescape_sentinels(self.rendered.as_ref()) {
+            self.rendered = unescaped.into();
+        }
+    }
+
     /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
     /// bracketing each footnote marker, *keeping* the marker itself, so the
     /// content renders normally. Called after a section title's reference text
@@ -590,12 +743,22 @@ impl<'src> Content<'src> {
                     && xref.derived.is_none()
                     && template.contains(&Content::xref_placeholder(index))
                 {
-                    warnings.unresolved(&xref.target, source);
+                    warnings.unresolved(&unescape_sentinels(&xref.target), source);
                 }
             }
         }
 
-        self.rebuild_rendered(renderer);
+        // Content that carries no deferred cross-reference is untouched here:
+        // its rendering left escaped form at the end of substitution, and
+        // unescaping again would read a document's own escape sequence as one
+        // of ours.
+        if self.deferred.is_some() {
+            self.rebuild_rendered(renderer);
+
+            // The template is held in escaped form, so the rebuilt rendering is
+            // too; hand it back as the document wrote it.
+            self.unescape_sentinels();
+        }
     }
 
     /// Rebuilds [`Content::rendered`] from the deferred template and the
@@ -678,7 +841,9 @@ pub(crate) fn render_xref_template(
     xrefs: &[XrefSegment],
     renderer: &dyn InlineSubstitutionRenderer,
 ) -> String {
-    render_template(template, xrefs, renderer)
+    // The template is held in escaped form (see `escape_sentinels`); this is
+    // the title's final rendering, so it leaves escaped form here.
+    unescape_sentinels(&render_template(template, xrefs, renderer)).into_owned()
 }
 
 /// Splices resolved (or fallback) cross-reference renderings into a placeholder
@@ -726,11 +891,13 @@ fn render_template(
             }
 
             None => {
-                // Unreachable while `template` and `xrefs` come from the same
-                // `Content` (indices are assigned sequentially). If that
-                // invariant is ever broken, emit the raw placeholder rather than
-                // silently dropping the span, so the breakage is visible.
-                debug_assert!(false, "xref placeholder index {body:?} out of range");
+                // Not a placeholder this template owns: emit the text
+                // literally. Placeholder indices are assigned sequentially into
+                // the same `Content`'s `xrefs`, so this is unreachable for a
+                // placeholder the substitution wrote; text is never rejected
+                // here (nor asserted against) because a sequence that merely
+                // looks like a placeholder is content, and content is passed
+                // through.
                 out.push(XREF_PLACEHOLDER_START);
                 out.push_str(body);
                 out.push(XREF_PLACEHOLDER_END);
@@ -773,7 +940,9 @@ impl FootnoteDeferred {
     /// Renders the footnote text from the template and the current (resolved or
     /// unresolved) state of its cross-references.
     pub(crate) fn render(&self, renderer: &dyn InlineSubstitutionRenderer) -> String {
-        render_template(&self.template, &self.xrefs, renderer)
+        // The template is held in escaped form (see `escape_sentinels`); the
+        // footnote's text is user-facing, so it leaves escaped form here.
+        unescape_sentinels(&render_template(&self.template, &self.xrefs, renderer)).into_owned()
     }
 
     /// Resolves the footnote's cross-references using `resolver`, reporting any
@@ -793,7 +962,7 @@ impl FootnoteDeferred {
             });
 
             if xref.resolved.is_none() && xref.derived.is_none() {
-                warnings.unresolved(&xref.target, source);
+                warnings.unresolved(&unescape_sentinels(&xref.target), source);
             }
         }
     }
@@ -878,6 +1047,103 @@ mod tests {
 
             assert!(matches!(content.rendered, CowStr::Boxed(_)));
             assert_eq!(content.rendered.as_ref(), "ab");
+        }
+    }
+
+    mod escape_sentinels {
+        use std::borrow::Cow;
+
+        use super::super::{
+            FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, PASSTHROUGH_PLACEHOLDER_END,
+            PASSTHROUGH_PLACEHOLDER_START, RESERVED_SENTINELS, SENTINEL_ESCAPE,
+            XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, escape_sentinels, is_reserved_sentinel,
+            unescape_sentinels,
+        };
+
+        #[test]
+        fn the_range_test_and_the_table_describe_the_same_codepoints() {
+            for (sentinel, _) in RESERVED_SENTINELS {
+                assert!(
+                    is_reserved_sentinel(sentinel),
+                    "{sentinel:?} is reserved but not covered by the range test"
+                );
+            }
+
+            for c in '\u{0}'..=char::MAX {
+                assert_eq!(
+                    is_reserved_sentinel(c),
+                    RESERVED_SENTINELS
+                        .iter()
+                        .any(|(sentinel, _)| *sentinel == c),
+                    "the range test and the table disagree about {c:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn borrows_text_with_no_reserved_codepoint() {
+            assert!(matches!(
+                escape_sentinels("plain text"),
+                Cow::Borrowed("plain text")
+            ));
+
+            assert!(matches!(
+                unescape_sentinels("plain text"),
+                Cow::Borrowed("plain text")
+            ));
+        }
+
+        #[test]
+        fn escaped_text_holds_no_reserved_codepoint() {
+            let typed = format!(
+                "a{XREF_PLACEHOLDER_START}0{XREF_PLACEHOLDER_END}b{FOOTNOTE_MARKER_START}\
+                 c{FOOTNOTE_MARKER_END}d{PASSTHROUGH_PLACEHOLDER_START}1\
+                 {PASSTHROUGH_PLACEHOLDER_END}e{SENTINEL_ESCAPE}f"
+            );
+
+            let escaped = escape_sentinels(&typed);
+
+            for reserved in [
+                XREF_PLACEHOLDER_START,
+                XREF_PLACEHOLDER_END,
+                FOOTNOTE_MARKER_START,
+                FOOTNOTE_MARKER_END,
+                PASSTHROUGH_PLACEHOLDER_START,
+                PASSTHROUGH_PLACEHOLDER_END,
+            ] {
+                assert!(
+                    !escaped.contains(reserved),
+                    "escaped text still contains {reserved:?}: {escaped:?}"
+                );
+            }
+
+            // The escape introducer is the one reserved codepoint that remains,
+            // and every occurrence of it is one the escaping wrote.
+            assert_eq!(escaped.matches(SENTINEL_ESCAPE).count(), 7, "{escaped:?}");
+
+            assert_eq!(unescape_sentinels(&escaped), typed);
+        }
+
+        #[test]
+        fn round_trips_an_escape_introducer_followed_by_a_tag() {
+            // The sequence a document is most likely to be mangled by: its own
+            // escape introducer followed by a character that is also an escape
+            // tag. Escaping the introducer keeps the pair distinguishable.
+            let typed = format!("x{SENTINEL_ESCAPE}ay");
+
+            assert_eq!(unescape_sentinels(&escape_sentinels(&typed)), typed);
+        }
+
+        #[test]
+        fn passes_a_dangling_escape_introducer_through() {
+            // Cannot arise from `escape_sentinels` (which always writes a tag),
+            // so this only pins down that a malformed sequence is content, not a
+            // dropped character.
+            let dangling = format!("x{SENTINEL_ESCAPE}");
+            assert_eq!(unescape_sentinels(&dangling), dangling);
+
+            let unknown_tag = format!("x{SENTINEL_ESCAPE}zy");
+            assert_eq!(unescape_sentinels(&unknown_tag), unknown_tag);
         }
     }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -727,8 +727,14 @@ impl<'src> Content<'src> {
             debug_assert!(!template.is_empty());
 
             for (index, xref) in xrefs.iter_mut().enumerate() {
+                // A target is matched against the catalog, which holds the
+                // document's own text (an ID as it was written, a section's
+                // reference text). The segment keeps the target in escaped form
+                // — it is rendered back into escaped text — so the key handed
+                // to the resolver leaves escaped form here. See
+                // [`escape_sentinels`].
                 xref.resolved = resolver.resolve(&ResolutionContext {
-                    target: &xref.target,
+                    target: &unescape_sentinels(&xref.target),
                     provided_text: xref.provided_text.as_deref(),
                     derived: xref.derived.as_ref(),
                 });
@@ -955,8 +961,10 @@ impl FootnoteDeferred {
         source: Span<'src>,
     ) {
         for xref in self.xrefs.iter_mut() {
+            // The catalog holds the document's own text, so the lookup key
+            // leaves escaped form here (see `Content::resolve_references`).
             xref.resolved = resolver.resolve(&ResolutionContext {
-                target: &xref.target,
+                target: &unescape_sentinels(&xref.target),
                 provided_text: xref.provided_text.as_deref(),
                 derived: xref.derived.as_ref(),
             });

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -764,11 +764,11 @@ impl<'src> Content<'src> {
     /// Rebuilds [`Content::rendered`] from the deferred template and the
     /// current (resolved or unresolved) state of its cross-references.
     fn rebuild_rendered(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
-        let Some(deferred) = self.deferred.as_ref() else {
-            return;
-        };
-
-        self.rendered = render_template(&deferred.template, &deferred.xrefs, renderer).into();
+        // Both callers establish that there is a template to rebuild from, so
+        // the guard here is only a safety net.
+        if let Some(deferred) = self.deferred.as_ref() {
+            self.rendered = render_template(&deferred.template, &deferred.xrefs, renderer).into();
+        }
     }
 }
 
@@ -1050,6 +1050,36 @@ mod tests {
         }
     }
 
+    mod impl_debug {
+        use crate::{
+            Span,
+            content::{Content, XrefSegment},
+        };
+
+        #[test]
+        fn shows_the_deferred_state_only_when_there_is_one() {
+            let mut content = Content::from(Span::new("see <<a>>"));
+
+            // The cross-reference-free case (the overwhelming majority) debugs
+            // as a plain `original` + `rendered` pair.
+            assert!(!format!("{content:?}").contains("deferred"));
+
+            content.set_deferred_xrefs(vec![XrefSegment {
+                target: "a".to_string(),
+                provided_text: None,
+                window: None,
+                roles: vec![],
+                xrefstyle: None,
+                derived: None,
+                resolved: None,
+            }]);
+
+            let debug = format!("{content:?}");
+            assert!(debug.contains("deferred"), "{debug:?}");
+            assert!(debug.contains("XrefSegment"), "{debug:?}");
+        }
+    }
+
     mod escape_sentinels {
         use std::borrow::Cow;
 
@@ -1236,6 +1266,62 @@ mod tests {
                 sanitize_title("Title <dangling and more"),
                 "Title <dangling and more",
             );
+        }
+    }
+
+    mod render_template {
+        use super::super::{
+            XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, XrefSegment, render_template,
+        };
+        use crate::parser::HtmlSubstitutionRenderer;
+
+        fn segment(target: &str) -> XrefSegment {
+            XrefSegment {
+                target: target.to_string(),
+                provided_text: None,
+                window: None,
+                roles: vec![],
+                xrefstyle: None,
+                derived: None,
+                resolved: None,
+            }
+        }
+
+        fn render(template: &str, xrefs: &[XrefSegment]) -> String {
+            render_template(template, xrefs, &HtmlSubstitutionRenderer {})
+        }
+
+        #[test]
+        fn splices_a_reference_into_its_placeholder() {
+            let template = format!("see {XREF_PLACEHOLDER_START}0{XREF_PLACEHOLDER_END} here");
+
+            assert_eq!(
+                render(&template, &[segment("a")]),
+                r##"see <a href="#a">[a]</a> here"##
+            );
+        }
+
+        #[test]
+        fn passes_an_unterminated_placeholder_through_literally() {
+            // A start sentinel with no end cannot arise from the substitution
+            // (which always writes both), and a document's own copy is escaped
+            // before it gets here, so this only pins down that the text is
+            // emitted rather than swallowed.
+            let unterminated = format!("a{XREF_PLACEHOLDER_START}0 no end");
+
+            assert_eq!(render(&unterminated, &[segment("a")]), unterminated);
+        }
+
+        #[test]
+        fn passes_an_unmatched_placeholder_through_literally() {
+            // Likewise for a bracketed body that names no reference this
+            // template owns: a sequence that merely looks like a placeholder is
+            // content, and reaches the output as content.
+            let out_of_range = format!("x{XREF_PLACEHOLDER_START}9{XREF_PLACEHOLDER_END}y");
+            assert_eq!(render(&out_of_range, &[segment("a")]), out_of_range);
+
+            let non_numeric = format!("x{XREF_PLACEHOLDER_START}xyz{XREF_PLACEHOLDER_END}y");
+            assert_eq!(render(&non_numeric, &[segment("a")]), non_numeric);
         }
     }
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,8 +6,10 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
+    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle,
+    PASSTHROUGH_PLACEHOLDER_END, PASSTHROUGH_PLACEHOLDER_START, XrefSegment, escape_sentinels,
     rehome_xref_placeholders, render_xref_template, sanitize_title, strip_footnote_marker_spans,
+    unescape_sentinels,
 };
 
 mod macros;

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -5,7 +5,10 @@ use regex::{Captures, Regex, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup, substitution_step::substitute_attributes_in_text},
+    content::{
+        Content, PASSTHROUGH_PLACEHOLDER_END, PASSTHROUGH_PLACEHOLDER_START, SubstitutionGroup,
+        substitution_step::substitute_attributes_in_text,
+    },
     parser::{QuoteScope, QuoteType},
     warnings::WarningType,
 };
@@ -146,13 +149,13 @@ impl Passthroughs {
         let index = self.0.len();
         self.0.push(passthrough);
 
-        dest.push('\u{96}');
+        dest.push(PASSTHROUGH_PLACEHOLDER_START);
 
         // Append the index in place with `write!`, avoiding the temporary
         // `String` a `push_str(&format!(...))` would allocate.
         let _ = write!(dest, "{index}");
 
-        dest.push('\u{97}');
+        dest.push(PASSTHROUGH_PLACEHOLDER_END);
     }
 }
 
@@ -384,7 +387,10 @@ impl InlinePassMacroReplacer<'_> {
 
 static PASS_WITH_INDEX: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
-    Regex::new("\u{96}(\\d+)\u{97}").unwrap()
+    Regex::new(&format!(
+        "{PASSTHROUGH_PLACEHOLDER_START}(\\d+){PASSTHROUGH_PLACEHOLDER_END}"
+    ))
+    .unwrap()
 });
 
 /// Matches an inline passthrough, which may span multiple lines.
@@ -704,7 +710,10 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
             subbed_text.rendered = new_text.into();
         }
 
-        if subbed_text.rendered().contains('\u{96}') {
+        if subbed_text
+            .rendered()
+            .contains(PASSTHROUGH_PLACEHOLDER_START)
+        {
             // Recursively apply passthrough replacement and write the result.
             let replacer = PassthroughRestoreReplacer(self.0, self.1);
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -226,6 +226,38 @@ impl SubstitutionGroup {
         parser: &Parser,
         attrlist: Option<&Attrlist>,
     ) {
+        self.apply_keeping_sentinels_escaped(content, parser, attrlist);
+
+        // Hand back the document's own text: the sentinel codepoints escaped on
+        // the way in (see `Content::escape_sentinels`) are restored now that
+        // every pass that reads them has run.
+        content.unescape_sentinels();
+    }
+
+    /// Applies this substitution group, leaving the result in the *escaped*
+    /// sentinel form (see
+    /// [`escape_sentinels`](crate::content::escape_sentinels)).
+    ///
+    /// Only the section-title path wants this: it has one more sentinel-reading
+    /// pass to run (excising the footnote markers from the reference text and
+    /// auto-generated ID) before the text is user-facing, and that pass must
+    /// not see a document's own copy of a marker sentinel. It calls
+    /// [`Content::unescape_sentinels`] itself once that pass is done. Every
+    /// other caller wants [`apply`](Self::apply).
+    pub(crate) fn apply_keeping_sentinels_escaped(
+        &self,
+        content: &mut Content<'_>,
+        parser: &Parser,
+        attrlist: Option<&Attrlist>,
+    ) {
+        // The substitution steps below mark their work in-band, with sentinel
+        // codepoints spliced into the same string as the document's text. A
+        // document can type those codepoints itself, so its own copies are
+        // escaped out of the way first; otherwise they are read back as the
+        // parser's own control sequences (forging, for instance, a second
+        // cross-reference into the output).
+        content.escape_sentinels();
+
         let steps = self.steps();
 
         let passthroughs: Option<Passthroughs> =

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Regex, RegexBuilder, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, escape_sentinels},
+    content::{Content, escape_sentinels, unescape_sentinels},
     document::{InterpretedValue, RefType},
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
@@ -398,9 +398,16 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                     // Assigning an ID to inline quoted text (e.g.,
                     // `[#free_the_world]#free the world#`) makes that phrase
                     // referenceable, so register it in the catalog. A duplicate
-                    // ID here is non-fatal (first registration wins).
+                    // ID here is non-fatal (first registration wins). The ID is
+                    // read out of escaped text, and the catalog holds the
+                    // document's own (see `escape_sentinels`), so it leaves
+                    // escaped form on the way in.
                     if let Some(id) = &id {
-                        let _ = self.parser.register_ref(id, None, RefType::Anchor);
+                        let _ = self.parser.register_ref(
+                            &unescape_sentinels(id),
+                            None,
+                            RefType::Anchor,
+                        );
                     }
 
                     self.parser.renderer.render_quoted_substitution(
@@ -441,9 +448,12 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                 // Assigning an ID to inline quoted text (e.g.,
                 // `[#free_the_world]#free the world#`) makes that phrase
                 // referenceable, so register it in the catalog. A duplicate ID
-                // here is non-fatal (first registration wins).
+                // here is non-fatal (first registration wins). The ID leaves
+                // escaped form on the way in, as above.
                 if let Some(id) = &id {
-                    let _ = self.parser.register_ref(id, None, RefType::Anchor);
+                    let _ =
+                        self.parser
+                            .register_ref(&unescape_sentinels(id), None, RefType::Anchor);
                 }
 
                 self.parser

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Regex, RegexBuilder, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::Content,
+    content::{Content, escape_sentinels},
     document::{InterpretedValue, RefType},
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
@@ -642,6 +642,12 @@ struct AttributeReplacer<'p> {
     /// whole line in `drop-line` mode, or a line the dropped reference left
     /// empty in `drop` mode (Asciidoctor's `reject_if_empty`).
     missing_on_line: bool,
+
+    /// Whether a substituted attribute value should have its reserved sentinel
+    /// codepoints escaped on the way in. Set only when replacing references in
+    /// content being substituted, which is held in escaped form (see
+    /// [`escape_sentinels`]).
+    escape_sentinels: bool,
 }
 
 impl<'p> AttributeReplacer<'p> {
@@ -679,7 +685,15 @@ impl<'p> AttributeReplacer<'p> {
             source_matches,
             match_index: 0,
             missing_on_line: false,
+            escape_sentinels: false,
         }
+    }
+
+    /// Escapes the reserved sentinel codepoints of every attribute value this
+    /// replacer splices in, for the content path (see the field docs).
+    fn escaping_sentinels(mut self) -> Self {
+        self.escape_sentinels = true;
+        self
     }
 
     /// Returns the source span to attribute a recorded warning to for the
@@ -807,7 +821,17 @@ impl Replacer for AttributeReplacer<'_> {
         // A value-less `Set` attribute (e.g. `:foo:` with no `=value`)
         // substitutes to an empty string, matching Asciidoctor.
         if let InterpretedValue::Value(value) = value {
-            dest.push_str(value.as_ref());
+            // An attribute's value is stored as the document wrote it, so a
+            // reserved sentinel codepoint in it enters the text being
+            // substituted unescaped unless it is escaped here (see
+            // `escape_sentinels`). Only the content path asks for this: a value
+            // spliced into a macro target or an attribute list is not part of
+            // the escaped text and is restored by no one.
+            if self.escape_sentinels {
+                dest.push_str(&escape_sentinels(value.as_ref()));
+            } else {
+                dest.push_str(value.as_ref());
+            }
         }
     }
 }
@@ -871,7 +895,8 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
         // against `source_lines.len()`, so the entry is always present; `.get`
         // keeps the access panic-free regardless.
         let source_line = source_lines.and_then(|lines| lines.get(index).copied());
-        let mut replacer = AttributeReplacer::new(parser, mode, source, source_line);
+        let mut replacer =
+            AttributeReplacer::new(parser, mode, source, source_line).escaping_sentinels();
 
         let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
 

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{XrefSegment, render_xref_template},
+    content::{XrefSegment, render_xref_template, unescape_sentinels},
     document::Catalog,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext},
 };
@@ -205,8 +205,12 @@ fn compute<'src>(
     let mut xrefs = node.xrefs.clone();
 
     for xref in xrefs.iter_mut() {
+        // The catalog holds the document's own text, so a target leaves escaped
+        // form to be matched against it (see `Content::resolve_references`).
+        let target = unescape_sentinels(&xref.target);
+
         let mut resolved = resolver.resolve(&ResolutionContext {
-            target: &xref.target,
+            target: &target,
             provided_text: xref.provided_text.as_deref(),
             derived: xref.derived.as_ref(),
         });
@@ -230,7 +234,7 @@ fn compute<'src>(
         // correct.
         if !has_explicit_text
             && let Some(reference) = resolved.as_mut()
-            && let Some(target_id) = lookup_id(catalog, &xref.target)
+            && let Some(target_id) = lookup_id(catalog, &target)
             && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
             && reference.href.strip_prefix('#') == Some(target_id.as_str())
         {
@@ -269,7 +273,7 @@ fn compute<'src>(
         // A target that resolved to nothing — and did not carry its own derived
         // destination — is an unresolved reference, reported against the title.
         if resolved.is_none() && xref.derived.is_none() {
-            warnings.unresolved(&xref.target, node.source);
+            warnings.unresolved(&target, node.source);
         }
 
         xref.resolved = resolved;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1867,7 +1867,12 @@ impl Parser {
         // references. The stored `text` is the unresolved fallback rendering
         // until then, so it is always clean.
         let (text, deferred) = if xrefs.is_empty() {
-            (text, None)
+            // The text was extracted from content held in escaped sentinel form
+            // (see `escape_sentinels`); it is user-facing from here, so it
+            // leaves escaped form now. The deferred branch below does the same
+            // from `FootnoteDeferred::render`, keeping its template escaped for
+            // later re-rendering.
+            (crate::content::unescape_sentinels(&text).into_owned(), None)
         } else {
             let deferred = crate::content::FootnoteDeferred::new(text, xrefs);
             let rendered = deferred.render(&*self.renderer);

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -14,5 +14,6 @@ mod origin;
 pub(crate) mod prelude;
 pub(crate) mod sdd;
 mod security;
+mod sentinels;
 mod table_cell_directive_warnings;
 mod xref;

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -1,0 +1,177 @@
+//! Regression tests for documents that type the codepoints the substitution
+//! pipeline uses as in-band control sentinels (issue #1235).
+//!
+//! The pipeline marks its own work inside the text it is substituting: a
+//! deferred cross-reference leaves `U+E000 <index> U+E001` behind, a footnote
+//! marker in a section title is bracketed with `U+E002`/`U+E003`, and an
+//! extracted passthrough is stood in for by `U+0096 <index> U+0097`. Those
+//! codepoints are unassigned (Private Use Area) or non-printing (C1), but a
+//! document can type them, so they are escaped out of the document's own text
+//! before substitution begins and restored on the way out.
+//!
+//! Two properties are covered:
+//!
+//!   * the output carries exactly the cross-references, footnotes, and
+//!     passthroughs the document wrote — a typed sentinel sequence is never
+//!     read back as the parser's own; and
+//!   * the typed codepoints reach the output unchanged, since a Private Use
+//!     Area character is content like any other.
+
+use crate::{
+    Document, Parser,
+    blocks::{Block, FindBlocks, IsBlock, SimpleBlock},
+};
+
+/// Returns the rendered text of the last paragraph in `doc`, which is where
+/// each of these documents writes the text under test (an anchor the
+/// cross-references point at comes first).
+fn last_paragraph<'a>(doc: &'a Document<'a>) -> &'a str {
+    fn walk<'a>(blocks: impl Iterator<Item = &'a Block<'a>>, found: &mut Vec<&'a SimpleBlock<'a>>) {
+        for block in blocks {
+            if let Block::Simple(simple) = block {
+                found.push(simple);
+            } else {
+                walk(block.child_blocks(), found);
+            }
+        }
+    }
+
+    let mut found = vec![];
+    walk(doc.child_blocks(), &mut found);
+
+    found
+        .last()
+        .expect("expected at least one simple block")
+        .content()
+        .rendered()
+}
+
+#[test]
+fn a_typed_placeholder_cannot_forge_a_cross_reference() {
+    // The document writes one cross-reference and, separately, the characters
+    // that the cross-reference substitution uses to mark a deferred reference.
+    let doc = Parser::default().parse(concat!(
+        "[[a]]anchor\n",
+        "\n",
+        "<<a>> x\u{e000}0\u{e001}y\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert_eq!(
+        rendered.matches("<a href=").count(),
+        1,
+        "the document wrote one cross-reference; got {rendered:?}"
+    );
+
+    // The typed codepoints are content, and reach the output as content.
+    assert_eq!(rendered, "<a href=\"#a\">[a]</a> x\u{e000}0\u{e001}y");
+}
+
+#[test]
+fn a_typed_placeholder_start_does_not_capture_a_real_placeholder() {
+    // A lone start sentinel ahead of a real cross-reference would, unescaped,
+    // make the reference's own placeholder look like the tail of a malformed
+    // one — the case that reached `debug_assert!(false, …)` before this was
+    // escaped.
+    let doc = Parser::default().parse(concat!("[[a]]anchor\n", "\n", "\u{e000}<<a>>\n"));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "\u{e000}<a href=\"#a\">[a]</a>",
+        "the typed sentinel is content and the reference renders once"
+    );
+}
+
+#[test]
+fn a_typed_placeholder_is_inert_without_any_cross_reference() {
+    // Nothing to forge here, but the text must still round-trip exactly.
+    let doc = Parser::default().parse("a\u{e000}0\u{e001}b\n");
+    assert_eq!(last_paragraph(&doc), "a\u{e000}0\u{e001}b");
+}
+
+#[test]
+fn a_placeholder_from_an_attribute_value_cannot_forge_a_cross_reference() {
+    // An attribute value is substituted into the text after it was escaped, so
+    // it is escaped as it is spliced in; otherwise it is a second road to the
+    // same forgery.
+    let doc = Parser::default().parse(concat!(
+        ":sentinel: \u{e000}0\u{e001}\n",
+        "\n",
+        "[[a]]anchor\n",
+        "\n",
+        "<<a>> {sentinel}\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert_eq!(rendered.matches("<a href=").count(), 1, "{rendered:?}");
+    assert_eq!(rendered, "<a href=\"#a\">[a]</a> \u{e000}0\u{e001}");
+}
+
+#[test]
+fn a_typed_passthrough_placeholder_cannot_forge_a_passthrough() {
+    // The passthrough placeholders are the same kind of in-band mark, and are
+    // escaped alongside the cross-reference ones: this document's `<b>` is
+    // unescaped output the passthrough asked for, and must appear exactly once.
+    let doc = Parser::default().parse("+++<b>+++ and \u{96}0\u{97} tail\n");
+
+    let rendered = last_paragraph(&doc);
+
+    assert_eq!(rendered.matches("<b>").count(), 1, "{rendered:?}");
+    assert_eq!(rendered, "<b> and \u{96}0\u{97} tail");
+}
+
+#[test]
+fn a_typed_placeholder_inside_a_passthrough_cannot_forge_a_cross_reference() {
+    // A passthrough's text is spliced back in after the cross-reference
+    // substitution ran, so it is restored into text that already carries
+    // placeholders.
+    let doc = Parser::default().parse(concat!(
+        "[[a]]anchor\n",
+        "\n",
+        "<<a>> +x\u{e000}0\u{e001}+\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert_eq!(rendered.matches("<a href=").count(), 1, "{rendered:?}");
+    assert_eq!(rendered, "<a href=\"#a\">[a]</a> x\u{e000}0\u{e001}");
+}
+
+#[test]
+fn a_typed_marker_sentinel_does_not_truncate_a_section_reftext() {
+    // The footnote-marker sentinels bracket a marker so it can be excised from
+    // a section's reference text and auto-generated ID. A typed start sentinel
+    // would otherwise open a span that the real marker's end sentinel closes,
+    // swallowing the title text in between.
+    let doc = Parser::default().parse(concat!(
+        "== Alpha\u{e002}beta footnote:[a note]\n",
+        "\n",
+        "body\n",
+    ));
+
+    let Some(Block::Section(section)) = doc.child_blocks().next() else {
+        panic!("expected a section block");
+    };
+
+    let title = section.section_title();
+
+    // The heading keeps every character the document wrote, plus its footnote
+    // marker.
+    assert!(title.starts_with("Alpha\u{e002}beta"), "{title:?}");
+    assert!(title.contains(r#"class="footnote""#), "{title:?}");
+
+    // The reference text (and the ID derived from it) drops only the footnote
+    // marker.
+    assert_eq!(section.id(), Some("_alphabeta"));
+}
+
+#[test]
+fn a_typed_escape_introducer_round_trips() {
+    // The codepoint that introduces an escaped sentinel is itself escaped, so a
+    // document that types it — even followed by a character that is otherwise
+    // an escape tag — gets it back verbatim rather than as some other sentinel.
+    let doc = Parser::default().parse("x\u{e004}ay\u{e004}gz\n");
+    assert_eq!(last_paragraph(&doc), "x\u{e004}ay\u{e004}gz");
+}

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -167,6 +167,68 @@ fn a_typed_marker_sentinel_does_not_truncate_a_section_reftext() {
     assert_eq!(section.id(), Some("_alphabeta"));
 }
 
+/// Returns the rendered text of the last paragraph together with the number of
+/// warnings the parse recorded — an unresolved cross-reference both renders its
+/// fallback and warns, so the count is what separates "resolved" from "looks
+/// resolved".
+fn last_paragraph_and_warnings(source: &str) -> (String, usize) {
+    let doc = Parser::default().parse(source);
+    let warnings = doc.warnings().count();
+
+    let mut rendered = String::new();
+    for block in doc.descendant_blocks() {
+        if let Block::Simple(simple) = block {
+            rendered = simple.content().rendered().to_string();
+        }
+    }
+
+    (rendered, warnings)
+}
+
+#[test]
+fn a_natural_cross_reference_matches_a_title_holding_a_sentinel() {
+    // A natural cross-reference matches on the target's *reference text*, which
+    // for a section is its rendered title — the document's own text, held
+    // outside the escaped form the substitution works in. The target is read
+    // out of escaped text, so it leaves escaped form to be matched, or a title
+    // carrying a reserved codepoint could never be referenced by name.
+    let (rendered, warnings) =
+        last_paragraph_and_warnings("== Alpha\u{e000}beta\n\nSee <<Alpha\u{e000}beta>>.\n");
+
+    assert_eq!(warnings, 0, "reference did not resolve: {rendered:?}");
+    assert_eq!(
+        rendered,
+        "See <a href=\"#_alphabeta\">Alpha\u{e000}beta</a>."
+    );
+}
+
+#[test]
+fn a_cross_reference_matches_an_id_holding_a_sentinel() {
+    // An ID assigned to inline quoted text is read out of escaped text and
+    // registered, so it leaves escaped form on the way into the catalog to meet
+    // the (likewise unescaped) target.
+    let (rendered, warnings) =
+        last_paragraph_and_warnings("[#a\u{e000}b]#phrase#\n\nSee <<a\u{e000}b>>.\n");
+
+    assert_eq!(warnings, 0, "reference did not resolve: {rendered:?}");
+    assert_eq!(
+        rendered, "See <a href=\"#a\u{e000}b\">[a\u{e000}b]</a>.",
+        "the ID reaches the output as the document wrote it"
+    );
+}
+
+#[test]
+fn a_cross_reference_matches_a_block_id_holding_a_sentinel() {
+    // A block's ID comes from its attribute list, which is parsed from the
+    // source and so never enters escaped form at all. The target it is matched
+    // against does, which is why the two meet unescaped.
+    let (rendered, warnings) =
+        last_paragraph_and_warnings("[#a\u{e000}b]\nparagraph\n\nSee <<a\u{e000}b>>.\n");
+
+    assert_eq!(warnings, 0, "reference did not resolve: {rendered:?}");
+    assert_eq!(rendered, "See <a href=\"#a\u{e000}b\">[a\u{e000}b]</a>.");
+}
+
 #[test]
 fn a_typed_escape_introducer_round_trips() {
     // The codepoint that introduces an escaped sentinel is itself escaped, so a


### PR DESCRIPTION
Fixes #1235.

## The problem

The substitution pipeline marks its own work **in-band**, splicing sentinel codepoints into the same string as the document's text:

| Sentinels | Purpose |
| --- | --- |
| `U+E000` … `U+E001` | bracket a deferred cross-reference's placeholder index |
| `U+E002` … `U+E003` | bracket a footnote's marker while a section title is substituted |
| `U+0096` … `U+0097` | stand in for an extracted passthrough |

The comments on the first two claimed these "cannot collide with user text". As the issue shows, they can — a Private Use Area codepoint is unassigned, but perfectly typeable and perfectly valid in a `&str`. A document that wrote one cross-reference plus the characters `U+E000 0 U+E001` had that text read back as a placeholder and rendered a **second cross-reference it never wrote**, in release builds where the `debug_assert!` on the same path is compiled out.

The passthrough placeholders forge the same way, which is the sharper edge of the same bug, since a passthrough's payload is unescaped output:

```rust
// before: "<b> and <b> tail" — the `<b>` is replayed where the document typed a placeholder
Parser::default().parse("+++<b>+++ and \u{96}0\u{97} tail");
```

## The fix

Option 2 from the issue: escape on the way in, unescape on the way out, so a placeholder is unambiguous by construction.

- `escape_sentinels` / `unescape_sentinels` (`parser/src/content/content.rs`) map each reserved codepoint to `U+E004 <tag>`. The escape introducer is itself in the table, so escaping is exactly reversible; text with no reserved codepoint is borrowed through unchanged, so the common case does not allocate.
- `SubstitutionGroup::apply` escapes the content before substitution begins — ahead of passthrough extraction, so the passthrough placeholders are covered too — and unescapes at the end. Everything the readers see unescaped is therefore something the pipeline wrote itself, and a private-use character the document typed reaches the output as the content it is.
- Escaping and unescaping are exact inverses, so matched pairs nest: a passthrough's text is substituted by a nested `apply` while it is itself held in escaped form, and comes back correctly escaped for splicing.
- The deferred cross-reference template stays escaped, since it is an internal representation re-rendered on each resolution; the paths that turn it into user-facing text (`Content::resolve_references`, `FootnoteDeferred::render`, `render_xref_template`, `Parser::define_footnote`) unescape their result.
- The section-title path calls the new `apply_keeping_sentinels_escaped` and unescapes once it has excised the footnote markers, so that excision also sees only the parser's own sentinels.
- An attribute value is stored as the document wrote it, so it is escaped as it is spliced into content — otherwise `:x: <U+E000>0<U+E001>` is a second road to the same forgery.
- The `debug_assert!(false, …)` in `render_template` is dropped. It is now unreachable, and a sequence that merely looks like a placeholder is content: it is emitted as content rather than asserted against.
- The doc comments' "cannot collide with user text" claim is gone, replaced by a description of what actually makes the sentinels unambiguous.

### The catalog boundary

A catalog entry holds the document's own text, so it sits outside the escaped form:

- An ID from an attribute list (`[#id]`) is parsed from the source and never enters escaped form at all.
- A section's reference text is unescaped as it is derived.
- The one key read out of escaped text — the ID assigned to inline quoted text — is unescaped on the way in.

A cross-reference target, by contrast, is read out of escaped text, so it is unescaped where it is handed to a resolver, at all three resolution sites. The segment keeps the escaped target, which is what gets rendered back into escaped text, so the destination still reaches the output as the document wrote it. (Thanks to @greptile for catching that these two sides had diverged — see the resolved thread.)

## Result

Every row of the issue's table, in both debug and release builds:

| Input | Rendered |
| --- | --- |
| `<<a>> tail` | `<a href="#a">[a]</a> tail` |
| `<<a>> x<U+E000>0<U+E001>y` | `<a href="#a">[a]</a> x<U+E000>0<U+E001>y` ✅ one reference, typed text intact |
| `a<U+E000>0<U+E001>b` | `a<U+E000>0<U+E001>b` |
| `*<U+E000><<a>>` | `*<U+E000><a href="#a">[a]</a>` ✅ no panic |

## Tests

New `parser/src/tests/sentinels.rs` covers the forgery routes end to end: a typed placeholder beside a real cross-reference, a typed start sentinel capturing a real placeholder (the `debug_assert!` case), a placeholder delivered through an attribute value, one inside a passthrough, a typed passthrough placeholder, a typed marker sentinel in a section title (reference text and generated ID stay whole), and a round trip of the escape introducer itself. Three more cover the catalog boundary — a natural reference to a section title, a quoted-text ID, and a block ID, each asserting zero warnings, since the fallback rendering alone does not distinguish resolved from unresolved.

Unit tests in `content.rs` cover the escaping pair directly (including that its fast range test and its table agree over every codepoint) and both placeholder fallbacks in `render_template`.

`cargo test` (4757 tests, debug and release), `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo +nightly fmt --check`, and `cargo doc --no-deps --document-private-items` are all clean. `parser/src/content/content.rs` is at 100% line coverage.

## Notes for review

- One boundary remains: a resolved destination comes back from the catalog unescaped and is spliced into text that still gets one final unescape pass, so a reference text containing the escape introducer `U+E004` followed by an escape tag character would be rewritten. That needs the introducer specifically, not the sentinels this PR is about. It disappears entirely under the out-of-band template the issue suggests as its first option, which I would rather do as a follow-up than fold into this change.
- `[[id]]` anchors, bibliography anchors, and footnote IDs reject these codepoints at the lexical level, so no catalog key on those routes can carry one. I confirmed that empirically rather than writing defensive unescaping for them.
- Fixing the passthrough placeholders is a small extension beyond the issue's cross-reference scope; they are the same in-band mark and forge output in the same way, so they share the escape table. Happy to split them out if you would rather keep the change narrow.