### PR TITLE
feat: Fold a title's rendering too (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6321,6 +6321,71 @@ Each phase is a reviewable unit with a clear exit gate.
   `DeferredContent::template` — waits on both, and on the whole-document parity harness no longer
   needing the template as the oracle the fold is checked against.
 
+  *Step 6 landed as (a title's rendering joins the fold, closing the retirement's other half):*
+  the increment above retired the deferred-cross-reference sentinel system for content resolved by
+  [`Content::resolve_references`](../../parser/src/content/content.rs) and named a title as what
+  still deferred. A title is not resolved per content: a cross-reference between two titles —
+  forward, or circular — needs coordination the per-content pass cannot do, so
+  [`title_refs`](../../parser/src/document/title_refs.rs) computes every title's rendering together,
+  in document order, breaking cycles the way Asciidoctor does. That pass rendered the template.
+
+  It now folds instead, and **where** it folds is the whole design. The obvious place is the pass's
+  write-back walk, after the resolutions are computed — and that is wrong: the pass needs each
+  title's rendering *while it runs*, because that string is the link text a reference **to** that
+  title splices in. Folding afterwards would leave the template render standing as the coordination
+  input and add a second one, which is precisely the double callback the increment above removed. So
+  the fold happens inside `compute`, in place of `render_xref_template`, with the template kept as
+  the fallback. `the_title_pass_renders_each_title_once` pins it with a counting renderer, and fails
+  on the write-back placement.
+
+  Folding there means folding without a `&mut` to the blocks — the pass walks them again afterwards
+  to install what it computed — so [`fold_resolved_title`](../../parser/src/content/content.rs)
+  folds a **clone** of the title's tree, and the real tree still takes the later mirror. Only the
+  block-level destinations are installed into that clone: a fold emits a footnote's *marker* and
+  never descends into its subtree, so the mirror's footnote half has no counterpart here (it was
+  written, found dead by coverage, and removed).
+
+  The coordination survives the fold because it never lived in the template. A
+  [`ResolvedReference`](../../parser/src/parser/reference_resolver.rs) carries the reference text
+  the pass computed for its target, `assign_tree_xrefs` installs it on the node, and `fold_xref`
+  reads it there — so the fold reproduces the coordinated answer, cycles and all, rather than a
+  per-title one.
+  `a_folded_heading_keeps_the_cross_title_coordination` pins three shapes (a forward reference, a
+  cycle whose inner link text falls back to `[id]` with the nested anchor dropped, and a footnote in
+  a heading) — and passes on the base branch too, which is the point: **this increment changes no
+  output.** Measured over the whole suite, 59 of 60 deferred titles take the fold and every one of
+  them reproduces the template byte for byte; the 60th has an empty tree and keeps the template.
+
+  It costs callbacks, and the review that found it was right to. Folding renders the **whole**
+  title, where the template render it replaces touched only the placeholders: measured on
+  `== A *bold* image:x.png[X] a < b <<t>>`, total renderer calls go 13 → 16, and the three added are
+  duplicates of calls the string pipeline already made at parse time. That is the transitional cost
+  of an authoritative fold rather than one this path invents — a plain paragraph's `<` is rendered
+  twice *today* (once by `run_pipeline`, once by the fold that overwrites its answer), and a
+  deferred paragraph has paid exactly this since the increment above; the fixtures that were already
+  folding measure 9 → 9 and 12 → 12, unchanged. A title was the last content on the cheaper template
+  path, and it was cheaper only because its rendering was less correct. The duplication ends for all
+  of them together when step 6 takes the string pipeline off the production path; it cannot end
+  here, because folding a tree means rendering it. What *is* avoidable, and avoided, is rendering
+  the same title twice within the pass.
+
+  It also corrected an oracle the increment above introduced.
+  `the_fold_reproduces_the_template_for_every_deferred_content` walked block titles, and could not:
+  a title's own deferred segments are never resolved in place — the pass resolves a *clone* of them,
+  since the coordination is cross-title — so `rendered_from_template` renders the **uncoordinated**
+  fallback for one. It passed only because every title fixture in that corpus happened to coincide
+  (`[tgt]` on both sides). A section-title fixture made it fail honestly; titles are out of that
+  test now, and covered by the coordination pins instead.
+
+  What still defers is `xref:sec[*bold*,role=*hl*]` — a rendered span reaching a value the macro
+  families read as a *string*. It is no longer only a cross-reference concern: `Ref::roles` is
+  `Vec<CowStr>`, and the link and image families draw the same boundary in their own gates, so
+  closing it means giving a computed *string* slot somewhere to put fold-time markup rather than
+  teaching one family one form. Retiring the template itself — the sentinel constants,
+  `render_template`, `DeferredContent::template` — waits on that and on
+  `Content::rendered_from_template`, which is now the only thing keeping the fold differentiated
+  against an independent construction.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7584,11 +7649,33 @@ Each phase is a reviewable unit with a clear exit gate.
        — both closed as the two preps above. Exactly one of the two renderings runs: rendering both
        and keeping the second would be *observable*, not merely wasteful, since a stateful host
        renderer would see every callback twice in one pass
-       (`resolution_renders_a_deferred_content_once`). That costs the whole-document harness its oracle for this content, so the template's answer
-       becomes reachable test-only and a fourteen-fixture corpus compares the two directly. What
+       (`resolution_renders_a_deferred_content_once`). That costs the whole-document harness its
+       oracle for this content, so the template's answer becomes reachable test-only and a
+       fixture corpus compares the two directly. What
        still defers is `xref:sec[*bold*,role=*hl*]` (a rendered span reaching a string-read value)
        and a **title's** deferred cross-references, which `title_refs` still renders from the
-       template. See the step's own "landed as" note above. What remains of step 6 is the
+       template. See the step's own "landed as" note above.
+
+     - ✅ **a title's rendering joins the fold — the retirement's other half.**
+       [`title_refs`](../../parser/src/document/title_refs.rs) computes every title's rendering
+       together, in document order, so a cross-reference between titles coordinates; it now folds
+       the title's tree in place of rendering its template. **Inside `compute`**, not in the
+       write-back walk — the pass needs each rendering *while it runs*, as the link text a
+       reference to that title splices in, so folding afterwards would leave both and render every
+       deferred title twice (`the_title_pass_renders_each_title_once`, which fails on that
+       placement). It folds a **clone** of the tree, since the pass holds no `&mut` to the blocks
+       there, and installs only the block-level destinations: a fold emits a footnote's marker
+       without descending into its subtree. The coordination rides on the destinations, not the
+       template, so it survives — pinned over a forward reference, a cycle, and a footnote in a
+       heading, all of which pass on base too: **this changes no output.** 59 of 60 deferred titles
+       in the suite take the fold, each reproducing the template byte for byte; the 60th has an
+       empty tree. It costs three duplicate renderer callbacks per deferred title (13 → 16 on a
+       heading carrying a span, an image and a special character) — the transitional cost of an
+       authoritative fold, which every other content already pays and which ends for all of them
+       when step 6 takes the string pipeline off the production path. It also corrected an oracle:
+       the previous increment's template differential
+       walked block titles, whose segments are never resolved in place, and passed only by
+       coincidence. See the step's own "landed as" note above. What remains of step 6 is the
        passthrough sentinel system and the side effects wired for real.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -525,12 +525,21 @@ impl<'src> SectionBlock<'src> {
             .mirror_tree_xref_resolution(block_ordered, footnote_ordered);
     }
 
-    /// Returns the section title's inline tree. Used by the inline-tree tests
-    /// to inspect the title's mirrored cross-reference resolution; empty
-    /// unless tree building is enabled on the [`Parser`](crate::Parser).
-    #[cfg(test)]
+    /// Returns the section title's inline tree — the tree the document-order
+    /// title pass folds to render this heading, and which that pass then
+    /// mirrors its resolved destinations into.
     pub(crate) fn section_title_inlines(&self) -> &[crate::inlines::InlineNode<'src>] {
         self.section_title.inlines()
+    }
+
+    /// The document attributes in force where this heading was written, when
+    /// they were retained — the order-dependent half of the render context a
+    /// fold of the tree above needs. See
+    /// [`Content::render_attributes`](crate::content::Content).
+    pub(crate) fn section_title_render_attributes(
+        &self,
+    ) -> Option<&crate::parser::ResolvedAttributes> {
+        self.section_title.render_attributes()
     }
 
     /// Returns the ID under which this section is registered in the catalog, if

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -901,6 +901,82 @@ impl<'src> Content<'src> {
     }
 }
 
+/// Renders a **title's** tree, with `block_ordered` / `footnote_ordered`
+/// installed into a copy of it, or `None` when that tree is not authoritative
+/// for the title.
+///
+/// This is [`Content::refold`] for the one path that cannot use it. A title's
+/// rendering is computed by the document-order pass
+/// (the `title_refs` module) rather than installed by
+/// [`resolve_references`](Content::resolve_references), because a
+/// cross-reference between two titles needs coordination the per-content pass
+/// cannot do — and that pass needs each title's rendering *while it runs*, as
+/// the link text another title's reference splices in. So the fold has to
+/// happen there, in place of the template render, rather than after it: taking
+/// both would render every deferred title twice through a host renderer that
+/// may be counting (see `Content::resolve_references`).
+///
+/// Hence the copy. The pass holds no `&mut` to the blocks while it computes —
+/// it walks them again afterwards to install what it computed — so it folds a
+/// clone of the tree and leaves the real one to that later mirror, which
+/// installs the same destinations from the same lists.
+///
+/// `None` is the same carve-out
+/// [`mirror_tree_xref_resolution`](Content::mirror_tree_xref_resolution)
+/// reports: a tree holding fewer block-level cross-references than the string
+/// pipeline deferred does not describe this title, so folding it would drop the
+/// construct. The caller renders the template instead.
+///
+/// Folding renders the **whole** title, not just its cross-references — every
+/// styled span, image and special character in it — where the template render
+/// this replaces touched only the placeholders. Measured on a heading carrying
+/// all three, that is three more renderer callbacks per deferred title (13 → 16
+/// for `== A *bold* image:x.png[X] a < b <<t>>`). The calls are duplicates: the
+/// string pipeline already made them at parse time.
+///
+/// That is the transitional cost of an authoritative fold, not a cost this path
+/// adds. Every content already pays it — a plain paragraph's `<` is rendered
+/// twice today, once by `run_pipeline` and once by the fold that overwrites its
+/// answer — and a *deferred paragraph* has paid exactly this since the fold
+/// moved to resolution time. A title was the last content still on the cheaper
+/// template path, and it was cheaper only because its rendering was less
+/// correct. The duplication ends for all of them together, when step 6 takes
+/// the string pipeline off the production path; it cannot end here, because
+/// folding a tree means rendering it.
+///
+/// What this *does* avoid is rendering the same title twice within this pass:
+/// the fold replaces the template render rather than joining it — see the
+/// caller, and `the_title_pass_renders_each_title_once`.
+///
+/// Only the **block-level** destinations are installed, and the mirror's
+/// footnote half has no counterpart here: a fold emits a footnote's *marker*
+/// and never descends into its subtree (see `fold_footnote`), so a destination
+/// installed there could not reach this string. The real tree still gets both,
+/// from the caller's own later mirror — that tree is read by consumers, not
+/// just folded.
+pub(crate) fn fold_resolved_title(
+    inlines: &[InlineNode<'_>],
+    block_ordered: &[Option<ResolvedReference>],
+    attributes: &ResolvedAttributes,
+    renderer: &dyn InlineSubstitutionRenderer,
+    parser: &Parser,
+) -> Option<String> {
+    if inlines.is_empty() || count_tree_xrefs(inlines) != block_ordered.len() {
+        return None;
+    }
+
+    let mut tree = inlines.to_vec();
+
+    let mut next = 0;
+    assign_tree_xrefs(&mut tree, block_ordered, &mut next);
+
+    let context = parser.render_context_with(attributes.clone());
+
+    Some(crate::content::inline_builder::fold_html(
+        &tree, renderer, &context,
+    ))
+}
+
 /// Builds the placeholder-ordered list of resolved destinations that
 /// [`Content::mirror_tree_xref_resolution`] installs into an inline tree.
 ///

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,8 +6,8 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xrefs, footnote_tree_xrefs,
-    rehome_xref_placeholders, render_xref_template, sanitize_title,
+    FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xrefs, fold_resolved_title,
+    footnote_tree_xrefs, rehome_xref_placeholders, render_xref_template, sanitize_title,
 };
 
 pub(crate) mod inline_builder;

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -619,6 +619,7 @@ impl<'src> Document<'src> {
                 resolver,
                 renderer,
                 &mut warnings,
+                parser,
             );
 
             // Footnote text is extracted out of block content, so its
@@ -668,6 +669,7 @@ impl<'src> Document<'src> {
                 &resolver,
                 renderer,
                 &mut warnings,
+                parser,
             );
 
             // Footnote text is extracted out of block content, so its

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -25,8 +25,12 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{XrefSegment, block_tree_xrefs, footnote_tree_xrefs, render_xref_template},
+    content::{
+        XrefSegment, block_tree_xrefs, fold_resolved_title, footnote_tree_xrefs,
+        render_xref_template,
+    },
     document::Catalog,
+    inlines::InlineNode,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
         ResolvedReference,
@@ -75,6 +79,18 @@ struct TitleNode<'src> {
 
     /// The title's source span, for anchoring an unresolved-reference warning.
     source: Span<'src>,
+
+    /// A copy of the title's inline tree, which the pass folds to produce
+    /// `rendered` — see [`fold_resolved_title`] for why it is a copy.
+    inlines: Vec<InlineNode<'src>>,
+
+    /// The document attributes in force where this title was written, retained
+    /// on its content because a fold running later than its parse cannot read
+    /// them from the parser (design §4.2's second sentinel system).
+    ///
+    /// `None` leaves the title on the template path, as it does everywhere
+    /// else.
+    render_attributes: Option<crate::parser::ResolvedAttributes>,
 }
 
 /// Resolves the cross-references embedded in every section heading and block
@@ -91,6 +107,7 @@ pub(crate) fn resolve_title_references<'src>(
     resolver: &dyn ReferenceResolver,
     renderer: &dyn InlineSubstitutionRenderer,
     warnings: &mut ReferenceWarnings<'src>,
+    parser: &crate::Parser,
 ) {
     let mut nodes: Vec<TitleNode<'src>> = Vec::new();
     collect(blocks, &mut nodes);
@@ -124,6 +141,7 @@ pub(crate) fn resolve_title_references<'src>(
             &mut memo,
             &mut in_progress,
             warnings,
+            parser,
         );
     }
 
@@ -144,11 +162,16 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
                     section.reference_id()
                 };
 
+                let template = template.to_string();
+                let xrefs = xrefs.to_vec();
+
                 nodes.push(TitleNode {
-                    template: template.to_string(),
-                    xrefs: xrefs.to_vec(),
+                    template,
+                    xrefs,
                     map_id,
                     source: section.section_title_source(),
+                    inlines: section.section_title_inlines().to_vec(),
+                    render_attributes: section.section_title_render_attributes().cloned(),
                 });
             }
         } else {
@@ -161,15 +184,19 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
             // mutably borrowed while the template is in scope.
             let source = block.span();
 
-            if let Some((template, xrefs)) = block
-                .block_title_content_mut()
-                .and_then(|title| title.deferred_parts())
+            if let Some(title) = block.block_title_content_mut()
+                && let Some((template, xrefs)) = title.deferred_parts()
             {
+                let template = template.to_string();
+                let xrefs = xrefs.to_vec();
+
                 nodes.push(TitleNode {
-                    template: template.to_string(),
-                    xrefs: xrefs.to_vec(),
+                    template,
+                    xrefs,
                     map_id: None,
                     source,
+                    inlines: title.inlines().to_vec(),
+                    render_attributes: title.render_attributes().cloned(),
                 });
             }
         }
@@ -232,6 +259,7 @@ fn compute<'src>(
     memo: &mut [Option<Resolution>],
     in_progress: &mut [bool],
     warnings: &mut ReferenceWarnings<'src>,
+    parser: &crate::Parser,
 ) -> String {
     if let Some(Some(resolution)) = memo.get(index) {
         return resolution.rendered.clone();
@@ -300,6 +328,7 @@ fn compute<'src>(
                         memo,
                         in_progress,
                         warnings,
+                        parser,
                     ))
                 };
             }
@@ -314,13 +343,11 @@ fn compute<'src>(
         xref.resolved = resolved;
     }
 
-    let rendered = render_xref_template(&node.template, &xrefs, renderer);
-
     // The resolved destinations, in placeholder order and filtered to those the
     // template still splices, so they line up one-to-one with the title tree's
     // cross-reference nodes when mirrored (see `write_back`). This reuses the
-    // very `xrefs` that produced `rendered`, so the tree cannot disagree with
-    // the string.
+    // very `xrefs` the rendering below is computed from, so the tree cannot
+    // disagree with the string.
     let block_ordered = block_tree_xrefs(&node.template, &xrefs);
 
     // The complementary set: a cross-reference the title's footnotes carry was
@@ -328,6 +355,24 @@ fn compute<'src>(
     // is absent from `block_ordered` and belongs to a footnote subtree of the
     // title tree instead.
     let footnote_ordered = footnote_tree_xrefs(&node.template, &xrefs);
+
+    // The title's rendering is a **fold of its tree**, with the destinations
+    // just resolved installed into it — the same answer `Content::refold` gives
+    // a deferred paragraph, reached here rather than after the pass because
+    // this string is also what a reference *to* this title splices in as its
+    // link text. Rendering the template as well, and keeping only one, would
+    // put every deferred title through a host renderer twice.
+    //
+    // The template is the fallback for a title whose tree the builder left
+    // short of the cross-references the string pipeline deferred, and for one
+    // that retained no attributes to fold under.
+    let rendered = node
+        .render_attributes
+        .as_ref()
+        .and_then(|attributes| {
+            fold_resolved_title(&node.inlines, &block_ordered, attributes, renderer, parser)
+        })
+        .unwrap_or_else(|| render_xref_template(&node.template, &xrefs, renderer));
 
     if let Some(flag) = in_progress.get_mut(index) {
         *flag = false;

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -596,10 +596,8 @@ fn the_fold_reproduces_the_template_for_every_deferred_content() {
         "See <<other.adoc#topic>>.",
         // A macro-form reference carrying an attribute list.
         "[[tgt]]Target.\n\nSee xref:tgt[the target,role=hl].",
-        // In a table cell and in a block title, which reach resolution by
-        // their own paths.
+        // In a table cell, which reaches resolution by its own path.
         "[[tgt]]Target.\n\n|===\n|See <<tgt>>.\n|===",
-        "[[tgt]]Target.\n\n.See <<tgt>>\nA paragraph.",
     ];
 
     let renderer = HtmlSubstitutionRenderer {};
@@ -634,15 +632,21 @@ fn the_fold_reproduces_the_template_for_every_deferred_content() {
             fixture: &str,
             compared: &mut usize,
         ) {
-            // Every content-bearing shape this corpus reaches: a paragraph, a
-            // block title (its own substituted content), and a simple table
-            // cell (which is not a block at all).
+            // Every content-bearing shape this corpus reaches: a paragraph and
+            // a simple table cell (which is not a block at all).
+            //
+            // A **title** is deliberately not one of them, block or section.
+            // `rendered_from_template` renders a content's *own* deferred
+            // segments, and a title's are never resolved in place: the
+            // document-order pass resolves a clone of them (it has to — the
+            // coordination is cross-title) and installs only the result. So the
+            // template it would render here is the uncoordinated one, and
+            // comparing against it would report a divergence the title does not
+            // have. Titles are covered by
+            // `a_folded_heading_keeps_the_cross_title_coordination` instead,
+            // which pins the coordinated answer directly.
             if let Block::Simple(simple) = block {
                 check(simple.content(), renderer, fixture, compared);
-            }
-
-            if let Some(title) = block.block_title_content() {
-                check(title, renderer, fixture, compared);
             }
 
             if let Block::Table(table) = block {
@@ -747,5 +751,120 @@ fn resolution_renders_a_deferred_content_once() {
         counting.xrefs.get(),
         2,
         "resolution rendered this content's cross-references more than once"
+    );
+}
+
+#[test]
+fn a_folded_heading_keeps_the_cross_title_coordination() {
+    // A title's rendering is a fold of its tree too, taken by the
+    // document-order pass (`title_refs`) in place of the template render it
+    // used to do — not after it, since that string is also the link text a
+    // reference *to* this title splices in, and computing both would put every
+    // deferred title through a host renderer twice.
+    //
+    // What makes a title its own case is the coordination: the pass resolves
+    // titles in document order and lets one title's rendering become another's
+    // reference text, breaking cycles the way Asciidoctor does. That survives
+    // the fold because it rides on the *destination* — a `ResolvedReference`
+    // carries the text the pass computed, the mirror installs it on the node,
+    // and `fold_xref` reads it there — rather than on the template.
+    //
+    // So the oracle here is the coordinated answer itself, not the title's own
+    // template: a title's deferred segments are never resolved in place (the
+    // pass resolves a clone), so rendering that template would give the
+    // *uncoordinated* fallback and prove nothing.
+    let cases = [
+        // A forward reference: `<<second>>` names a heading parsed later, whose
+        // reference text is its own title. The uncoordinated answer is `[second]`.
+        (
+            "== See <<second>>\n\nBody.\n\n[[second]]\n== The Second\n\nMore.",
+            vec![r##"See <a href="#second">The Second</a>"##, "The Second"],
+        ),
+        // A cycle: computing `a` recurses into `b`, which reaches `a` while it
+        // is still in progress and falls back to the bracketed `[a]` rather
+        // than recursing forever. `b`'s rendering is then spliced into `a`'s as
+        // link text, where the renderer drops the nested anchor.
+        (
+            "[[a]]\n== A cites <<b>>\n\nBody.\n\n[[b]]\n== B cites <<a>>\n\nMore.",
+            vec![
+                r##"A cites <a href="#b">B cites [a]</a>"##,
+                r##"B cites <a href="#a">[a]</a>"##,
+            ],
+        ),
+        // A footnote inside a heading: its embedded reference is re-homed out
+        // of the title's own template, so the two correlation lists partition.
+        (
+            "[[tgt]]Target.\n\n== A Heading.footnote:[see <<tgt>>]\n\nBody.",
+            vec![concat!(
+                "A Heading.",
+                r##"<sup class="footnote">[<a id="_footnoteref_1" class="footnote" "##,
+                r##"href="#_footnotedef_1" title="View footnote.">1</a>]</sup>"##
+            )],
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let mut parser = parser();
+        let doc = parser.parse(source);
+
+        let headings: Vec<String> = doc
+            .child_blocks()
+            .filter_map(|block| match block {
+                crate::blocks::Block::Section(section) => Some(section.section_title().to_string()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(headings, expected, "for {source:?}");
+    }
+}
+
+#[test]
+fn the_title_pass_renders_each_title_once() {
+    use crate::parser::{CatalogResolver, InlineSubstitutionRenderer, XrefRenderParams};
+
+    // The title-side counterpart of `resolution_renders_a_deferred_content_once`,
+    // and the property that makes the fold a *replacement* for the document-order
+    // pass's template render rather than an addition to it.
+    //
+    // The pass needs each title's rendering while it runs — it is the link text
+    // a reference to that title splices in — so the fold has to happen inside
+    // `compute`, in place of `render_xref_template`. Folding after the pass
+    // instead (in its write-back walk, the obvious place) would leave both, and
+    // every deferred title would reach a host renderer twice.
+    #[derive(Debug, Default)]
+    struct CountingRenderer {
+        xrefs: std::cell::Cell<usize>,
+    }
+
+    impl InlineSubstitutionRenderer for CountingRenderer {
+        fn render_xref(&self, params: &XrefRenderParams, dest: &mut String) {
+            self.xrefs.set(self.xrefs.get() + 1);
+            HtmlSubstitutionRenderer {}.render_xref(params, dest);
+        }
+    }
+
+    // Two headings, one cross-reference each, and neither references the other
+    // — so the pass has no reason to render either more than once and the count
+    // is exactly the number of cross-references.
+    let mut parser = parser();
+    let mut doc = parser.parse_deferred(concat!(
+        "[[tgt]]Target.\n\n",
+        "== First sees <<tgt>>\n\n",
+        "Body.\n\n",
+        "== Second sees <<tgt>>\n\n",
+        "More.",
+    ));
+
+    let catalog = doc.catalog().clone();
+    let resolver = CatalogResolver::new(&catalog);
+    let counting = CountingRenderer::default();
+
+    doc.resolve_references(&resolver, &counting, &parser);
+
+    assert_eq!(
+        counting.xrefs.get(),
+        2,
+        "the document-order title pass rendered a title more than once"
     );
 }


### PR DESCRIPTION
The other half of the deferred-cross-reference sentinel system's retirement (#1277), which closed it for content resolved by `Content::resolve_references` and named a title as what still deferred.

A title is not resolved per content: a cross-reference between two titles — forward, or circular — needs coordination the per-content pass cannot do, so `title_refs` computes every title's rendering together, in document order, breaking cycles the way Asciidoctor does. That pass rendered the template. It now folds the title's tree instead.

## Where it folds is the whole design

The obvious place is the pass's write-back walk, after the resolutions are computed. That is wrong: the pass needs each title's rendering *while it runs*, because that string is the link text a reference **to** that title splices in. Folding afterwards would leave the template render standing as the coordination input and add a second one — precisely the double callback #1277 removed, in the other path.

So the fold happens inside `compute`, in place of `render_xref_template`, with the template kept as the fallback. `the_title_pass_renders_each_title_once` pins it with a counting renderer, and fails on the write-back placement.

Folding there means folding without a `&mut` to the blocks — the pass walks them again afterwards to install what it computed — so `fold_resolved_title` folds a **clone** of the title's tree, and the real tree still takes the later mirror. Only the block-level destinations are installed into that clone: a fold emits a footnote's *marker* and never descends into its subtree, so the mirror's footnote half has no counterpart here. (It was written, found dead by coverage, and removed.)

## The coordination survives, because it never lived in the template

A `ResolvedReference` carries the reference text the pass computed for its target, `assign_tree_xrefs` installs it on the node, and `fold_xref` reads it there. So the fold reproduces the coordinated answer, cycles and all, rather than a per-title one.

`a_folded_heading_keeps_the_cross_title_coordination` pins three shapes: a forward reference, a cycle whose inner link text falls back to `[id]` with the nested anchor dropped, and a footnote in a heading. It passes on the base branch too, which is the point: **this changes no output.**

Measured over the whole suite, 59 of 60 deferred titles take the fold and every one reproduces the template byte for byte; the 60th has an empty tree and keeps the template, exercising the carve-out.

## It also corrects an oracle #1277 introduced

`the_fold_reproduces_the_template_for_every_deferred_content` walked block titles, and could not: a title's own deferred segments are never resolved in place — the pass resolves a clone of them, since the coordination is cross-title — so `rendered_from_template` renders the *uncoordinated* fallback for one. It passed only because every title fixture in that corpus happened to coincide (`[tgt]` on both sides). A section-title fixture made it fail honestly. Titles are out of that test now, with the reason recorded there, and covered by the coordination pins instead.

## What still defers

`xref:sec[*bold*,role=*hl*]` — a rendered span reaching a value the macro families read as a *string*. It is no longer only a cross-reference concern: `Ref::roles` is `Vec<CowStr>`, and the link and image families draw the same boundary in their own gates, so closing it means giving a computed *string* slot somewhere to put fold-time markup rather than teaching one family one form.

Retiring the template itself waits on that, and on `Content::rendered_from_template`, now the only thing keeping the fold differentiated against an independent construction.

## Verification

- `cargo test --workspace`: 5437 pass, 0 fail; no golden changes.
- Whole-suite title probe: 59/60 fold, all byte-identical to the template.
- Both new tests checked by removing the property they pin.
- Coverage diff-neutral: `content.rs` 21/8, `title_refs.rs` 5/0 — identical to base.
- Preflight clean: fmt (nightly), clippy, doc (nightly).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_