### PR TITLE
feat: Recognize a cross-reference whose target is attribute-expanded (inline-ast Phase 4, step 6 prep)

### DIFF
--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         normalize_text_lf_escaped_bracket,
     },
-    inlines::{Image, InlineNode, RawForm},
+    inlines::{Image, InlineNode, RawForm, RawOrigin},
     parser::{
         InlineSubstitutionRenderer, has_dangerous_scheme, has_dangerous_self_href, is_uri_ish,
     },
@@ -304,6 +304,70 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
         .get(piece.node_index)
         .and_then(charref_entity)
         .is_some()
+}
+
+/// [`range_has_no_opaque_piece`], further admitting a
+/// [`Raw`](InlineNode::Raw) leaf a **substitution produced in place** — an
+/// expanded attribute value's literal `<`, `>`, or `&`, which §3.4.1 leaves
+/// unescaped because the value expands *after* `specialcharacters` ran
+/// ([`RawOrigin::Substitution`]).
+///
+/// The match string stands such a leaf in as one placeholder, so a value
+/// reading it needs the same splice a masked construct's does
+/// ([`restore_masked_passthroughs`](super::links)) — but the *timing* that
+/// makes [`range_is_restorable`] wrong for a cross-reference does not apply
+/// here, and that is the whole distinction:
+///
+/// - A **masked passthrough** is restored by a later pass. A deferred
+///   cross-reference's target is captured into its segment *before* that pass
+///   runs, so the string pipeline's own `href` holds the sentinel — and a tree
+///   that read the restored bytes would diverge from it (see
+///   `a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`).
+///   [`range_is_restorable`] admits it; this does not.
+///
+/// - A **substitution-produced** leaf was never extracted and is never
+///   restored. Its bytes are simply *there*, in the very haystack the string
+///   replacer reads, so filling the placeholder in reaches parity rather than
+///   departing from it.
+///
+/// Deciding this from the node's own [`RawOrigin`] rather than from the
+/// extraction pass's `Masked` list is what makes it reliable: that list is
+/// keyed by location identity and is empty on call paths where the identity is
+/// not in hand, so the same node classified differently depending on which pass
+/// was asking.
+pub(in crate::content::inline_builder) fn range_is_substitution_restorable(
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+    range: &std::ops::Range<usize>,
+) -> bool {
+    for piece in pieces {
+        let p_end = piece.s_start + piece.s_len;
+
+        // Skip pieces that do not overlap the range.
+        if p_end <= range.start || piece.s_start >= range.end {
+            continue;
+        }
+
+        if !piece.atomic {
+            continue;
+        }
+
+        if matches!(
+            nodes.get(piece.node_index),
+            Some(InlineNode::Raw {
+                origin: RawOrigin::Substitution,
+                ..
+            })
+        ) {
+            continue;
+        }
+
+        if !atomic_piece_is_recoverable(nodes, piece) {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -7,8 +7,10 @@
 use super::computed_value_children;
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind, holds_carried_token,
-    image::range_has_no_opaque_piece, macro_text_children, rebuild_macro_level,
-    restored_value_children, tokened_split_agrees, tokened_text,
+    image::{range_has_no_opaque_piece, range_is_substitution_restorable},
+    links::restore_masked_passthroughs,
+    macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
+    tokened_text,
 };
 use crate::{
     Parser, Span,
@@ -119,6 +121,56 @@ pub(super) fn xref_macros_level<'src>(
     }
 
     rebuild_macro_level(&nodes, &pieces, &s, matches)
+}
+
+/// Mirrors the string replacer's own `id.contains('<')` refusal: a shorthand
+/// whose id holds rendered inline markup is not a valid reference, and
+/// Asciidoctor leaves it untouched (`<<link:https://example.com[], Example>>`).
+///
+/// This became reachable only with
+/// [`range_is_substitution_restorable`].
+/// Before it, markup in an id was always an *opaque* piece, so the gate refused
+/// the match before any id existed to check — which is why
+/// [`build_xref_shorthand_node`] documents needing no counterpart to the guard.
+/// A substitution-produced `<` is not opaque (`:markup: <b>x</b>`, then
+/// `<<{markup}>>`), so the check has to be made for real now.
+///
+/// It reads the **restored** id, since that is what the replacer's `id` holds:
+/// a `<` hiding behind a placeholder is still a `<` to it.
+fn shorthand_id_has_no_rendered_markup(
+    s: &str,
+    id_range: &std::ops::Range<usize>,
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+    parser: &Parser,
+) -> bool {
+    let matched = s.get(id_range.start..id_range.end).unwrap_or_default();
+
+    !restored_range(matched, id_range.clone(), nodes, pieces, parser).contains('<')
+}
+
+/// The bytes a range of the level's match string holds once every placeholder
+/// standing in for a **substitution-produced** [`Raw`](InlineNode::Raw) leaf is
+/// filled in — which is what the string replacer's own haystack held there.
+///
+/// Borrowed unchanged when the range crosses no such leaf, which is every
+/// ordinary cross-reference.
+///
+/// Only reached for a range
+/// [`range_is_substitution_restorable`]
+/// admitted, so the splice never reaches a masked construct — whose bytes the
+/// replacer would *not* have held yet, and which keeps its match deferred.
+fn restored_range<'a>(
+    matched: &'a str,
+    range: std::ops::Range<usize>,
+    nodes: &[InlineNode<'_>],
+    pieces: &[Piece],
+    parser: &Parser,
+) -> std::borrow::Cow<'a, str> {
+    restore_masked_passthroughs(matched, &range, nodes, pieces, parser.renderer.as_ref())
+        .map_or(std::borrow::Cow::Borrowed(matched), |(text, _)| {
+            std::borrow::Cow::Owned(text)
+        })
 }
 
 /// Finds every recognized cross-reference at this level — the `xref:` macro
@@ -242,7 +294,10 @@ fn find_xref_matches<'src>(
                 // makes. A comma the *markup* of an opaque piece contributes
                 // cannot move that split unnoticed: such a piece would have to
                 // sit in the id half, which this gate then rejects.
-                range_has_no_opaque_piece(nodes, pieces, &shorthand_id_range(s, inner))
+                let id_range = shorthand_id_range(s, inner);
+
+                range_is_substitution_restorable(nodes, pieces, &id_range)
+                    && shorthand_id_has_no_rendered_markup(s, &id_range, nodes, pieces, parser)
             }
 
             None => {
@@ -266,7 +321,7 @@ fn find_xref_matches<'src>(
                 // the same reason.
                 let attrlist_text = caps.get(4).filter(|text| text.as_str().contains('='));
 
-                range_has_no_opaque_piece(nodes, pieces, &(target.start()..target.end()))
+                range_is_substitution_restorable(nodes, pieces, &(target.start()..target.end()))
                     && attrlist_text.is_none_or(|text| {
                         range_has_no_opaque_piece(nodes, pieces, &(text.start()..text.end()))
                             || attrlist_text_carries_its_opaque_pieces(
@@ -459,9 +514,24 @@ fn build_xref_node<'src>(
     // match whose group 2 (the shorthand's inner) participated to
     // [`build_xref_shorthand_node`] instead.
     #[allow(clippy::unwrap_used)]
-    let raw_target = caps.get(3).unwrap().as_str();
+    let target_match = caps.get(3).unwrap();
 
-    let (target, derived) = xref_target_and_derived(raw_target, true, parser);
+    // The target's bytes as the string replacer reads them. A leaf the match
+    // string stands in as a placeholder — an expanded attribute value's `&`,
+    // say (`xref:{cpp}[…]`, where `{cpp}` is `C&#43;&#43;`) — contributes its
+    // own bytes here. The gate admits only such leaves, so the splice always
+    // finishes the value into bytes the replacer's own haystack held; a
+    // *masked* construct, whose bytes it would not have held yet, keeps the
+    // match deferred instead.
+    let restored_target = restored_range(
+        target_match.as_str(),
+        target_match.range(),
+        nodes,
+        pieces,
+        parser,
+    );
+
+    let (target, derived) = xref_target_and_derived(restored_target.as_ref(), true, parser);
 
     let raw_text = caps.get(4).map_or("", |m| m.as_str());
     let (children, window, roles, xrefstyle) =
@@ -690,6 +760,15 @@ fn build_xref_shorthand_node<'src>(
     let inner_data = s.get(inner.start..inner.end).unwrap_or_default();
 
     // Split an optional ", reference text" off the id at the first comma.
+    //
+    // Split on the **matched** bytes, not on restored ones. Only the id half is
+    // read as a string and so only it is restored (below); the text half
+    // becomes structured children, and its range is in match-string
+    // coordinates — restoring the whole inner first would shift every offset
+    // the text is then sliced with. No comma can hide behind a placeholder
+    // anyway: a substitution leaves a `Raw` leaf only for `<`, `>`, and `&`, so
+    // a comma in an expanded value is `Text` and stands in the match string
+    // itself.
     let comma = inner_data.find(',');
 
     let raw_id = match comma {
@@ -697,7 +776,13 @@ fn build_xref_shorthand_node<'src>(
         None => inner_data,
     };
 
-    let (target, derived) = xref_target_and_derived(raw_id.trim(), false, parser);
+    // The id's bytes as the string replacer reads them — see
+    // [`restored_range`]. The `trim` is applied after, on the restored value,
+    // exactly as the replacer trims its own `id`.
+    let id_range = inner.start..inner.start + raw_id.len();
+    let restored_id = restored_range(raw_id, id_range, nodes, pieces, parser);
+
+    let (target, derived) = xref_target_and_derived(restored_id.trim(), false, parser);
 
     let location = source_slice(pieces, full.clone(), root);
 
@@ -764,10 +849,28 @@ mod tests {
     };
     use crate::{
         HasSpan, Parser, Span,
-        content::{Content, SubstitutionStep},
+        content::{Content, SubstitutionGroup, SubstitutionStep},
         inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
         parser::{HtmlSubstitutionRenderer, XrefStyle},
     };
+
+    /// The string pipeline's output through the **whole** `Normal` group —
+    /// the attributes step included — with any deferred cross-reference
+    /// finalized to its unresolved fallback.
+    ///
+    /// [`golden_xref`] deliberately drives the macro-family steps only, which
+    /// is right for a verbatim fixture and wrong for one whose target is
+    /// *attribute-expanded*: it would leave `{cpp}` unexpanded on the golden
+    /// side while the builder expands it, and report the difference as a
+    /// divergence the fixture does not have.
+    fn golden_whole_pipeline(source: &str) -> String {
+        let parser = Parser::default();
+        let mut content = Content::from(Span::new(source));
+
+        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
+        content.finalize_deferred(&HtmlSubstitutionRenderer {});
+        content.rendered_str().to_string()
+    }
 
     /// The string pipeline's output through the **macros** step for `source`,
     /// with any deferred cross-references finalized to their unresolved
@@ -2423,6 +2526,43 @@ mod tests {
             ),
             golden_normal(source, &parser)
         );
+    }
+
+    #[test]
+    fn an_xref_target_may_be_attribute_expanded() {
+        // The point of this increment. `{cpp}` is `C&#43;&#43;`, and §3.4.1
+        // leaves an expanded value's `&` unescaped — so the target crosses two
+        // `Raw` leaves, which the match string stands in as placeholders.
+        //
+        // Those leaves are `RawOrigin::Substitution`: nothing extracted them
+        // and nothing restores them, so the string replacer's own haystack held
+        // exactly these bytes. Filling the placeholders in therefore reaches
+        // parity rather than departing from it — where a *masked* passthrough,
+        // which the replacer would not have restored yet, keeps its match
+        // deferred (`a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`).
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in [
+            "see xref:{cpp}[{cpp}].",
+            "see xref:{cpp}[].",
+            "see <<{cpp}>>.",
+            "see <<{cpp},the {cpp} page>>.",
+        ] {
+            let nodes = build_src(Span::new(fixture));
+
+            assert_eq!(
+                fold_html(&nodes, &renderer),
+                golden_whole_pipeline(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+
+        // The target itself is the *restored* value, not the placeholders a
+        // first attempt at this left in it.
+        let nodes = build_src(Span::new("see xref:{cpp}[{cpp}]."));
+        let reference = assert_xref(&nodes[1]);
+
+        assert_eq!(reference.target.as_ref(), "C&#43;&#43;");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -795,12 +795,15 @@ mod tests {
         // unescaped because the value expands *after* `specialcharacters` ran.
         // Nothing extracted it and nothing restores it — the string replacer
         // reads these very bytes. `{cpp}` is `C&#43;&#43;`, so the expansion
-        // leaves one `Raw` per `&`, twice per occurrence.
+        // leaves one `Raw` per `&`.
+        //
+        // Deliberately in plain flow rather than inside a macro: a construct
+        // that *recognizes* the expanded value consumes these leaves into its
+        // own node, which is exactly what
+        // `an_xref_target_may_be_attribute_expanded` pins for `xref:{cpp}[…]`.
         assert_eq!(
-            origins("see xref:{cpp}[{cpp}]."),
+            origins("see {cpp} today."),
             vec![
-                (RawOrigin::Substitution, "&".to_string()),
-                (RawOrigin::Substitution, "&".to_string()),
                 (RawOrigin::Substitution, "&".to_string()),
                 (RawOrigin::Substitution, "&".to_string()),
             ]


### PR DESCRIPTION
The second prep for retiring the **deferred-cross-reference sentinel system** (§4.2's second), and the first thing #1272's `RawOrigin` is for.

`xref:{cpp}[{cpp}]` was left literal by the builder while the string pipeline recognized it:

```
rendered:  see <a href="#C&#43;&#43;">C&#43;&#43;</a>.
folded:    see xref:C&#43;&#43;[C&#43;&#43;].
```

`{cpp}` is `C&#43;&#43;`, and §3.4.1 leaves an expanded value's `&` unescaped — so the target crosses two `Raw` leaves, which the match string stands in as placeholders, and the gate deferred on them.

Those leaves are `RawOrigin::Substitution`: nothing extracted them and nothing restores them, so the string replacer's own haystack held exactly these bytes. Filling the placeholders in reaches parity rather than departing from it. `range_is_substitution_restorable` admits only such leaves, and `restored_range` fills them the way the link family already fills a masked construct's.

A **masked passthrough stays deferred**, which is the distinction the whole thing rests on: it is restored by a *later* pass, and a deferred cross-reference's target is captured into its segment before that pass runs — so the string pipeline's own `href` holds the sentinel there, and matching it is a documented keep.

## Two things this turned up

**The shorthand needs the replacer's `id.contains('<')` guard for real now.** `build_xref_shorthand_node` documented needing no counterpart to it, because markup in an id was always an opaque piece and the gate refused the match before any id existed. A substitution-produced `<` is *not* opaque (`:markup: <b>x</b>`, then `<<{markup}>>`), so the check has to be made — against the **restored** id, since a `<` hiding behind a placeholder is still a `<` to the replacer. Without it, `an_xref_over_a_rendered_span_in_an_expanded_value_is_still_deferred` fails.

**Only the id half of a shorthand may be restored.** Restoring the whole inner first shifts every offset the *reference text* is then sliced with — which corrupted `<<sec,a +++<b>x</b>+++ text>>` into a trailing `&gt;&`, caught by the whole-pipeline snapshot corpus. The text becomes structured children in match-string coordinates and must stay there; only the id is read as a string. No comma can hide behind a placeholder anyway, since a substitution leaves a `Raw` leaf only for `<`, `>`, and `&`.

## On the golden

The new test's golden comes from the **whole** `Normal` group rather than `golden_xref`, which drives the macro-family steps only. On an attribute-expanded fixture that would leave `{cpp}` unexpanded on the golden side while the builder expands it, and report a divergence the fixture does not have — a false failure I hit and had to diagnose before the test meant anything.

## Verification

- `cargo test --workspace`: **5432 pass, 0 fail**.
- Corpus-wide fold-parity audit: **0 new, 1 closed** — and the one closed is exactly this fixture:
  ```
  src="see xref:{cpp}[{cpp}]." rendered="see <a href="#C&#43;&#43;">…" folded="see xref:C&#43;&#43;[…]"
  ```
- Coverage diff-neutral: `xref.rs` 16/7, `image.rs` 5/2, total 575/323 — identical to base.
- Preflight clean: `cargo +nightly fmt --all --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_