### PR TITLE
feat: A computed string slot takes the untranslated source (inline-ast step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6497,6 +6497,85 @@ Each phase is a reviewable unit with a clear exit gate.
   why a segment's `provided_text` cannot come from a node. Answering it once unblocks both; leaving
   it unanswered blocks both no matter how much else lands.
 
+  *Step 6 landed as (a computed string slot takes the author's untranslated source):* the survey
+  above named one question two of its six items turn on — whether a computed **string** slot
+  (`Ref::roles`, `window`, `xrefstyle`, and the link and image families' equivalents) can hold
+  markup that exists only at fold time — and observed that answering it once unblocks both. This
+  increment answers it, for the cross-reference family.
+
+  There were three answers available, and the first two are what the two systems had already picked.
+  The **string pipeline** spells the piece into the slot: a rendered span reaches `role=` as its own
+  markup (`class="&lt;strong&gt;hl&lt;/strong&gt;"`), and a masked passthrough reaches it as a bare
+  `\u{96}0\u{97}` sentinel, because the deferred cross-reference's template is captured before
+  passthroughs are restored. The **builder** refused the whole match, which is why
+  `xref:sec[*bold*,role=*hl*]` had stayed deferred since part 3c. Neither is what the author wrote.
+  What they wrote is the *source*, and a source is a value a string can hold, so that is the third
+  answer and the one taken:
+  [`untranslated_value`](../../parser/src/content/inline_builder/macros/mod.rs) walks a computed
+  value's [`tokened_text`](../../parser/src/content/inline_builder/macros/mod.rs) tokens the way
+  `restored_value_children` walks them and replaces each with the untranslated text of the node it
+  stands for.
+
+  "Untranslated" is per node kind, and the two cases differ for a reason. A
+  [`Raw`](../../parser/src/inlines/inline_node.rs) leaf contributes its **value**, not its source
+  span: a passthrough's `+++` / `++` / `$$` delimiters are syntax saying *do not substitute this*,
+  so the body is precisely the literal text the author asked for, and the delimiters have no
+  business in a class name. Every other node contributes its **source span**, so `role=*hl*` yields
+  `*hl*` rather than the `<strong>hl</strong>` the Quotes step made of it. Attribute references and
+  special characters are untouched by either rule — they are resolved before the value is read, so
+  `role={rolename}` still expands — and only markup the *Quotes* step produced is unwound.
+
+  With that, the per-**slot** boundary `attrlist_text_carries_its_opaque_pieces` drew disappears:
+  its three "no token may reach `window` / `xrefstyle` / a role" checks are gone and
+  `holds_carried_token` with them, so the family's gate is now the *split* question alone. That
+  question still has members — `xref:sec[a *b, c* d,role=hl]`, whose rendered `<strong>b,
+  c</strong>` hides a comma the attribute split reads, so the two readings disagree about the
+  match's own extent — which is what keeps the narrowed re-fold gate from becoming vacuous now that
+  the string-slot class has left it.
+
+  The rule also makes the fold **safer** than the string it is replacing, which is worth recording
+  because it is a deliberate divergence rather than a bug found. A slot's value is text, and the
+  renderer escapes text for the attribute it is building, so `role=+++x&y"z+++` lands as
+  `class="x&amp;y&quot;z"` — inert. The string pipeline cannot make that guarantee anywhere: a
+  passthrough is restored into the *rendered* string after every escape has already run, so a
+  crafted body can close an attribute and open another. That is Asciidoctor's behavior too
+  ([asciidoctor#2661](https://github.com/asciidoctor/asciidoctor/issues/2661), open since 2018 and
+  settled there as intended), and this crate keeps matching it on the string path; the tree simply
+  does not reproduce it. For a cross-reference the string path does not even reach the value — it
+  leaks the sentinel — so there is no output worth matching.
+
+  Two unit tests pin the rule (the three slots, the `Raw`-versus-span split via
+  `xrefstyle=+++full+++`, and `role={rn}` still expanding) and the escaping, and the recorder test
+  that pinned the old deferral is now two: one on the split disagreement that still defers, one on
+  the form that now resolves through the mirror. Audit: 48 rows before, 49 after, with three rows
+  moving and all three the same two fixtures — `xref:sec[*bold*,role=*hl*]` leaving the unrecognized
+  set for `class="*hl*"`, and the split-disagreement fixture appearing only because the rewritten
+  recorder test introduces that source at document scope for the first time.
+
+  One guard came out of review. The bytes a token is built from — `\u{96}` and `\u{97}` — are ones
+  an **author** can write, and `build_match_string` stands an opaque piece in as a private-use
+  codepoint, so every one reaching the gate is the author's own. They make the tokening ambiguous
+  exactly where a value is read as a *string*: the search for a token cannot tell them apart from
+  the pass's own, so it would splice a node's source into the author's text and leave the real token
+  standing. [`Passthroughs::restore_to`](../../parser/src/content/passthroughs.rs) has the same
+  blind spot — the wart the image bracket's own sibling test pins — but it reaches it over the
+  *finished* string, where a `role=` it never restores into simply keeps the author's bytes. So such
+  a text **defers**, which is precisely what the per-slot check this increment replaced did for the
+  same bytes, and the four shapes are byte-identical to the increment's own base.
+
+  *What this unblocks, and what it deliberately does not:* the survey's other blocked item goes with
+  it — a deferred cross-reference's segment holds its `provided_text` as a string where the node
+  holds children, and a display text is markup by nature, so that slot takes the fold of the
+  children rather than the rule above. The image and link families are **not** the mechanical
+  follow-on they look like, and the probe that established it is worth recording: applying the same
+  rule to the image bracket moves `image:pause.png[title=*Pause* and Resume]` — a fixture from the
+  AsciiDoc language docs — from `title="<strong>Pause</strong> and Resume"` to `title="*Pause* and
+  Resume"` (three tests in the suite, no more). That is a **parity break** rather than a closed
+  deferral, and the slot has a reading neither system offers — the span's plain text, `title="Pause
+  and Resume"`, which is the only one an HTML `title` can actually show. So it wants deciding on its
+  own rather than inheriting this increment's answer, and until it is decided the image family keeps
+  freezing the rendered markup and the link family keeps refusing the match.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7816,6 +7895,31 @@ Each phase is a reviewable unit with a clear exit gate.
        in the suite warns. With this, **every** recognition side effect is performed from the tree,
        and what is left of step 6 is the string pipeline itself. See the step's own "landed as"
        note above.
+
+     - ✅ **a computed string slot takes the author's untranslated source.** The survey of what
+       `run_pipeline` still owns named one question two of its six items turn on: whether a
+       computed **string** slot — `Ref::roles`, `window`, `xrefstyle`, and the link and image
+       families' equivalents — can hold markup that exists only at fold time. It can, as the
+       author's *source* for the piece:
+       [`untranslated_value`](../../parser/src/content/inline_builder/macros/mod.rs) replaces each
+       token with the node's value (a `Raw` leaf — the passthrough delimiters are syntax, the body
+       is the literal text) or its source span (everything else), leaving attribute references and
+       special characters alone. The cross-reference family's per-slot gate and
+       `holds_carried_token` go with it, so `xref:sec[*bold*,role=*hl*]` is recognized and resolves
+       through the mirror, and what still defers is the *split* disagreement alone
+       (`xref:sec[a *b, c* d,role=hl]`) — which is what keeps the narrowed re-fold gate non-vacuous
+       — plus a text carrying **author-written** `\u{96}`/`\u{97}` bytes, which make every token
+       in it ambiguous.
+       The fold is also safer than the string it replaces: a slot's value is text the renderer
+       escapes, where a passthrough restored into the *rendered* string is not (asciidoctor#2661,
+       matched on the string path, not reproduced on the tree's). Audit: 48 rows before, 49 after,
+       all three moving rows the same two fixtures. This also unblocks the survey's other item (a
+       deferred segment's `provided_text` takes the fold of the node's children — a display text is
+       markup by nature). The image and link families do **not** follow automatically: the same
+       rule there is a *parity break* on an AsciiDoc-language-docs fixture
+       (`image:pause.png[title=*Pause* and Resume]`) rather than a closed deferral, and the slot has
+       a third reading neither system offers, so it wants deciding on its own. See the step's own
+       "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -21,7 +21,7 @@ use super::{
     special_chars::{Masked, unescaped_value_children},
 };
 use crate::{
-    Parser, Span,
+    HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::restored_entity_pattern,
     inlines::{CharRef, InlineNode},
@@ -857,8 +857,8 @@ pub(super) fn restored_markup_text(
 /// It answers only the *split*, not what the caller then does with each value.
 /// A token reaching a value the caller reads as a **string** — a
 /// cross-reference's `window=` / `role=` / `xrefstyle=` — splits identically
-/// on both sides and still has no bytes the caller can use, so a caller with
-/// such a slot asks [`holds_carried_token`] about it as well.
+/// on both sides and still has no bytes of its own the caller can read, so
+/// such a slot takes [`untranslated_value`] of it instead.
 pub(super) fn tokened_split_agrees(
     tokened: &str,
     carried: &[InlineNode<'_>],
@@ -888,16 +888,62 @@ pub(super) fn tokened_split_agrees(
             })
 }
 
-/// Whether `value` — one attribute the parse handed back — still holds a
-/// [`tokened_text`] token, which means an opaque piece landed in a value the
-/// caller reads as a **string** rather than carrying structurally.
+/// Rebuilds a computed value a family reads as a **string** — an `xref`'s
+/// `role`, `window` or `xrefstyle`, and the link and image families'
+/// equivalents — replacing each [`tokened_text`] token with the *untranslated*
+/// text of the node it stands for.
 ///
-/// A node has no bytes there, so such a match is deferred. This is the same
-/// per-*slot* boundary [`text_attrlist`](links)'s own `pre_restore` draws,
-/// reached for the stronger reason: a masked construct at least has a body to
-/// splice.
-pub(super) fn holds_carried_token(value: &str) -> bool {
-    value.contains('\u{96}')
+/// A string slot has nowhere to put a node, so the alternative to this is
+/// refusing the whole match (which is what the gate used to do) or spelling the
+/// token into the output (which is what the string pipeline does, emitting
+/// either rendered markup or a raw `\u{96}0\u{97}` sentinel). Neither is what
+/// the author wrote. What they wrote is the source, so that is what the slot
+/// takes.
+///
+/// "Untranslated" is per node kind, and the two cases differ for a reason:
+///
+/// - a [`Raw`](InlineNode::Raw) leaf contributes its **value**, not its source
+///   span: a passthrough's `+++`/`++`/`$$` delimiters are syntax saying *do not
+///   substitute this*, so the body is precisely the literal text the author
+///   asked for, and the delimiters have no business in a class name;
+/// - every other node contributes its **source span**, so `role=*hl*` yields
+///   `*hl*` rather than the `<strong>hl</strong>` the Quotes step made of it.
+///
+/// Attribute references and special characters are untouched by either rule —
+/// they are resolved before this value is read (`role={rolename}` still
+/// expands), and only markup the *Quotes* step produced is unwound.
+///
+/// The renderer escapes what it receives for the attribute it is building, so a
+/// body carrying a `"` lands inert rather than breaking out. That is this
+/// crate's own guarantee: Asciidoctor splices such a body in raw (asciidoctor
+/// issue #2661, open since 2018 and settled there as intended behavior), which
+/// is a divergence this crate takes deliberately.
+///
+/// The walk is index-keyed and left to right, exactly like
+/// [`restored_value_children`]'s: each token is sought only in the bytes after
+/// the previous one, and a token the parse dropped is simply not found.
+pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+
+    for (n, node) in carried.iter().enumerate() {
+        let token = format!("\u{96}{n}\u{97}");
+
+        if let Some(pos) = rest.find(&token) {
+            out.push_str(rest.get(..pos).unwrap_or_default());
+
+            match node {
+                InlineNode::Raw { value, .. } => out.push_str(value.as_ref()),
+                other => out.push_str(other.span().data()),
+            }
+
+            rest = rest.get(pos + token.len()..).unwrap_or_default();
+        }
+    }
+
+    out.push_str(rest);
+
+    out
 }
 
 /// Rebuilds a computed value that still holds [`tokened_text`] /

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -6,11 +6,11 @@
 #[allow(unused_imports)]
 use super::computed_value_children;
 use super::{
-    ComputedSpecials, MacroMatch, MacroMatchKind, holds_carried_token,
+    ComputedSpecials, MacroMatch, MacroMatchKind,
     image::{range_has_no_opaque_piece, range_is_substitution_restorable},
     links::restore_masked_passthroughs,
     macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
-    tokened_text,
+    tokened_text, untranslated_value,
 };
 use crate::{
     Parser, Span,
@@ -415,6 +415,12 @@ fn attrlist_text_carries_its_opaque_pieces(
     pieces: &[Piece],
     parser: &Parser,
 ) -> bool {
+    // Author-written token bytes make every token in this text ambiguous — see
+    // `text_carries_author_written_token_bytes`.
+    if text_carries_author_written_token_bytes(raw_text) {
+        return false;
+    }
+
     let (tokened, carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
 
     // The split must land where the string replacer's own parse of the markup
@@ -439,22 +445,38 @@ fn attrlist_text_carries_its_opaque_pieces(
         return true;
     }
 
-    // And no token may reach one of the three values this family reads as a
-    // **string**: a node has no bytes there.
-    let window_is_clean = attrlist
-        .named_attribute("window")
-        .is_none_or(|a| !holds_carried_token(a.value()));
+    // A token reaching one of the three values this family reads as a
+    // **string** — `window`, `xrefstyle`, a role — used to refuse the whole
+    // match here, because a node has no bytes to put in a string slot. It no
+    // longer does: `untranslated_value` gives the slot the author's *source*
+    // for the piece the token stands for, which is a value a string can hold.
+    // See its doc comment for the rules and for the divergence from the string
+    // pipeline that follows.
+    true
+}
 
-    let xrefstyle_is_clean = attrlist
-        .named_attribute("xrefstyle")
-        .is_none_or(|a| !holds_carried_token(a.value()));
-
-    let roles_are_clean = !attrlist
-        .roles()
-        .iter()
-        .any(|role| holds_carried_token(role));
-
-    window_is_clean && xrefstyle_is_clean && roles_are_clean
+/// Whether `raw_text` — a macro's own **match-string** bytes, before any
+/// tokening — carries a byte a [`tokened_text`] token is built from.
+///
+/// It should not: [`build_match_string`] stands an opaque piece in as
+/// [`SPAN_PLACEHOLDER`](super::super::quotes), a private-use codepoint, so
+/// every `\u{96}` / `\u{97}` reaching here is one the **author** wrote.
+///
+/// Those bytes make the whole tokening ambiguous, and the ambiguity bites
+/// precisely where a value is read as a *string*. A token is found by
+/// searching the parsed value for its bytes, and the search cannot tell an
+/// author's `\u{96}0\u{97}` from the one this pass emitted: it would splice a
+/// node's source into the author's text and leave the real token standing.
+/// (`Passthroughs::restore_to` has the same blind spot — the wart the image
+/// bracket's own sibling test pins — but the string pipeline reaches it over
+/// the *finished* string, where a `role=` it never restores into simply keeps
+/// the author's bytes.)
+///
+/// So a text carrying one defers, which is what the per-slot check this
+/// replaced did for the same bytes. It is a deferral, not a rewrite: the tree
+/// claims no construct, and the string pipeline's own reading stands.
+fn text_carries_author_written_token_bytes(raw_text: &str) -> bool {
+    raw_text.contains('\u{96}') || raw_text.contains('\u{97}')
 }
 
 /// The match-string range of a `<<…>>` shorthand's **id half**: its inner up to
@@ -619,19 +641,25 @@ fn xref_macro_text<'src>(
         let first = attrlist.nth_attribute(1).map(|a| a.value().to_string());
 
         if first.as_deref() != Some(normalized.as_str()) {
+            // The three values this family reads as **strings**. Each is read
+            // off the *tokened* parse, so a value enclosing a rendered span or
+            // a masked passthrough holds that piece's token rather than any
+            // bytes of its own; `untranslated_value` puts the author's source
+            // back in its place (see its own doc comment for the two rules and
+            // for the deliberate divergence from Asciidoctor that follows).
             let window = attrlist
                 .named_attribute("window")
-                .map(|a| CowStr::from(a.value().to_string()));
+                .map(|a| CowStr::from(untranslated_value(a.value(), &carried)));
 
             let roles = attrlist
                 .roles()
                 .iter()
-                .map(|r| CowStr::from(r.to_string()))
+                .map(|r| CowStr::from(untranslated_value(r, &carried)))
                 .collect();
 
             let xrefstyle = attrlist
                 .named_attribute("xrefstyle")
-                .map(|a| XrefStyle::parse(a.value()));
+                .map(|a| XrefStyle::parse(&untranslated_value(a.value(), &carried)));
 
             let children = match first.filter(|s| !s.is_empty()) {
                 None => vec![],
@@ -1993,27 +2021,124 @@ mod tests {
     }
 
     #[test]
-    fn a_span_in_a_computed_attribute_is_a_documented_divergence() {
-        // The boundary this increment does *not* move, drawn per **slot**: a
-        // `window=`, a `role=`, or an `xrefstyle=` is read as a **string**,
-        // and an enclosed span has no bytes to be read as — its markup exists
-        // only at fold time. The reference is therefore left unrecognized
-        // where the string pipeline builds one over the markup, with the
-        // span's own tags rendered verbatim into the attribute.
+    fn an_author_written_token_byte_defers_the_match() {
+        // The bytes a token is built from are `\u{96}` and `\u{97}`, and an
+        // **author** can write them: `build_match_string` stands an opaque
+        // piece in as a private-use codepoint, so every one reaching the gate
+        // is the author's own. They make the tokening ambiguous exactly where
+        // this increment reads a value as a *string* — the search for a token
+        // cannot tell the author's bytes from the pass's own, and would splice
+        // a node's source into the author's text while leaving the real token
+        // standing. Such a text defers, which is what the per-slot check this
+        // increment replaced did for the same bytes.
         for source in [
-            "xref:sec[*a*,role=*b*]",
-            "xref:sec[a,window=*b*]",
-            "xref:sec[a,xrefstyle=*b*]",
+            "xref:sec[*b*,role=\u{96}0\u{97}hl]",
+            "xref:sec[*b*,role=hl\u{96}0\u{97}]",
+            "xref:sec[+++p+++,role=\u{96}0\u{97}hl]",
         ] {
             let nodes = build_src(Span::new(source));
 
             assert!(
                 nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "a span in a computed attribute must be left unrecognized: {nodes:?}"
+                "an author-written token byte must defer the match: {nodes:?}"
             );
 
-            assert!(golden_xref(source).contains("<a href"));
+            // The string pipeline builds one, keeping the author's bytes: it
+            // reaches its own restore over the *finished* string, which never
+            // rewrites a `role=` it did not extract into.
+            assert!(golden_whole_pipeline(source).contains("<a href"));
         }
+
+        // A text with **no** opaque piece never reaches that gate, and needs
+        // not to: there is no token to confuse, so the author's bytes pass
+        // through to the slot exactly as the string pipeline passes them.
+        let source = "xref:sec[a,role=\u{96}0\u{97}hl]";
+        assert_eq!(
+            fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+            golden_whole_pipeline(source)
+        );
+    }
+
+    #[test]
+    fn a_computed_attribute_read_as_a_string_takes_the_untranslated_source() {
+        // The boundary this increment moved, drawn per **slot**: a `window=`,
+        // a `role=`, or an `xrefstyle=` is read as a **string**, and an
+        // enclosed span has no bytes to be read as — its markup exists only at
+        // fold time. That used to leave the whole reference unrecognized.
+        // Now the slot takes the *source* the author wrote for the piece,
+        // which is a value a string can hold, and the reference is recognized.
+        let nodes = build_src(Span::new("xref:sec[*a*,role=*b*]"));
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.roles.len(), 1);
+        assert_eq!(reference.roles[0].as_ref(), "*b*");
+
+        let nodes = build_src(Span::new("xref:sec[a,window=*b*]"));
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.window.as_deref(), Some("*b*"));
+
+        // A masked passthrough contributes its **body**, not its source span:
+        // the `+++` delimiters are syntax saying *do not substitute this*, so
+        // the body is exactly the literal text asked for — here a value the
+        // string pipeline cannot express at all (`full` reaches the slot as a
+        // sentinel, so it never selects a style).
+        let nodes = build_src(Span::new("xref:sec[a,xrefstyle=+++full+++]"));
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.xrefstyle, Some(XrefStyle::Full));
+
+        // An attribute reference is untouched by either rule — it is resolved
+        // before this value is read, and only markup the *Quotes* step made is
+        // unwound.
+        let mut parser = Parser::default();
+        parser = parser.with_intrinsic_attribute(
+            "rn",
+            "myrole",
+            crate::parser::ModificationContext::Anywhere,
+        );
+
+        let nodes = build(Span::new("xref:sec[a,role={rn}]"), &parser, None);
+
+        let reference = assert_xref(&nodes[0]);
+        assert_eq!(reference.roles.len(), 1);
+        assert_eq!(reference.roles[0].as_ref(), "myrole");
+    }
+
+    #[test]
+    fn an_untranslated_string_attribute_is_escaped_by_the_renderer() {
+        // What the slot holds is *text*, and the renderer escapes it for the
+        // attribute it is building — so a body carrying a `"` or an `&` lands
+        // inert rather than breaking out of the tag. The string pipeline
+        // cannot make this guarantee (a passthrough is restored into the
+        // rendered string after every escape has run), which is the whole
+        // reason the values differ; here it does not even reach the value,
+        // leaking the sentinel that stood for it instead.
+        for (source, expected) in [
+            (
+                "xref:sec[a,role=+++x&y\"z+++]",
+                "<a href=\"#sec\" class=\"x&amp;y&quot;z\">a</a>",
+            ),
+            (
+                "xref:sec[a,window=+++_bl\"ank+++]",
+                "<a href=\"#sec\" target=\"_bl&quot;ank\">a</a>",
+            ),
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                expected,
+                "the fold regressed for {source:?}"
+            );
+
+            assert!(
+                golden_whole_pipeline(source).contains('\u{96}'),
+                "the string pipeline is expected to leak its sentinel for {source:?}"
+            );
+        }
+
+        // A value with nothing opaque in it is at parity, as it always was.
+        let source = "xref:sec[a,role=hl]";
+        assert_eq!(
+            fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+            golden_xref(source)
+        );
     }
 
     #[test]

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1314,28 +1314,31 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 
 #[test]
 fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
-    // `xref:sec[*bold*,role=*hl*]` is a documented builder divergence (a
-    // rendered span reaching a value this family reads as a **string** — a
-    // `role=`, a `window=`, an `xrefstyle=` — is left unrecognized, since a
-    // span's markup exists only at fold time), so the tree holds *fewer*
-    // cross-reference nodes than the string pipeline deferred. The positional
-    // resolution mirror must detect the count mismatch and skip — leaving the
-    // tree in its honest unresolved state — rather than assign destinations to
-    // the wrong nodes (or panic).
+    // `xref:sec[a *b, c* d,role=hl]` is a documented builder divergence: the
+    // string replacer splits the attribute list over the span's **markup**,
+    // whose `<strong>b, c</strong>` hides a comma the split reads, so the two
+    // readings disagree about the match's own extent and the builder defers
+    // rather than claim a construct the rendered document contradicts. The
+    // tree therefore holds *fewer* cross-reference nodes than the string
+    // pipeline deferred. The positional resolution mirror must detect the
+    // count mismatch and skip — leaving the tree in its honest unresolved
+    // state — rather than assign destinations to the wrong nodes (or panic).
     let mut parser = Parser::default();
-    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=*hl*].");
+    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[a *b, c* d,role=hl].");
 
-    // The rendered output is unaffected. That count mismatch is also what
-    // keeps this content on the **template** path: a deferred content is
-    // re-folded from its tree once resolution has installed its destinations
-    // (`Content::refold`), and the mirror's own success is the gate. Here the
-    // mirror skipped, so the tree is known not to describe this content and
-    // folding it would drop the cross-reference outright.
+    // The rendered output is the string pipeline's own — anchor cut short
+    // inside the span, which is precisely the reading the builder refused to
+    // claim. That count mismatch is also what keeps this content on the
+    // **template** path: a deferred content is re-folded from its tree once
+    // resolution has installed its destinations (`Content::refold`), and the
+    // mirror's own success is the gate. Here the mirror skipped, so the tree
+    // is known not to describe this content and folding it would drop the
+    // cross-reference outright.
     let rendered = collect_rendered(&doc);
     assert!(
         rendered
             .iter()
-            .any(|s| s.contains("href=\"#sec\"") && s.contains("<strong>bold</strong>")),
+            .any(|s| s.contains("href=\"#sec\"") && s.contains("<strong>b</a>")),
         "the rendered xref regressed: {rendered:?}"
     );
 
@@ -1344,6 +1347,36 @@ fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
     assert!(
         refs.iter().all(|r| r.variant != RefVariant::Xref),
         "expected the deferred xref form to stay unrecognized in the tree: {refs:?}"
+    );
+}
+
+#[test]
+fn a_span_in_a_string_valued_xref_attribute_now_mirrors() {
+    // The counterpart the increment *moved*: a rendered span reaching one of
+    // the three values this family reads as a **string** used to defer for
+    // want of anywhere to put a node. It no longer does — the slot takes the
+    // author's own source for the piece — so the construct is recognized, the
+    // counts agree, and the mirror installs the destination.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[*bold*,role=*hl*].");
+
+    let refs = collect_refs(&doc);
+
+    assert!(
+        refs.iter().any(|r| r.variant == RefVariant::Xref
+            && r.roles.iter().any(|role| role.as_ref() == "*hl*")
+            && r.resolved.as_ref().is_some_and(|res| res.href == "#sec")),
+        "expected a resolved xref carrying the untranslated role: {refs:?}"
+    );
+
+    // And the rendering follows the tree rather than the string pipeline's
+    // `class="&lt;strong&gt;hl&lt;/strong&gt;"` — the documented divergence.
+    let rendered = collect_rendered(&doc);
+    assert!(
+        rendered
+            .iter()
+            .any(|s| s.contains("class=\"*hl*\"") && s.contains("<strong>bold</strong>")),
+        "the rendered xref regressed: {rendered:?}"
     );
 }
 


### PR DESCRIPTION
## What

The step-6 survey (#1282) named one question that **two of its six remaining items** turn on:

> whether a computed **string** slot — `Ref::roles`, `window`, `xrefstyle`, and the link and image families' equivalents — can hold markup that exists only at fold time. Today it cannot, which is why `xref:sec[*bold*,role=*hl*]` stays deferred and why a segment's `provided_text` cannot come from a node. Answering it once unblocks both; leaving it unanswered blocks both no matter how much else lands.

This increment answers it, for the **cross-reference family**.

## The answer

Three answers were available, and the first two are what the two systems had already picked:

| | what reaches `role=` for `xref:sec[*bold*,role=*hl*]` |
| --- | --- |
| string pipeline | `class="&lt;strong&gt;hl&lt;/strong&gt;"` — the piece's own rendered markup (and for a masked passthrough, a bare `\u{96}0\u{97}` sentinel, since the deferred xref's template is captured before passthroughs are restored) |
| builder, before | *nothing* — the whole match was refused |
| builder, now | `class="*hl*"` — the author's own source |

Neither of the first two is what the author wrote. What they wrote is the **source**, and a source is a value a string can hold.

`untranslated_value` walks a computed value's `tokened_text` tokens the way `restored_value_children` walks them, and replaces each with the untranslated text of the node it stands for:

- a **`Raw`** leaf contributes its **value**, not its source span: a passthrough's `+++` / `++` / `$$` delimiters are syntax saying *do not substitute this*, so the body is precisely the literal text the author asked for, and the delimiters have no business in a class name;
- every other node contributes its **source span**, so `role=*hl*` yields `*hl*` rather than the `<strong>hl</strong>` the Quotes step made of it.

Attribute references and special characters are untouched by either rule — they are resolved before the value is read, so `role={rolename}` still expands, and only markup the *Quotes* step produced is unwound.

## What this removes

`attrlist_text_carries_its_opaque_pieces` drops its three "no token may reach `window` / `xrefstyle` / a role" checks, and `holds_carried_token` goes with them (it had no other caller). The family's gate is now the **split** question alone.

That question still has members — `xref:sec[a *b, c* d,role=hl]`, whose rendered `<strong>b, c</strong>` hides a comma the attribute split reads, so the two readings disagree about the match's own extent — which is what keeps the narrowed re-fold gate from becoming vacuous now that the string-slot class has left it.

## One guard, from review

Greptile's P1 on the first push was correct and is fixed in `1176cd2`. `untranslated_value` finds a carried node's token by searching the parsed value for `\u{96}`*n*`\u{97}`, and that search cannot tell those bytes apart from ones the **author** wrote — so `xref:sec[*b*,role=\u{96}0\u{97}hl]` folded to `class="*b*hl"`, splicing the span's source into the author's text and leaving the real token standing. Three shapes were affected, and this PR is what made them reachable, since `holds_carried_token` refused on exactly those bytes.

`text_carries_author_written_token_bytes` now defers the match when the macro's match-string text carries a `\u{96}` or `\u{97}`. Those are always the author's there — `build_match_string` stands an opaque piece in as `SPAN_PLACEHOLDER` (`\u{E0F0}`, private use) — and when they are present no token in the text is trustworthy. All four shapes are **byte-identical to this PR's base**, verified by running the same probe on `e51bc7b`; a text with no opaque piece never reaches that gate, so `xref:sec[a,role=\u{96}0\u{97}hl]` stays recognized and at parity.

## A deliberate divergence worth recording

The rule makes the fold **safer** than the string it replaces. A slot's value is text, and the renderer escapes text for the attribute it is building, so `xref:sec[a,role=+++x&y"z+++]` folds to `class="x&amp;y&quot;z"` — inert.

The string pipeline cannot make that guarantee anywhere: a passthrough is restored into the *rendered* string after every escape has already run, so a crafted body can close an attribute and open another. That is Asciidoctor's behavior too ([asciidoctor#2661](https://github.com/asciidoctor/asciidoctor/issues/2661), open since 2018 and settled there as intended), and this crate keeps matching it on the string path — the tree simply does not reproduce it. For a cross-reference the string path does not even reach the value (it leaks the sentinel), so there is no output worth matching.

## What follows, and what deliberately does not

The survey's **other** blocked item goes with this one: a deferred cross-reference's segment holds its `provided_text` as a string where the node holds children, and a display text is markup by nature, so that slot takes the fold of the children rather than this rule.

The **image and link families do not follow automatically**, and the probe that established that is recorded in the design note. Applying the same rule to the image bracket moves `image:pause.png[title=*Pause* and Resume]` — a fixture from the AsciiDoc language docs — from `title="<strong>Pause</strong> and Resume"` to `title="*Pause* and Resume"` (three tests, no more). That is a **parity break** rather than a closed deferral, and the slot has a reading neither system offers — the span's plain text, `title="Pause and Resume"`, the only one an HTML `title` can actually show. It wants deciding on its own, so this PR leaves the image family freezing the rendered markup and the link family refusing the match.

## Tests

- `a_computed_attribute_read_as_a_string_takes_the_untranslated_source` — the three slots, the `Raw`-versus-span split (via `xrefstyle=+++full+++`, a value the string pipeline cannot express at all), and `role={rn}` still expanding.
- `an_untranslated_string_attribute_is_escaped_by_the_renderer` — the escaping, plus an assertion that the string pipeline leaks its sentinel for the same sources.
- `an_author_written_token_byte_defers_the_match` — the guard above, all four shapes.
- The recorder test that pinned the old deferral is now **two**: `xref_mirror_is_skipped_when_the_tree_defers_a_reference_form` (rewritten onto the split disagreement, which still defers) and `a_span_in_a_string_valued_xref_attribute_now_mirrors` (the form that now resolves through the mirror).

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace --all-features` green (5,446 + 6)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: missed regions/lines **unchanged** on both changed files (`macros/mod.rs` 4/2, `macros/xref.rs` 16/7) — every new region covered.
- **Fold-parity audit**: 48 rows before, 49 after; three rows move and all three are the same two fixtures — `xref:sec[*bold*,role=*hl*]` leaving the unrecognized set for `class="*hl*"` (one closed, one new), and `xref:sec[a *b, c* d,role=hl]` appearing only because the rewritten recorder test introduces that source at document scope for the first time (the split-disagreement class, already documented, still deferred). Unchanged by the guard.

Design doc: new "*Step 6 landed as (a computed string slot takes the author's untranslated source)*" narrative plus its §5.2 checklist entry.