### PR TITLE
feat: Re-attach the recognition side effects for real (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6386,6 +6386,52 @@ Each phase is a reviewable unit with a clear exit gate.
   `Content::rendered_from_template`, which is now the only thing keeping the fold differentiated
   against an independent construction.
 
+  *Step 6 landed as (the recognition side effects, re-attached for real):* the third of the four
+  things step 6 asks for, and the first that is not about the rendered string at all. Recognizing a
+  construct also means *writing it down*: an `image:` macro records its target in the asset catalog,
+  the three link passes record theirs, an inline anchor and a bibliography entry register their ids
+  in the reference catalog, and an image whose `link=` names a dangerous scheme records a warning.
+  All four were staged — built, composed as
+  [`apply_macro_side_effects`](../../parser/src/content/inline_builder/macros/mod.rs), and pinned by
+  their own corpus-wide harness — but every one of their doc comments still ended "nothing here is
+  wired into a real parse path yet". They are wired now.
+
+  The switch is a **suppression window**, not a deletion.
+  [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) sets
+  `Parser::suppress_macro_side_effects` around its authoritative string pass and replays the four
+  from the tree afterwards. The string replacers' own `register_image` / `register_link` /
+  `register_ref` calls and the image family's dangerous-scheme warning stay where they are, gated;
+  deleting them outright is what the *next* step does, when `run_pipeline` leaves the production
+  path. Both paths share one `Parser` now, which is exactly why step 6 says to re-attach the side
+  effects at the cutover — "which is what avoids double-counting each registration".
+
+  Three details decided themselves. The replay runs **after** the whole string pass rather than
+  during its macros step: across contents that preserves document order, and within one content
+  `apply_macro_side_effects` already composes the families in the string pipeline's own pass order,
+  which is what its own doc comment was written to guarantee. A suppressed `register_ref` returns
+  **`Ok`**, not an error, because the string replacer raises its duplicate-id warning on `Err` and
+  that warning is the replay's to raise. And the *link* family's dangerous-scheme warning is **not**
+  suppressed, because the replay does not carry it — only the image family's is among the four.
+
+  Two things fell out of testing rather than design. The window was first gated on a tree actually
+  being built; the whole suite passes without that gate, and the reason is sound rather than
+  incidental — the only content reaching `apply` without a tree is a passthrough body the *builder*
+  re-enters for, handed the counter-safe clone whose catalog is discarded with it. The gate is gone.
+  And the flag is saved and restored rather than cleared, which no fixture currently distinguishes
+  (the suite is green either way, since none puts a registering construct after a nested `apply`
+  within one content); it is kept because it is correct by construction rather than by that absence,
+  and the code says so.
+
+  The audit is a whole-suite catalog diff rather than a rendered-string one, since no rendered byte
+  changes: every parse in the suite dumps its images, links, refs and warnings, and the **3,773**
+  records are byte-identical between this branch and its base. Dropping the replay fails **69**
+  tests; hoisting the window from one pass to a whole parse fails **161** — the first says the tree
+  is really the source now, the second says the description-list **term** carve-out is real. A term
+  runs the substitution steps directly rather than through `SubstitutionGroup::apply`, so it builds
+  no tree and has nothing to replay from; it stays correct only because it never enters the window.
+  That is the last thing still registering from the string pipeline, and it goes when the pipeline
+  does.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7675,8 +7721,24 @@ Each phase is a reviewable unit with a clear exit gate.
        when step 6 takes the string pipeline off the production path. It also corrected an oracle:
        the previous increment's template differential
        walked block titles, whose segments are never resolved in place, and passed only by
-       coincidence. See the step's own "landed as" note above. What remains of step 6 is the
-       passthrough sentinel system and the side effects wired for real.
+       coincidence. See the step's own "landed as" note above.
+
+     - ✅ **the recognition side effects, re-attached for real.** The third of step 6's four asks,
+       and the first that is not about the rendered string:
+       [`apply_macro_side_effects`](../../parser/src/content/inline_builder/macros/mod.rs) — an
+       image target, three link passes' targets, an anchor's and a bibliography entry's id, and the
+       image family's dangerous-`link=` warning — runs from the tree, once per content, while
+       `Parser::suppress_macro_side_effects` gates the string pipeline's own copies for the same
+       pass. A **suppression window** rather than a deletion, because deleting the replacers'
+       registrations is what the next step does when `run_pipeline` leaves the production path.
+       A suppressed `register_ref` returns `Ok`, since the duplicate-id warning is the replay's to
+       raise; the *link* family's dangerous-scheme warning is not suppressed, since the replay does
+       not carry it. No rendered byte changes, so the audit is a catalog diff: **3,773** parses,
+       images/links/refs/warnings byte-identical to base. Dropping the replay fails 69 tests;
+       hoisting the window to a whole parse fails 161 — the second is the description-list **term**
+       carve-out, the last thing still registering from the string pipeline. See the step's own
+       "landed as" note above. What remains of step 6 is taking `run_pipeline` off the production
+       path, which takes the passthrough sentinel system and that carve-out with it.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -535,9 +535,11 @@ fn structural_anchor_reftext<'src>(
 /// deferred registrations, staged as its own building block for the eventual
 /// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
 /// calling it exactly once per parse, after the single-pass builder replaces
-/// the recorder as `Content`'s tree source, so nothing here is wired into a
-/// real parse yet — it is exercised only by this module's own tests, against
-/// their own `Parser`.
+/// the recorder as `Content`'s tree source. That is now done:
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) calls this
+/// once per content, from the tree it just built, and the string replacer's own
+/// `register_ref` is suppressed for that content (see
+/// `Parser::suppress_macro_side_effects`).
 ///
 /// `source` is the whole original content span being processed, used — like
 /// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
@@ -663,8 +665,10 @@ pub(crate) fn apply_ref_side_effects(
 /// recursion here (and none needed for the bracketed label either: it stays in
 /// the flow as ordinary sibling nodes, see [`biblio_anchor_level`]).
 ///
-/// As with every staged side effect in this module, **nothing here is wired
-/// into a real parse path yet** — it is exercised only by this module's own
+/// As with every recognition side effect in this module, this now runs on the
+/// real parse path — see
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects). It is also
+/// exercised directly by this module's own
 /// tests, against their own [`Parser`].
 pub(crate) fn apply_biblio_side_effects(
     nodes: &[InlineNode<'_>],

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1198,8 +1198,9 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 /// the eventual cutover (design §5.2, Phase 4 step 6): re-attaching it for
 /// real means calling it exactly once per parse, after the single-pass
 /// builder replaces the recorder as `Content`'s tree source, so nothing here
-/// is wired into a real parse yet — it is exercised only by this module's own
-/// tests, against their own `Parser`.
+/// is now wired into the real parse path — see
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects) — and is also
+/// exercised directly by this module's own tests, against their own `Parser`.
 ///
 /// Recurses into every container an `Image` node can be nested inside —
 /// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2014,9 +2014,10 @@ fn build_email_node<'src>(
 /// for the link family, staged as its own building block for the eventual
 /// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
 /// calling it exactly once per parse, after the single-pass builder replaces
-/// the recorder as `Content`'s tree source, so nothing here is wired into a
-/// real parse yet — it is exercised only by this module's own tests, against
-/// their own `Parser`.
+/// the recorder as `Content`'s tree source. That is now done: this runs once
+/// per content from the tree, and the string replacers' own `register_link`
+/// calls are suppressed for that content (see
+/// `Parser::suppress_macro_side_effects`).
 ///
 /// # Registration order across the three link forms
 ///

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -456,10 +456,19 @@ fn apply_reference_families<'src>(
 /// place (see [`apply_footnotes`](super::footnotes::apply_footnotes)'s own doc
 /// comment); it already runs during [`build`](super::build), not here.
 ///
-/// As with each of the three functions it composes, **nothing here is wired
-/// into a real parse path yet** — it is exercised only by this module's own
-/// tests, against their own `Parser`. `source` and `leading_anchor_registered`
-/// are threaded straight through to
+/// This is the **production** entry point for all four side effects:
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) calls it
+/// once per content, from the tree it just built, while the string pipeline's
+/// own copies are suppressed for that content (see
+/// `Parser::suppress_macro_side_effects`). Design §5.2's step 6 asks for
+/// exactly that — "re-attach the recognition side effects ... at the cutover
+/// ... which is what avoids double-counting each registration".
+///
+/// It runs *after* the whole string pass rather than during its macros step.
+/// Across contents that preserves document order, and within one content the
+/// composition below preserves the string pipeline's own pass order, which is
+/// what the two orderings above require. `source` and
+/// `leading_anchor_registered` are threaded straight through to
 /// [`anchors::apply_ref_side_effects`] — see its own doc comment for both.
 pub(crate) fn apply_macro_side_effects(
     nodes: &[InlineNode<'_>],

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -323,7 +323,15 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
                 has_dangerous_scheme(link.value()).then_some(link.value())
             };
 
-            if let Some(rejected) = rejected {
+            // Suppressed for content whose tree replays this warning — see
+            // `Parser::suppress_macro_side_effects`. It is one of the four
+            // recognition side effects `apply_macro_side_effects` re-attaches,
+            // unlike the *link* family's own dangerous-scheme warning below,
+            // which the replay does not carry and which is therefore left to
+            // this pass in every case.
+            if let Some(rejected) = rejected
+                && !self.parser.suppress_macro_side_effects.get()
+            {
                 self.parser.record_substitution_warning(
                     self.source,
                     WarningType::UnsafeLinkSchemeRejected(rejected.to_owned()),

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -243,7 +243,32 @@ impl SubstitutionGroup {
             None
         };
 
+        // The string pipeline's own macro side effects — an image target, a link
+        // target, an anchor's or bibliography entry's id, and the image
+        // family's dangerous-`link=` warning — are suppressed for the duration
+        // of this pass, and replayed from the tree below. Both paths share one
+        // `Parser` now, so recognizing a construct twice would record it twice.
+        //
+        // Unconditional, rather than gated on a tree actually being built. The
+        // only content that reaches here without one is a passthrough body the
+        // *builder* re-enters `apply` for, and that call is handed the
+        // counter-safe clone — whose catalog is discarded with it — so nothing
+        // it records was ever going to be kept. The string pipeline's own
+        // re-entry for such a body carries the real parser and does build a
+        // tree, so it replays like any other content.
+        //
+        // Saved and restored rather than cleared. Either re-entry happens while
+        // this window is open and closes a window of its own, so clearing would
+        // leave the rest of *this* pass unsuppressed. No fixture currently
+        // distinguishes the two — the suite is green either way — because none
+        // puts a registering construct after a nested `apply` within one
+        // content; restoring is kept because it is correct by construction
+        // rather than by that absence.
+        let suppressed = parser.suppress_macro_side_effects.replace(true);
+
         self.run_pipeline(content, parser, attrlist);
+
+        parser.suppress_macro_side_effects.set(suppressed);
 
         if let Some((value, mut tree_parser)) = tree_seed {
             // The builder must not recurse into tree building itself: a
@@ -285,6 +310,23 @@ impl SubstitutionGroup {
 
                 content.rendered = crate::strings::CowStr::from(folded);
             }
+
+            // The recognition side effects the string pipeline just skipped,
+            // replayed from the tree — design §5.2's step 6, "re-attach the
+            // recognition side effects". They run here, after the whole
+            // pipeline rather than during its macros step, which keeps them in
+            // document order across contents and in the string pipeline's own
+            // pass order within one (see `apply_macro_side_effects`).
+            //
+            // `leading_anchor_registered` is `false`: the one caller that
+            // pre-registers a leading anchor is a description-list term, which
+            // runs the steps directly rather than through this function.
+            crate::content::inline_builder::apply_macro_side_effects(
+                &tree,
+                parser,
+                content.original(),
+                false,
+            );
 
             content.set_inlines(tree);
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -476,6 +476,35 @@ pub struct Parser {
     /// (`passthrough_step::passthrough_text`), and that nested content needs no
     /// tree of its own. Nothing else sets it, and no public API exposes it.
     pub(crate) build_inline_tree: bool,
+
+    /// Whether the **string pipeline's** macro-recognition side effects — an
+    /// image target, a link target, an inline anchor's or bibliography entry's
+    /// id, and the image family's dangerous-`link=`-scheme warning — are
+    /// suppressed for the content currently being substituted.
+    ///
+    /// Those four are exactly what
+    /// [`apply_macro_side_effects`](crate::content::inline_builder) replays;
+    /// the *link* family's own dangerous-scheme warning is not among them,
+    /// and so is not suppressed here.
+    ///
+    /// Set by `SubstitutionGroup::apply` around its authoritative string pass,
+    /// for exactly the content whose tree it then replays them from.
+    /// Recognizing a construct twice would otherwise record it twice, since
+    /// both paths now share one `Parser`.
+    ///
+    /// It is a `Cell` because every recording method takes `&self` — the
+    /// substitution steps hold a shared borrow — and it is saved and restored
+    /// rather than merely cleared, because a passthrough body with its own
+    /// substitution list re-enters `apply` while the outer content's window is
+    /// still open.
+    ///
+    /// One path deliberately never enters that window and so keeps registering
+    /// from the string pipeline: a description-list **term**, which runs the
+    /// substitution steps directly rather than through
+    /// `SubstitutionGroup::apply` (`blocks::list_item_marker`) and so builds no
+    /// tree to replay from. It disappears when step 6 takes the string pipeline
+    /// off the production path.
+    pub(crate) suppress_macro_side_effects: std::cell::Cell<bool>,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -591,6 +620,7 @@ impl Default for Parser {
             input_mtime: None,
             datetime_context: RefCell::new(None),
             build_inline_tree: true,
+            suppress_macro_side_effects: std::cell::Cell::new(false),
         }
     }
 }
@@ -1777,6 +1807,19 @@ impl Parser {
         reftext: Option<&str>,
         ref_type: RefType,
     ) -> Result<(), crate::document::DuplicateIdError> {
+        // Suppressed for content whose tree replays this registration — see
+        // `suppress_macro_side_effects`. `Ok` rather than an error is what the
+        // caller needs: the string replacer raises its duplicate-id warning on
+        // `Err`, and that warning is the replay's to raise, from the same
+        // `register_ref` reaching the real catalog a moment later.
+        //
+        // Only a *macro* registration can reach here inside that window — the
+        // block, section and description-list-term registrations all happen
+        // outside substitution — so nothing else is caught by it.
+        if self.suppress_macro_side_effects.get() {
+            return Ok(());
+        }
+
         self.catalog
             .borrow_mut()
             .register_ref(id, reftext, ref_type)
@@ -1803,6 +1846,10 @@ impl Parser {
     /// Takes `&self` so it can be called from the macros substitution step,
     /// which only holds a shared reference to the parser.
     pub(crate) fn register_image(&self, target: String, imagesdir: Option<String>) {
+        if self.suppress_macro_side_effects.get() {
+            return;
+        }
+
         if self.catalog_assets {
             self.catalog.borrow_mut().register_image(target, imagesdir);
         }
@@ -1818,6 +1865,10 @@ impl Parser {
     /// Takes `&self` so it can be called from the macros substitution step,
     /// which only holds a shared reference to the parser.
     pub(crate) fn register_link(&self, target: String) {
+        if self.suppress_macro_side_effects.get() {
+            return;
+        }
+
         if self.catalog_assets {
             self.catalog.borrow_mut().register_link(target);
         }

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -545,3 +545,134 @@ fn the_replay_is_not_a_no_op_for_any_family() {
         ]
     );
 }
+
+// The replay wired for real: `SubstitutionGroup::apply` performs these four
+// from the tree, and the string pipeline's own copies are suppressed for the
+// same content. What follows pins that switch through a whole parse, where the
+// harness above pins the two sides against each other in isolation.
+
+#[test]
+fn a_real_parse_records_each_side_effect_exactly_once() {
+    // The switch's own failure mode is not "nothing recorded" — the suite would
+    // be loud about that — but "recorded twice", which a `Vec`-backed catalog
+    // shows and a set-backed one would hide. Every fixture below carries a
+    // construct from a different family, and each must appear once.
+    let mut parser = Parser::default()
+        .with_catalog_assets(true)
+        .with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere);
+
+    let doc = parser.parse(concat!(
+        "image:x.png[X] and link:y.html[Y] and https://z.example[Z]\n",
+        "\n",
+        "[[anchor-id]]An anchor, and mailto:a@b.example[A].\n",
+    ));
+
+    let catalog = doc.catalog();
+
+    let images: Vec<(String, Option<String>)> = catalog
+        .images()
+        .iter()
+        .map(|i| (i.target.clone(), i.imagesdir.clone()))
+        .collect();
+
+    assert_eq!(
+        images,
+        [("x.png".to_string(), None)],
+        "an image target should be catalogued once"
+    );
+
+    // Pass order, not source order: the auto-link / formal-URL pass runs ahead
+    // of the `link:`/`mailto:` macro pass, so `z` precedes `y` even though it is
+    // written after it. `apply_macro_side_effects` reproduces that ordering
+    // because it composes the families in the string pipeline's own order — the
+    // property `links::apply_link_side_effects` documents for itself.
+    assert_eq!(
+        catalog.links().to_vec(),
+        [
+            "https://z.example".to_string(),
+            "y.html".to_string(),
+            "mailto:a@b.example".to_string(),
+        ],
+        "each link target should be catalogued once, in pass order"
+    );
+
+    assert!(
+        catalog.refs.contains_key("anchor-id"),
+        "the inline anchor's id should be registered: {:?}",
+        catalog.refs
+    );
+}
+
+#[test]
+fn a_duplicate_id_warns_once_through_a_real_parse() {
+    // The duplicate-id warning is the one side effect driven by a *failed*
+    // registration, so it is the one the suppression could most easily double
+    // or lose: the string replacer raises it when `register_ref` returns `Err`,
+    // and a suppressed `register_ref` returns `Ok`. The replay's own call to
+    // the real catalog is what must raise it instead — exactly once.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[dup]]One. [[dup]]Two.");
+
+    let duplicates: Vec<_> = doc
+        .warnings()
+        .filter(|w| matches!(w.warning, WarningType::DuplicateId(_)))
+        .collect();
+
+    assert_eq!(
+        duplicates.len(),
+        1,
+        "expected exactly one duplicate-id warning: {duplicates:?}"
+    );
+}
+
+#[test]
+fn a_description_list_term_still_registers_from_the_string_pipeline() {
+    // The carve-out, pinned. A term runs the substitution steps directly rather
+    // than through `SubstitutionGroup::apply` (see
+    // `blocks::list_item_marker::DefinedTerm::substitute`), so it builds no tree
+    // and has nothing to replay from — and it stays correct only because it
+    // never enters the suppression window, which lives inside `apply`. Hoisting
+    // the flag to cover a whole parse rather than one pass would drop this
+    // registration silently.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[term-id]]A term:: its description.");
+
+    assert!(
+        doc.catalog().refs.contains_key("term-id"),
+        "a term's leading anchor should still be registered: {:?}",
+        doc.catalog().refs
+    );
+}
+
+#[test]
+fn a_passthrough_body_with_its_own_macros_registers_once() {
+    // The nesting case the save-and-*restore* exists for. A `pass:` macro with
+    // an explicit substitution list re-enters `SubstitutionGroup::apply` for its
+    // body while the outer content's suppression window is open, and closes a
+    // window of its own on the way out. Restoring the previous value is what
+    // leaves the outer content suppressed for everything *after* the
+    // passthrough; clearing it instead would let the string pipeline record
+    // `outer.png` alongside the replay's copy.
+    //
+    // The body's own image is not catalogued at all, on this branch or before
+    // it — a pre-existing gap in how a `pass:`-with-subs body reaches the
+    // catalog, unrelated to this switch and unchanged by it. What this fixture
+    // pins is the count for `outer.png`, which is what the flag's lifetime
+    // decides.
+    let mut parser = Parser::default().with_catalog_assets(true);
+
+    let doc = parser.parse("pass:m[image:inner.png[I]] then image:outer.png[O]");
+
+    let images: Vec<String> = doc
+        .catalog()
+        .images()
+        .iter()
+        .map(|i| i.target.clone())
+        .collect();
+
+    assert_eq!(
+        images,
+        ["outer.png".to_string()],
+        "the image after a passthrough should be catalogued exactly once"
+    );
+}


### PR DESCRIPTION
The third of the four things step 6 asks for, and the first that is not about the rendered string at all. Recognizing a construct also means *writing it down*: an `image:` macro records its target in the asset catalog, the three link passes record theirs, an inline anchor and a bibliography entry register their ids in the reference catalog, and an image whose `link=` names a dangerous scheme records a warning.

All four were staged — built, composed as `apply_macro_side_effects`, and pinned by their own corpus-wide harness — but every one of their doc comments still ended *"nothing here is wired into a real parse path yet"*. They are wired now.

## A suppression window, not a deletion

`SubstitutionGroup::apply` sets `Parser::suppress_macro_side_effects` around its authoritative string pass and replays the four from the tree afterwards. The string replacers' own `register_image` / `register_link` / `register_ref` calls and the image family's dangerous-scheme warning stay where they are, gated. Deleting them outright is what the next step does, when `run_pipeline` leaves the production path.

Both paths share one `Parser` now, which is exactly why step 6 says to re-attach the side effects at the cutover — *"which is what avoids double-counting each registration."*

## Three details decided themselves

The replay runs **after** the whole string pass rather than during its macros step. Across contents that preserves document order, and within one content `apply_macro_side_effects` already composes the families in the string pipeline's own pass order, which its doc comment was written to guarantee.

A suppressed `register_ref` returns **`Ok`**, not an error: the string replacer raises its duplicate-id warning on `Err`, and that warning is the replay's to raise, from the same call reaching the real catalog a moment later.

The **link** family's dangerous-scheme warning is *not* suppressed. Only the image family's is among the four the replay carries.

## Two things testing decided

The window was first gated on a tree actually being built. The whole suite passes without that gate, and the reason is sound rather than incidental: the only content reaching `apply` without a tree is a passthrough body the *builder* re-enters for, and that call is handed the counter-safe clone whose catalog is discarded with it. The gate is gone.

The flag is saved and restored rather than cleared, which no fixture currently distinguishes — the suite is green either way, since none puts a registering construct after a nested `apply` within one content. It is kept because it is correct by construction rather than by that absence, and the code says so rather than implying coverage it does not have.

## Verification

No rendered byte changes, so the audit is a catalog diff rather than a string one: every parse in the suite dumps its images, links, refs and warnings, and the **3,773** records are byte-identical between this branch and its base.

- `cargo test --workspace`: 5441 pass, 0 fail.
- Dropping the replay fails **69** tests — the tree is really the source.
- Hoisting the window from one pass to a whole parse fails **161** — the description-list **term** carve-out is real. A term runs the substitution steps directly rather than through `SubstitutionGroup::apply`, so it builds no tree and has nothing to replay from; it stays correct only because it never enters the window. That is the last thing still registering from the string pipeline, and it goes when the pipeline does.
- Four new tests drive the switch through whole parses, where the existing harness pins the two sides against each other in isolation.
- Coverage diff-neutral: identical missed lines in every changed file; all three suppression gates fully covered on both branches.
- Preflight clean: fmt (nightly), clippy, doc (nightly).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_