### PR TITLE
feat: An attribute slot keeps its fold-time markup (inline-ast step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6629,6 +6629,80 @@ Each phase is a reviewable unit with a clear exit gate.
   bytes for every term in the suite. Coverage is diff-neutral on all four changed files. Both halves
   are falsifiable: dropping the term's leading-anchor registration fails five tests, and passing
   `false` for the flag while still registering fails two (a doubled duplicate-id warning).
+
+  *Step 6 landed as (a computed attribute slot keeps its fold-time markup, made inert where it
+  lands):* the increment above answered the string-slot question for the cross-reference family and
+  said in the same breath that the image and link families were **not** the mechanical follow-on
+  they looked like — applying the same rule there moves
+  `image:pause.png[title=*Pause* and Resume]`, a fixture from the AsciiDoc language docs, from
+  `title="<strong>Pause</strong> and Resume"` to `title="*Pause* and Resume"`. Three readings were
+  available and the third, `title="Pause and Resume"` (the span's plain text, the only one an HTML
+  `title` can actually show), belonged to neither system. The decision is the first: **the title
+  example goes on working as it does today**, with the security concern that made the
+  cross-reference rule attractive answered on its own terms rather than by giving up the formatting.
+
+  The two families were not in the same place, which is what made this one increment rather than
+  two. The **image** family already froze a rendered span's markup into its bracket — it had to,
+  since every value an image holds is one `render_image` writes out, so the alternative deferred
+  every such bracket and the language-docs fixture lost its whole macro (the increment that closed
+  the cutover's last-but-one golden regression). The **link** families drew the opposite rule for
+  the same bytes: `text_attrlist` admitted a rendered span in the display text, which becomes the
+  node's children, and refused the whole match when a token reached any other slot
+  (`rendered_token_escaped_the_display_text`), so `link:index.html[Docs,role=*hl*]`,
+  `title=*Pause*`, `window=*x*` and `id=*x*` were all left **literal** — not a different rendering
+  of the macro but no macro at all, where the string pipeline builds one. That gate is deleted, so
+  the three `Attrlist`-bearing families now share the image bracket's rule and the same
+  `tokened_split_agrees` check remains the only thing a rendered piece must satisfy.
+
+  What makes the frozen bytes the *right* bytes is that they are the string replacer's own: it
+  parses its attribute list out of a haystack the quotes step has already rendered with this same
+  renderer, so `title="<strong>Pause</strong> and Resume"` is what it writes too. The cost is the
+  one the image family already carries and every frozen value on this branch owes — a *later* fold
+  through a different renderer would see the parse-time renderer's markup there — and §4.6 is
+  where a fold-**materialized** attribute value belongs. Until then this is parity, and it is now
+  uniform across the families rather than one of them being an exception.
+
+  The security half is what the decision asks for, and it is a real gap rather than a restatement.
+  A value reaching an attribute is escaped for the `"` delimiter *where it lands* — that is the
+  policy `render_image`, `render_icon`, and `render_xref` already state in so many words — and
+  `render_link` and `render_icon_or_image` left three out of it: a link's `id`, the `class` both
+  of them join their roles into, and the `target` a `window=` writes. Each is reachable today,
+  with no tree involved:
+  `link:x[Docs,role=+++a"b+++]` renders `class="a"b"` and injects whatever follows. They take
+  `encode_attribute_value` now, like the `href` and `title` beside them. That is what separates
+  this reading from the string pipeline's: escaping at render time is inert for markup an author
+  wrote (`<strong>` carries no quote, so the formatting survives untouched) and fatal to a
+  breakout — while the string pipeline splices a passthrough's body into the *finished* string
+  after every escape has run, which is asciidoctor#2661 and which the tree goes on not
+  reproducing. `a_rendered_slot_cannot_break_out_of_its_attribute` pins the pair.
+
+  Audit: **36** rows either side, 0 new and 0 closed. (The count is not comparable with the
+  earlier increments' because the sweep itself had to change: `rendered` *is* the fold now, so
+  comparing the fold against it answers nothing. It captures the string pipeline's own answer
+  where `apply` still has it — after `run_pipeline`, before the fold overwrites it — and
+  compares there instead, which also means a deferred cross-reference's content, folded later, no
+  longer contributes.) No golden source in the suite writes a rendered span into a link's
+  attribute list, which is why the class survived this long, and none writes a `"` into one of the
+  three newly-escaped slots. Falsifiability comes from the corpora instead: two rows join the
+  side-effect sweep, and they fail on base for a reason worth naming — a deferred macro is not
+  merely rendered literally, it also **registers nothing**, so
+  `link:https://example.org[Docs,role=*hl*]` was missing from `Document::catalog()` where the
+  string pipeline records it. The divergence test that pinned the old per-slot deferral is now a
+  parity corpus of ten fixtures, with the split-disagreement half kept as its own test.
+  Coverage is diff-neutral on all changed files.
+
+  *What this leaves:* the cross-reference family keeps the previous increment's rule rather than
+  joining this one, and the two are consistent because their string paths are: a deferred
+  cross-reference's template is captured **before** passthroughs are restored, so the string
+  pipeline leaks a `\u{96}0\u{97}` sentinel into `class=` and escapes a rendered span into
+  `class="&lt;strong&gt;hl&lt;/strong&gt;"` — there is no output there worth matching, so the
+  author's source is the better answer, while here there is one and it is Asciidoctor's. What still
+  defers in the link families is the split disagreement (`link:index.html[a *b, c* d,role=hl]`, the
+  markup-perturbed reading against the well-formed one) and a `mailto:`'s pre-restore subject and
+  body. `render_anchor`'s own `id`, and an inline SVG's rewritten `width`/`height`, still
+  interpolate unescaped; neither is reachable from this class (an anchor id admits no span, and an
+  inline SVG has no attribute list a span survives into), so both are left where they are.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -7993,6 +8067,27 @@ Each phase is a reviewable unit with a clear exit gate.
        `apply_macros_with_leading_anchor_registered` and `InlineAnchorReplacer`'s own flag go with
        it. Audit: 49 rows either side, 0 new, 0 closed; coverage diff-neutral on all four files.
        See the step's own "landed as" note above.
+
+     - ✅ **a computed attribute slot keeps its fold-time markup, made inert where it lands.** The
+       question the increment above left open and named as needing a decision of its own: whether
+       the image and link families' computed **string** slots should take the author's untranslated
+       source, as the cross-reference family's now do. They should not — that moves
+       `image:pause.png[title=*Pause* and Resume]`, an AsciiDoc-language-docs fixture, off the
+       answer both this crate and Asciidoctor give — so the two families keep the *fold-time*
+       markup, and the security property the source rule bought is obtained where it actually
+       belongs, at the attribute the value lands in. The **image** family already froze such a span
+       into its bracket; the **link** families deferred the whole macro whenever a token reached a
+       slot `render_link` writes out, leaving `link:index.html[Docs,role=*hl*]` literal and its
+       target unregistered. `rendered_token_escaped_the_display_text` is deleted, so the three
+       [`Attrlist`](../../parser/src/attributes/attrlist.rs)-bearing families share one rule and
+       [`tokened_split_agrees`](../../parser/src/content/inline_builder/macros/mod.rs) is the only
+       thing a rendered piece must still satisfy. The safety half closes a real gap in the policy
+       `render_image`/`render_icon`/`render_xref` already state: a link's `id` and `class` and the
+       `target` a `window=` writes took no `encode_attribute_value`, so
+       `link:x[Docs,role=+++a"b+++]` renders `class="a"b"` and injects what follows — reachable
+       today with no tree involved. Audit: 36 rows either side, 0 new, 0 closed (the sweep itself
+       had to be re-derived, `rendered` being the fold now); coverage diff-neutral on all changed
+       files. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -887,26 +887,32 @@ fn masked_default_alt(
 /// splices into the string pipeline's own finished string, so restoring one
 /// into a parsed value is faithful wherever that value goes.
 ///
-/// A **rendered span** is admitted too, and this is the one family where that
-/// is both necessary and safe.
+/// A **rendered span** is admitted too, and this is where that rule was first
+/// drawn; [`text_attrlist`](super::links) now draws the same one, so the three
+/// [`Attrlist`]-bearing families agree.
 ///
 /// *Necessary*, because it is the only way an image reaches parity at all.
 /// Every value an image's bracket holds is one `render_image` writes out — an
-/// `alt`, a `title`, a `width` — so the per-slot rule the link families draw
-/// ([`rendered_token_escaped_the_display_text`](super::links)) would defer
-/// *every* such bracket, and `image:pause.png[title=*Pause* and Resume]` (a
-/// fixture from the AsciiDoc language docs) would lose its whole macro. A link
-/// has somewhere else to put a rendered span — its display text becomes the
-/// node's children — and an image has no display text at all.
+/// `alt`, a `title`, a `width` — so a rule refusing a token in such a slot
+/// would defer *every* such bracket, and
+/// `image:pause.png[title=*Pause* and Resume]` (a fixture from the AsciiDoc
+/// language docs) would lose its whole macro. The link families had somewhere
+/// else to put a rendered span — a display text becomes the node's children —
+/// and drew that per-slot rule for a while; it cost them the same macro for
+/// `link:index.html[Docs,title=*Pause*]`, so they dropped it.
 ///
-/// *Safe*, because the frozen bytes are the bytes. The string replacer reads
-/// its own bracket out of a haystack the quotes step has already rendered
-/// **with this same renderer**, so `title="<strong>Pause</strong> and Resume"`
-/// is what it writes too; freezing the span's build-time fold here reproduces
-/// that exactly rather than approximating it. It is also the same trade this
-/// very function's masked branch already makes for a
-/// [`Stem`](crate::inlines::Stem), whose "body" is likewise a build-time fold
-/// ([`restorable_body`]).
+/// *Safe*, in two senses. The frozen bytes are the bytes: the string replacer
+/// reads its own bracket out of a haystack the quotes step has already
+/// rendered **with this same renderer**, so
+/// `title="<strong>Pause</strong> and Resume"` is what it writes too, and
+/// freezing the span's build-time fold here reproduces that exactly rather
+/// than approximating it. It is the same trade this very function's masked
+/// branch already makes for a [`Stem`](crate::inlines::Stem), whose "body" is
+/// likewise a build-time fold ([`restorable_body`]). And the markup cannot
+/// escape the attribute it is carried into: every value the image, icon and
+/// link renderers interpolate is escaped for the `"` delimiter where it lands
+/// (`encode_attribute_value`), so a span rendering a quote of its own —
+/// `[.r"z]#b#` — closes nothing.
 ///
 /// What a frozen value cannot survive is being folded again through a
 /// *different* renderer — [`render_with`](crate::Parser) (design §3.3.1,
@@ -1021,24 +1027,18 @@ pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
 
     /// What the token restores to: exactly what the fold of
     /// [`node`](Self::node) emits (see [`restorable_body`]).
-    pub(in crate::content::inline_builder) body: Cow<'a, str>,
-
-    /// Whether this piece is markup the **fold** writes rather than a *masked*
-    /// construct whose body the string pipeline itself splices.
     ///
-    /// The distinction is what a caller admitting both has to act on. A masked
-    /// construct's body is known at build time in the same sense the string
-    /// pipeline knows it — `Passthroughs::restore_to` splices exactly these
-    /// bytes into its own finished string — so restoring it into a parsed
-    /// value is faithful wherever that value goes. A *rendered* piece's markup
-    /// is a function of the renderer, and [`body`](Self::body) freezes it with
-    /// the parser's own; that is right for a value nothing emits (it is what
-    /// the string replacer's own attribute list holds there) and wrong for one
-    /// a renderer writes out, since a custom backend would then see the
-    /// built-in backend's markup. A caller admitting these must therefore
-    /// carry the value **structurally** and refuse a match whose token reached
-    /// a slot the fold reads — see [`text_attrlist`](super::links).
-    pub(in crate::content::inline_builder) rendered: bool,
+    /// For a *masked* construct those bytes are known at build time in the
+    /// same sense the string pipeline knows them —
+    /// `Passthroughs::restore_to` splices exactly these into its own finished
+    /// string. For a **rendered** piece (admitted under
+    /// [`Tokened::MaskedOrRendered`]) they are the build-time fold with the
+    /// parser's own renderer, which is what the string replacer's
+    /// already-rendered haystack holds there; freezing them is what lets a
+    /// slot a renderer writes out carry markup the author wrote, at the cost
+    /// of a *later* fold with some other renderer seeing the parse-time
+    /// renderer's bytes in that slot.
+    pub(in crate::content::inline_builder) body: Cow<'a, str>,
 }
 
 /// Which pieces [`tokened_bracket`] gives a token to.
@@ -1050,9 +1050,11 @@ pub(in crate::content::inline_builder) enum Tokened {
     Masked,
 
     /// Also any other **opaque** piece: a rendered span, an
-    /// earlier-recognized macro node. Its body is the build-time fold, which
-    /// only a caller that carries the value structurally and refuses a token
-    /// in a slot the fold reads may use (see [`MaskedPiece::rendered`]).
+    /// earlier-recognized macro node. Its body is the build-time **fold** with
+    /// the parser's own renderer — the bytes the string replacer reads out of
+    /// its own already-rendered haystack there — which is what lets a value
+    /// carry markup an author wrote into a slot a renderer writes out (see
+    /// [`MaskedPiece::body`]).
     MaskedOrRendered,
 }
 
@@ -1128,11 +1130,7 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
             .flatten()
             .and_then(|node| {
                 if let Some(body) = restorable_body(node, renderer) {
-                    return Some(MaskedPiece {
-                        node,
-                        body,
-                        rendered: false,
-                    });
+                    return Some(MaskedPiece { node, body });
                 }
 
                 if admits == Tokened::Masked || charref_entity(node).is_some() {
@@ -1146,7 +1144,6 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
                         renderer,
                         &parser.render_context(),
                     )),
-                    rendered: true,
                 })
             });
 
@@ -1882,8 +1879,7 @@ mod tests {
         // The boundary this family used to keep, now lifted for the half that
         // could not survive it: an image's **bracket** crossing a rendered
         // span. See [`bracket_is_recognizable`] for why a frozen span is both
-        // necessary and safe here where it is neither for a link's other
-        // slots.
+        // necessary and safe — the rule the link families now share.
         for source in [
             // The fixture from the AsciiDoc language docs that named this.
             "Click image:pause.png[title=*Pause* and Resume] when you need a break.",

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -7,10 +7,7 @@
 use super::computed_value_children;
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind,
-    image::{
-        MaskedPiece, Tokened, range_is_restorable, range_is_verbatim, restorable_body,
-        tokened_bracket,
-    },
+    image::{Tokened, range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
     macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
 };
 use crate::{
@@ -115,14 +112,13 @@ use crate::{
 /// with it a **bare** link's shown text (a slice of the target's own range)
 /// and the `<url>` form's whole interior (see [`build_angle_link_node`]). An
 /// **attribute-list text** is computed too — its display text comes back from
-/// an [`Attrlist`] parse rather than from a range — so [`text_attrlist`] keeps
-/// the same gate there for a *rendered* span, whose bytes exist only at fold
-/// time: a placeholder inside a parsed value has no node it can be mapped back
-/// to. A **masked** construct is the one such piece that does, its body being
-/// known at build time: [`text_attrlist`] tokens it through the parse and
-/// splices the node back into the children afterwards
-/// ([`restored_value_children`]). This is the third family to take that lift,
-/// after the cross-reference one (`xref::find_xref_matches`) and the
+/// an [`Attrlist`] parse rather than from a range — so [`text_attrlist`] gives
+/// every opaque piece there an index-keyed token instead: a **masked**
+/// construct, whose body is known at build time, and a **rendered** span,
+/// whose markup is its build-time fold. Each token comes back as the node
+/// itself in the display text ([`restored_value_children`]) and as those bytes
+/// in a slot the renderer writes out. This is the third family to take that
+/// lift, after the cross-reference one (`xref::find_xref_matches`) and the
 /// `link:`/`mailto:` macro ([`find_link_macro_matches`]).
 ///
 /// What the admission cannot do is make the *recognition* agree in every case,
@@ -374,10 +370,11 @@ fn build_inline_link_node<'src>(
     // admitted — see [`inline_link_level`]'s own rendered-span note. Its
     // closing `]` needs no gate of its own: that byte is literal, and no atomic
     // piece — a placeholder, or an entity delimited by `&` and `;` — can supply
-    // it. (A text carrying an attribute list has its own gate inside
+    // it. (A text carrying an attribute list is handled inside
     // `text_attrlist`, since its display text comes back from a *parse*
-    // rather than from a range: a masked construct is tokened through that
-    // parse and restored after it, a rendered span still deferred.)
+    // rather than from a range: every opaque piece is tokened through that
+    // parse, and each token is restored afterwards as the node itself in the
+    // display text or as its bytes in a slot the renderer writes out.)
     //
     // An expanded attribute value and an escaped special are admitted
     // throughout, since every value read here comes off the match string —
@@ -918,14 +915,14 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// piece's own node whole into them — so the text is carried *structurally*,
 /// and the fold re-renders exactly the markup the string replacer captured
 /// there. The **target** stays gated, since it is a value this pass computes
-/// off the match string. So does an **attribute-list text**, for the same
-/// reason: its display text comes back from an [`Attrlist`] parse rather than
-/// from a range, and a placeholder inside a *parsed* value has no node it can
-/// be mapped back to — unless it stands for a **masked** construct, whose body
-/// is known at build time, which [`text_attrlist`] tokens through the parse and
-/// splices back into the children afterwards ([`restored_value_children`]).
-/// This is the second family to take that lift, after the cross-reference one
-/// (see `xref::find_xref_matches`).
+/// off the match string. An **attribute-list text** takes a different route
+/// again: its display text comes back from an [`Attrlist`] parse rather than
+/// from a range, so [`text_attrlist`] gives every opaque piece there an
+/// index-keyed token before the parse and restores each afterwards — as the
+/// node itself in the display text ([`restored_value_children`]), and as its
+/// bytes (a masked body, or a rendered span's build-time fold) in a slot the
+/// renderer writes out. This is the second family to take that lift, after the
+/// cross-reference one (see `xref::find_xref_matches`).
 ///
 /// What the admission cannot do is make the *recognition* agree in every case,
 /// because the string replacer matches over the markup itself where this
@@ -1055,10 +1052,9 @@ fn find_link_macro_matches<'src>(
         // having it re-derived from `location` — so a *wholly* expanded macro
         // (`:m: link:index.html[Docs]`, then `{m}`) is recognized, with only
         // its `location` taking design §4.4's coarse span. A text carrying an
-        // attribute list has its own gate inside `text_attrlist`, since its
-        // display text comes back from a *parse*: a masked construct is
-        // tokened through that parse and restored after it, a rendered span
-        // still deferred.
+        // attribute list is handled inside `text_attrlist`, since its display
+        // text comes back from a *parse*: every opaque piece is tokened
+        // through that parse and restored after it.
         if let Some(target) = caps.get(3)
             && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
@@ -1544,40 +1540,6 @@ struct TextAttrlist<'src> {
     restores: Vec<InlineNode<'src>>,
 }
 
-/// Whether any [`rendered`](MaskedPiece::rendered) piece's token came back
-/// from the parse in a slot other than the **first positional** attribute —
-/// the one slot [`text_attrlist`]'s caller carries structurally.
-///
-/// Every other slot is a value `render_link` writes out (an `id`, a `title`,
-/// a `role`, a `window`, an option), where a body frozen with the parser's own
-/// renderer would put the built-in backend's markup in a custom backend's
-/// output. A *masked* piece is exempt: its body is what the string pipeline
-/// itself splices, so it is faithful wherever it lands.
-fn rendered_token_escaped_the_display_text(
-    attrs: &Attrlist<'_>,
-    masked: &[MaskedPiece<'_, '_>],
-) -> bool {
-    let rendered: Vec<String> = masked
-        .iter()
-        .enumerate()
-        .filter(|(_, piece)| piece.rendered)
-        .map(|(n, _)| format!("\u{96}{n}\u{97}"))
-        .collect();
-
-    attrs.attributes().enumerate().any(|(index, attribute)| {
-        // `attributes()` yields every attribute in order, so index 0 is the
-        // first positional one whenever the list has any positional attribute
-        // at all; a named attribute there is not a display text and is checked
-        // like the rest.
-        let is_display_text = index == 0 && attribute.name().is_none();
-
-        !is_display_text
-            && rendered
-                .iter()
-                .any(|token| attribute.value().contains(token.as_str()))
-    })
-}
-
 /// Parses a link's bracketed **display text** as the [`Attrlist`]`<'src>` its
 /// node carries, mirroring what the string replacers parse: a
 /// newline-normalized copy of the (pre-`\]`-unescape) bracketed text, joined
@@ -1623,6 +1585,30 @@ fn rendered_token_escaped_the_display_text(
 /// [`restored_value_children`]) rather than as bytes the fold would escape a
 /// second time.
 ///
+/// A **rendered** piece — a span the quotes step made, an
+/// earlier-recognized macro node — is admitted the same way, in every slot,
+/// and its token's body is the *build-time fold* with the parser's own
+/// renderer ([`MaskedPiece`](super::image::MaskedPiece)). Those are the bytes
+/// the string replacer reads out of its own already-rendered haystack there, so
+/// a slot `render_link` writes out reproduces the string pipeline's answer
+/// (`link:x[Docs,title=*Pause*]` keeps its `<strong>`), which is the whole
+/// point: a frozen body is what makes the markup an author wrote survive into
+/// the attribute. Freezing costs one thing — a *later* fold with some other
+/// renderer sees the parse-time renderer's markup in those slots — and that is
+/// the same trade the image family's bracket makes for every value it holds
+/// ([`bracket_attrlist`](super::image)), so the three
+/// [`Attrlist`]-bearing families now agree on it. It is safe because a value
+/// reaching an attribute is escaped for the `"` delimiter where it lands
+/// (`encode_attribute_value`, applied by `render_link` to every slot it
+/// writes), so markup carried into a `title`/`class`/`id`/`target` cannot
+/// close the attribute it sits in — the guarantee the string pipeline cannot
+/// make, since it splices a passthrough's body into the *finished* string
+/// after every escape has run (asciidoctor#2661).
+///
+/// The **display text** is exempt from the freeze rather than from the escape:
+/// it becomes the node's children, so the fold renders each piece itself,
+/// with whatever renderer the fold is running.
+///
 /// `pre_restore` names the positional slots whose value the caller reads
 /// **before** that restore, and a token reaching one of them defers the whole
 /// match. There is exactly one such caller: a `mailto:`'s comma list, whose
@@ -1636,14 +1622,9 @@ fn rendered_token_escaped_the_display_text(
 /// rather than per family so that a masked piece in the display text beside a
 /// plain subject still restores.
 ///
-/// Returns `None` — the one shape still deferred outright — when the text
-/// crosses an **opaque** piece (a rendered span, an earlier-recognized macro
-/// node). That is not a bytes problem the match string can solve:
-/// [`build_match_string`] stands such a piece in as one [`SPAN_PLACEHOLDER`]
-/// where the string replacer's haystack holds its markup, and — unlike a
-/// masked construct, whose body is known at build time — its bytes exist only
-/// at fold time, so there is nothing to token (see [`link_macro_level`]'s own
-/// rendered-span note).
+/// Returns `None` for those two shapes alone: a `pre_restore` slot holding a
+/// token, and a list whose two parses disagree about the match's own extent
+/// ([`tokened_split_agrees`]).
 fn text_attrlist<'src>(
     raw_text: &str,
     text_range: std::ops::Range<usize>,
@@ -1683,27 +1664,14 @@ fn text_attrlist<'src>(
 
     let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
 
-    // Two things have to hold before a token may stand for a **rendered**
-    // piece, and they are independent.
-    //
-    // First the *split* must land where the string replacer's own parse of the
+    // One thing has to hold before a token may stand for a **rendered** piece:
+    // the *split* must land where the string replacer's own parse of the
     // markup lands. A token carries none of the `,` / `=` / `"` the split
     // reads, and the replacer's markup may (`link:x[a *b, c* d,role=hl]`), so
     // the two are compared parse against parse — see [`tokened_split_agrees`].
-    //
-    // Then the value must be one nothing emits. A rendered piece's body is
-    // frozen with the parser's own renderer (see [`MaskedPiece::rendered`]),
-    // which is faithful for the display text — it becomes the node's children,
-    // carrying each piece's own node — and wrong for every other slot, each of
-    // which `render_link` writes out. This is the same per-**slot** boundary
-    // `pre_restore` below draws.
     let carried: Vec<InlineNode<'src>> = masked.iter().map(|piece| piece.node.clone()).collect();
 
     if !tokened_split_agrees(&tokened, &carried, parser) {
-        return None;
-    }
-
-    if rendered_token_escaped_the_display_text(&attrs, &masked) {
         return None;
     }
 
@@ -5185,24 +5153,86 @@ mod tests {
     }
 
     #[test]
-    fn a_span_in_a_rendered_attribute_defers_the_match() {
-        // The boundary this does *not* move, drawn per **slot**. A rendered
-        // piece's body is frozen with the parser's own renderer, which is
-        // faithful only for a value nothing emits — the display text, which
-        // becomes the node's children and carries each piece's own node. Every
-        // other slot is one `render_link` writes out, where the frozen markup
-        // would be the built-in backend's in a custom backend's output, so a
-        // span there defers the whole match. The split-agreement check is the
-        // other half, and defers for a different reason: see the fixtures
-        // below.
+    fn a_span_in_a_rendered_attribute_keeps_its_markup() {
+        // The boundary this family used to draw per **slot**, now gone. A
+        // rendered piece's body is the build-time fold with the parser's own
+        // renderer — the very bytes the string replacer reads out of its own
+        // already-rendered haystack — so a slot `render_link` writes out
+        // reproduces the string pipeline's answer rather than deferring the
+        // whole macro to literal text. This is the image family's own bracket
+        // rule (`bracket_attrlist`), which the three `Attrlist`-bearing
+        // families now share.
         for source in [
+            // The three shapes that used to defer, one per family.
             "link:index.html[x,role=*b*]",
             "link:index.html[x,title=*b*]",
             "https://example.org[x,role=*b*]",
-            // And the other half of the two checks: a span whose own markup
-            // carries a character the split reads, so the string replacer's
-            // list divides where the token cannot — the match's very extent
-            // differs, and it is deferred rather than recognized.
+            // Every other slot `render_link` writes out.
+            "link:index.html[x,id=*b*]",
+            "link:index.html[x,window=*b*]",
+            "link:index.html[x,opts=*b*]",
+            // The `mailto:` spelling, whose own comma list has slots of its
+            // own beside the named ones.
+            "mailto:a@example.org[x,title=*b*]",
+            // A span in a slot *and* in the display text at once — the two
+            // readings coexist: the text carries its node structurally, the
+            // slot takes the frozen bytes.
+            "link:index.html[*a*,role=*b*]",
+            // Other span kinds, and a span the slot only partly holds.
+            "link:index.html[x,title=`code` here]",
+            "link:index.html[x,title=a [.r]#b# c]",
+        ] {
+            assert_eq!(
+                fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
+                golden_macros(source),
+                "fold diverged from the string pipeline for {source:?}"
+            );
+
+            // Not vacuous: each fixture really is a link now, and the slot
+            // really does carry the span's markup.
+            let nodes = build_src(Span::new(source));
+
+            assert!(
+                nodes.iter().any(|n| matches!(n, InlineNode::Ref(_))),
+                "the match must be recognized: {nodes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_rendered_slot_cannot_break_out_of_its_attribute() {
+        // What makes carrying fold-time markup into a slot safe: the value is
+        // escaped for the `"` delimiter where it lands, so a span whose own
+        // markup carries a quote cannot close the attribute it sits in. The
+        // string pipeline reaches the same bytes here because it renders from
+        // the same values; what it cannot make inert is a *passthrough*, whose
+        // body it splices into the finished string after every escape has run
+        // (asciidoctor#2661) — the deliberate divergence its own test pins.
+        for (source, expected) in [
+            (
+                r#"link:index.html[x,title=[.r"z]#b#]"#,
+                r#"title="<span class=&quot;r&quot;z&quot;>b</span>""#,
+            ),
+            (
+                r#"link:index.html[x,role=[.r]#b#]"#,
+                r#"class="<span class=&quot;r&quot;>b</span>""#,
+            ),
+        ] {
+            let folded = fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {});
+
+            assert!(folded.contains(expected), "{source:?}: {folded:?}");
+            assert_eq!(folded, golden_macros(source), "{source:?}");
+        }
+    }
+
+    #[test]
+    fn a_span_whose_markup_splits_the_attribute_list_defers_the_match() {
+        // The other half of the two checks the rendered-piece token used to
+        // face, and the one that stays: a span whose own markup carries a
+        // character the split reads, so the string replacer's list divides
+        // where the token cannot. The match's very extent differs, so it is
+        // deferred rather than recognized — `tokened_split_agrees`.
+        for source in [
             "link:index.html[a *b, c* d,role=hl]",
             "https://example.org[a *b, c* d,role=hl]",
         ] {
@@ -5210,7 +5240,7 @@ mod tests {
 
             assert!(
                 nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "a span in a rendered attribute must stay literal: {nodes:?}"
+                "a split the two readings disagree on must stay literal: {nodes:?}"
             );
 
             // The string pipeline, by contrast, *does* build a link here.

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -1246,15 +1246,26 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             // handler), so escape the quote delimiter here — mirroring the
             // image `alt`/`title` handling.
             target = encode_attribute_value(params.target.clone()),
+            // The `id` and each role are author-supplied for the same reason
+            // the `target` is, and reach this attribute by the same route, so
+            // they take the same escape — as `render_xref`'s own roles and the
+            // icon branch's `class` fragments already do.
             id = if let Some(id) = id {
-                format!(r#" id="{id}""#)
+                format!(r#" id="{id}""#, id = encode_attribute_value(id.to_owned()))
             } else {
                 "".to_owned()
             },
             class = if roles.is_empty() {
                 "".to_owned()
             } else {
-                format!(r#" class="{roles}""#, roles = roles.join(" "))
+                format!(
+                    r#" class="{roles}""#,
+                    roles = roles
+                        .iter()
+                        .map(|role| encode_attribute_value((*role).to_owned()))
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                )
             },
             // Mirrors Asciidoctor's HTML5 converter: `title="#{node.attr 'title'}"`
             // is emitted (after the class) when the link carries a `title`
@@ -1604,7 +1615,19 @@ fn render_icon_or_image(
     roles.insert(0, type_);
 
     dest.push_str(r#"<span class=""#);
-    dest.push_str(&roles.join(" "));
+
+    // The wrapper's own `type_` is a literal, but every other role here — an
+    // attribute-list role, and a `float=` value — is author-supplied and takes
+    // the same quote escape the `href` above and the icon branch's own `class`
+    // fragments take.
+    dest.push_str(
+        &roles
+            .iter()
+            .map(|role| encode_attribute_value((*role).to_owned()))
+            .collect::<Vec<String>>()
+            .join(" "),
+    );
+
     dest.push_str(r#"">"#);
     dest.push_str(&img);
     dest.push_str("</span>");
@@ -1985,7 +2008,15 @@ fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&str>) -> Strin
             "".to_string()
         };
 
-        format!(r#" target="{window}"{rel_noopener}"#)
+        // The `window` is author-supplied (a `window=` attribute, or the `^`
+        // suffix's hard-coded `_blank`), so the quote delimiter is escaped
+        // here for the same reason the `href` and `title` escape it. The
+        // `_blank` comparison above reads the value as written, before the
+        // escape, so a `rel="noopener"` decision is unaffected.
+        format!(
+            r#" target="{window}"{rel_noopener}"#,
+            window = encode_attribute_value(window.to_owned())
+        )
     } else if let Some(rel) = rel {
         format!(r#" rel="{rel}""#)
     } else {

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -195,6 +195,11 @@ const CORPUS: &[&str] = &[
     "a https://example.org[] bare-macro link",
     "visit https://example.org/path?q=1 now",
     "link:https://example.org[Example,role=external,window=_blank]",
+    // A rendered span in a slot `render_link` writes out. Both spellings were
+    // left *literal* by the builder until the slot rule went, so neither
+    // registered its target where the string pipeline registers one.
+    "link:https://example.org[Docs,role=*hl*] and more",
+    "https://example.org[Docs,title=*Pause* and Resume] and more",
     //
     // Anchors and bibliography entries.
     "[[the-anchor]]Anchored paragraph.",

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -7,10 +7,10 @@
 //!
 //! Two properties are covered:
 //!
-//!   * every `href`/`target`, the icon `class`/`title`/`width`/`height`
-//!     attributes, and the quoted-text `class` (role) attribute escape the `"`
-//!     delimiter, so a stray quote cannot close the attribute and inject
-//!     further markup; and
+//!   * every `href`/`target`, the link `id`/`class`, the image and icon
+//!     `class`/`title`/`width`/`height` attributes, and the quoted-text `class`
+//!     (role) attribute escape the `"` delimiter, so a stray quote cannot close
+//!     the attribute and inject further markup; and
 //!   * the explicit `link:` macro rejects targets whose scheme could execute
 //!     script (`javascript:`, `data:`, `vbscript:`), rendering them as inert
 //!     source text rather than a live link.
@@ -105,6 +105,29 @@ fn link_target_preserves_single_escaped_ampersand_in_query() {
     assert_eq!(
         render_paragraph("link:/search?a=1&b=2[txt]"),
         r#"<a href="/search?a=1&amp;b=2">txt</a>"#
+    );
+}
+
+#[test]
+fn link_id_class_and_target_escape_quote_delimiter() {
+    // The `href` and `title` were escaped from the start; the `id`, each role
+    // joined into the `class`, and the `window`'s `target` reach the same
+    // attribute row by the same author-supplied route, so a `"` in any of them
+    // must be escaped rather than close the attribute it sits in.
+    assert_eq!(
+        render_paragraph(r#"link:x[txt,id='a"b',role='c"d',window='e"f']"#),
+        r#"<a href="x" id="a&quot;b" class="c&quot;d" target="e&quot;f">txt</a>"#
+    );
+}
+
+#[test]
+fn link_class_does_not_double_escape_special_characters() {
+    // `< > &` arrive already escaped from the special-characters step; the
+    // added quote-escaping must leave them singly escaped, as it does for the
+    // `href` above.
+    assert_eq!(
+        render_paragraph("link:x[txt,role='a<b&c']"),
+        r#"<a href="x" class="a&lt;b&amp;c">txt</a>"#
     );
 }
 
@@ -236,6 +259,18 @@ fn image_link_self_escapes_src_and_href_without_double_escaping() {
     assert_eq!(
         render_macros(r#"image:a"x.png[alt,link=self]"#),
         r#"<span class="image"><a class="image" href="a&quot;x.png"><img src="a&quot;x.png" alt="alt"></a></span>"#
+    );
+}
+
+#[test]
+fn image_wrapper_class_and_link_target_escape_quote_delimiter() {
+    // The `<span class="image …">` wrapper joins the author's own roles (and a
+    // `float=`) into a `class`, and a `link=` may carry a `window=` whose value
+    // becomes the anchor's `target`. Both are author-supplied and take the same
+    // quote escape the `href` beside them already takes.
+    assert_eq!(
+        render_macros(r#"image:x.png[alt,role='a"b',link=y,window='c"d']"#),
+        r#"<span class="image a&quot;b"><a class="image" href="y" target="c&quot;d"><img src="x.png" alt="alt"></a></span>"#
     );
 }
 


### PR DESCRIPTION
#1283 answered the computed-string-slot question for the cross-reference family and said in the same breath that the image and link families were **not** the mechanical follow-on they looked like: applying the same rule there moves `image:pause.png[title=*Pause* and Resume]` — an AsciiDoc language-docs fixture — from `title="<strong>Pause</strong> and Resume"` to `title="*Pause* and Resume"`, a parity break rather than a closed deferral. A third reading neither system offers (`title="Pause and Resume"`, the span's plain text) was on the table too.

**The decision: the title example keeps working as it does today**, with #1283's security concern answered where it belongs — at the attribute the value lands in — rather than by giving up the formatting.

## The two families were not in the same place

The **image** family already froze a rendered span's markup into its bracket. It had to: every value an image holds is one `render_image` writes out, so the alternative deferred *every* such bracket and the language-docs fixture lost its whole macro.

The **link** families drew the opposite rule for the same bytes. `text_attrlist` admitted a rendered span in the display text (which becomes the node's children) and refused the whole match when a token reached any other slot, so

```
link:index.html[Docs,role=*hl*]
link:index.html[Docs,title=*Pause* and Resume]
https://example.org[Docs,window=*x*]
```

were all left **literal** — not a different rendering of the macro but no macro at all, where the string pipeline builds one. And a deferred macro registers nothing, so the target was also missing from `Document::catalog()`.

`rendered_token_escaped_the_display_text` is deleted. The three `Attrlist`-bearing families now share the image bracket's rule, and `tokened_split_agrees` is the only thing a rendered piece must still satisfy.

## Why the frozen bytes are the right bytes

The string replacer parses its attribute list out of a haystack the quotes step has already rendered with this same renderer, so `title="<strong>Pause</strong> and Resume"` is what it writes too. The cost is the one the image family already carries and every frozen value on this branch owes — a *later* fold through a different renderer would see the parse-time renderer's markup there — and §4.6 is where a fold-**materialized** attribute value belongs. Until then this is parity, now uniform across the families rather than one of them being an exception.

## The security half

A value reaching an attribute is escaped for the `"` delimiter *where it lands* — the policy `render_image`, `render_icon` and `render_xref` already state in so many words. `render_link` and `render_icon_or_image` left three out of it: a link's `id`, the `class` both of them join their roles into, and the `target` a `window=` writes. Each is reachable today with no tree involved — `link:x[Docs,role=+++a"b+++]` emits a `class` attribute whose value is `a"b`, so the quote closes the attribute early and everything after it is parsed as fresh markup.

They take `encode_attribute_value` now, like the `href` and `title` beside them. That is what separates this reading from the string pipeline's: escaping at render time is inert for markup an author wrote (`<strong>` carries no quote, so the formatting survives untouched) and fatal to a breakout — while the string pipeline splices a passthrough's body into the *finished* string after every escape has run ([asciidoctor#2661](https://github.com/asciidoctor/asciidoctor/issues/2661)), which the tree goes on not reproducing.

## Evidence

- **Audit:** 36 rows either side, 0 new and 0 closed. The count is not comparable with earlier increments' because the sweep itself had to be re-derived — `rendered` *is* the fold now, so comparing the fold against it answers nothing; it captures the string pipeline's own answer after `run_pipeline`, before the fold overwrites it.
- **Coverage:** diff-neutral on every changed file (missed regions 5/18/11 and missed lines 2/9/3 on `image.rs`/`links.rs`/`inline_substitution_renderer.rs`, identical to base).
- **Falsifiability:** two rows join the side-effect sweep and fail on base (a deferred macro registers nothing). The divergence test that pinned the old per-slot deferral is now a ten-fixture parity corpus; the split-disagreement half keeps its own test. `a_rendered_slot_cannot_break_out_of_its_attribute` pins the escape, and four new rows in `tests/security.rs` pin the renderer half.
- Full preflight green: nightly `fmt --check`, `clippy --all-targets`, `test --workspace` (5,456 passing), nightly `doc --document-private-items`.

## What this leaves

The cross-reference family keeps #1283's rule rather than joining this one, and the two are consistent because their string paths are: a deferred cross-reference's template is captured *before* passthroughs are restored, so the string pipeline leaks a sentinel into `class=` and escapes a rendered span into `class="&lt;strong&gt;hl&lt;/strong&gt;"` — no output worth matching, so the author's source is the better answer, while here there is one and it is Asciidoctor's.

Still deferred in the link families: the split disagreement (`link:index.html[a *b, c* d,role=hl]`) and a `mailto:`'s pre-restore subject and body.

The deferred re-fold leak Greptile raised (a frozen attribute body re-folded by a *different* renderer at `resolve_references` time) is verified real but pre-existing — reproduced identically on `inline-ast` for the image family, where this PR changes no byte. Evidence is in the thread; the fix belongs to the §4.6 seam reshape.

---
_Generated by [Claude Code](https://claude.ai/code/session_019XerthjcmSs8HirHXrbHDo)_