### PR TITLE
feat: Retire the deferred-cross-reference sentinel system (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6164,6 +6164,163 @@ Each phase is a reviewable unit with a clear exit gate.
 
   Coverage is diff-neutral (`fold.rs` 3/3, `xref.rs` 16/7, `ref_node.rs` 0/0 — identical to base).
 
+  *Step 6 landed as (each deferred content retains its own document attributes):* the second
+  prep, and the one that makes a later fold *possible* rather than merely correct. A fold running
+  after the parse needs the document state its content was written under, and by then the parse
+  has moved on — so a content carrying a deferred cross-reference now keeps its
+  [`ResolvedAttributes`](../../parser/src/parser/resolved_attributes.rs), snapshotted where "now"
+  is still that point in the document. Retention is narrow on purpose: deferred content is the
+  only content whose rendering is rebuilt after the parse, so it is the only content that will be
+  folded after it. Everything else — nearly everything — keeps `None`.
+
+  It retains the *attributes* rather than a whole `RenderContext`, and the difference is not
+  cosmetic. A `RenderContext` holds the path resolver and the two file handlers as `Rc<dyn …>`, so
+  retaining one would cost `Content` — and with it
+  [`Document`](../../parser/src/document/document.rs) — its `Send`/`Sync`. `Document` is both today
+  (`Parser`, holding six `Rc<dyn …>`, deliberately is not), nothing pinned it, and the regression
+  would have been silent;
+  `document_stays_send_and_sync` now pins it. Splitting the halves is also the more accurate model:
+  document attributes are **order-dependent** (a `:imagesdir:` line rebinds them for everything
+  after it) so they must be frozen per content, while the resolver and handlers are **parse-wide
+  configuration** that cannot change mid-parse, so freezing them buys nothing. The increment that
+  folds at resolution time assembles a context from this plus that configuration, which its caller
+  already holds. `ResolvedAttributes` is `Arc`-shared internally, so retention allocates nothing
+  beyond its box, and it is `Eq`, so `OwnedTitle` keeps its derived equality.
+
+  Nothing read it yet, which is the staging: landing the retention while it is a provable no-op is
+  what keeps the step that consumes it falsifiable. Audit: 54 divergences before and after, 0 new,
+  0 closed. Coverage diff-neutral.
+
+  *Step 6 landed as (the fold takes a `RenderContext`, not a `Parser`):* the third prep, and the
+  one that finishes what merging `main` started. `RenderContext` landed on `main` as *the document
+  state a renderer reads*; the merge wired the string pipeline's own call sites to it but left
+  [`fold_html`](../../parser/src/content/inline_builder/fold.rs) taking a `&Parser` and building a
+  context per rendered element. Faithful, but the wrong shape — a fold running later than its parse
+  cannot derive its context from the live parser, because the attributes have moved on. So the fold
+  takes the context, threaded from the one place that starts it, which is also strictly less work:
+  the per-element construction is gone, and with it the ~117ns per rendered element #1265 measured.
+
+  Two things had to move for that signature to exist. `fold_image` and `fold_link` parsed an
+  *empty* `Attrlist` for a hand-built node carrying none, which needs a parser;
+  [`Attrlist::empty`](../../parser/src/attributes/attrlist.rs) builds the zero-attribute list
+  directly, keeping the node's own zero-length location so lifetime and position still match (and
+  removing an attribute-reference substitution pass from that path). And the builder's own five
+  internal folds — a masked piece's body, an anchor's reference text, the pre-escape probe, the
+  restored-markup splice, the title's reference text — each take `parser.render_context()` at their
+  call site, where a parser is in hand. No behavior change: the context a fold now receives is the
+  one it was building for itself.
+
+  *Step 6 landed as (a `Raw` node records where its content came from):* the fourth prep, and the
+  first of the two builder preps the retirement's own audit turned up.
+  [`Raw`](../../parser/src/inlines/inline_node.rs) gains an
+  [`origin`](../../parser/src/inlines/inline_node.rs) orthogonal to its `form`: `Passthrough` for
+  content the extraction pass pulled out before any step ran (`+++…+++`, `++…++`, `$$…$$`,
+  `pass:[…]`, an inline STEM body), `Substitution` for raw output a substitution produced in place
+  — an expanded attribute value's literal special (which §3.4.1 leaves unescaped, the value having
+  expanded *after* `specialcharacters` ran), a special an effective order never escaped, or a slice
+  of an entity's own bytes.
+
+  It answers two questions. For a **consumer** it sharpens the security story §3.4 gives this node
+  kind: "this document emits raw HTML" is visible as `Raw` nodes, and whether that came from an
+  author writing an explicit passthrough or from a substitution expanding an attribute value is the
+  difference between a deliberate escape hatch and a value that may have arrived from elsewhere.
+  For the **builder** it is the difference between content the extraction pass is *holding* and
+  content that is simply there. A cross-reference's target is captured into its deferred segment
+  before the restore pass runs, so a computed value reading a `Passthrough` node's bytes sees the
+  extraction sentinel, while one reading a `Substitution` node's sees exactly what the string
+  replacer saw.
+
+  Recording it on the node is the point. A first attempt inferred the same distinction from the
+  `Masked` list the extraction pass builds, and it does not work: that list is keyed by location
+  identity and is empty on call paths where the identity is not in hand, so the same node was
+  classified differently depending on which pass asked. Provenance is a fact about the node, so it
+  belongs on the node — the same reasoning that put `form` there. Nothing read it yet.
+
+  *Step 6 landed as (a cross-reference whose target is attribute-expanded):* the fifth prep, the
+  first thing `RawOrigin` is *for*, and one of the two regressions the retirement's probe found.
+  `xref:{cpp}[{cpp}]` was left literal by the builder while the string pipeline recognized it:
+  `{cpp}` is `C&#43;&#43;`, §3.4.1 leaves an expanded value's `&` unescaped, so the target crosses
+  two `Raw` leaves that the match string stands in as placeholders — and the gate deferred on them.
+  Those leaves are `Substitution`: nothing extracted them and nothing restores them, so the string
+  replacer's own haystack held exactly these bytes, and filling the placeholders in **reaches**
+  parity rather than departing from it. `range_is_substitution_restorable` admits only such leaves;
+  a masked passthrough stays deferred, which is the distinction the whole thing rests on — it is
+  restored by a *later* pass, and a deferred cross-reference's target is captured before that pass
+  runs, so the string pipeline's own `href` holds the sentinel there.
+
+  Two things it turned up. The shorthand needs the replacer's `id.contains('<')` guard **for real**
+  now: `build_xref_shorthand_node` documented needing no counterpart, because markup in an id was
+  always an opaque piece and the gate refused the match before any id existed — but a
+  substitution-produced `<` is not opaque (`:markup: <b>x</b>`, then `<<{markup}>>`), and the check
+  has to be made against the *restored* id. And only the **id half** of a shorthand may be restored:
+  restoring the whole inner first shifts every offset the reference text is then sliced with, which
+  corrupted `<<sec,a +++<b>x</b>+++ text>>` into a trailing `&gt;&`. The text becomes structured
+  children in match-string coordinates and must stay there; only the id is read as a string. The new
+  test's golden comes from the *whole* `Normal` group rather than `golden_xref`, which drives the
+  macro-family steps only and would leave `{cpp}` unexpanded on the golden side.
+
+  *Step 6 landed as (the deferred-cross-reference sentinel system, retired — the second of the
+  three):* the fold becomes authoritative for the one content kind the cutover had to carve out.
+  Such a content's rendering is rebuilt from a placeholder template on **every** resolution pass
+  ([`Content::rebuild_rendered`](../../parser/src/content/content.rs)), so a fold taken at parse
+  time would be overwritten by the next pass — and would anyway be answering a question the
+  document has not settled, since the destinations are not known yet. It is folded at the **end of
+  resolution** instead ([`Content::refold`](../../parser/src/content/content.rs)), which is the
+  same answer one step later, assembled from the attributes the content retained (prep 2) paired
+  with the parser's own configuration through a `RenderContext` (prep 3).
+
+  The carve-out does not disappear so much as **narrow to something principled**. It was
+  `content.deferred_parts().is_none()` — *any* deferred cross-reference keeps the template. It is
+  now the count match
+  [`mirror_tree_xref_resolution`](../../parser/src/content/content.rs) already computes: the tree's
+  block-level cross-reference nodes against the segments whose placeholders are still in the
+  template. Where they agree, the tree holds every cross-reference the string pipeline deferred and
+  a fold of it *is* this content's rendering. Where they differ, the builder left one of its
+  documented forms unrecognized, so folding would **lose** the construct rather than render it
+  differently — and the template stays. That gate self-liquidates: each builder prep that teaches
+  one more form shrinks it, and it vanishes when none is left. The **footnote** half of the mirror
+  is deliberately not part of the gate — a footnote's text is extracted out of the block, so a fold
+  emits the marker and never descends into the subtree whose correlation was skipped.
+
+  Exactly **one** of the two renderings runs — the fold or the template, never one overwritten by
+  the other. That is not merely thrift: a renderer is a host-supplied trait object, so a stateful
+  one (a recorder, a numbering backend, anything counting its own callbacks) would see every
+  callback for a deferred content twice in a single resolution pass. A probe measuring the fold
+  against the template *inside* the pass showed exactly that as 11 rows of recorder counter drift
+  — the symptom, read at first as an artifact of the measurement.
+  `resolution_renders_a_deferred_content_once` pins the property with a counting renderer, which
+  `Document::resolve_references` takes as an ordinary argument.
+
+  Retiring the double render costs the whole-document parity harness its oracle for exactly the
+  content this step changed: `check_document` folds each location's tree and compares it against
+  `rendered_html()`, which for a deferred content now *is* that fold. So the template's answer
+  becomes reachable on its own — `Content::rendered_from_template`, test-only — and
+  `the_fold_reproduces_the_template_for_every_deferred_content` compares the two over a corpus of
+  fourteen cross-reference fixtures (both spellings, empty and absent reference texts, unresolved
+  targets, several in one content, a formatting span, an inter-document target, a footnote-embedded
+  reference, an attribute-styled one, a table cell, a block title). Both new tests fail if their
+  property is removed, checked by removing it.
+
+  Sizing the step took a probe over the whole suite (fold vs. template at every resolution):
+  **14** divergences, of which 11 were the recorder drift above, one is an *improvement* the code's
+  own comment predicted, and two were real regressions — both of which became preps 4/5 above. That
+  improvement is `a_post_replacement_in_a_cross_reference_text_is_now_at_parity`, a divergence
+  pinned since the cross-product sweep with a note saying it would close exactly here: a
+  `+`-line-break in a cross-reference's display text now gets its `<br>`, because a display text is
+  a subtree either way and the fold walks subtrees, where the string pipeline's step never saw
+  inside a template.
+
+  What still defers is the **shape** the second regression had: `xref:sec[*bold*,role=*hl*]` — a
+  rendered span reaching a value the macro families read as a *string* (`role=`, `window=`,
+  `xrefstyle=`). It is the last known member of the class, it is what keeps the narrowed gate from
+  being vacuous, and it is a builder prep like the five above rather than anything this system owes.
+  Also still deferred: a **section or block title's** deferred cross-references, which
+  [`title_refs`](../../parser/src/document/title_refs.rs) resolves in document order with
+  cross-title coordination the per-content pass cannot do, and which still take their rendering from
+  that pass's template. Retiring the template *itself* — the sentinel constants, `render_template`,
+  `DeferredContent::template` — waits on both, and on the whole-document parity harness no longer
+  needing the template as the oracle the fold is checked against.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7371,6 +7528,68 @@ Each phase is a reviewable unit with a clear exit gate.
        style* rather than *ask the document*. Pinned by four whole-document fixtures that fail on
        base, not by the audit, which cannot see this class. See the step's own "landed as" note
        above.
+
+     - ✅ **prep (each deferred content retains its own document attributes).** A fold running
+       later than its parse needs the document state its content was written under, and the parse
+       has moved on; a content carrying a deferred cross-reference now keeps its
+       [`ResolvedAttributes`](../../parser/src/parser/resolved_attributes.rs), snapshotted where
+       "now" is still that point in the document. The *attributes* and not a whole `RenderContext`:
+       that holds `Rc<dyn …>` handlers, so retaining one would cost
+       [`Document`](../../parser/src/document/document.rs) its `Send`/`Sync` — which it has today,
+       nothing pinned, and `document_stays_send_and_sync` now does. Attributes are order-dependent
+       and must be frozen; the resolver and handlers are parse-wide and need not be. A provable
+       no-op: audit 54 rows either side, 0 new, 0 closed. See the step's own "landed as" note above.
+
+     - ✅ **prep (the fold takes a `RenderContext`, not a `Parser`).** Finishing what merging
+       `main` started: the merge left [`fold_html`](../../parser/src/content/inline_builder/fold.rs)
+       taking a `&Parser` and building a context *per rendered element*, which a later-than-parse
+       fold cannot do. The context is threaded from the one place that starts it — strictly less
+       work, and the ~117ns per rendered element #1265 measured goes with it.
+       [`Attrlist::empty`](../../parser/src/attributes/attrlist.rs) replaces the parser-needing
+       empty-list parse in `fold_image`/`fold_link`, and the builder's five internal folds take
+       `parser.render_context()` at their own call sites. No behavior change. See the step's own
+       "landed as" note above.
+
+     - ✅ **prep (a `Raw` node records where its content came from).**
+       [`Raw`](../../parser/src/inlines/inline_node.rs) gains an `origin` orthogonal to its `form`:
+       `Passthrough` for what the extraction pass pulled out before any step ran, `Substitution` for
+       raw output a substitution produced in place. For a consumer it sharpens §3.4's security story
+       (a deliberate escape hatch vs. a value that may have arrived from elsewhere); for the builder
+       it separates content the extraction pass is *holding* from content that is simply there —
+       which the prep below needs. Inferring it from the extraction pass's `Masked` list was tried
+       first and does not work: that list is keyed by location identity and empty on some call
+       paths, so the same node classified differently depending on who asked. Nothing read it yet.
+       See the step's own "landed as" note above.
+
+     - ✅ **prep (a cross-reference whose target is attribute-expanded).** The first thing
+       `RawOrigin` is for, and one of the two regressions the retirement's probe found.
+       `xref:{cpp}[{cpp}]` was left literal while the string pipeline recognized it — the target
+       crosses two `Raw` leaves the match string stands in as placeholders. They are `Substitution`
+       leaves, so the string replacer's own haystack held exactly those bytes and filling them in
+       *reaches* parity; a masked passthrough stays deferred, since it is restored by a later pass
+       than the one that captures a deferred target. Turned up two more things: the shorthand needs
+       the replacer's `id.contains('<')` guard for real (a substitution-produced `<` is not opaque),
+       and only the **id half** may be restored — restoring the whole inner shifts the offsets the
+       reference text is sliced with. See the step's own "landed as" note above.
+
+     - ✅ **the deferred-cross-reference sentinel system, retired (the second of the three).**
+       [`Content::refold`](../../parser/src/content/content.rs) folds a deferred content at the
+       **end of resolution** — the same answer one step later — from the attributes it retained
+       paired with the parser's configuration. The carve-out narrows rather than vanishing: from
+       *any* deferred cross-reference to the count match
+       [`mirror_tree_xref_resolution`](../../parser/src/content/content.rs) already computes, so the
+       fold is authoritative except where the builder is known not to recognize the construct, and
+       the gate self-liquidates as preps land. A whole-suite probe sized it: 14 divergences, 11 the
+       test-only recorder's counter, 1 an improvement its own comment predicted, 2 real regressions
+       — both closed as the two preps above. Exactly one of the two renderings runs: rendering both
+       and keeping the second would be *observable*, not merely wasteful, since a stateful host
+       renderer would see every callback twice in one pass
+       (`resolution_renders_a_deferred_content_once`). That costs the whole-document harness its oracle for this content, so the template's answer
+       becomes reachable test-only and a fourteen-fixture corpus compares the two directly. What
+       still defers is `xref:sec[*bold*,role=*hl*]` (a rendered span reaching a string-read value)
+       and a **title's** deferred cross-references, which `title_refs` still renders from the
+       template. See the step's own "landed as" note above. What remains of step 6 is the
+       passthrough sentinel system and the side effects wired for real.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -935,6 +935,7 @@ impl<'src> Block<'src> {
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
+        parser: &Parser,
     ) {
         // A section is not resolved here: its resolvable content is its
         // heading, which `content_mut` deliberately does not expose (see
@@ -943,24 +944,24 @@ impl<'src> Block<'src> {
         // cross-references *between* titles (forward and circular) — something
         // per-content resolution cannot see.
         if let Some(content) = self.content_mut() {
-            content.resolve_references(resolver, renderer, warnings);
+            content.resolve_references(resolver, renderer, warnings, parser);
         }
 
         // Tables hold their resolvable content in cells rather than in a single
         // `content_mut()` value, so they are resolved explicitly here.
         if let Self::Table(table) = self {
-            table.resolve_references(resolver, renderer, warnings);
+            table.resolve_references(resolver, renderer, warnings, parser);
         }
 
         // A Markdown-style blockquote holds its nested blocks in its own owned
         // source, which the generic `child_blocks_mut()` walk below does not
         // reach, so they are resolved explicitly here.
         if let Self::Quote(quote) = self {
-            quote.resolve_references(resolver, renderer, warnings);
+            quote.resolve_references(resolver, renderer, warnings, parser);
         }
 
         for child in self.child_blocks_mut() {
-            child.resolve_references(resolver, renderer, warnings);
+            child.resolve_references(resolver, renderer, warnings, parser);
         }
     }
 

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -578,6 +578,7 @@ impl<'src> QuoteBlock<'src> {
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
+        parser: &Parser,
     ) {
         let source = self.source;
 
@@ -594,7 +595,7 @@ impl<'src> QuoteBlock<'src> {
                 let mut owned_warnings = ReferenceWarnings::default();
 
                 for block in &mut dependent.blocks {
-                    block.resolve_references(resolver, renderer, &mut owned_warnings);
+                    block.resolve_references(resolver, renderer, &mut owned_warnings, parser);
                 }
 
                 owned_warnings.rehome_into(warnings, source);

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -554,6 +554,7 @@ impl<'src> TableBlock<'src> {
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
+        parser: &Parser,
     ) {
         let rows = self
             .header_row
@@ -563,7 +564,7 @@ impl<'src> TableBlock<'src> {
 
         for row in rows {
             for cell in row.cells.iter_mut() {
-                cell.resolve_references(resolver, renderer, warnings);
+                cell.resolve_references(resolver, renderer, warnings, parser);
             }
         }
     }
@@ -2331,15 +2332,16 @@ impl<'src> TableCell<'src> {
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
+        parser: &Parser,
     ) {
         let source = self.source;
 
         match &mut self.content {
             TableCellContent::Simple(content) => {
-                content.resolve_references(resolver, renderer, warnings);
+                content.resolve_references(resolver, renderer, warnings, parser);
             }
             TableCellContent::AsciiDoc(cell) => {
-                cell.resolve_references(resolver, renderer, warnings, source);
+                cell.resolve_references(resolver, renderer, warnings, source, parser);
             }
         }
     }
@@ -2542,11 +2544,12 @@ impl<'src> AsciiDocCell<'src> {
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
         source: Span<'src>,
+        parser: &Parser,
     ) {
         match self {
             Self::Borrowed(cell) => {
                 for block in &mut cell.blocks {
-                    block.resolve_references(resolver, renderer, warnings);
+                    block.resolve_references(resolver, renderer, warnings, parser);
                 }
 
                 // A cell footnote records no document location (it is defined in
@@ -2570,7 +2573,12 @@ impl<'src> AsciiDocCell<'src> {
                         let mut owned_warnings = ReferenceWarnings::default();
 
                         for block in &mut dependent.blocks {
-                            block.resolve_references(resolver, renderer, &mut owned_warnings);
+                            block.resolve_references(
+                                resolver,
+                                renderer,
+                                &mut owned_warnings,
+                                parser,
+                            );
                         }
 
                         // A cell footnote records no document location, so its
@@ -3393,6 +3401,7 @@ mod tests {
             &HtmlSubstitutionRenderer {},
             &mut warnings,
             Span::new(""),
+            &crate::Parser::default(),
         );
 
         // Resolution was skipped silently: no warnings, and the two references

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -4,7 +4,7 @@
 //! [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 
 use crate::{
-    Span,
+    Parser, Span,
     content::Passthrough,
     inlines::{InlineNode, RefVariant},
     parser::{
@@ -636,6 +636,7 @@ impl<'src> Content<'src> {
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
+        parser: &Parser,
     ) {
         let source = self.original;
 
@@ -672,8 +673,79 @@ impl<'src> Content<'src> {
             }
         }
 
-        self.rebuild_rendered(renderer);
-        self.resolve_tree_references();
+        // Exactly **one** of the two renderings runs. The fold is authoritative
+        // only where the tree is known to hold every cross-reference the string
+        // pipeline deferred, which `resolve_tree_references` reports as it
+        // mirrors; everywhere else the template's answer stands. Running both
+        // and keeping the second would be observable, not merely wasteful: a
+        // renderer is a host-supplied trait object, so a stateful one — a
+        // recorder, a numbering backend, anything counting its own callbacks —
+        // would see every callback for this content twice in one pass.
+        //
+        // Reaching the second arm means this content has deferred parts, and a
+        // content's retained attributes travel with those
+        // (`set_render_attributes` is called for exactly that content — see
+        // `only_deferred_content_retains_its_render_attributes`), so it always
+        // binds. It is written as a binding rather than an unwrap because the
+        // invariant lives in that pairing, not in the field's type.
+        if self.resolve_tree_references()
+            && let Some(attributes) = self.render_attributes.as_deref().cloned()
+        {
+            self.refold(attributes, renderer, parser);
+        } else {
+            self.rebuild_rendered(renderer);
+        }
+    }
+
+    /// Re-renders this content from its **tree**, now that resolution has
+    /// installed each cross-reference's destination into it.
+    ///
+    /// This is what retires the deferred-cross-reference sentinel system
+    /// (design §4.2's second). `rendered_html()` became a fold of the tree for
+    /// every other content at the cutover; the one exception was content
+    /// carrying a deferred cross-reference, whose rendering is rebuilt on every
+    /// resolution pass and so could not be a fold *taken at parse time*. It can
+    /// be a fold taken **here** instead — after the pass that resolved it —
+    /// which is the same answer reached one step later.
+    ///
+    /// `attributes` are the document attributes this content was parsed under,
+    /// which it retained itself because they are order-dependent; they are
+    /// paired here with the parser's own configuration, which is not. A content
+    /// that retained none has no deferred cross-reference and was already
+    /// folded authoritatively at parse time, so it never reaches here.
+    ///
+    /// **The caller gates this on the mirror having succeeded**, which is the
+    /// carve-out that replaces the old one. Until now a content carrying *any*
+    /// deferred cross-reference kept the template path end to end; now only one
+    /// whose tree does **not** hold every cross-reference the string pipeline
+    /// deferred does. That is the single-pass builder's documented set of
+    /// unrecognized forms (see the `inline_builder` module) — where one of them
+    /// applies, the tree is known not to describe this content, so folding it
+    /// would *lose* the construct rather than render it differently. The signal
+    /// is the block-level count match
+    /// [`mirror_tree_xref_resolution`](Self::mirror_tree_xref_resolution)
+    /// already computes, so the carve-out narrows on its own as each builder
+    /// prep teaches the builder one more form, and disappears when none is
+    /// left.
+    ///
+    /// This runs **instead of**
+    /// [`rebuild_rendered`](Self::rebuild_rendered), not after it. The template
+    /// still exists — it is what the other arm renders, and what the test-only
+    /// `rendered_from_template` keeps the fold differentiated against — but
+    /// rendering both and discarding one would be
+    /// observable rather than merely wasteful, since a stateful host renderer
+    /// would see every callback for this content twice in a single resolution
+    /// pass.
+    fn refold(
+        &mut self,
+        attributes: ResolvedAttributes,
+        renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
+    ) {
+        let context = parser.render_context_with(attributes);
+        let folded = crate::content::inline_builder::fold_html(&self.inlines, renderer, &context);
+
+        self.rendered = CowStr::from(folded);
     }
 
     /// Mirrors the destinations just resolved for this content's deferred
@@ -701,19 +773,25 @@ impl<'src> Content<'src> {
     /// template when the footnote's text is extracted, so it is excluded from
     /// the block correlation above and correlated instead with the tree's
     /// footnote subtrees (see [`footnote_tree_xrefs`]).
-    fn resolve_tree_references(&mut self) {
+    ///
+    /// Returns what
+    /// [`mirror_tree_xref_resolution`](Self::mirror_tree_xref_resolution)
+    /// returns — whether the tree holds exactly the block-level
+    /// cross-references the string pipeline deferred — and `false` for a
+    /// content with no tree or nothing deferred, neither of which is re-folded.
+    fn resolve_tree_references(&mut self) -> bool {
         if self.inlines.is_empty() {
-            return;
+            return false;
         }
 
         let Some(deferred) = self.deferred.as_ref() else {
-            return;
+            return false;
         };
 
         let block_ordered = block_tree_xrefs(&deferred.template, &deferred.xrefs);
         let footnote_ordered = footnote_tree_xrefs(&deferred.template, &deferred.xrefs);
 
-        self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered);
+        self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered)
     }
 
     /// Installs a pre-computed list of resolved cross-reference destinations —
@@ -739,13 +817,28 @@ impl<'src> Content<'src> {
     /// It is a no-op for a tree holding no cross-reference node,
     /// non-destructive, and re-resolvable: each call overwrites the tree's
     /// resolved state from `block_ordered` and `footnote_ordered`.
+    ///
+    /// Returns whether the **block-level** correlation ran — i.e. whether the
+    /// tree holds exactly the cross-reference nodes whose placeholders the
+    /// string pipeline left in the template. A `false` means the builder left
+    /// at least one of them unrecognized, so this content's tree is known not
+    /// to describe its rendering; a caller that folds the tree instead of
+    /// rebuilding from that template (see [`refold`](Self::refold)) uses this
+    /// to tell the two apart.
+    ///
+    /// The **footnote** correlation is deliberately not part of that answer: a
+    /// footnote's text is extracted out of this content, so it is not part of
+    /// [`rendered`](Self::rendered) — a fold emits the footnote's *marker* and
+    /// never descends into its subtree (see `fold_footnote`). A footnote-side
+    /// skip therefore leaves the tree's own footnote nodes honestly unresolved
+    /// without making a fold of this content wrong.
     pub(crate) fn mirror_tree_xref_resolution(
         &mut self,
         block_ordered: &[Option<ResolvedReference>],
         footnote_ordered: &[Option<ResolvedReference>],
-    ) {
+    ) -> bool {
         if self.inlines.is_empty() {
-            return;
+            return false;
         }
 
         // The correlation is positional, so it requires the tree to hold
@@ -757,7 +850,8 @@ impl<'src> Content<'src> {
         // pairing is unknowable; the mirror is skipped for that list — leaving
         // its nodes in their honest unresolved state — rather than assigning
         // destinations to the wrong nodes.
-        if count_tree_xrefs(&self.inlines) == block_ordered.len() {
+        let block_mirrored = count_tree_xrefs(&self.inlines) == block_ordered.len();
+        if block_mirrored {
             let mut next = 0;
             assign_tree_xrefs(&mut self.inlines, block_ordered, &mut next);
         }
@@ -766,6 +860,34 @@ impl<'src> Content<'src> {
             let mut next = 0;
             assign_footnote_tree_xrefs(&mut self.inlines, footnote_ordered, &mut next);
         }
+
+        block_mirrored
+    }
+
+    /// Renders this content **from its deferred template**, without installing
+    /// the result — the answer [`refold`](Self::refold) replaced, exposed so a
+    /// test can still compare the two.
+    ///
+    /// A deferred content's rendering is now a fold of its tree wherever the
+    /// tree is authoritative, so the whole-document parity harness — which
+    /// checks a fold against [`rendered_html`](Self::rendered_html) — would
+    /// otherwise be comparing the fold against itself for exactly the content
+    /// the retirement changed. This is the independent construction it compares
+    /// against instead.
+    ///
+    /// `None` for a content with nothing deferred, which has no template.
+    #[cfg(test)]
+    pub(crate) fn rendered_from_template(
+        &self,
+        renderer: &dyn InlineSubstitutionRenderer,
+    ) -> Option<String> {
+        let deferred = self.deferred.as_ref()?;
+
+        Some(render_template(
+            &deferred.template,
+            &deferred.xrefs,
+            renderer,
+        ))
     }
 
     /// Rebuilds [`Content::rendered`] from the deferred template and the

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -189,27 +189,27 @@ mod tests {
     };
 
     #[test]
-    fn a_post_replacement_in_a_cross_reference_text_is_a_documented_divergence() {
-        // Found by the cross-product sweep
-        // (`fold_matches_the_real_pipeline_for_every_construct_in_every_container`
-        // in the parent module), and it is the **deferred-cross-reference
-        // sentinel system** (design §4.2) showing through.
+    fn a_post_replacement_in_a_cross_reference_text_is_now_at_parity() {
+        // Once a documented divergence, and **closed by the retirement of the
+        // deferred-cross-reference sentinel system** (design §4.2's second) —
+        // exactly where this test's own note said it would close.
         //
-        // A link's display text and a cross-reference's sit in the same
-        // position in the source, and this step treats them alike. The string
-        // pipeline cannot: by the time it runs, a *link* has been rendered
-        // inline into the one flat string this step scans, so its display text
-        // gets its `<br>` — while a deferred cross-reference has been replaced
-        // by a sentinel pair whose text lives in a **template**, which this
-        // step never sees at all. So the same bytes in the same place get a
-        // line break in one and not in the other, decided by nothing the
-        // author wrote.
+        // The asymmetry was the sentinel system showing through. A link's
+        // display text and a cross-reference's sit in the same position in the
+        // source, and this step treats them alike. The string pipeline could
+        // not: by the time it ran, a *link* had been rendered inline into the
+        // one flat string this step scans, so its display text got its `<br>`
+        // — while a deferred cross-reference had been replaced by a sentinel
+        // pair whose text lived in a **template**, which this step never saw at
+        // all. The same bytes in the same place got a line break in one and not
+        // the other, decided by nothing the author wrote.
         //
         // A tree has one answer for both, because a display text is a subtree
-        // either way and this step walks subtrees. That is what §4.2's
-        // retirement of the sentinel system makes true for real, so this is a
-        // **keep**: the divergence closes when the cutover deletes the
-        // template, not before.
+        // either way and this step walks subtrees. Now that a deferred content
+        // is *folded* after resolution rather than rebuilt from its template,
+        // that one answer is the one a caller reads: all three rows below are
+        // at parity, and the cross-reference's `<br>` is no longer conditional
+        // on which pipeline produced it.
         //
         // Driven through a real document, where the cross-reference resolves —
         // a bare `Content` has no catalog, so *every* cross-reference is left
@@ -245,15 +245,16 @@ mod tests {
                     r##"<a id="tgt"></a>Target."##.to_string(),
                     r##"<a id="tgt"></a>Target."##.to_string()
                 ),
-                // The cross-reference: the string pipeline never scanned its
-                // display text, the tree did.
+                // The cross-reference, now at parity: `rendered_html()` is the
+                // fold, so its display text gets the same `<br>` the link's
+                // does. Before the retirement the left side read `pre z +`.
                 (
-                    "x <a href=\"#tgt\">pre z +\nw post</a> y".to_string(),
+                    "x <a href=\"#tgt\">pre z<br>\nw post</a> y".to_string(),
                     "x <a href=\"#tgt\">pre z<br>\nw post</a> y".to_string()
                 ),
-                // The link, in the same position, at parity on both sides —
-                // which is what makes the line above an asymmetry rather than
-                // a rule.
+                // The link, in the same position — which is what made the row
+                // above an asymmetry rather than a rule, and is now simply the
+                // same answer twice.
                 (
                     "x <a href=\"l.html\">pre z<br>\nw post</a> y".to_string(),
                     "x <a href=\"l.html\">pre z<br>\nw post</a> y".to_string()

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -261,19 +261,21 @@ impl SubstitutionGroup {
                 attrlist,
             );
 
-            // The tree is now **authoritative** for the rendered string: what
+            // The tree is **authoritative** for the rendered string: what
             // `rendered_html()` returns is a fold of it, not the string
             // pipeline's own output (design §5.2 Phase 4, step 6).
             //
-            // Content carrying a *deferred cross-reference* is the one
-            // exception, and it is temporary. Such a content's rendered string
-            // is rebuilt from a placeholder template each time resolution runs
-            // (`Content::rebuild_rendered`), so making the fold authoritative
-            // there means teaching resolution to re-fold instead — which is the
-            // deferred-cross-reference sentinel system's own retirement (§4.2's
-            // second), and its own increment. Until then such a content keeps
-            // the template path end to end rather than having the two
-            // mechanisms interleave.
+            // Content carrying a *deferred cross-reference* is folded at a
+            // different time rather than a different way. Such a content's
+            // rendering is rebuilt from a placeholder template each time
+            // resolution runs (`Content::rebuild_rendered`), so a fold taken
+            // *here* would be overwritten by the next resolution pass — and
+            // before that pass the destinations are not known, so it would also
+            // be answering a question the document has not settled yet. It is
+            // folded at the **end of resolution** instead (`Content::refold`),
+            // which is the same answer one step later. Until then it keeps the
+            // template's answer, which is the honest one for an unresolved
+            // document.
             if content.deferred_parts().is_none() {
                 let folded = crate::content::inline_builder::fold_html(
                     &tree,
@@ -288,16 +290,11 @@ impl SubstitutionGroup {
 
             // Content carrying a deferred cross-reference is the only content
             // whose rendering is rebuilt after the parse, so it is the only
-            // content that will be *folded* after the parse — and a fold needs
-            // the document attributes this content was written under, which by
-            // then the parse has moved on from. Retain them here, where "now"
-            // is still that point in the document.
-            //
-            // Nothing reads them yet: the retirement of the
-            // deferred-cross-reference sentinel system (design §4.2's second)
-            // is the increment that re-folds instead of rebuilding from the
-            // template. Landing the retention first is what keeps that step
-            // checkable — this one changes no output at all.
+            // content that is *folded* after the parse — and a fold needs the
+            // document attributes this content was written under, which by then
+            // the parse has moved on from. Retain them here, where "now" is
+            // still that point in the document. `Content::refold` reads them
+            // back.
             if content.deferred_parts().is_some() {
                 content.set_render_attributes(parser.snapshot_attributes());
             }

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -244,7 +244,7 @@ impl Docinfo {
                 let catalog = parser.catalog();
                 let resolver = CatalogResolver::new(&catalog);
                 let mut ref_warnings = ReferenceWarnings::default();
-                content.resolve_references(&resolver, &*parser.renderer, &mut ref_warnings);
+                content.resolve_references(&resolver, &*parser.renderer, &mut ref_warnings, parser);
             }
 
             let substituted = content.rendered_owned();

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -580,17 +580,34 @@ impl<'src> Document<'src> {
     /// [`warnings()`](Self::warnings) sees it alongside every other parse-time
     /// diagnostic. Because each sweep is independent, those warnings replace
     /// (rather than accumulate on top of) any left by an earlier sweep.
+    ///
+    /// # The `parser` argument
+    ///
+    /// Pass the [`Parser`] that produced this document. Resolving a
+    /// cross-reference changes what its content renders to, and re-rendering
+    /// needs the parse-wide configuration a renderer reads — the path resolver
+    /// and the image/SVG file handlers. A [`Document`] cannot retain those
+    /// itself: they are `Rc`-held, and holding them would cost it `Send` and
+    /// `Sync`. The order-dependent half — the document attributes in force
+    /// where each block was written — *is* retained per content, so only the
+    /// parse-wide half is supplied here.
+    ///
+    /// A parser configured differently from the one that parsed will therefore
+    /// resolve targets identically but may render an affected block's images or
+    /// paths differently. Multi-document pipelines that build one parser per
+    /// document should pass that document's own.
     pub fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
     ) -> Vec<ReferenceWarning> {
         self.internal.with_dependent_mut(|_owner, dependent| {
             let source = dependent.source;
             let mut warnings = ReferenceWarnings::default();
 
             for block in dependent.blocks.iter_mut() {
-                block.resolve_references(resolver, renderer, &mut warnings);
+                block.resolve_references(resolver, renderer, &mut warnings, parser);
             }
 
             // Section titles are resolved separately, in document order, so
@@ -625,6 +642,7 @@ impl<'src> Document<'src> {
     pub(crate) fn resolve_against_own_catalog(
         &mut self,
         renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
     ) -> Vec<ReferenceWarning> {
         self.internal.with_dependent_mut(|_owner, dependent| {
             let source = dependent.source;
@@ -638,7 +656,7 @@ impl<'src> Document<'src> {
 
             let resolver = CatalogResolver::new(&dependent.catalog);
             for block in dependent.blocks.iter_mut() {
-                block.resolve_references(&resolver, renderer, &mut warnings);
+                block.resolve_references(&resolver, renderer, &mut warnings, parser);
             }
 
             // Section titles are resolved separately, in document order, so

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -683,7 +683,7 @@ impl Parser {
         // Resolve cross-references against this document's own catalog. For
         // multi-document workflows, use `parse_deferred` and resolve later with
         // a caller-supplied resolver via `Document::resolve_references`.
-        document.resolve_against_own_catalog(&*self.renderer);
+        document.resolve_against_own_catalog(&*self.renderer, self);
 
         document
     }
@@ -1380,6 +1380,24 @@ impl Parser {
     /// [`InlineSubstitutionRenderer`]: crate::parser::InlineSubstitutionRenderer
     pub(crate) fn render_context(&self) -> RenderContext {
         RenderContext::new(self)
+    }
+
+    /// Takes a [`RenderContext`] that pairs `attributes` with **this parser's
+    /// configuration** — its path resolver and file handlers.
+    ///
+    /// This is how a fold running *later than its parse* is assembled. The two
+    /// halves come from different places on purpose:
+    ///
+    /// - the document attributes are **order-dependent** (a `:imagesdir:` line
+    ///   rebinds them for everything after it), so they must be the ones the
+    ///   content was parsed under — retained on the content itself, see
+    ///   `Content::render_attributes`;
+    /// - the resolver and handlers are **parse-wide configuration** that cannot
+    ///   change mid-parse, so the parser supplies them at fold time. They are
+    ///   also `Rc<dyn …>`, which is why a content does not retain them: doing
+    ///   so would cost [`Document`] its `Send`/`Sync`.
+    pub(crate) fn render_context_with(&self, attributes: ResolvedAttributes) -> RenderContext {
+        RenderContext::from_parts(attributes, self)
     }
 
     /// Returns the reference instant this parse has already captured for its

--- a/parser/src/parser/render_context.rs
+++ b/parser/src/parser/render_context.rs
@@ -85,6 +85,20 @@ impl RenderContext {
         }
     }
 
+    /// Builds a context pairing `attributes` — a snapshot taken at some
+    /// earlier point in the parse — with `parser`'s configuration.
+    ///
+    /// See [`Parser::render_context_with`](crate::Parser), which is how this is
+    /// reached, for why the two halves come from different places.
+    pub(super) fn from_parts(attributes: ResolvedAttributes, parser: &Parser) -> Self {
+        Self {
+            attributes,
+            path_resolver: Rc::clone(&parser.path_resolver),
+            image_file_handler: parser.image_file_handler.clone(),
+            svg_file_handler: parser.svg_file_handler.clone(),
+        }
+    }
+
     /// Returns the value of the document attribute named `name`, exactly as
     /// [`Parser::attribute_value`] would have answered when this context was
     /// taken.

--- a/parser/src/tests/asciidoc_lang/macros/xref_validate.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref_validate.rs
@@ -45,11 +45,12 @@ See <<foobar>>.
     // In pedantic (verbose) mode the resolution pass reports a reference it
     // cannot resolve within the same document. This crate surfaces that as a
     // `ReferenceWarning` returned from `resolve_references`.
-    let mut doc = Parser::default().parse_deferred("See <<foobar>>.\n\n[#foobaz]\n== Foobaz\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<foobar>>.\n\n[#foobaz]\n== Foobaz\n");
 
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].target, "foobar");
@@ -66,7 +67,7 @@ See <<foobar>>.
 
     // Resolution is repeatable: a second sweep replaces the first sweep's
     // warnings rather than accumulating a duplicate.
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(warnings.len(), 1);
     assert_eq!(doc.warnings().count(), 1);
 }

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -548,3 +548,204 @@ fn each_content_retains_the_attributes_of_its_own_point_in_the_document() {
 
     assert_eq!(dirs, vec!["<unset>".to_string(), "img".to_string()]);
 }
+
+// The retirement of the deferred-cross-reference sentinel system (design
+// §4.2's second): a deferred content's rendering is a fold of its tree, taken
+// at the end of resolution.
+
+#[test]
+fn the_fold_reproduces_the_template_for_every_deferred_content() {
+    use crate::blocks::Block;
+
+    // The differential the retirement rests on, and the one `check_document`
+    // above can no longer supply on its own. That harness folds each location's
+    // tree and compares it against `rendered_html()` — which, for a deferred
+    // content, *is* now that fold, so the comparison would pass by identity.
+    //
+    // `Content::rendered_from_template` renders the other answer: the
+    // placeholder template the string pipeline built, with each resolved
+    // destination substituted back in, exactly as `rebuild_rendered` would have
+    // installed it before this increment. Comparing the two is comparing the
+    // fold against an independent construction again.
+    //
+    // Every fixture here carries at least one cross-reference the builder
+    // recognizes, so the fold is authoritative for it and the comparison is not
+    // vacuous — `at_least_one_fold_was_authoritative` below pins that.
+    let fixtures = [
+        // The two spellings, resolved.
+        "[[tgt]]Target.\n\nSee <<tgt>>.",
+        "[[tgt]]Target.\n\nSee xref:tgt[the target].",
+        // A reference text, and one that is present but empty.
+        "[[tgt]]Target.\n\nSee <<tgt,the target>>.",
+        "[[tgt]]Target.\n\nSee <<tgt,>>.",
+        // Unresolved: the fallback both paths have to agree on.
+        "See <<missing>>.",
+        // Several in one content, so the positional correlation is exercised.
+        "[[a]]A.\n\n[[b]]B.\n\nSee <<a>>, <<b>>, and <<missing>>.",
+        // A reference sharing its content with rendered markup on either side.
+        "[[tgt]]Target.\n\n*Bold* then <<tgt>> then _italic_.",
+        // A reference inside a formatting span.
+        "[[tgt]]Target.\n\n*See <<tgt>> here.*",
+        // Attribute-dependent styling, which the retained attributes carry.
+        ":xrefstyle: full\n:sectnums:\n\n== Install\n\nSee <<_install>>.",
+        // A footnote-embedded reference: its segment is re-homed out of the
+        // block template, so the block's own correlation must still line up.
+        "[[tgt]]Target.\n\nA claim.footnote:[see <<tgt>> for details]",
+        // Inter-document form, whose destination is derived rather than looked
+        // up.
+        "See <<other.adoc#topic>>.",
+        // A macro-form reference carrying an attribute list.
+        "[[tgt]]Target.\n\nSee xref:tgt[the target,role=hl].",
+        // In a table cell and in a block title, which reach resolution by
+        // their own paths.
+        "[[tgt]]Target.\n\n|===\n|See <<tgt>>.\n|===",
+        "[[tgt]]Target.\n\n.See <<tgt>>\nA paragraph.",
+    ];
+
+    let renderer = HtmlSubstitutionRenderer {};
+    let mut compared = 0;
+
+    for fixture in fixtures {
+        let mut parser = parser();
+        let doc = parser.parse(fixture);
+
+        fn check(
+            content: &crate::content::Content<'_>,
+            renderer: &HtmlSubstitutionRenderer,
+            fixture: &str,
+            compared: &mut usize,
+        ) {
+            let Some(template) = content.rendered_from_template(renderer) else {
+                return;
+            };
+
+            assert_eq!(
+                content.rendered_html(),
+                template,
+                "the fold diverged from the template for {fixture:?}"
+            );
+
+            *compared += 1;
+        }
+
+        fn walk<'src>(
+            block: &Block<'src>,
+            renderer: &HtmlSubstitutionRenderer,
+            fixture: &str,
+            compared: &mut usize,
+        ) {
+            // Every content-bearing shape this corpus reaches: a paragraph, a
+            // block title (its own substituted content), and a simple table
+            // cell (which is not a block at all).
+            if let Block::Simple(simple) = block {
+                check(simple.content(), renderer, fixture, compared);
+            }
+
+            if let Some(title) = block.block_title_content() {
+                check(title, renderer, fixture, compared);
+            }
+
+            if let Block::Table(table) = block {
+                let rows = table
+                    .header_row()
+                    .into_iter()
+                    .chain(table.body_rows())
+                    .chain(table.footer_row());
+
+                for row in rows {
+                    for cell in row.cells() {
+                        if let TableCellContent::Simple(content) = cell.content() {
+                            check(content, renderer, fixture, compared);
+                        }
+                    }
+                }
+            }
+
+            for child in block.child_blocks() {
+                walk(child, renderer, fixture, compared);
+            }
+        }
+
+        for block in doc.child_blocks() {
+            walk(block, &renderer, fixture, &mut compared);
+        }
+    }
+
+    assert!(
+        compared >= fixtures.len(),
+        "expected at least one deferred content per fixture, compared {compared}"
+    );
+}
+
+#[test]
+fn at_least_one_fold_was_authoritative() {
+    use crate::blocks::Block;
+    // What keeps the comparison above from passing vacuously. A content whose
+    // tree the builder left short of the string pipeline's deferred count keeps
+    // the template path, and would match itself trivially; this pins that the
+    // ordinary case is not that case — the tree holds the cross-reference, so
+    // `Content::refold` really did produce the string compared above.
+    use crate::inlines::{InlineNode, RefVariant};
+
+    let mut parser = parser();
+    let doc = parser.parse("[[tgt]]Target.\n\nSee <<tgt>>.");
+
+    let has_resolved_xref = doc.child_blocks().any(|block| {
+        let Block::Simple(simple) = block else {
+            return false;
+        };
+
+        simple.content().inlines().iter().any(|node| {
+            matches!(node, InlineNode::Ref(reference)
+                if reference.variant == RefVariant::Xref && reference.resolved.is_some())
+        })
+    });
+
+    assert!(
+        has_resolved_xref,
+        "expected the tree to carry the resolved cross-reference the fold reads"
+    );
+}
+
+#[test]
+fn resolution_renders_a_deferred_content_once() {
+    use crate::parser::{CatalogResolver, InlineSubstitutionRenderer, XrefRenderParams};
+
+    // A renderer is a host-supplied trait object, so *how many times* it is
+    // called during one resolution pass is observable — a stateful one (a
+    // recorder, a numbering backend, anything counting its own callbacks) sees
+    // whatever this pass does.
+    //
+    // Both renderings exist: the template's (`rebuild_rendered`) and the
+    // tree's (`refold`). Exactly one of them runs for any given content —
+    // whichever is authoritative for it — rather than one running and then
+    // being overwritten by the other.
+    #[derive(Debug, Default)]
+    struct CountingRenderer {
+        xrefs: std::cell::Cell<usize>,
+    }
+
+    impl InlineSubstitutionRenderer for CountingRenderer {
+        fn render_xref(&self, params: &XrefRenderParams, dest: &mut String) {
+            self.xrefs.set(self.xrefs.get() + 1);
+            HtmlSubstitutionRenderer {}.render_xref(params, dest);
+        }
+    }
+
+    // Two cross-references, so a doubled pass reads 4 rather than 2 and the
+    // assertion cannot pass by an off-by-one coincidence.
+    let mut parser = parser();
+    let mut doc = parser.parse_deferred("[[tgt]]Target.\n\nSee <<tgt>> and <<tgt>> again.");
+
+    let catalog = doc.catalog().clone();
+    let resolver = CatalogResolver::new(&catalog);
+    let counting = CountingRenderer::default();
+
+    doc.resolve_references(&resolver, &counting, &parser);
+
+    assert_eq!(
+        counting.xrefs.get(),
+        2,
+        "resolution rendered this content's cross-references more than once"
+    );
+}

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1325,8 +1325,12 @@ fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
     let mut parser = Parser::default();
     let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=*hl*].");
 
-    // The rendered output is unaffected (the string pipeline is
-    // authoritative), …
+    // The rendered output is unaffected. That count mismatch is also what
+    // keeps this content on the **template** path: a deferred content is
+    // re-folded from its tree once resolution has installed its destinations
+    // (`Content::refold`), and the mirror's own success is the gate. Here the
+    // mirror skipped, so the tree is known not to describe this content and
+    // folding it would drop the cross-reference outright.
     let rendered = collect_rendered(&doc);
     assert!(
         rendered
@@ -1378,6 +1382,20 @@ fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
     assert!(
         footnote_refs.iter().all(|r| r.resolved.is_none()),
         "the footnote mirror must skip on a count mismatch: {footnote_refs:?}"
+    );
+
+    // The block's own rendering is unaffected either way. `Content::refold`
+    // gates only on the **block** half of the mirror, which succeeded here, so
+    // this content *is* re-folded from its tree — and that is correct: a
+    // footnote's text is extracted out of the block, so what the block renders
+    // for it is the marker, which the fold emits without descending into the
+    // subtree whose correlation was skipped.
+    let rendered = collect_rendered(&doc);
+    assert!(
+        rendered
+            .iter()
+            .any(|s| s.contains("href=\"#c\"") && s.contains("class=\"footnote\"")),
+        "the rendered block regressed: {rendered:?}"
     );
 }
 
@@ -1632,7 +1650,7 @@ fn inline_tree_same_target_refs_keep_per_reference_resolution() {
 
     let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("See <<tgt,first>> and <<tgt,second>>.");
-    doc.resolve_references(&PerTextResolver, &HtmlSubstitutionRenderer {});
+    doc.resolve_references(&PerTextResolver, &HtmlSubstitutionRenderer {}, &parser);
 
     let hrefs: Vec<String> = collect_refs(&doc)
         .iter()
@@ -1959,12 +1977,16 @@ fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
 
     // First pass: the resolver recognizes the target, so the heading's tree xref
     // carries its destination.
-    doc.resolve_references(&FixedResolver(Some("#tgt")), &HtmlSubstitutionRenderer {});
+    doc.resolve_references(
+        &FixedResolver(Some("#tgt")),
+        &HtmlSubstitutionRenderer {},
+        &parser,
+    );
     assert_eq!(title_xref_href(&doc).as_deref(), Some("#tgt"));
 
     // Second pass: the resolver no longer recognizes the target, so the tree xref
     // must fall back to unresolved rather than keep the stale destination.
-    doc.resolve_references(&FixedResolver(None), &HtmlSubstitutionRenderer {});
+    doc.resolve_references(&FixedResolver(None), &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(
         title_xref_href(&doc),
         None,
@@ -2316,10 +2338,14 @@ fn re_resolving_clears_a_now_unresolved_footnote_tree_destination() {
     let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("A claim.footnote:[see <<tgt>>]");
 
-    doc.resolve_references(&FixedResolver(Some("#tgt")), &HtmlSubstitutionRenderer {});
+    doc.resolve_references(
+        &FixedResolver(Some("#tgt")),
+        &HtmlSubstitutionRenderer {},
+        &parser,
+    );
     assert_eq!(footnote_xref_href(&doc).as_deref(), Some("#tgt"));
 
-    doc.resolve_references(&FixedResolver(None), &HtmlSubstitutionRenderer {});
+    doc.resolve_references(&FixedResolver(None), &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(
         footnote_xref_href(&doc),
         None,

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -316,14 +316,15 @@ fn footnote_in_heading_does_not_advance_a_counter_twice() {
 fn unresolved_reference_falls_back_and_warns() {
     // Parse without resolving, then resolve against the document's own catalog
     // (cloned so it does not alias the `&mut doc` borrow).
-    let mut doc = Parser::default().parse_deferred("See <<nope>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<nope>>.\n");
 
     // Before resolution, the reference is pending.
     assert!(first_simple(&doc).content().has_unresolved_refs());
 
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].target, "nope");
@@ -349,7 +350,8 @@ fn xrefstyle_survives_deferred_resolution() {
 
     // Parse without resolving: the target section is parsed *after* the
     // reference, so it is still pending and renders the unresolved fallback.
-    let mut doc = Parser::default().parse_deferred(src);
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred(src);
     assert!(first_simple(&doc).content().has_unresolved_refs());
     assert_eq!(
         first_paragraph(&doc),
@@ -360,7 +362,7 @@ fn xrefstyle_survives_deferred_resolution() {
     // the signifier and number from the catalog entry registered for the target.
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
     assert!(warnings.is_empty());
     assert_eq!(
         first_paragraph(&doc),
@@ -374,7 +376,8 @@ fn host_resolver_can_attach_signifier() {
     // from a catalog `RefEntry`) can still opt a target into `full`/`short`
     // formatting by attaching a signifier with `with_signifier`. The style still
     // comes from the referencing document.
-    let mut doc = Parser::default().parse_deferred(":xrefstyle: full\n\nSee <<install>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred(":xrefstyle: full\n\nSee <<install>>.\n");
 
     let resolver = CrossDocResolver {
         index: HashMap::from([(
@@ -390,7 +393,7 @@ fn host_resolver_can_attach_signifier() {
         )]),
     };
 
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
     assert!(warnings.is_empty());
     assert_eq!(
         first_paragraph(&doc),
@@ -403,9 +406,9 @@ fn reference_to_this_document_by_name_resolves_within_it() {
     // A target that names the document being parsed is a reference *into* this
     // document after all, so its fragment resolves against this document's own
     // catalog — even though the target was written in inter-document form.
-    let mut doc = Parser::default()
-        .with_primary_file_name("guide.adoc")
-        .parse_deferred("See <<guide.adoc#install>>.\n\n[#install]\n== Installation\n");
+    let mut parser = Parser::default().with_primary_file_name("guide.adoc");
+    let mut doc =
+        parser.parse_deferred("See <<guide.adoc#install>>.\n\n[#install]\n== Installation\n");
 
     // The fragment names a section parsed after the reference, so it is pending
     // until resolution, exactly like a plain forward reference.
@@ -413,7 +416,7 @@ fn reference_to_this_document_by_name_resolves_within_it() {
 
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert!(warnings.is_empty());
 
@@ -429,19 +432,19 @@ fn reference_to_this_document_by_explicit_docname_attribute_resolves_within_it()
     // `docname` attribute rather than a primary file name. Asciidoctor treats
     // `doc.attributes['docname']` as the single source of truth for the
     // self-reference match, so an API-provided `docname` must be honored too.
-    let mut doc = Parser::default()
-        .with_intrinsic_attribute(
-            "docname",
-            "guide",
-            crate::parser::ModificationContext::ApiOnly,
-        )
-        .parse_deferred("See <<guide.adoc#install>>.\n\n[#install]\n== Installation\n");
+    let mut parser = Parser::default().with_intrinsic_attribute(
+        "docname",
+        "guide",
+        crate::parser::ModificationContext::ApiOnly,
+    );
+    let mut doc =
+        parser.parse_deferred("See <<guide.adoc#install>>.\n\n[#install]\n== Installation\n");
 
     assert!(first_simple(&doc).content().has_unresolved_refs());
 
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert!(warnings.is_empty());
 
@@ -529,7 +532,8 @@ fn host_resolver_can_override_a_derived_destination() {
     // only a default: it is offered to the resolver (as
     // `ResolutionContext::derived`) rather than imposed, so a host that resolves
     // targets across a corpus can answer with its own.
-    let mut doc = Parser::default().parse_deferred("See <<tigers#about,About Tigers>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<tigers#about,About Tigers>>.\n");
 
     // Until a resolver has run, the derived destination is what renders.
     assert_eq!(
@@ -538,7 +542,7 @@ fn host_resolver_can_override_a_derived_destination() {
     );
 
     let resolver = DerivedRewritingResolver;
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert!(warnings.is_empty());
 
@@ -553,11 +557,12 @@ fn derived_destination_stands_when_the_resolver_declines() {
     // A resolver that returns `None` for a target that names another document
     // leaves the derived destination in place, and — unlike a target it could
     // not resolve — that is not reported as an unresolved reference.
-    let mut doc = Parser::default().parse_deferred("See <<tigers#about>> and <<nope>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<tigers#about>> and <<nope>>.\n");
 
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].target, "nope");
@@ -614,7 +619,7 @@ fn cross_document_resolution() {
     // Document A still has the pending reference until we resolve it.
     assert!(first_simple(&doc_a).content().has_unresolved_refs());
 
-    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
     assert!(warnings.is_empty());
 
     assert_eq!(
@@ -649,7 +654,7 @@ fn xrefstyle_carries_across_documents() {
     }
     let resolver = CrossDocResolver { index };
 
-    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
     assert!(warnings.is_empty());
     assert_eq!(
         first_paragraph(&doc_a),
@@ -661,7 +666,8 @@ fn xrefstyle_carries_across_documents() {
 fn resolution_is_repeatable() {
     // Resolving twice against different resolvers yields the second result —
     // resolution is non-destructive.
-    let mut doc = Parser::default().parse_deferred("See <<topic>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<topic>>.\n");
 
     let first = CrossDocResolver {
         index: HashMap::from([(
@@ -669,7 +675,7 @@ fn resolution_is_repeatable() {
             ResolvedReference::new("first.html#topic".to_string(), Some("First".to_string())),
         )]),
     };
-    doc.resolve_references(&first, &HtmlSubstitutionRenderer {});
+    doc.resolve_references(&first, &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(
         first_paragraph(&doc),
         "See <a href=\"first.html#topic\">First</a>."
@@ -681,7 +687,7 @@ fn resolution_is_repeatable() {
             ResolvedReference::new("second.html#topic".to_string(), Some("Second".to_string())),
         )]),
     };
-    doc.resolve_references(&second, &HtmlSubstitutionRenderer {});
+    doc.resolve_references(&second, &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(
         first_paragraph(&doc),
         "See <a href=\"second.html#topic\">Second</a>."
@@ -694,7 +700,8 @@ fn re_resolution_is_a_full_independent_sweep() {
     // resolver that no longer knows a target re-reports it as unresolved and
     // reverts the rendering to the fallback, even though an earlier pass had
     // resolved it.
-    let mut doc = Parser::default().parse_deferred("See <<topic>>.\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("See <<topic>>.\n");
 
     let knows_topic = CrossDocResolver {
         index: HashMap::from([(
@@ -702,7 +709,7 @@ fn re_resolution_is_a_full_independent_sweep() {
             ResolvedReference::new("first.html#topic".to_string(), Some("Topic".to_string())),
         )]),
     };
-    let warnings = doc.resolve_references(&knows_topic, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&knows_topic, &HtmlSubstitutionRenderer {}, &parser);
     assert!(warnings.is_empty());
     assert_eq!(
         first_paragraph(&doc),
@@ -714,7 +721,7 @@ fn re_resolution_is_a_full_independent_sweep() {
     let knows_nothing = CrossDocResolver {
         index: HashMap::new(),
     };
-    let warnings = doc.resolve_references(&knows_nothing, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&knows_nothing, &HtmlSubstitutionRenderer {}, &parser);
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].target, "topic");
     assert_eq!(first_paragraph(&doc), "See <a href=\"#topic\">[topic]</a>.");
@@ -725,8 +732,8 @@ fn footnote_cross_references_resolve_via_host_resolver() {
     // Cross-references inside a footnote are resolved through a host-supplied
     // resolver too (the multi-document path), and an unresolved one falls back
     // and is reported.
-    let mut doc =
-        Parser::default().parse_deferred("Text.footnote:[See <<topic>> and <<missing>>.]\n");
+    let mut parser = Parser::default();
+    let mut doc = parser.parse_deferred("Text.footnote:[See <<topic>> and <<missing>>.]\n");
 
     let resolver = CrossDocResolver {
         index: HashMap::from([(
@@ -734,7 +741,7 @@ fn footnote_cross_references_resolve_via_host_resolver() {
             ResolvedReference::new("other.html#topic".to_string(), Some("Topic".to_string())),
         )]),
     };
-    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {}, &parser);
 
     assert_eq!(
         doc.catalog().footnotes()[0].text,
@@ -1368,11 +1375,14 @@ mod xrefs_in_titles {
             }
         }
 
-        let mut doc = Parser::default().parse_deferred("== See <<b>>\n\n[#b]\n== B <<missing>>");
+        let mut parser = Parser::default();
+
+        let mut doc = parser.parse_deferred("== See <<b>>\n\n[#b]\n== B <<missing>>");
 
         doc.resolve_references(
             &BespokeResolver,
             &crate::parser::HtmlSubstitutionRenderer {},
+            &Parser::default(),
         );
 
         let sections: Vec<_> = doc
@@ -1409,10 +1419,15 @@ mod xrefs_in_titles {
             }
         }
 
-        let mut doc = Parser::default().parse_deferred("== See <<b>>\n\n[#b]\n== B <<c>>");
+        let mut parser = Parser::default();
 
-        let warnings =
-            doc.resolve_references(&KnowsNothing, &crate::parser::HtmlSubstitutionRenderer {});
+        let mut doc = parser.parse_deferred("== See <<b>>\n\n[#b]\n== B <<c>>");
+
+        let warnings = doc.resolve_references(
+            &KnowsNothing,
+            &crate::parser::HtmlSubstitutionRenderer {},
+            &parser,
+        );
 
         let sections: Vec<_> = doc
             .child_blocks()
@@ -1470,6 +1485,7 @@ mod xrefs_in_titles {
         doc.resolve_references(
             &ExternalResolver,
             &crate::parser::HtmlSubstitutionRenderer {},
+            &Parser::default(),
         );
 
         let sections: Vec<_> = doc


### PR DESCRIPTION
The second of §4.2's three sentinel systems loses its reason to exist, and the cutover's one carve-out narrows to something principled.

Content carrying a deferred cross-reference kept the template path end to end, because its rendered string is rebuilt from a placeholder template on *every* resolution pass (`Content::rebuild_rendered`) — so a fold taken at parse time would be overwritten by the next pass, and would anyway be answering a question the document has not settled yet. It is folded at the **end of resolution** instead (`Content::refold`), which is the same answer one step later, assembled from the attributes the content retained (#1267) paired with the parser's own configuration through a `RenderContext` (#1268).

## The carve-out narrows rather than vanishing

The old predicate was `content.deferred_parts().is_none()`: *any* deferred cross-reference kept the template. The new one is the count match `mirror_tree_xref_resolution` already computes — the tree's block-level cross-reference nodes against the segments whose placeholders are still in the template.

Where they agree, the tree holds every cross-reference the string pipeline deferred, and a fold of it *is* this content's rendering. Where they differ, the builder left one of its documented forms unrecognized, so folding would **lose** the construct rather than render it differently, and the template stays. That gate self-liquidates: each builder prep that teaches one more form shrinks it, and it vanishes when none is left.

The **footnote** half of the mirror is deliberately not part of the gate. A footnote's text is extracted out of the block, so it is not part of `rendered` — the fold emits the marker (`fold_footnote`) and never descends into the subtree whose correlation was skipped.

The parse-time fold keeps its own `deferred_parts().is_none()` guard, so an unresolved `parse_deferred` document still reads the template's answer, which is the honest one before resolution has run.

## Exactly one rendering runs

The fold and the template render are alternatives, not a render followed by an overwrite. A renderer is a host-supplied trait object, so running both is *observable*, not merely wasteful: a stateful one — a recorder, a numbering backend, anything counting its own callbacks — would see every callback for a deferred content twice in a single resolution pass.

`resolution_renders_a_deferred_content_once` pins it with a counting renderer, which `Document::resolve_references` takes as an ordinary argument.

That costs the whole-document parity harness its oracle for exactly the content this step changed: `check_document` folds each location's tree and compares it against `rendered_html()`, which for a deferred content now *is* that fold. So the template's answer becomes reachable on its own — `Content::rendered_from_template`, test-only — and `the_fold_reproduces_the_template_for_every_deferred_content` compares the two over fourteen cross-reference fixtures: both spellings, empty and absent reference texts, unresolved targets, several in one content, a formatting span, an inter-document target, a footnote-embedded reference, an attribute-styled one, a table cell, and a block title. Both new tests were checked by removing the property they pin.

## Sizing it

A whole-suite probe (fold vs. template at every resolution) found 14 divergences: 11 were the inline recorder's counter drift described above — the symptom of the double render, read at first as an artifact of the measurement — one is an improvement, and two were real regressions, both of which became #1272/#1276.

That improvement is `a_post_replacement_in_a_cross_reference_text_...`, pinned since the cross-product sweep with a note saying it would close exactly here: a `+` line break in a cross-reference's display text now gets its `<br>`, because a display text is a subtree either way and the fold walks subtrees, where the string pipeline's step never saw inside a template. The test is rewritten to assert parity.

## What still defers

`xref:sec[*bold*,role=*hl*]` — a rendered span reaching a value the macro families read as a *string* (`role=`, `window=`, `xrefstyle=`). It is the last known member of the class and is what keeps the narrowed gate from being vacuous; `xref_mirror_is_skipped_when_the_tree_defers_a_reference_form` fails without the gate.

A section or block title's deferred cross-references, which `title_refs` resolves in document order with cross-title coordination the per-content pass cannot do, still take their rendering from that pass's template.

Retiring the template *itself* waits on both, and on the whole-document parity harness no longer needing it as the oracle the fold is checked against.

## API

`Document::resolve_references` takes the `Parser` that produced the document: re-rendering needs the parse-wide configuration a renderer reads (path resolver, image/SVG file handlers), which a `Document` cannot retain without losing `Send`/`Sync`. Documented on the method.

## Design doc

Adds the narrative and checklist entries for #1267, #1268, #1272 and #1276, which landed without them, alongside this step's own.

## Verification

- `cargo test --workspace`: 5435 pass, 0 fail.
- Resolution-time probe: all rows accounted for; the divergence set is identical whether the gate reads both halves of the mirror or only the block half.
- Coverage diff-neutral: `content.rs` 21/8, `substitution_group.rs` 0/0, `render_context.rs` 0/0 — the remaining misses are pre-existing defensive branches in `render_template` and a `Debug` impl.
- Preflight clean: fmt (nightly), clippy, doc (nightly).