### PR TITLE
feat: Replay the callout registration from the tree too (inline-ast Phase 4, step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6432,6 +6432,34 @@ Each phase is a reviewable unit with a clear exit gate.
   That is the last thing still registering from the string pipeline, and it goes when the pipeline
   does.
 
+  *Step 6 landed as (the callout registration, the last recognition side effect):* the increment
+  above re-attached the four **macro** side effects and left one behind, because it is not a macro
+  family at all: a callout is recognized in *verbatim* content, where the macros step never runs.
+  [`apply_callout_side_effects`](../../parser/src/content/inline_builder/callouts.rs) replays it the
+  same way, as a sibling call rather than part of the composition, and the suppression flag widens
+  from `suppress_macro_side_effects` to `suppress_recognition_side_effects` to say so.
+
+  It is simpler than the macro four in two ways and more subtle in one. Simpler: a
+  [`Callout`](../../parser/src/inlines/callout.rs) node already carries its **resolved** number — an
+  auto-numbered `<.>` was resolved when the node was built — so the replay consults no counter, and
+  the ordering that matters is satisfied for free, since the consumer
+  ([`Parser::callout_defined`](../../parser/src/parser/parser.rs)) reads it when the *following*
+  block, the callout list, is parsed.
+
+  Subtle: a duplicated registration here would be **invisible**. `CalloutCatalog` holds one
+  `Vec<u32>`, read through `contains` and cleared per list, so registering `1` twice answers exactly
+  as registering it once — unlike the asset and reference catalogs, whose entries a consumer reads
+  in order and where a double shows immediately. So the gate on the string pipeline's own
+  `register_callout` buys nothing observable *today*; it is there for correctness by construction
+  and for the day the pipeline goes, and the code says that rather than implying a check it cannot
+  make. What *is* falsifiable is the replay: without it, `no callout found for <N>` fires for every
+  callout list in the suite.
+
+  Two tests drive it through whole parses — a matching list that must not warn paired with an
+  overshooting one that must, and an auto-numbered `<.>` pair — and both fail when the replay is
+  removed. With this, every recognition side effect the string pipeline performs is performed from
+  the tree, and what is left of step 6 is the string pipeline itself.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7737,8 +7765,20 @@ Each phase is a reviewable unit with a clear exit gate.
        images/links/refs/warnings byte-identical to base. Dropping the replay fails 69 tests;
        hoisting the window to a whole parse fails 161 — the second is the description-list **term**
        carve-out, the last thing still registering from the string pipeline. See the step's own
-       "landed as" note above. What remains of step 6 is taking `run_pipeline` off the production
-       path, which takes the passthrough sentinel system and that carve-out with it.
+       "landed as" note above.
+
+     - ✅ **the callout registration, the last recognition side effect.** Not a macro family — a
+       callout is recognized in *verbatim* content, where the macros step never runs — so
+       [`apply_callout_side_effects`](../../parser/src/content/inline_builder/callouts.rs) replays
+       it as a sibling call, and the flag widens to `suppress_recognition_side_effects`. A
+       `Callout` node already carries its **resolved** number, so the replay consults no counter,
+       and the consumer (`Parser::callout_defined`) reads it a block later, when the callout list
+       is parsed. A duplicate here would be *invisible* — `CalloutCatalog` is one `Vec<u32>` read
+       through `contains` — so the gate buys correctness by construction rather than anything
+       observable, and says so; what is falsifiable is the replay, without which every callout list
+       in the suite warns. With this, **every** recognition side effect is performed from the tree,
+       and what is left of step 6 is the string pipeline itself. See the step's own "landed as"
+       note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -52,6 +52,58 @@ use crate::{
 /// does not call `Parser::register_callout`, deferring the callout catalog's
 /// validation to the cutover (design §5.2 Phase 4, step 6), exactly as the
 /// image and link increments defer their own catalog registrations.
+/// Registers every callout the tree carries with `parser`, so the callout list
+/// that annotates the block can be validated against them.
+///
+/// The callouts step's own recognition side effect, replayed from the tree —
+/// the counterpart of
+/// [`apply_macro_side_effects`](super::macros::apply_macro_side_effects) for
+/// the one family that is not a macro. It runs on the real parse path from
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup), while
+/// `Parser::suppress_recognition_side_effects` gates the string pipeline's own
+/// `register_callout` for the same content.
+///
+/// A callout number is registered in document order, which is what
+/// [`Parser::callout_defined`](crate::Parser) reads when the following callout
+/// list is parsed — a *later block*, so this runs early enough for it.
+///
+/// A [`Callout`](InlineNode::Callout) node's `number` is already the resolved
+/// sequential value for an auto-numbered `<.>`, so no counter is consulted
+/// here. A number that does not parse as a `u32` is skipped, exactly as the
+/// string pipeline skips it.
+///
+/// The walk recurses into every container a node can nest inside. Callouts are
+/// recognized in **verbatim** content, where no quotes or macros step runs, so
+/// in practice they are always top-level; recursing costs nothing and keeps
+/// this walk from silently narrowing if that ever stops being true.
+pub(crate) fn apply_callout_side_effects(nodes: &[InlineNode<'_>], parser: &Parser) {
+    for node in nodes {
+        match node {
+            InlineNode::Callout(callout) => {
+                if let Ok(number) = callout.number.parse::<u32>() {
+                    parser.register_callout(number);
+                }
+            }
+
+            InlineNode::Styled(styled) => apply_callout_side_effects(&styled.children, parser),
+            InlineNode::Ref(reference) => apply_callout_side_effects(&reference.children, parser),
+            InlineNode::Footnote(footnote) => {
+                apply_callout_side_effects(&footnote.children, parser);
+            }
+            InlineNode::IndexTerm(index_term) => {
+                apply_callout_side_effects(&index_term.children, parser);
+            }
+            InlineNode::Anchor(anchor) => {
+                if let Some(reftext) = anchor.reftext.as_ref() {
+                    apply_callout_side_effects(reftext, parser);
+                }
+            }
+
+            _ => {}
+        }
+    }
+}
+
 pub(super) fn apply_callouts<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -417,6 +417,12 @@ mod snapshot;
 mod test_support;
 
 use attribute_refs::{SplicedSpecials, apply_attribute_references};
+// Staged for the eventual authoritative-fold half of the cutover (see this
+// module's own doc comment); not yet called from any real parse path, so —
+// unlike the step re-exports below — reachable only via `cfg(test)` callers
+// and future external callers today.
+#[allow(unused_imports)]
+pub(crate) use callouts::apply_callout_side_effects;
 use callouts::apply_callouts;
 use char_replacements::apply_character_replacements;
 // Consumed only by `cfg(test)` callers and future external callers until the
@@ -424,11 +430,6 @@ use char_replacements::apply_character_replacements;
 #[allow(unused_imports)]
 pub(crate) use fold::{fold_html, fold_reference_text};
 use footnotes::apply_footnotes;
-// Staged for the eventual authoritative-fold half of the cutover (see this
-// module's own doc comment); not yet called from any real parse path, so —
-// unlike the step re-exports below — reachable only via `cfg(test)` callers
-// and future external callers today.
-#[allow(unused_imports)]
 pub(crate) use macros::apply_macro_side_effects;
 use macros::{ComputedSpecials, apply_macros};
 use passthrough_step::apply_passthroughs;

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -324,13 +324,13 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
             };
 
             // Suppressed for content whose tree replays this warning — see
-            // `Parser::suppress_macro_side_effects`. It is one of the four
+            // `Parser::suppress_recognition_side_effects`. It is one of the four
             // recognition side effects `apply_macro_side_effects` re-attaches,
             // unlike the *link* family's own dangerous-scheme warning below,
             // which the replay does not carry and which is therefore left to
             // this pass in every case.
             if let Some(rejected) = rejected
-                && !self.parser.suppress_macro_side_effects.get()
+                && !self.parser.suppress_recognition_side_effects.get()
             {
                 self.parser.record_substitution_warning(
                     self.source,

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -264,11 +264,11 @@ impl SubstitutionGroup {
         // puts a registering construct after a nested `apply` within one
         // content; restoring is kept because it is correct by construction
         // rather than by that absence.
-        let suppressed = parser.suppress_macro_side_effects.replace(true);
+        let suppressed = parser.suppress_recognition_side_effects.replace(true);
 
         self.run_pipeline(content, parser, attrlist);
 
-        parser.suppress_macro_side_effects.set(suppressed);
+        parser.suppress_recognition_side_effects.set(suppressed);
 
         if let Some((value, mut tree_parser)) = tree_seed {
             // The builder must not recurse into tree building itself: a
@@ -327,6 +327,12 @@ impl SubstitutionGroup {
                 content.original(),
                 false,
             );
+
+            // The callouts step's own registration, replayed the same way. It
+            // is not a macro family — callouts are recognized in verbatim
+            // content, where the macros step does not run at all — so it is a
+            // sibling call rather than part of the composition above.
+            crate::content::inline_builder::apply_callout_side_effects(&tree, parser);
 
             content.set_inlines(tree);
 

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1568,7 +1568,13 @@ impl LookaheadReplacer for CalloutReplacer<'_> {
 
         // Register this callout so the callout list that annotates this block
         // can be validated against the callouts it references.
-        if let Ok(n) = number.parse::<u32>() {
+        //
+        // Suppressed for content whose tree replays this — see
+        // `Parser::suppress_recognition_side_effects` and
+        // `inline_builder::apply_callout_side_effects`.
+        if let Ok(n) = number.parse::<u32>()
+            && !self.parser.suppress_recognition_side_effects.get()
+        {
             self.parser.register_callout(n);
         }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -477,15 +477,16 @@ pub struct Parser {
     /// tree of its own. Nothing else sets it, and no public API exposes it.
     pub(crate) build_inline_tree: bool,
 
-    /// Whether the **string pipeline's** macro-recognition side effects — an
-    /// image target, a link target, an inline anchor's or bibliography entry's
-    /// id, and the image family's dangerous-`link=`-scheme warning — are
-    /// suppressed for the content currently being substituted.
+    /// Whether the **string pipeline's** recognition side effects — an image
+    /// target, a link target, an inline anchor's or bibliography entry's id,
+    /// the image family's dangerous-`link=`-scheme warning, and a callout
+    /// number — are suppressed for the content currently being substituted.
     ///
-    /// Those four are exactly what
-    /// [`apply_macro_side_effects`](crate::content::inline_builder) replays;
-    /// the *link* family's own dangerous-scheme warning is not among them,
-    /// and so is not suppressed here.
+    /// Those are exactly what the builder replays: the first four through
+    /// [`apply_macro_side_effects`](crate::content::inline_builder), the last
+    /// through [`apply_callout_side_effects`](crate::content::inline_builder).
+    /// The *link* family's own dangerous-scheme warning is not among them, and
+    /// so is not suppressed here.
     ///
     /// Set by `SubstitutionGroup::apply` around its authoritative string pass,
     /// for exactly the content whose tree it then replays them from.
@@ -504,7 +505,7 @@ pub struct Parser {
     /// `SubstitutionGroup::apply` (`blocks::list_item_marker`) and so builds no
     /// tree to replay from. It disappears when step 6 takes the string pipeline
     /// off the production path.
-    pub(crate) suppress_macro_side_effects: std::cell::Cell<bool>,
+    pub(crate) suppress_recognition_side_effects: std::cell::Cell<bool>,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -620,7 +621,7 @@ impl Default for Parser {
             input_mtime: None,
             datetime_context: RefCell::new(None),
             build_inline_tree: true,
-            suppress_macro_side_effects: std::cell::Cell::new(false),
+            suppress_recognition_side_effects: std::cell::Cell::new(false),
         }
     }
 }
@@ -1808,7 +1809,7 @@ impl Parser {
         ref_type: RefType,
     ) -> Result<(), crate::document::DuplicateIdError> {
         // Suppressed for content whose tree replays this registration — see
-        // `suppress_macro_side_effects`. `Ok` rather than an error is what the
+        // `suppress_recognition_side_effects`. `Ok` rather than an error is what the
         // caller needs: the string replacer raises its duplicate-id warning on
         // `Err`, and that warning is the replay's to raise, from the same
         // `register_ref` reaching the real catalog a moment later.
@@ -1816,7 +1817,7 @@ impl Parser {
         // Only a *macro* registration can reach here inside that window — the
         // block, section and description-list-term registrations all happen
         // outside substitution — so nothing else is caught by it.
-        if self.suppress_macro_side_effects.get() {
+        if self.suppress_recognition_side_effects.get() {
             return Ok(());
         }
 
@@ -1846,7 +1847,7 @@ impl Parser {
     /// Takes `&self` so it can be called from the macros substitution step,
     /// which only holds a shared reference to the parser.
     pub(crate) fn register_image(&self, target: String, imagesdir: Option<String>) {
-        if self.suppress_macro_side_effects.get() {
+        if self.suppress_recognition_side_effects.get() {
             return;
         }
 
@@ -1865,7 +1866,7 @@ impl Parser {
     /// Takes `&self` so it can be called from the macros substitution step,
     /// which only holds a shared reference to the parser.
     pub(crate) fn register_link(&self, target: String) {
-        if self.suppress_macro_side_effects.get() {
+        if self.suppress_recognition_side_effects.get() {
             return;
         }
 

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -676,3 +676,86 @@ fn a_passthrough_body_with_its_own_macros_registers_once() {
         "the image after a passthrough should be catalogued exactly once"
     );
 }
+
+// The callouts step's own registration, replayed from the tree — the one
+// recognition side effect that is not a macro family.
+
+#[test]
+fn a_callout_list_validates_against_tree_registered_callouts() {
+    // `Parser::callout_defined` is what a callout list consults when it is
+    // parsed, one block after the listing that defines them. With the string
+    // pipeline's `register_callout` suppressed, the numbers it finds are the
+    // ones `apply_callout_side_effects` put there from the tree — so a list
+    // whose items match the callouts must produce no warning, and one that
+    // overshoots must still be caught.
+    let mut parser = Parser::default();
+
+    let doc = parser.parse(concat!(
+        "----\n",
+        "line one <1>\n",
+        "line two <2>\n",
+        "----\n",
+        "<1> First.\n",
+        "<2> Second.\n",
+    ));
+
+    let callout_warnings: Vec<_> = doc
+        .warnings()
+        .filter(|w| matches!(w.warning, WarningType::NoCalloutFound(_)))
+        .collect();
+
+    assert!(
+        callout_warnings.is_empty(),
+        "a matching callout list should not warn: {callout_warnings:?}"
+    );
+
+    // The complement: a list item with no callout behind it. This is what fails
+    // if the replay stops registering, so it is the assertion that keeps the
+    // pair above from passing vacuously.
+    let doc = parser.parse(concat!(
+        "----\n",
+        "line one <1>\n",
+        "----\n",
+        "<1> First.\n",
+        "<2> Second.\n",
+    ));
+
+    let missing: Vec<_> = doc
+        .warnings()
+        .filter(|w| matches!(w.warning, WarningType::NoCalloutFound(2)))
+        .collect();
+
+    assert_eq!(
+        missing.len(),
+        1,
+        "expected one `no callout found for <2>` warning: {:?}",
+        doc.warnings().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn an_auto_numbered_callout_registers_its_resolved_number() {
+    // `<.>` carries no number in the source; the builder resolves it to the
+    // sequential value and stores that on the node, so the replay registers a
+    // real number rather than re-deriving one from a counter it does not have.
+    let mut parser = Parser::default();
+
+    let doc = parser.parse(concat!(
+        "----\n",
+        "line one <.>\n",
+        "line two <.>\n",
+        "----\n",
+        "<.> First.\n",
+        "<.> Second.\n",
+    ));
+
+    let callout_warnings: Vec<_> = doc
+        .warnings()
+        .filter(|w| matches!(w.warning, WarningType::NoCalloutFound(_)))
+        .collect();
+
+    assert!(
+        callout_warnings.is_empty(),
+        "auto-numbered callouts should register 1 and 2: {callout_warnings:?}"
+    );
+}


### PR DESCRIPTION
#1280 re-attached the four **macro** recognition side effects and left one behind, because it is not a macro family at all: a callout is recognized in *verbatim* content, where the macros step never runs.

`apply_callout_side_effects` replays it the same way, as a sibling call rather than part of the composition, and the suppression flag widens from `suppress_macro_side_effects` to `suppress_recognition_side_effects` to say so.

## Simpler than the macro four in two ways

A `Callout` node already carries its **resolved** number — an auto-numbered `<.>` was resolved when the node was built — so the replay consults no counter.

The ordering that matters is satisfied for free. `Parser::callout_defined` is read when the *following* block, the callout list, is parsed, which is well after this content's `apply` returns.

## And more subtle in one

A duplicated registration here would be **invisible**. `CalloutCatalog` holds one `Vec<u32>`, read through `contains` and cleared per list, so registering `1` twice answers exactly as registering it once — unlike the asset and reference catalogs, whose entries a consumer reads in order and where a double shows immediately.

So the gate on the string pipeline's own `register_callout` buys nothing observable today. It is there for correctness by construction and for the day the pipeline goes, and the code says that rather than implying a check it cannot make.

What *is* falsifiable is the replay: without it, `no callout found for <N>` fires for every callout list in the suite.

## Verification

- `cargo test --workspace`: 5443 pass, 0 fail; no golden changes.
- Two new tests drive it through whole parses — a matching callout list that must not warn paired with an overshooting one that must, and an auto-numbered `<.>` pair. Both fail when the replay is removed.
- Patch coverage 32/32 lines, measured with CI's own invocation (`cargo llvm-cov --workspace --all-features --lcov --ignore-filename-regex tests`) rather than a narrower local one.
- Preflight clean: fmt (nightly), clippy, doc (nightly).

With this, every recognition side effect the string pipeline performs is performed from the tree, and what is left of step 6 is the string pipeline itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Q9RJdn8r8yqg3rVe1ejvU)_