### PR TITLE
feat: A description-list term joins the tree (inline-ast step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6576,6 +6576,59 @@ Each phase is a reviewable unit with a clear exit gate.
   own rather than inheriting this increment's answer, and until it is decided the image family keeps
   freezing the rendered markup and the link family keeps refusing the match.
 
+  *Step 6 landed as (a description-list term joins the tree — the last content registering from the
+  string pipeline):* the increment that re-attached the recognition side effects measured what still
+  registered outside the tree by widening its suppression window to a whole parse and counting the
+  failures: 161, of which the second cause was "the description-list **term** carve-out, the last
+  thing still registering from the string pipeline". This is that carve-out.
+
+  A term ran the substitution steps **directly** — `Passthroughs::extract_from`, five
+  `SubstitutionStep::apply` calls, `restore_to`, `finalize_deferred` — a hand copy of
+  `run_pipeline`'s body written before there was a tree to build. So a term had no tree, its
+  rendering was the string pipeline's rather than a fold, and its constructs registered from the
+  replacers. It runs through
+  [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) now, under a group
+  spelled out for it: the `normal` order minus its attribute-references step, which already ran
+  during *parsing* so the `::` marker could be recognized at all. The seed, the authoritative fold,
+  the suppression window and the replay all come with that.
+
+  One rule had to move rather than disappear. A leading `[[id]]` / `[[id,reftext]]` in a term takes
+  the **rest of the term** as its default reference text, so `[[cpu]]CPU::` makes `<<cpu>>` display
+  *CPU* — a fact about where the anchor sits in a *term*, not about the node, so it cannot live in
+  [`apply_ref_side_effects`](../../parser/src/content/inline_builder/macros/anchors.rs). It runs
+  from the same tree instead, at the one point where the tree exists and nothing has registered from
+  it yet: between the build and the replay. The replay is then told the anchor is already registered
+  — which is what `leading_anchor_registered`, the parameter the side-effect increment staged and
+  every caller passed `false`, has been waiting for.
+
+  Reading that rule off the tree makes one deliberate difference. The regex it replaces ran *before*
+  the macros step, so a term whose remainder held a macro registered the macro's **source**:
+  `[[x]]image:a.png[]Term::` catalogued `image:a.png[]Term` as the reference text. The fold of the
+  same nodes gives the rendering, which is what every other reference text on this branch is. Two
+  tests pin the rule and that difference; a third pins the property the suppression window newly
+  puts at risk for a term, that a registering construct in one is recorded exactly **once**.
+
+  A second difference is a limitation of *when* a term registers rather than of reading the rule off
+  the tree, and review asked for it to be pinned. The leading anchor is registered while the term is
+  **parsed** — which is what lets a later cross-reference resolve it at all — and that is before any
+  cross-reference *inside* the term has a destination, so a `<<b>>` there contributes its unresolved
+  fallback to the catalogued reference text and keeps it: the entry is never revisited. The tree is
+  the better of the two readings even so. The regex ran before the macros step, so it caught the
+  same reference as escaped *source* (`See &lt;&lt;b&gt;&gt;`), never a link at all; the fold gives
+  `See <a href="#b">[b]</a>`. Neither depends on whether the target is defined before or after the
+  term, and `a_terms_default_reftext_folds_before_nested_references_resolve` pins both directions.
+
+  Three pieces of machinery go with the carve-out: the `LEADING_INLINE_ANCHOR` regex,
+  `apply_macros_with_leading_anchor_registered`, and `InlineAnchorReplacer`'s own
+  `leading_anchor_registered` field and the check it guarded. The string replacers' *registrations*
+  stay — deleting those is what happens when `run_pipeline` leaves the production path — but nothing
+  passes `true` through them any more, so the branch that read it was dead.
+
+  The audit is the cleanest kind of no-op: **49** rows either side, 0 new and 0 closed. A term now
+  goes through the same fold every other content does, and it reproduces the string pipeline's own
+  bytes for every term in the suite. Coverage is diff-neutral on all four changed files. Both halves
+  are falsifiable: dropping the term's leading-anchor registration fails five tests, and passing
+  `false` for the flag while still registering fails two (a doubled duplicate-id warning).
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7920,6 +7973,26 @@ Each phase is a reviewable unit with a clear exit gate.
        (`image:pause.png[title=*Pause* and Resume]`) rather than a closed deferral, and the slot has
        a third reading neither system offers, so it wants deciding on its own. See the step's own
        "landed as" note above.
+
+     - ✅ **a description-list term joins the tree.** The carve-out the side-effect increment
+       measured and named: a term ran the substitution steps *directly* — a hand copy of
+       `run_pipeline`'s body predating the tree — so it had no tree, its rendering was not a fold,
+       and its constructs registered from the replacers. It goes through
+       [`SubstitutionGroup::apply`](../../parser/src/content/substitution_group.rs) now, under the
+       `normal` order minus its attribute-references step (which already ran during *parsing*, so
+       the `::` marker could be recognized). The term's one rule of its own — a leading `[[id]]`
+       takes the **rest of the term** as its default reference text — runs from the same tree,
+       between the build and the replay, which is what finally passes `leading_anchor_registered`
+       its `true`. Reading it off the tree makes one deliberate difference: the default reference
+       text is now the *rendering* of the rest, where the pre-macros regex catalogued a macro's
+       source (`[[x]]image:a.png[]Term::`). A term also registers while it is *parsed*, so a
+       cross-reference inside it contributes its unresolved fallback to the catalogued reference
+       text and keeps it — a limitation of *when*, not of the tree, and still the better of the two
+       readings (the regex caught the same reference as escaped source, never a link).
+       `LEADING_INLINE_ANCHOR`,
+       `apply_macros_with_leading_anchor_registered` and `InlineAnchorReplacer`'s own flag go with
+       it. Audit: 49 rows either side, 0 new, 0 closed; coverage diff-neutral on all four files.
+       See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -4,13 +4,25 @@ use regex::Regex;
 
 use crate::{
     HasSpan, Parser, Span,
-    content::{
-        Content, Passthroughs, SubstitutionStep, apply_macros_with_leading_anchor_registered,
-    },
-    document::RefType,
+    content::{Content, SubstitutionGroup, SubstitutionStep},
     span::MatchedItem,
-    warnings::{Warning, WarningType},
+    warnings::Warning,
 };
+
+/// The substitution group a description-list **term** takes: the `normal`
+/// group's own order, minus the attribute-references step that already ran
+/// during parsing (so `{blank}` and friends were resolved before the marker
+/// was recognized). Asciidoctor substitutes a term with `normal` too; this
+/// spelling is the same list with the one already-applied step removed.
+static TERM_SUBSTITUTIONS: LazyLock<SubstitutionGroup> = LazyLock::new(|| {
+    SubstitutionGroup::Custom(vec![
+        SubstitutionStep::SpecialCharacters,
+        SubstitutionStep::Quotes,
+        SubstitutionStep::CharacterReplacements,
+        SubstitutionStep::Macros,
+        SubstitutionStep::PostReplacement,
+    ])
+});
 
 /// A list item is signaled by one of several designated marker sequences.
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -206,57 +218,15 @@ impl<'src> ListItemMarker<'src> {
             return;
         };
 
-        // A description-list term is substituted with the `normal` group. The
-        // attribute-references step already ran during parsing (so the marker
-        // could be recognized), so the remaining steps run here. Passthrough
-        // spans are extracted first and restored last so their payloads are
-        // shielded from the intervening substitutions, mirroring the structure
-        // of `SubstitutionGroup::apply` for the normal group.
-        let passthroughs = Passthroughs::extract_from(term, parser);
-
-        SubstitutionStep::SpecialCharacters.apply(term, parser, None);
-        SubstitutionStep::Quotes.apply(term, parser, None);
-        SubstitutionStep::CharacterReplacements.apply(term, parser, None);
-
-        // A leading inline anchor (`[[id]]` or `[[id,reftext]]`) at the start of
-        // the term is registered in the catalog before the macros step renders
-        // it, so that only its own duplicate-registration warning is suppressed
-        // during that pass. Any other term goes straight through the macros
-        // step.
-        if term.rendered_html().starts_with("[[") {
-            if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term.rendered_html()) {
-                let id = &captures[1];
-
-                // If reftext is provided, use it. Otherwise, use the text after
-                // the anchor as the default reftext.
-                let reftext = captures.get(2).map(|m| m.as_str().to_string()).or_else(|| {
-                    // Use the text after the anchor as default reftext.
-                    captures.get(3).map(|m| m.as_str().trim().to_string())
-                });
-
-                // Register the anchor in the catalog.
-                if let Err(_duplicate_error) =
-                    parser.register_ref(id, reftext.as_deref(), RefType::Anchor)
-                {
-                    warnings.push(Warning::new(
-                        term.original(),
-                        WarningType::DuplicateId(id.to_string()),
-                    ));
-                }
-            }
-
-            apply_macros_with_leading_anchor_registered(term, parser);
-        } else {
-            SubstitutionStep::Macros.apply(term, parser, None);
-        }
-
-        SubstitutionStep::PostReplacement.apply(term, parser, None);
-
-        // Restore the extracted passthroughs and finalize any deferred
-        // cross-references, matching the tail of `SubstitutionGroup::apply`.
-        passthroughs.restore_to(term, parser);
-        term.set_passthroughs(passthroughs.0);
-        term.finalize_deferred(&*parser.renderer);
+        // A description-list term is substituted with the `normal` group, in
+        // that group's own order minus its attribute-references step, which
+        // already ran during parsing so the marker could be recognized at all.
+        // Running it through `SubstitutionGroup::apply` rather than the steps
+        // directly is what gives the term a **tree**: the seed, the
+        // authoritative fold, and the replay of every recognition side effect
+        // come with it, so a term no longer registers from the string pipeline
+        // (design §5.2 Phase 4, step 6 — this was the last content that did).
+        TERM_SUBSTITUTIONS.apply_to_description_list_term(term, parser, warnings);
     }
 
     /// Return a mutable reference to the term content of a description-list
@@ -539,29 +509,6 @@ static DESCRIPTION_LIST_MARKER: LazyLock<Regex> = LazyLock::new(|| {
             )
             (?::::?:?|;;)           # Delimiter: ::, :::, ::::, or ;;
             (?:$|[\ \t])            # End of line or whitespace after marker
-        "#,
-    )
-    .unwrap()
-});
-
-/// Matches a leading inline anchor at the start of text.
-///
-/// Captures:
-/// - Group 1: The anchor ID
-/// - Group 2: Optional reftext (after comma)
-/// - Group 3: Text after the anchor (used as default reftext if group 2 is
-///   absent)
-static LEADING_INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
-    #[allow(clippy::unwrap_used)]
-    Regex::new(
-        r#"(?x)
-            ^                           # Start of string
-            \[\[                        # Opening [[
-            ([\p{Alphabetic}_:]         # (1) Anchor ID: first char must be letter, _, or :
-             [\p{Alphabetic}\p{Nd}_\-:.]*)  # Rest of ID: letters, digits, _, -, :, .
-            (?:,\s*([^\]]+))?           # (2) Optional reftext after comma
-            \]\]                        # Closing ]]
-            (.*)                        # (3) Text after the anchor
         "#,
     )
     .unwrap()

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -547,15 +547,14 @@ fn structural_anchor_reftext<'src>(
 /// [`InlineAnchorReplacer`](crate::content::macros) does (against the
 /// content's own span, not the individual anchor's).
 ///
-/// `leading_anchor_registered` mirrors
-/// [`apply_macros_with_leading_anchor_registered`](super::apply_macros)'s own
-/// parameter: a description-list term pre-registers its own leading
-/// `[[id]]`/`[[id,reftext]]` before running the macros pass (see
-/// `DefinedTerm::substitute` in `blocks::list_item_marker`), so — once this
-/// function is wired in for real at the same call site — passing `true` there
-/// suppresses the duplicate-id warning this function would otherwise raise
-/// for that very same anchor, which sits at byte offset `0` of `source`.
-/// Every other caller passes `false`.
+/// `leading_anchor_registered` says a description-list **term**'s leading
+/// `[[id]]`/`[[id,reftext]]` was already registered, with the rest of the term
+/// as its default reference text — the term's own rule, which runs from the
+/// same tree just before this function (see
+/// `SubstitutionGroup::apply_to_description_list_term`). Passing `true`
+/// suppresses the duplicate-id warning this function would otherwise raise for
+/// that very anchor, which sits at byte offset `0` of `source`. Every other
+/// caller passes `false`.
 ///
 /// Recurses into every container an id-bearing node can be nested inside —
 /// [`Styled`](InlineNode::Styled), [`Ref`](InlineNode::Ref),

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -24,21 +24,6 @@ use crate::{
 };
 
 pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
-    apply_macros_internal(content, parser, false);
-}
-
-pub(crate) fn apply_macros_with_leading_anchor_registered(
-    content: &mut Content<'_>,
-    parser: &Parser,
-) {
-    apply_macros_internal(content, parser, true);
-}
-
-fn apply_macros_internal(
-    content: &mut Content<'_>,
-    parser: &Parser,
-    leading_anchor_registered: bool,
-) {
     let /* mut */ text = content.rendered_html().to_string();
     let found_square_bracket = text.contains('[');
     let found_colon = text.contains(':');
@@ -163,7 +148,6 @@ fn apply_macros_internal(
         let replacer = InlineAnchorReplacer {
             parser,
             source: content.original(),
-            leading_anchor_registered,
             haystack: &haystack,
         };
 
@@ -1715,7 +1699,6 @@ pub(crate) static INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
 struct InlineAnchorReplacer<'p, 'src, 'h> {
     parser: &'p Parser,
     source: Span<'src>,
-    leading_anchor_registered: bool,
 
     /// The text being scanned, retained so the shorthand form can be tested for
     /// a preceding `[` (see the bibliography-anchor note in `replace_append`).
@@ -1773,7 +1756,6 @@ impl Replacer for InlineAnchorReplacer<'_, '_, '_> {
                 .parser
                 .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor)
                 .is_err()
-            && !(self.leading_anchor_registered && caps.get(0).is_some_and(|m| m.start() == 0))
         {
             self.parser.record_substitution_warning(
                 self.source,

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -25,10 +25,9 @@ mod macros;
 pub(crate) use macros::{
     INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR, INLINE_EMAIL, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
     INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
-    INLINE_XREF, NormalizedCaps, URI_SNIFF, apply_macros_with_leading_anchor_registered, basename,
-    document_xrefstyle, encode_uri_component, extract_attributes_from_text,
-    normalize_footnote_text, normalize_index_text, normalize_text_lf_escaped_bracket,
-    split_kbd_keys, strip_see_and_seealso,
+    INLINE_XREF, NormalizedCaps, URI_SNIFF, basename, document_xrefstyle, encode_uri_component,
+    extract_attributes_from_text, normalize_footnote_text, normalize_index_text,
+    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -2,6 +2,7 @@ use crate::{
     HasSpan, Parser,
     attributes::Attrlist,
     content::{Content, Passthroughs, SubstitutionStep},
+    document::RefType,
     warnings::WarningType,
 };
 
@@ -226,6 +227,43 @@ impl SubstitutionGroup {
         parser: &Parser,
         attrlist: Option<&Attrlist<'src>>,
     ) {
+        self.apply_inner(content, parser, attrlist, None);
+    }
+
+    /// [`apply`](Self::apply) for a description-list **term**, which is the one
+    /// content with a registration rule of its own: a leading `[[id]]` /
+    /// `[[id,reftext]]` at the very start of the term is registered with the
+    /// **rest of the term** as its default reference text, so `[[cpu]]CPU::`
+    /// makes `<<cpu>>` display *CPU*.
+    ///
+    /// That rule cannot live in
+    /// [`apply_ref_side_effects`](crate::content::inline_builder): a leading
+    /// anchor is only special because of where it sits in a *term*, which is a
+    /// fact about the caller, not about the node. So the term passes its
+    /// warnings list here, the rule runs between the tree build and the replay
+    /// — the one point where the tree exists and nothing has registered from it
+    /// yet — and the replay is then told the anchor is already registered, so
+    /// it does not raise a second duplicate-id warning for it.
+    ///
+    /// Before this branch's step 6 the term ran the steps directly and
+    /// registered from the string pipeline, which made it the last content
+    /// doing so. It no longer is.
+    pub(crate) fn apply_to_description_list_term<'src>(
+        &self,
+        content: &mut Content<'src>,
+        parser: &Parser,
+        warnings: &mut Vec<crate::warnings::Warning<'src>>,
+    ) {
+        self.apply_inner(content, parser, None, Some(warnings));
+    }
+
+    fn apply_inner<'src>(
+        &self,
+        content: &mut Content<'src>,
+        parser: &Parser,
+        attrlist: Option<&Attrlist<'src>>,
+        term_warnings: Option<&mut Vec<crate::warnings::Warning<'src>>>,
+    ) {
         // Snapshot the pre-substitution value and the parser *before* the
         // authoritative pass runs. The parser clone captures every document
         // counter (footnote/callout numbers, `{counter:…}` values) at its
@@ -318,14 +356,19 @@ impl SubstitutionGroup {
             // document order across contents and in the string pipeline's own
             // pass order within one (see `apply_macro_side_effects`).
             //
-            // `leading_anchor_registered` is `false`: the one caller that
-            // pre-registers a leading anchor is a description-list term, which
-            // runs the steps directly rather than through this function.
+            // A description-list term's own leading-anchor rule runs first,
+            // between the build and the replay — see
+            // `apply_to_description_list_term`. Every other content passes
+            // `false`: it has no anchor registered ahead of the replay.
+            let leading_anchor_registered = term_warnings.is_some_and(|warnings| {
+                Self::register_term_leading_anchor(&tree, parser, content, warnings)
+            });
+
             crate::content::inline_builder::apply_macro_side_effects(
                 &tree,
                 parser,
                 content.original(),
-                false,
+                leading_anchor_registered,
             );
 
             // The callouts step's own registration, replayed the same way. It
@@ -347,6 +390,74 @@ impl SubstitutionGroup {
                 content.set_render_attributes(parser.snapshot_attributes());
             }
         }
+    }
+
+    /// Registers a description-list term's leading inline anchor, from the
+    /// term's own tree, and answers whether it did.
+    ///
+    /// The rule mirrors what the term used to read out of its half-substituted
+    /// string with a regex: the anchor must be the term's **first** node and
+    /// must start at the term's own first byte, and its reference text is its
+    /// own `[[id,reftext]]` text when it has one, or else the **rest of the
+    /// term**, trimmed.
+    ///
+    /// Reading "the rest of the term" from the tree rather than from that
+    /// string is one deliberate difference. The regex ran *before* the macros
+    /// step, so a term whose remainder held a macro registered the macro's
+    /// **source** as its reference text (`[[x]]image:a.png[]Term` registered
+    /// `image:a.png[]Term`); the fold of the same nodes gives the rendering
+    /// instead, which is what every other reference text on this branch is.
+    ///
+    /// Being the tree's **first** node is the whole of "at the start of the
+    /// term": that is what the regex's `^` anchor said, and the two agree
+    /// because a term's own source begins at its first non-space character.
+    /// There is deliberately no second test of the node's byte offset, and no
+    /// [`is_bibliography`](crate::inlines::Anchor) check either — a
+    /// bibliography anchor registers under its own
+    /// [`RefType`] from its own earlier pass, but it cannot lead a term in the
+    /// first place, since a bibliography list item's principal text is never
+    /// parsed as one. Both would be branches no input can take.
+    fn register_term_leading_anchor<'src>(
+        tree: &[crate::inlines::InlineNode<'src>],
+        parser: &Parser,
+        content: &Content<'src>,
+        warnings: &mut Vec<crate::warnings::Warning<'src>>,
+    ) -> bool {
+        use crate::inlines::InlineNode;
+
+        let Some(InlineNode::Anchor(anchor)) = tree.first() else {
+            return false;
+        };
+
+        let reftext = match &anchor.reftext {
+            Some(reftext) => Some(crate::content::inline_builder::fold_html(
+                reftext,
+                parser.renderer.as_ref(),
+                &parser.render_context(),
+            )),
+
+            None => {
+                let rest = crate::content::inline_builder::fold_html(
+                    tree.get(1..).unwrap_or_default(),
+                    parser.renderer.as_ref(),
+                    &parser.render_context(),
+                );
+
+                Some(rest.trim().to_string())
+            }
+        };
+
+        if parser
+            .register_ref(&anchor.id, reftext.as_deref(), RefType::Anchor)
+            .is_err()
+        {
+            warnings.push(crate::warnings::Warning::new(
+                content.original(),
+                WarningType::DuplicateId(anchor.id.to_string()),
+            ));
+        }
+
+        true
     }
 
     /// Runs **only** the string pipeline over `content` — no inline tree, no

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2591,6 +2591,146 @@ fn footnote_xref_mirror_leaves_a_block_level_reference_alone() {
     assert_eq!(resolved_href_in(content.inlines()), None);
 }
 
+#[test]
+fn a_description_list_term_carries_an_inline_tree() {
+    // A description-list term used to run the substitution steps directly,
+    // which left it the one content with no tree at all — and, with the
+    // recognition side effects now replayed from the tree, the last content
+    // still registering from the string pipeline. It runs through
+    // `SubstitutionGroup::apply_to_description_list_term` now, so it has both.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[cpu]]*CPU*:: The brain of the computer.");
+
+    let tree = description_term_tree(&doc);
+
+    assert!(
+        matches!(tree.first(), Some(InlineNode::Anchor(anchor)) if anchor.id.as_ref() == "cpu"),
+        "expected the term's leading anchor as a node: {tree:?}"
+    );
+
+    assert!(
+        matches!(tree.get(1), Some(InlineNode::Styled(_))),
+        "expected the term's formatting span as a node: {tree:?}"
+    );
+}
+
+#[test]
+fn a_term_registers_its_leading_anchor_from_the_tree() {
+    // The term's own rule — a leading `[[id]]` takes the **rest of the term**
+    // as its default reference text — now runs from the tree, between the
+    // build and the replay (see
+    // `SubstitutionGroup::apply_to_description_list_term`). An explicit
+    // `[[id,reftext]]` still wins over the default.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[cpu]]CPU:: The brain.\n\n[[gpu,Graphics]]GPU:: The other one.");
+
+    assert_eq!(
+        doc.catalog().get_ref("cpu").unwrap().reftext.as_deref(),
+        Some("CPU")
+    );
+
+    assert_eq!(
+        doc.catalog().get_ref("gpu").unwrap().reftext.as_deref(),
+        Some("Graphics")
+    );
+}
+
+#[test]
+fn a_terms_default_reftext_is_the_rendering_of_the_rest() {
+    // The one deliberate difference reading that rule off the tree makes. The
+    // regex it replaces ran *before* the macros step, so a term whose
+    // remainder held a macro registered the macro's **source** as the
+    // reference text; the fold of the same nodes gives the rendering, which is
+    // what every other reference text on this branch is.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[x]]image:a.png[]Term:: d");
+
+    assert_eq!(
+        doc.catalog().get_ref("x").unwrap().reftext.as_deref(),
+        Some(r#"<span class="image"><img src="a.png" alt="a"></span>Term"#)
+    );
+}
+
+#[test]
+fn a_term_performs_each_recognition_side_effect_exactly_once() {
+    // What the replay has to get right for a term specifically: the string
+    // pipeline's own registrations are suppressed for the term's pass now, so
+    // a construct that registers must be recorded once by the replay — not
+    // twice, and not zero times.
+    let mut parser = Parser::default().with_catalog_assets(true);
+    let doc = parser.parse("image:a.png[]Term:: https://example.org[Link]");
+
+    let catalog = doc.catalog();
+
+    assert_eq!(
+        catalog
+            .images
+            .iter()
+            .map(|i| i.target.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a.png"]
+    );
+
+    // The description (not the term) carries the link, which registers through
+    // the ordinary content path — so the two halves of the item agree.
+    assert_eq!(
+        catalog.links.iter().map(|l| l.as_str()).collect::<Vec<_>>(),
+        vec!["https://example.org"]
+    );
+}
+
+#[test]
+fn a_terms_default_reftext_folds_before_nested_references_resolve() {
+    // A term's leading anchor is registered while the term is *parsed*, which
+    // is what lets a later cross-reference resolve it at all — and that is
+    // before any cross-reference *inside* the term has a destination. So a
+    // `<<b>>` in the term contributes its **unresolved fallback** to the
+    // catalogued reference text, and keeps it: the entry is never revisited.
+    //
+    // This is a limitation of registering at parse time, not of reading the
+    // reftext from the tree, and the tree is the better of the two readings.
+    // The regex this increment replaced ran before the macros step, so it
+    // caught the reference as escaped *source* (`See &lt;&lt;b&gt;&gt;`) —
+    // never a link at all. Both are unchanged by whether the target is
+    // defined before or after the term.
+    for source in [
+        "[[a]]See <<b>>:: d\n\n[[b]]Target:: e\n\nRef: <<a>>.",
+        "[[b]]Target:: e\n\n[[a]]See <<b>>:: d\n\nRef: <<a>>.",
+    ] {
+        let mut parser = Parser::default();
+        let doc = parser.parse(source);
+
+        assert_eq!(
+            doc.catalog().get_ref("a").unwrap().reftext.as_deref(),
+            Some(r##"See <a href="#b">[b]</a>"##),
+            "the term's catalogued reftext regressed for {source:?}"
+        );
+
+        let rendered = collect_rendered(&doc);
+        assert!(
+            rendered
+                .iter()
+                .any(|s| s.contains(r##"<a href="#a">See [b]</a>"##)),
+            "the reference to the term regressed: {rendered:?}"
+        );
+    }
+}
+
+/// The inline tree of the first description-list term in `doc`.
+fn description_term_tree<'a>(doc: &'a crate::Document<'a>) -> Vec<InlineNode<'a>> {
+    use crate::blocks::{Block, FindBlocks, ListItemMarker};
+
+    for block in doc.descendant_blocks() {
+        if let Block::ListItem(item) = block
+            && let ListItemMarker::DefinedTerm { term, .. } = item.list_item_marker()
+        {
+            return term.inlines().to_vec();
+        }
+    }
+
+    panic!("no description-list term in the document");
+}
+
 /// One resolved destination, for the footnote-embedded list.
 fn fixed_destination() -> Vec<Option<crate::parser::ResolvedReference>> {
     vec![Some(crate::parser::ResolvedReference::new(


### PR DESCRIPTION
## What

#1280 measured what still registered outside the tree by widening its suppression window to a whole parse and counting the failures: **161**, of which the second cause was

> the description-list **term** carve-out, the last thing still registering from the string pipeline.

This is that carve-out.

A term ran the substitution steps **directly** — `Passthroughs::extract_from`, five `SubstitutionStep::apply` calls, `restore_to`, `finalize_deferred` — a hand copy of `run_pipeline`'s body written before there was a tree to build. So a term had no tree, its rendering was the string pipeline's rather than a fold, and its constructs registered from the replacers.

It runs through `SubstitutionGroup::apply` now, under a group spelled out for it: the `normal` order **minus its attribute-references step**, which already ran during *parsing* so the `::` marker could be recognized at all. The seed, the authoritative fold, the suppression window and the replay all come with that.

## The one rule that had to move

A leading inline anchor in a term takes the **rest of the term** as its default reference text:

```asciidoc
[[cpu]]CPU:: The brain of the computer.
```

registers `cpu` with reftext `CPU`, so a cross-reference to it displays *CPU*. That is a fact about where the anchor sits in a *term*, not about the node, so it cannot live in `apply_ref_side_effects`.

It runs from the same tree instead, at the one point where the tree exists and nothing has registered from it yet: **between the build and the replay** (`SubstitutionGroup::apply_to_description_list_term`). The replay is then told the anchor is already registered — which is what `leading_anchor_registered`, the parameter #1280 staged and every caller passed `false`, has been waiting for.

## One deliberate difference

The regex it replaces ran *before* the macros step, so a term whose remainder held a macro registered the macro's **source**. For `[[x]]image:a.png[]Term:: d`:

```
before:  image:a.png[]Term
now:     <span class="image">``&lt;img src="a.png" alt="a"&gt;``</span>Term
```

The fold of the same nodes gives the rendering, which is what every other reference text on this branch is.

## What this deletes

`LEADING_INLINE_ANCHOR`, `apply_macros_with_leading_anchor_registered`, and `InlineAnchorReplacer`'s own `leading_anchor_registered` field and the check it guarded. The string replacers' *registrations* stay — deleting those is what happens when `run_pipeline` leaves the production path — but nothing passes `true` through them any more, so the branch that read it was dead.

The new helper also has no byte-offset test and no `is_bibliography` check: being the tree's **first** node is the whole of "at the start of the term", and a bibliography anchor cannot lead a term (a bibliography list item's principal text is never parsed as one). Both would be branches no input can take — the same call sibling code in `inline_builder/` makes.

## Tests

- `a_description_list_term_carries_an_inline_tree` — the term has nodes at all (an `Anchor`, then a `Styled`).
- `a_term_registers_its_leading_anchor_from_the_tree` — the default reftext and the explicit `[[id,reftext]]` override.
- `a_terms_default_reftext_is_the_rendering_of_the_rest` — the deliberate difference above.
- `a_term_performs_each_recognition_side_effect_exactly_once` — the property the suppression window newly puts at risk for a term.

Both halves are falsifiable: dropping the term's leading-anchor registration fails **5** tests (3 existing + 2 new); passing `false` for the flag while still registering fails **2** (a doubled duplicate-id warning).

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace --all-features` green (5,450 + 6)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage **diff-neutral** on all four changed source files (`substitution_group.rs` 0 missed, `list_item_marker.rs` 59, `macros.rs` 2, `anchors.rs` 32 — unchanged either side).
- **Fold-parity audit**: 49 rows either side, **0 new, 0 closed**. A term now goes through the same fold every other content does, and reproduces the string pipeline's own bytes for every term in the suite.

Design doc: new "*Step 6 landed as (a description-list term joins the tree — the last content registering from the string pipeline)*" narrative plus its §5.2 checklist entry.