### PR TITLE
feat: Read a deferred cross-reference's segments off the tree (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6703,6 +6703,70 @@ Each phase is a reviewable unit with a clear exit gate.
   interpolate unescaped; neither is reachable from this class (an anchor id admits no span, and an
   inline SVG has no attribute list a span survives into), so both are left where they are.
 
+
+  *Step 6 landed as (a deferred cross-reference's segments, read off the tree):* the survey of what
+  `run_pipeline` still owns named six things and said two of them turned on **one** question —
+  whether a computed slot can hold markup that exists only at fold time. The increment two above
+  answered it for the computed *string* slots and named this as the other: an
+  [`XrefSegment`](../../parser/src/content/content.rs) holds every field a `Ref{Xref}` node already
+  carries — `target`, `window`, `roles`, `xrefstyle` and `derived` are plain values the builder
+  resolved at recognition time — **except** `provided_text`, which the segment holds as a string
+  where the node holds its display text as *children*.
+
+  That slot takes the **fold of those children**, and the two answers differ for a stated reason
+  rather than by accident. A computed string slot had no output worth matching: the string
+  pipeline captures a deferred cross-reference's template *before* passthroughs are restored, so a
+  `role=` leaks a `\u{96}0\u{97}` sentinel, and where it does not leak it spells rendered markup
+  into a class name. A **display text** is the opposite case — it is markup by nature, and the
+  string replacer captures exactly `<strong>bold</strong>` out of its own already-rendered haystack
+  — so here the fold *reproduces* the byte string rather than approximating it. One family, two
+  slots, two answers, each matching what its own string path actually produces.
+
+  [`block_tree_xref_segments`](../../parser/src/content/content.rs) and
+  [`footnote_tree_xref_segments`](../../parser/src/content/content.rs) are the derivation, walking
+  exactly the traversals [`assign_tree_xrefs`](../../parser/src/content/content.rs) and
+  `assign_footnote_tree_xrefs` already walk — so a derived segment and an installed destination
+  address the same node, and the block/footnote partition is the one
+  `block_tree_xrefs`/`footnote_tree_xrefs` already draw. Nothing is wired: they are staged building
+  blocks under `#[allow(dead_code)]` and a `cfg(test)` re-export, the same staging every recognition
+  side effect was under before the cutover re-attached it.
+
+  Two decisions are worth recording because a later reader will otherwise re-derive them. The fold
+  runs **at the end of the parse**, with the renderer the parse carried, which is where the string
+  replacer computes it too; deriving it at *resolution* time would read whatever renderer that
+  caller passed and hand the resolver a different `ResolutionContext` than the string pipeline does
+  — the same renderer-timing hazard review raised against the increment above, avoided here by
+  construction rather than argued about. And [`resolved`](../../parser/src/content/content.rs) is
+  deliberately **not** carried across: it is resolution's *output*, filled in later and mirrored
+  back onto the node, so a node re-read after a sweep yields the segment it yielded before one,
+  which is what makes the derivation idempotent.
+
+  [`inline_builder_xref_segment_parity`](../../parser/src/tests/inline_builder_xref_segment_parity.rs)
+  is the corpus, over whole documents parsed with `parse_deferred` (so both sides carry
+  `resolved: None` and the comparison is of *recognition* alone): 37 fixtures across both
+  spellings, the present-but-empty text, a display text carrying each of the three recoverable
+  pieces, a passthrough, a nested macro, the attribute-list form's other fields, a derived
+  destination, an unresolved target, several references in one content, a reference nested in a
+  span, the footnote-embedded complement, and three other content-bearing locations. Every field of
+  every segment is compared, and two vacuity guards keep a corpus that stopped deferring from
+  passing.
+  Exactly **one** shape diverges and it is the sibling increment's own, pinned as such: for
+  `xref:tgt[*bold*,role=*hl*]` the `role` differs by that increment's rule while `provided_text` is
+  byte-identical — which is precisely the claim this one makes.
+
+  Audit: **36** rows either side, 0 new and 0 closed, as it must be — the diff adds no production
+  path at all. Coverage is diff-neutral on `content.rs` (21 missed regions and 8 missed lines either
+  side). Falsifiable: deriving `provided_text` from the children's source spans instead of their
+  fold fails both tests.
+
+  *What this leaves of the survey:* three items. `Content::passthroughs()` as a tree-backed view
+  (public-API shaping, and *deleting* it is as live an option as building it), the link family's
+  dangerous-scheme warning (which needs a node-level fact, since a rejected macro is left literal
+  and there is no `Ref` node to hang it on), and the two the survey called hard-blocked — a
+  footnote's catalog text (an ordering problem: the registry is read *during* the same content's
+  substitution) and `{counter:}` advancement (solvable only **by** removing the pipeline). With
+  this one staged, the string-slot question the survey raised has no open consequences left.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8088,6 +8152,30 @@ Each phase is a reviewable unit with a clear exit gate.
        today with no tree involved. Audit: 36 rows either side, 0 new, 0 closed (the sweep itself
        had to be re-derived, `rendered` being the fold now); coverage diff-neutral on all changed
        files. See the step's own "landed as" note above.
+
+     - ✅ **a deferred cross-reference's segments, read off the tree.** The second of the two
+       survey items that turned on the computed-slot question, and the one the string-slot
+       increment named as taking the *other* answer. An
+       [`XrefSegment`](../../parser/src/content/content.rs) holds every field a `Ref{Xref}` node
+       already carries but `provided_text`, which the segment holds as a string where the node holds
+       its display text as **children** — so that slot takes the **fold** of them. A display text
+       is markup by nature and the string replacer captures `<strong>bold</strong>` out of its
+       own already-rendered haystack, where a computed *string* slot had no output worth matching
+       (its template is captured before passthroughs are restored, so it leaks a sentinel). One
+       family, two slots, two answers, each matching what its own string path produces.
+       [`block_tree_xref_segments`](../../parser/src/content/content.rs) and
+       [`footnote_tree_xref_segments`](../../parser/src/content/content.rs) walk exactly
+       `assign_tree_xrefs`' and `assign_footnote_tree_xrefs`' own traversals, so a derived segment
+       and an installed destination address the same node; both are staged and unwired, like every
+       recognition side effect before its re-attachment. The fold runs at the **end of the parse**
+       with the parse's own renderer — deriving it at resolution time would hand the resolver a
+       different `ResolutionContext` than the string pipeline does — and `resolved` is
+       deliberately not carried across, which is what makes the derivation idempotent.
+       [`inline_builder_xref_segment_parity`](../../parser/src/tests/inline_builder_xref_segment_parity.rs)
+       compares every field of every segment over 37 whole-document fixtures; exactly one shape
+       diverges and it is the sibling increment's own `role=`, pinned beside a `provided_text` that
+       is byte-identical. Audit: 36 rows either side, 0 new and 0 closed (the diff adds no
+       production path); coverage diff-neutral. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6743,21 +6743,51 @@ Each phase is a reviewable unit with a clear exit gate.
 
   [`inline_builder_xref_segment_parity`](../../parser/src/tests/inline_builder_xref_segment_parity.rs)
   is the corpus, over whole documents parsed with `parse_deferred` (so both sides carry
-  `resolved: None` and the comparison is of *recognition* alone): 37 fixtures across both
+  `resolved: None` and the comparison is of *recognition* alone): 44 fixtures across both
   spellings, the present-but-empty text, a display text carrying each of the three recoverable
   pieces, a passthrough, a nested macro, the attribute-list form's other fields, a derived
   destination, an unresolved target, several references in one content, a reference nested in a
-  span, the footnote-embedded complement, and three other content-bearing locations. Every field of
-  every segment is compared, and two vacuity guards keep a corpus that stopped deferring from
-  passing.
+  span, the footnote-embedded complement, and every other content-bearing location a deferred
+  reference reaches — a **section title** (the one the document-order pass owns, including a
+  forward reference and a reference between two titles) and a **table cell** among them. Every
+  field of every segment is compared, and two vacuity guards keep a corpus that stopped deferring
+  from passing.
   Exactly **one** shape diverges and it is the sibling increment's own, pinned as such: for
   `xref:tgt[*bold*,role=*hl*]` the `role` differs by that increment's rule while `provided_text` is
   byte-identical — which is precisely the claim this one makes.
 
-  Audit: **36** rows either side, 0 new and 0 closed, as it must be — the diff adds no production
-  path at all. Coverage is diff-neutral on `content.rs` (21 missed regions and 8 missed lines either
-  side). Falsifiable: deriving `provided_text` from the children's source spans instead of their
-  fold fails both tests.
+  Review turned up a real one, and it was **not** confined to the new code: a cross-reference
+  written inside a *visible index term* is deferred by the string pipeline (the replacer's
+  haystack holds the term's shown text inline) while every one of these walks skipped
+  [`IndexTerm`](../../parser/src/inlines/index_term.rs), the fifth nested node list and the one a
+  walk written by matching on `children` is bound to miss. The side-effect sweep found exactly this
+  for its own three walks an increment ago; `count_tree_xrefs`, `assign_tree_xrefs` and their two
+  footnote siblings still had it. The failure mode is worse than a dropped entry:
+  `See <<a>> and ((term <<b>>)) and <<c>>` derived `[a, c]` against a golden `[a, b, c]`, so once
+  wired every reference *after* the hidden one would take the wrong destination. All six walks —
+  the two new collectors and the four that predate them — now descend, and the corpus fixture that
+  pins it is deliberately the *between-two-visible-ones* shape rather than the simpler one, since
+  that is the shape a misalignment shows up in. The pre-existing walks were safe rather than wrong
+  before this, because the count guard declined to correlate on the mismatch; what they were not is
+  complete, and the tree was silently never authoritative for such a content.
+
+  The index-term family's own remaining deferral shows up from this side too and stays: the
+  `indexterm2:[…]` **macro** spelling reads its shown term from an attribute-list parse rather
+  than from a range, so the builder keeps it as a string and builds no subtree — there is no
+  node to derive a segment from. That is the builder's documented limitation, not the
+  derivation's, and the same count guard keeps it safe; its own test pins the difference, so the
+  day the builder learns that spelling the fixture moves into the corpus.
+
+  Audit: **36** rows either side, 0 new and 0 closed — the walk fix changes when the correlation
+  *succeeds*, not what any content renders to. Coverage is diff-neutral on both changed files
+  (`content.rs` 21 missed regions and 8 missed lines, `section.rs` 40 and 39, either side).
+  Falsifiable in three places, and the third had to be built: deriving `provided_text` from the
+  children's source spans instead of their fold fails the corpus; reverting either collector's
+  `IndexTerm` arm fails it on the between-two-visible-ones fixture; and reverting the *count* or
+  *assign* arm failed nothing at all, since the corpus never reaches those. That gap is what
+  `a_reference_hidden_by_an_index_term_still_correlates_onto_its_own_node` closes — it resolves
+  the same shape for real and asserts each node's own `href`, which is the assertion a
+  misalignment fails where a count would pass.
 
   *What this leaves of the survey:* three items. `Content::passthroughs()` as a tree-backed view
   (public-API shaping, and *deleting* it is as live an option as building it), the link family's
@@ -8174,8 +8204,12 @@ Each phase is a reviewable unit with a clear exit gate.
        [`inline_builder_xref_segment_parity`](../../parser/src/tests/inline_builder_xref_segment_parity.rs)
        compares every field of every segment over 37 whole-document fixtures; exactly one shape
        diverges and it is the sibling increment's own `role=`, pinned beside a `provided_text` that
-       is byte-identical. Audit: 36 rows either side, 0 new and 0 closed (the diff adds no
-       production path); coverage diff-neutral. See the step's own "landed as" note above.
+       is byte-identical. Review found one real bug, and not in the new code: a cross-reference
+       inside a **visible index term** is deferred by the string pipeline while all four
+       pre-existing xref walks skipped `IndexTerm`, so a reference hidden *between* two visible
+       ones misaligned every one after it. All six walks now descend; the count guard had kept the
+       old ones safe rather than complete. Audit: 36 rows either side, 0 new and 0 closed;
+       coverage diff-neutral on both changed files. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -532,6 +532,16 @@ impl<'src> SectionBlock<'src> {
         self.section_title.inlines()
     }
 
+    /// Returns the section title's [`Content`] itself, for a caller that needs
+    /// more of it than [`section_title_inlines`](Self::section_title_inlines)
+    /// and [`section_title_render_attributes`](Self::section_title_render_attributes)
+    /// expose — the deferred cross-reference segments a heading carries, which
+    /// the document-order title pass resolves.
+    #[cfg(test)]
+    pub(crate) fn section_title_content(&self) -> &Content<'src> {
+        &self.section_title
+    }
+
     /// The document attributes in force where this heading was written, when
     /// they were retained — the order-dependent half of the render context a
     /// fold of the tree above needs. See

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1069,6 +1069,184 @@ fn count_footnote_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
         .sum()
 }
 
+/// Derives the **block-level** deferred cross-reference segments from an
+/// already-built inline tree — the list `run_pipeline`'s own
+/// [`InlineXrefReplacer`](crate::content::macros) produces and
+/// [`Content::set_deferred_xrefs`] installs, read off the nodes instead.
+///
+/// This is one of the six things design §5.2's survey found the string pipeline
+/// still solely owning — the first of them the survey called *blocked* rather
+/// than merely unbuilt — staged here as its own building block exactly as every
+/// recognition side effect was (see
+/// [`apply_macro_side_effects`](crate::content::inline_builder)): nothing calls
+/// it on the production path yet, and wiring it in is the cutover's own job.
+///
+/// A [`Ref`](InlineNode::Ref)`{`[`Xref`](RefVariant::Xref)`}` node already
+/// carries every field an [`XrefSegment`] holds but one — `target`, `window`,
+/// `roles`, `xrefstyle` and `derived` are plain values the builder resolved at
+/// recognition time — so the survey recorded the family as blocked on
+/// [`provided_text`](XrefSegment::provided_text) alone, which the segment holds
+/// as a **string** where the node holds its display text as *children*.
+///
+/// That slot takes the **fold of those children**, and it is a different answer
+/// from the one the sibling increment gave `role=` / `window=` / `xrefstyle=`
+/// (the author's untranslated source, see
+/// [`untranslated_value`](crate::content::inline_builder)) for a reason worth
+/// stating: a display text *is* markup by nature. `xref:sec[*bold*]` shows
+/// bold text, and the string replacer captures exactly
+/// `<strong>bold</strong>` out of its own already-rendered haystack — so the
+/// fold reproduces the byte string rather than approximating it, where a
+/// computed string slot had no such answer to match.
+///
+/// The fold runs **here**, at the end of the parse, with the renderer the parse
+/// carried — which is where the string replacer computes it too. Deriving it
+/// later, at resolution time, would read whatever renderer that caller passed
+/// and hand the resolver a different [`ResolutionContext`] than the string
+/// pipeline does; taking it at build time keeps the two byte-identical and
+/// keeps this function a pure function of the tree plus the parse's own
+/// renderer.
+///
+/// Present-but-empty is preserved, because it is a distinction the renderer
+/// acts on: the `<<id,>>` shorthand records one empty
+/// [`Text`](InlineNode::Text) child, which the string replacer carries as
+/// `Some("")` and renders as an empty `<a>…</a>`, where an absent text
+/// (`None`) falls back to the target's reference text. So the `Option` keys on
+/// the **presence of a child**, not on what that child folds to — the same rule
+/// [`fold_xref`](crate::content::inline_builder) already applies, and the
+/// reason `build_xref_shorthand_node` builds a child for a comma-carrying
+/// shorthand at all.
+///
+/// The walk is [`assign_tree_xrefs`]'s, so the order is that walk's order: a
+/// pre-order traversal that consumes a slot per cross-reference node and does
+/// **not** descend into a [`Footnote`](InlineNode::Footnote) subtree, whose
+/// segments are re-homed out of the block template.
+/// [`footnote_tree_xref_segments`] derives the complementary list.
+// Consumed only by tests until the step 6 cutover wires it in, the same
+// staging every recognition side effect was under before it was re-attached.
+#[allow(dead_code)]
+pub(crate) fn block_tree_xref_segments(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+) -> Vec<XrefSegment> {
+    let mut out = Vec::new();
+    collect_tree_xref_segments(nodes, renderer, context, &mut out);
+    out
+}
+
+/// Derives the deferred cross-reference segments embedded in this tree's
+/// **footnote** subtrees — the exact complement of
+/// [`block_tree_xref_segments`], in the order
+/// [`footnote_tree_xrefs`] enumerates them.
+///
+/// A footnote cannot nest another footnote, so handing each footnote's own
+/// children to the block collector cannot skip anything — the same reuse
+/// [`assign_footnote_tree_xrefs`] makes.
+// Consumed only by tests until the step 6 cutover wires it in, the same
+// staging every recognition side effect was under before it was re-attached.
+#[allow(dead_code)]
+pub(crate) fn footnote_tree_xref_segments(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+) -> Vec<XrefSegment> {
+    let mut out = Vec::new();
+    collect_footnote_tree_xref_segments(nodes, renderer, context, &mut out);
+    out
+}
+
+/// The shared pre-order walk behind [`block_tree_xref_segments`], mirroring
+/// [`assign_tree_xrefs`]'s traversal so a derived segment and an installed
+/// destination address the same node.
+// Consumed only by tests until the step 6 cutover wires it in, the same
+// staging every recognition side effect was under before it was re-attached.
+#[allow(dead_code)]
+fn collect_tree_xref_segments(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+    out: &mut Vec<XrefSegment>,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Ref(reference) => {
+                if reference.variant == RefVariant::Xref {
+                    out.push(xref_segment_from_node(reference, renderer, context));
+                }
+
+                collect_tree_xref_segments(&reference.children, renderer, context, out);
+            }
+
+            InlineNode::Styled(styled) => {
+                collect_tree_xref_segments(&styled.children, renderer, context, out);
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// The shared walk behind [`footnote_tree_xref_segments`], mirroring
+/// [`assign_footnote_tree_xrefs`]'s traversal.
+// Consumed only by tests until the step 6 cutover wires it in, the same
+// staging every recognition side effect was under before it was re-attached.
+#[allow(dead_code)]
+fn collect_footnote_tree_xref_segments(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+    out: &mut Vec<XrefSegment>,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Footnote(footnote) => {
+                collect_tree_xref_segments(&footnote.children, renderer, context, out);
+            }
+
+            InlineNode::Ref(reference) => {
+                collect_footnote_tree_xref_segments(&reference.children, renderer, context, out);
+            }
+
+            InlineNode::Styled(styled) => {
+                collect_footnote_tree_xref_segments(&styled.children, renderer, context, out);
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// Reads one [`XrefSegment`] off a cross-reference node — see
+/// [`block_tree_xref_segments`] for why each field reads the way it does.
+///
+/// [`resolved`](XrefSegment::resolved) is deliberately **not** carried across:
+/// it is resolution's *output*, filled in later by
+/// [`Content::resolve_references`] and mirrored back onto the node by
+/// [`Content::mirror_tree_xref_resolution`]. A node re-read after a resolution
+/// sweep therefore yields the same segment it yielded before one, which is what
+/// makes this derivation idempotent.
+// Consumed only by tests until the step 6 cutover wires it in, the same
+// staging every recognition side effect was under before it was re-attached.
+#[allow(dead_code)]
+fn xref_segment_from_node(
+    reference: &crate::inlines::Ref<'_>,
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+) -> XrefSegment {
+    let provided_text = (!reference.children.is_empty())
+        .then(|| crate::content::inline_builder::fold_html(&reference.children, renderer, context));
+
+    XrefSegment {
+        target: reference.target.to_string(),
+        provided_text,
+        window: reference.window.as_ref().map(|w| w.to_string()),
+        roles: reference.roles.iter().map(|r| r.to_string()).collect(),
+        xrefstyle: reference.xrefstyle,
+        derived: reference.derived.clone(),
+        resolved: None,
+    }
+}
+
 /// Walks an inline node slice in document order and installs each
 /// cross-reference's resolved destination from `ordered` — the resolved state
 /// of the block-level deferred segments, in placeholder order — advancing

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1046,6 +1046,14 @@ fn count_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
 
             InlineNode::Styled(styled) => count_tree_xrefs(&styled.children),
 
+            // A **visible index term** shows its text in the flow, so the
+            // string replacer's own haystack holds any cross-reference written
+            // inside it and defers a segment for one. It is the fifth nested
+            // node list a tree can hold a construct in (see the side-effect
+            // sweep's own note), and the one a walk written by matching on
+            // `children` is bound to miss.
+            InlineNode::IndexTerm(index_term) => count_tree_xrefs(&index_term.children),
+
             _ => 0,
         })
         .sum()
@@ -1063,6 +1071,8 @@ fn count_footnote_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
             InlineNode::Ref(reference) => count_footnote_tree_xrefs(&reference.children),
 
             InlineNode::Styled(styled) => count_footnote_tree_xrefs(&styled.children),
+
+            InlineNode::IndexTerm(index_term) => count_footnote_tree_xrefs(&index_term.children),
 
             _ => 0,
         })
@@ -1181,6 +1191,10 @@ fn collect_tree_xref_segments(
                 collect_tree_xref_segments(&styled.children, renderer, context, out);
             }
 
+            InlineNode::IndexTerm(index_term) => {
+                collect_tree_xref_segments(&index_term.children, renderer, context, out);
+            }
+
             _ => {}
         }
     }
@@ -1209,6 +1223,10 @@ fn collect_footnote_tree_xref_segments(
 
             InlineNode::Styled(styled) => {
                 collect_footnote_tree_xref_segments(&styled.children, renderer, context, out);
+            }
+
+            InlineNode::IndexTerm(index_term) => {
+                collect_footnote_tree_xref_segments(&index_term.children, renderer, context, out);
             }
 
             _ => {}
@@ -1288,6 +1306,10 @@ fn assign_tree_xrefs(
                 assign_tree_xrefs(&mut styled.children, ordered, next);
             }
 
+            InlineNode::IndexTerm(index_term) => {
+                assign_tree_xrefs(&mut index_term.children, ordered, next);
+            }
+
             _ => {}
         }
     }
@@ -1320,6 +1342,10 @@ fn assign_footnote_tree_xrefs(
 
             InlineNode::Styled(styled) => {
                 assign_footnote_tree_xrefs(&mut styled.children, ordered, next);
+            }
+
+            InlineNode::IndexTerm(index_term) => {
+                assign_footnote_tree_xrefs(&mut index_term.children, ordered, next);
             }
 
             _ => {}

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -9,6 +9,13 @@ pub(crate) use content::{
     FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xrefs, fold_resolved_title,
     footnote_tree_xrefs, rehome_xref_placeholders, render_xref_template, sanitize_title,
 };
+// The staged, not-yet-wired derivation of a content's deferred cross-reference
+// segments from its inline tree — the last of design §5.2's six survey items,
+// exercised only by its own differential corpus until the cutover calls it for
+// real. Re-exported under `cfg(test)` for the same reason the functions carry
+// `#[allow(dead_code)]`: nothing on the production path reaches them yet.
+#[cfg(test)]
+pub(crate) use content::{block_tree_xref_segments, footnote_tree_xref_segments};
 
 pub(crate) mod inline_builder;
 

--- a/parser/src/tests/inline_builder_xref_segment_parity.rs
+++ b/parser/src/tests/inline_builder_xref_segment_parity.rs
@@ -1,0 +1,296 @@
+//! A differential harness for the **deferred cross-reference segments** read
+//! off the inline tree.
+//!
+//! Design §5.2's survey of what `run_pipeline` still solely owns named six
+//! things, two of them blocked on one question rather than on effort. This is
+//! the second of that pair: the [`XrefSegment`](crate::content::XrefSegment)
+//! list a content carries for its deferred cross-references. Every field on a
+//! segment is one a [`Ref`](crate::inlines::Ref)`{Xref}` node already holds —
+//! the survey said as much — *except* `provided_text`, which the segment holds
+//! as a string where the node holds its display text as children. The sibling
+//! increment that answered the computed-**string**-slot question unblocked it,
+//! and the answer here is the other one: a display text is markup by nature, so
+//! the slot takes the **fold of those children**.
+//!
+//! What this harness pins is that reading, over whole documents: for every
+//! content that deferred a cross-reference, the segments derived from the tree
+//! are field-for-field what `InlineXrefReplacer` itself produced. Nothing is
+//! wired — `block_tree_xref_segments` and `footnote_tree_xref_segments` are
+//! staged building blocks, exactly as every recognition side effect was before
+//! the cutover re-attached it — so this corpus is the only thing exercising
+//! them, and it is what a later increment stands on when it deletes the
+//! string pipeline's own construction.
+//!
+//! The documents are parsed with [`Parser::parse_deferred`], which does **not**
+//! resolve, so every segment's `resolved` is `None` on both sides: this
+//! compares what *recognition* produced, which is the half `run_pipeline`
+//! owns. (`resolved` is resolution's output and is deliberately not carried
+//! across by the derivation — see `xref_segment_from_node`.)
+
+use crate::{
+    Parser,
+    blocks::{Block, FindBlocks},
+    content::{Content, XrefSegment, block_tree_xref_segments, footnote_tree_xref_segments},
+    parser::{HtmlSubstitutionRenderer, ModificationContext},
+};
+
+/// A parser with `experimental` set, so a fixture's UI macros are recognized,
+/// matching the sibling whole-document harnesses.
+fn parser() -> Parser {
+    Parser::default().with_intrinsic_attribute_bool(
+        "experimental",
+        true,
+        ModificationContext::Anywhere,
+    )
+}
+
+/// Every [`Content`] in `doc` that carries a tree, in document order.
+///
+/// Unlike the [document-parity harness](super::inline_builder_document_parity)
+/// next door, this one needs the `Content` itself rather than its rendered
+/// string and tree, because the segments live on it — so it reaches each one
+/// through the accessors that return a `&Content` rather than through
+/// `IsBlock`'s two.
+fn contents<'src>(doc: &'src crate::Document<'src>) -> Vec<(String, &'src Content<'src>)> {
+    fn walk<'src>(block: &'src Block<'src>, out: &mut Vec<(String, &'src Content<'src>)>) {
+        match block {
+            Block::Simple(simple) => {
+                out.push(("paragraph".to_string(), simple.content()));
+            }
+
+            Block::RawDelimited(raw) => {
+                out.push(("raw delimited".to_string(), raw.content()));
+            }
+
+            Block::Admonition(admonition) => {
+                if let Some(content) = admonition.content() {
+                    out.push(("admonition".to_string(), content));
+                }
+            }
+
+            Block::Quote(quote) => {
+                if let Some(content) = quote.content() {
+                    out.push(("quote".to_string(), content));
+                }
+            }
+
+            _ => {}
+        }
+
+        // A block title (`.Title`) is substituted content in its own right and
+        // defers its own cross-references.
+        if let Some(title) = block.block_title_content() {
+            out.push(("block title".to_string(), title));
+        }
+
+        for child in block.child_blocks() {
+            walk(child, out);
+        }
+    }
+
+    let mut out = vec![];
+
+    for block in doc.child_blocks() {
+        walk(block, &mut out);
+    }
+
+    out
+}
+
+/// Splits a content's own segments the way
+/// [`block_tree_xrefs`](crate::content::block_tree_xrefs) and
+/// [`footnote_tree_xrefs`](crate::content::footnote_tree_xrefs) split them: a
+/// placeholder still in the template is block-level, one that has left it was
+/// re-homed onto a footnote.
+fn partition<'a>(
+    template: &str,
+    xrefs: &'a [XrefSegment],
+) -> (Vec<&'a XrefSegment>, Vec<&'a XrefSegment>) {
+    let mut block = vec![];
+    let mut footnote = vec![];
+
+    for (index, xref) in xrefs.iter().enumerate() {
+        if template.contains(&Content::xref_placeholder(index)) {
+            block.push(xref);
+        } else {
+            footnote.push(xref);
+        }
+    }
+
+    (block, footnote)
+}
+
+/// Sources whose contents defer at least one cross-reference. Each names the
+/// shape it is here for; the assertion covers every field of every segment, so
+/// a fixture pins more than the one thing it was added for.
+const CORPUS: &[&str] = &[
+    // ---- the two spellings, with and without a display text -------------
+    "See <<tgt>> here.\n\n[[tgt]]Target.",
+    "See <<tgt,the target>> here.\n\n[[tgt]]Target.",
+    "See xref:tgt[] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[the target] here.\n\n[[tgt]]Target.",
+    // The present-but-empty text: a comma with nothing after it. This is the
+    // distinction the `Option` keys on the *presence of a child* for.
+    "See <<tgt,>> here.\n\n[[tgt]]Target.",
+    "See xref:tgt[ ] here.\n\n[[tgt]]Target.",
+    // ---- a display text that is markup ----------------------------------
+    // The whole reason this slot takes the fold rather than the source: the
+    // string replacer captures the *rendered* span out of its own haystack.
+    "See <<tgt,*bold* text>> here.\n\n[[tgt]]Target.",
+    "See xref:tgt[*bold* text] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[`code` and _em_] here.\n\n[[tgt]]Target.",
+    "See <<tgt,a #mark# here>> here.\n\n[[tgt]]Target.",
+    // A text carrying an escaped special, a restored entity, and a
+    // typographic replacement — the three recoverable pieces.
+    "See xref:tgt[a < b] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[Tom &copy; Jerry] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[Pause (C) Resume] here.\n\n[[tgt]]Target.",
+    // A text carrying a passthrough, which the string pipeline restores into
+    // the segment separately (`restore_deferred_xref_passthroughs`) and the
+    // tree carries as a `Raw` child.
+    "See xref:tgt[a +++<b>raw</b>+++ x] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[a $$literal$$ x] here.\n\n[[tgt]]Target.",
+    // A nested macro in the display text.
+    "See xref:tgt[see image:i.png[I]] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[see link:l.html[L]] here.\n\n[[tgt]]Target.",
+    // ---- the attribute-list form, which fills the other fields ----------
+    "See xref:tgt[Text,role=hl] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[Text,window=_blank] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[Text,role=a b,window=_blank] here.\n\n[[tgt]]Target.",
+    "See xref:tgt[Text,xrefstyle=full] here.\n\n[[tgt]]Target.",
+    // A document-wide `xrefstyle`, which the node resolves at build time.
+    ":xrefstyle: full\n\nSee <<tgt>> here.\n\n[[tgt]]Target.",
+    // ---- a target that names a document (a *derived* destination) -------
+    "See <<other.adoc#sec>> here.",
+    "See xref:other.adoc#sec[Elsewhere] here.",
+    "See xref:other.adoc#[] here.",
+    // ---- unresolved targets, which still produce a segment --------------
+    "See <<nope>> here.",
+    "See xref:nope[Text] here.",
+    // ---- more than one reference in one content -------------------------
+    "See <<a>> and <<b>> and <<a>> again.\n\n[[a]]A.\n\n[[b]]B.",
+    "See <<a,First>> then xref:b[Second].\n\n[[a]]A.\n\n[[b]]B.",
+    // ---- a reference nested inside a container --------------------------
+    "See *a <<tgt>> b* here.\n\n[[tgt]]Target.",
+    "See #a <<tgt>> b# here.\n\n[[tgt]]Target.",
+    // ---- footnote-embedded references, the complementary list -----------
+    "See footnote:[a note with <<tgt>> inside].\n\n[[tgt]]Target.",
+    "See footnote:[see <<a>>] and <<b>>.\n\n[[a]]A.\n\n[[b]]B.",
+    "See <<a>> then footnote:[see <<b>>] then <<c>>.\n\n[[a]]A.\n\n[[b]]B.\n\n[[c]]C.",
+    // ---- other content-bearing locations --------------------------------
+    ".A title with <<tgt>>\nParagraph body.\n\n[[tgt]]Target.",
+    "[NOTE]\n====\nSee <<tgt>> here.\n====\n\n[[tgt]]Target.",
+    "[quote]\n____\nSee <<tgt>> here.\n____\n\n[[tgt]]Target.",
+];
+
+#[test]
+fn derived_segments_match_the_string_pipelines_own() {
+    let mut saw_block = 0usize;
+    let mut saw_footnote = 0usize;
+
+    for source in CORPUS {
+        let mut parser = parser();
+
+        // `parse_deferred` does not resolve, so both sides carry
+        // `resolved: None` and this compares recognition alone.
+        let doc = parser.parse_deferred(source);
+        let context = parser.render_context();
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for (what, content) in contents(&doc) {
+            let Some((template, xrefs)) = content.deferred_parts() else {
+                continue;
+            };
+
+            let (golden_block, golden_footnote) = partition(template, xrefs);
+
+            let derived_block = block_tree_xref_segments(content.inlines(), &renderer, &context);
+
+            let derived_footnote =
+                footnote_tree_xref_segments(content.inlines(), &renderer, &context);
+
+            saw_block += derived_block.len();
+            saw_footnote += derived_footnote.len();
+
+            let golden_block: Vec<XrefSegment> = golden_block.into_iter().cloned().collect();
+
+            let golden_footnote: Vec<XrefSegment> = golden_footnote.into_iter().cloned().collect();
+
+            assert_eq!(
+                derived_block, golden_block,
+                "block-level segments diverged for {what} of {source:?}"
+            );
+
+            assert_eq!(
+                derived_footnote, golden_footnote,
+                "footnote segments diverged for {what} of {source:?}"
+            );
+        }
+    }
+
+    // Guards against a vacuous pass: a corpus that stopped deferring (or a
+    // walk that stopped finding anything) would otherwise compare empty
+    // against empty for every fixture and report success.
+    assert!(
+        saw_block >= 40,
+        "the corpus stopped exercising block-level segments: {saw_block}"
+    );
+
+    assert!(
+        saw_footnote >= 3,
+        "the corpus stopped exercising footnote segments: {saw_footnote}"
+    );
+}
+
+#[test]
+fn a_rendered_span_in_a_string_read_slot_keeps_its_documented_divergence() {
+    // The one shape in this family whose derived segment is *not* the string
+    // pipeline's, and the divergence is deliberate: the increment that
+    // answered the computed-string-slot question gave `role=` / `window=` /
+    // `xrefstyle=` the author's **untranslated source**, because the string
+    // path there has no output worth matching (it captures the deferred
+    // template before passthroughs are restored, so it leaks a sentinel, and
+    // it spells a rendered span into a class name).
+    //
+    // What this pins is that the two answers coexist on one segment: the
+    // `role` differs by that rule, while `provided_text` — the field this
+    // increment is about — is byte-identical, because a display text is markup
+    // by nature and takes the fold of the node's children.
+    let source = "See xref:tgt[*bold*,role=*hl*] here.\n\n[[tgt]]Target.";
+
+    let mut parser = parser();
+    let doc = parser.parse_deferred(source);
+    let context = parser.render_context();
+    let renderer = HtmlSubstitutionRenderer {};
+
+    let (_, content) = contents(&doc)
+        .into_iter()
+        .find(|(_, content)| content.deferred_parts().is_some())
+        .expect("the fixture must defer a cross-reference");
+
+    let (template, xrefs) = content.deferred_parts().unwrap();
+    let (golden, _) = partition(template, xrefs);
+    let derived = block_tree_xref_segments(content.inlines(), &renderer, &context);
+
+    assert_eq!(derived.len(), 1);
+    assert_eq!(golden.len(), 1);
+
+    // The field this increment reads off the tree: identical.
+    assert_eq!(
+        derived[0].provided_text.as_deref(),
+        Some("<strong>bold</strong>")
+    );
+
+    assert_eq!(derived[0].provided_text, golden[0].provided_text);
+
+    // The field the sibling increment deliberately answers differently.
+    assert_eq!(derived[0].roles, ["*hl*"]);
+    assert_eq!(golden[0].roles, ["<strong>hl</strong>"]);
+
+    // Every other field still agrees, so the divergence is confined to the
+    // one slot its own increment named.
+    assert_eq!(derived[0].target, golden[0].target);
+    assert_eq!(derived[0].window, golden[0].window);
+    assert_eq!(derived[0].xrefstyle, golden[0].xrefstyle);
+    assert_eq!(derived[0].derived, golden[0].derived);
+}

--- a/parser/src/tests/inline_builder_xref_segment_parity.rs
+++ b/parser/src/tests/inline_builder_xref_segment_parity.rs
@@ -29,7 +29,7 @@
 
 use crate::{
     Parser,
-    blocks::{Block, FindBlocks},
+    blocks::{Block, FindBlocks, TableCellContent, TableRow},
     content::{Content, XrefSegment, block_tree_xref_segments, footnote_tree_xref_segments},
     parser::{HtmlSubstitutionRenderer, ModificationContext},
 };
@@ -52,6 +52,17 @@ fn parser() -> Parser {
 /// through the accessors that return a `&Content` rather than through
 /// `IsBlock`'s two.
 fn contents<'src>(doc: &'src crate::Document<'src>) -> Vec<(String, &'src Content<'src>)> {
+    fn cells<'src>(row: &'src TableRow<'src>, out: &mut Vec<(String, &'src Content<'src>)>) {
+        for cell in row.cells() {
+            // Only an inline (`Simple`) cell carries a single `Content`; an
+            // `AsciiDoc` cell is a nested standalone document, out of scope
+            // here exactly as it is for the sibling harness.
+            if let TableCellContent::Simple(content) = cell.content() {
+                out.push(("table cell".to_string(), content));
+            }
+        }
+    }
+
     fn walk<'src>(block: &'src Block<'src>, out: &mut Vec<(String, &'src Content<'src>)>) {
         match block {
             Block::Simple(simple) => {
@@ -71,6 +82,30 @@ fn contents<'src>(doc: &'src crate::Document<'src>) -> Vec<(String, &'src Conten
             Block::Quote(quote) => {
                 if let Some(content) = quote.content() {
                     out.push(("quote".to_string(), content));
+                }
+            }
+
+            // A **section title** is the location the document-order title pass
+            // resolves, with cross-title coordination the per-content pass
+            // cannot do — so it is the one deferred location whose segments a
+            // regression would be most visible in, and it reaches neither of
+            // the accessors above (a section's own content is its children).
+            Block::Section(section) => {
+                out.push(("section title".to_string(), section.section_title_content()));
+            }
+
+            // A table's cells are not blocks at all.
+            Block::Table(table) => {
+                if let Some(header) = table.header_row() {
+                    cells(header, out);
+                }
+
+                for row in table.body_rows() {
+                    cells(row, out);
+                }
+
+                if let Some(footer) = table.footer_row() {
+                    cells(footer, out);
                 }
             }
 
@@ -181,6 +216,22 @@ const CORPUS: &[&str] = &[
     ".A title with <<tgt>>\nParagraph body.\n\n[[tgt]]Target.",
     "[NOTE]\n====\nSee <<tgt>> here.\n====\n\n[[tgt]]Target.",
     "[quote]\n____\nSee <<tgt>> here.\n____\n\n[[tgt]]Target.",
+    // A **section title**, the location the document-order title pass owns —
+    // including a forward reference and a reference between two titles, the
+    // shapes that pass exists for.
+    "== See <<tgt>>\n\nBody.\n\n[[tgt]]Target.",
+    "== See <<second>>\n\nBody.\n\n[[second]]\n== The Second\n\nMore.",
+    "== A <<tgt,*bold*>> heading\n\nBody.\n\n[[tgt]]Target.",
+    // A **table cell**, which is not a block at all.
+    "|===\n|See <<tgt>> here. |Plain\n|===\n\n[[tgt]]Target.",
+    "|===\n|A <<tgt,*bold*>> cell\n|===\n\n[[tgt]]Target.",
+    // A cross-reference inside a **visible index term** — the fifth nested
+    // node list, which every one of these walks used to miss. The middle
+    // fixture is the one that matters: a reference the index term hides
+    // *between* two the walk does see, so a walk that skipped it would
+    // misalign the two after it rather than merely drop one.
+    "See ((a term with <<b>> in it)) here.\n\n[[b]]B.",
+    "See <<a>> and ((term <<b>>)) and <<c>>.\n\n[[a]]A.\n\n[[b]]B.\n\n[[c]]C.",
 ];
 
 #[test]
@@ -293,4 +344,114 @@ fn a_rendered_span_in_a_string_read_slot_keeps_its_documented_divergence() {
     assert_eq!(derived[0].window, golden[0].window);
     assert_eq!(derived[0].xrefstyle, golden[0].xrefstyle);
     assert_eq!(derived[0].derived, golden[0].derived);
+}
+
+#[test]
+fn a_reference_inside_an_index_term_macro_keeps_its_documented_divergence() {
+    // The index-term family's own remaining deferral, reached from this side.
+    // A *visible* term written in either shorthand carries its shown text as
+    // `children`, so a cross-reference inside it is a node the collectors walk
+    // — the parity corpus covers both spellings. The `indexterm2:[…]` **macro**
+    // spelling does not: its shown term comes back from an attribute-list parse
+    // rather than from a range of the match string, so the builder keeps it as
+    // a string and builds no subtree, and there is no node to derive a segment
+    // from.
+    //
+    // That is the builder's own documented limitation (see the index-term
+    // family's "landed as" note), not something the derivation can answer, and
+    // it is *safe* rather than merely known: the count guard
+    // `mirror_tree_xref_resolution` applies sees 0 tree slots against 1 deferred
+    // segment, so it declines to correlate and this content's tree is never
+    // treated as authoritative. This pins that the two sides really do differ
+    // here, so the day the builder learns the macro spelling this test fails and
+    // the fixture moves into the corpus above.
+    let source = "See indexterm2:[<<b>>] here.\n\n[[b]]B.";
+
+    let mut parser = parser();
+    let doc = parser.parse_deferred(source);
+    let context = parser.render_context();
+    let renderer = HtmlSubstitutionRenderer {};
+
+    let (_, content) = contents(&doc)
+        .into_iter()
+        .find(|(_, content)| content.deferred_parts().is_some())
+        .expect("the fixture must defer a cross-reference");
+
+    let (template, xrefs) = content.deferred_parts().unwrap();
+    let (golden, _) = partition(template, xrefs);
+    let derived = block_tree_xref_segments(content.inlines(), &renderer, &context);
+
+    // The string pipeline defers one; the tree offers none to derive from.
+    assert_eq!(golden.len(), 1);
+    assert_eq!(golden[0].target, "b");
+    assert!(
+        derived.is_empty(),
+        "the macro spelling now yields a subtree; fold this into the parity corpus: {derived:?}"
+    );
+}
+
+#[test]
+fn a_reference_hidden_by_an_index_term_still_correlates_onto_its_own_node() {
+    // The other half of the `IndexTerm` fix, and the half the corpus above
+    // cannot reach: `count_tree_xrefs` and `assign_tree_xrefs` are what
+    // *install* a resolved destination onto a node, and they skipped the same
+    // container the collectors did.
+    //
+    // The shape is chosen so a skip **misaligns** rather than merely drops: the
+    // hidden reference sits between two visible ones, so a walk that does not
+    // descend hands `<<c>>` the destination belonging to `<<b>>`. Asserting
+    // each node's own `href` is what catches that — a count assertion would
+    // not, and neither would a fixture with the hidden reference first or last.
+    //
+    // This also pins the *widening* the fix performs: before it, the count
+    // guard saw 2 tree slots against 3 deferred segments and declined to
+    // correlate at all, so no node carried a destination. Now every one does.
+    let mut parser = parser();
+
+    // `parse` resolves against the document's own catalog.
+    let doc =
+        parser.parse("See <<a>> and ((term <<b>>)) and <<c>>.\n\n[[a]]A.\n\n[[b]]B.\n\n[[c]]C.");
+
+    fn hrefs(nodes: &[crate::inlines::InlineNode<'_>], out: &mut Vec<(String, Option<String>)>) {
+        for node in nodes {
+            match node {
+                crate::inlines::InlineNode::Ref(reference)
+                    if reference.variant == crate::inlines::RefVariant::Xref =>
+                {
+                    out.push((
+                        reference.target.to_string(),
+                        reference.resolved.as_ref().map(|r| r.href.clone()),
+                    ));
+
+                    hrefs(&reference.children, out);
+                }
+
+                crate::inlines::InlineNode::Ref(reference) => hrefs(&reference.children, out),
+                crate::inlines::InlineNode::Styled(styled) => hrefs(&styled.children, out),
+                crate::inlines::InlineNode::IndexTerm(term) => hrefs(&term.children, out),
+                crate::inlines::InlineNode::Footnote(footnote) => hrefs(&footnote.children, out),
+
+                _ => {}
+            }
+        }
+    }
+
+    let (_, content) = contents(&doc)
+        .into_iter()
+        .find(|(_, content)| content.deferred_parts().is_some())
+        .expect("the fixture must defer a cross-reference");
+
+    let mut found = vec![];
+    hrefs(content.inlines(), &mut found);
+
+    // Each node carries its **own** target's destination — the assertion a
+    // misalignment fails, since `c` would otherwise hold `#b`.
+    assert_eq!(
+        found,
+        vec![
+            ("a".to_string(), Some("#a".to_string())),
+            ("b".to_string(), Some("#b".to_string())),
+            ("c".to_string(), Some("#c".to_string())),
+        ]
+    );
 }

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod hash;
 mod inline_builder_document_parity;
 mod inline_builder_recorder_parity;
 mod inline_builder_side_effect_parity;
+mod inline_builder_xref_segment_parity;
 mod inline_recorder;
 mod inline_substitution_renderer;
 mod origin;


### PR DESCRIPTION
#1282's survey of what `run_pipeline` still owns named six things and said **two of them turned on one question**: whether a computed slot can hold markup that exists only at fold time. #1283 answered it for the computed *string* slots and named this as the other. This is that one.

An `XrefSegment` holds every field a `Ref{Xref}` node already carries — `target`, `window`, `roles`, `xrefstyle` and `derived` are plain values the builder resolved at recognition time — **except** `provided_text`, which the segment holds as a string where the node holds its display text as *children*. That slot takes the **fold of those children**.

## Why this is the opposite answer to #1283's, on purpose

A computed **string** slot had no output worth matching: the string pipeline captures a deferred cross-reference's template *before* passthroughs are restored, so a `role=` leaks a sentinel, and where it does not leak it spells rendered markup into a class name. #1283 therefore gave it the author's untranslated source.

A **display text** is the opposite case — it is markup by nature, and the string replacer captures exactly `<strong>bold</strong>` out of its own already-rendered haystack. So here the fold *reproduces* the byte string rather than approximating it.

One family, two slots, two answers, each matching what its own string path actually produces. The corpus pins both on the same segment.

## What landed

`block_tree_xref_segments` and `footnote_tree_xref_segments` walk exactly the traversals `assign_tree_xrefs` and `assign_footnote_tree_xrefs` walk — so a derived segment and an installed destination address the same node — and the block/footnote partition is the one `block_tree_xrefs` / `footnote_tree_xrefs` already draw. Both are staged under `#[allow(dead_code)]` and a `cfg(test)` re-export, the same staging every recognition side effect was under before the cutover re-attached it.

Two decisions worth recording, because a later reader would otherwise re-derive them:

- **The fold runs at the end of the parse**, with the renderer the parse carried — which is where the string replacer computes it too. Deriving it at *resolution* time would read whatever renderer that caller passed and hand the resolver a different `ResolutionContext` than the string pipeline does. That is the same renderer-timing hazard raised in review on #1285, avoided here by construction rather than argued about.
- **`resolved` is deliberately not carried across.** It is resolution's *output*, filled in later and mirrored back onto the node, so a node re-read after a sweep yields the segment it yielded before one — which is what makes the derivation idempotent.

## The one production change, found in review

The derivation started out purely additive. Review then found a real bug — and **not in the new code**: a cross-reference written inside a *visible index term* is deferred by the string pipeline, while all four pre-existing xref walks (`count_tree_xrefs`, `assign_tree_xrefs`, and their two footnote siblings) skipped `IndexTerm`. That is the fifth nested node list, and the same gap the side-effect sweep closed for its own three walks one increment ago.

The failure mode is misalignment, not omission:

```
See <<a>> and ((term <<b>>)) and <<c>>
  golden:  [a, b, c]
  derived: [a, c]        ← <<c>> takes <<b>>'s destination
```

All six walks now descend. The pre-existing four were *safe* rather than wrong — the count guard saw 2 slots against 3 segments and declined to correlate — but the tree was silently never authoritative for such a content. The fix widens that, which is this PR's only production change.

## Evidence

- **Corpus:** `inline_builder_xref_segment_parity` compares every field of every segment over **44 whole-document fixtures** parsed with `parse_deferred` (so both sides carry `resolved: None` and this compares *recognition* alone): both spellings, the present-but-empty text, a display text carrying each of the three recoverable pieces, a passthrough, a nested macro, the attribute-list form's other fields, a derived destination, an unresolved target, several references in one content, a reference nested in a span, the footnote-embedded complement, and every other location a deferred reference reaches — **section titles** (the location the document-order `title_refs` pass owns, with a forward reference and a reference between two titles) and **table cells** among them. Two vacuity guards keep a corpus that stopped deferring from passing.
- **Two documented divergences**, each pinned by its own test: #1283's `role=` rule on `xref:tgt[*bold*,role=*hl*]` (where `provided_text` is byte-identical, which is precisely this PR's claim), and `indexterm2:[…]`, whose shown term comes from an attribute-list parse rather than a range so the builder builds no subtree — the index-term family's own documented deferral, kept safe by the same count guard.
- **Audit:** 36 rows either side, 0 new and 0 closed — the walk fix changes when the correlation *succeeds*, not what any content renders to.
- **Coverage:** diff-neutral on both changed files (`content.rs` 21 missed regions / 8 missed lines, `section.rs` 40 / 39, either side).
- **Falsifiability needed a third test, and finding that out mattered.** Reverting either *collector* `IndexTerm` arm fails the corpus; reverting the `count` or `assign` arm failed **nothing**, since the corpus never reaches those. `a_reference_hidden_by_an_index_term_still_correlates_onto_its_own_node` closes that gap — it resolves the same shape for real and asserts each node's own `href`, the assertion a misalignment fails where a count would pass. Both verified by sabotaging each arm.
- Full preflight green: nightly `fmt --check`, `clippy --all-targets`, `test --workspace` (5,460 passing), nightly `doc --document-private-items`.

## What this leaves of the survey

Three items. `Content::passthroughs()` as a tree-backed view (public-API shaping — *deleting* it is as live an option as building it), the link family's dangerous-scheme warning (needs a node-level fact, since a rejected macro is left literal and there is no `Ref` node to hang it on), and the two the survey called hard-blocked: a footnote's catalog text (an ordering problem — the registry is read *during* the same content's substitution) and `{counter:}` advancement (solvable only **by** removing the pipeline).

With this staged, the computed-slot question #1282 raised has no open consequences left.