### PR TITLE
feat: A Raw node records the passthrough it came from (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6797,6 +6797,66 @@ Each phase is a reviewable unit with a clear exit gate.
   substitution) and `{counter:}` advancement (solvable only **by** removing the pipeline). With
   this one staged, the string-slot question the survey raised has no open consequences left.
 
+
+  *Step 6 landed as (a `Raw` node records the passthrough it came from):* the survey's fifth item —
+  [`Content::passthroughs()`](../../parser/src/content/content.rs) — is the one it called a live
+  choice rather than a task: "*deleting* it is as live an option as building the view", since it is
+  `pub` with no production consumer. The choice is made, and it is the **middle path**: keep the API
+  and back it with the tree. This is that decision's first prerequisite, and measuring the gap first
+  made it much smaller than the survey feared.
+
+  The public surface is two methods, [`text`](../../parser/src/content/passthroughs.rs) and
+  [`subs`](../../parser/src/content/passthroughs.rs) — `type_` and `attrlist` are `pub(crate)`, with
+  no accessor — and **five of the seven** passthrough forms are already exactly recoverable from
+  what the tree holds: `+++…+++` and a bare `pass:[…]` are
+  [`AsIs`](../../parser/src/inlines/inline_node.rs)/`None`, `++…++` and `$$…$$` are
+  `Escaped`/`Verbatim`, and a `Stem` node names its own group. So the survey's "chunkier than it
+  looks" is right but localizes to two facts, both about the same form.
+
+  A `pass:c,q[…]` body defeats [`RawForm`](../../parser/src/inlines/inline_node.rs) twice. It folds
+  `AsIs` exactly as a `+++…+++` body does, so the form cannot tell an arbitrary group from no group
+  at all; and an arbitrary group needs the substitution pipeline, which a fold — taking a renderer
+  and a `RenderContext` rather than a `Parser`, as the increment that made that change established
+  — has no way to reach, so the body is substituted at **build** time and `value` holds the
+  *result* where `text()` returns the *input*. Both facts now ride on the node:
+  [`RawOrigin::Passthrough`](../../parser/src/inlines/inline_node.rs) gains `subs` and
+  `source_text`.
+
+  Putting them inside the variant rather than beside it is what keeps this small and honest. Only
+  the passthrough-origin construction sites change — six in the lib, all in
+  [`passthrough_step`](../../parser/src/content/inline_builder/passthrough_step.rs), which is
+  exactly where the extraction pass already knows the answer — and the invariant becomes
+  structural: a group exists precisely when the origin is a passthrough, with no `Option` that could
+  be `None` for one. `RawOrigin` loses `Copy` and gains no lifetime, `source_text` being an owned
+  `String` present for one rare form.
+
+  `RawForm` stays. It is the *fold's* contract — emit or escape — and the two deliberately disagree
+  where the bare `+…+` form folds `AsIs` while its group is `Verbatim`, which two of this module's
+  own tests now state rather than infer. That disagreement is the argument for keeping both: a
+  reader asking what the fold does and a reader asking what the author wrote are asking different
+  questions.
+
+  [`inline_builder_passthrough_record_parity`](../../parser/src/tests/inline_builder_passthrough_record_parity.rs)
+  is the corpus, comparing every record the tree holds against the entry the extraction pass made
+  for the same source, in order: the delimited forms, the two `pass:` spellings, four explicit
+  substitution lists, an escaped closing bracket on both, several forms in one content, the
+  attribute-list-prefixed spelling, and the three containers the walk descends into. Both new fields
+  are falsifiable — dropping `source_text`, or reporting `None` for a resolved list, each fails it.
+
+  Two forms record **nothing** where the pass records an entry, and both are the view's problem
+  rather than the record's: an inline **STEM** body is a `Stem` node, not a `Raw` one, and the `x-`
+  **compatibility marker** sends its body through the normal substitutions as a subtree (which is
+  why its entry's group is `Normal`, the one attribute-list-prefixed spelling that differs from its
+  siblings). Their own test pins both. Audit: 36 rows either side, 0 new and 0 closed — no rendered
+  byte moves, the fold reading `form` exactly as before. Coverage diff-neutral.
+
+  *What the view still needs:* those two forms reached from wherever the tree does hold them, and
+  then the walk itself — `Content::passthroughs()` returning a view built from the tree rather than
+  a field the extraction pass fills. One thing to check before trusting either: this increment
+  compared **document** order against extraction order and found them equal for every fixture, but
+  the bare `+…+` form is extracted in a *second* pass, so the two orders are not equal by
+  construction and the view's own increment owes that its own corpus.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8210,6 +8270,26 @@ Each phase is a reviewable unit with a clear exit gate.
        ones misaligned every one after it. All six walks now descend; the count guard had kept the
        old ones safe rather than complete. Audit: 36 rows either side, 0 new and 0 closed;
        coverage diff-neutral on both changed files. See the step's own "landed as" note above.
+
+     - ✅ **prep (a `Raw` node records the passthrough it came from).** The survey's fifth item is
+       the one it called a live *choice* — `Content::passthroughs()` is `pub` with no production
+       consumer, so deleting it was as real an option as backing it with the tree. The choice is the
+       middle path, and this is its first prerequisite. Measuring first shrank it: the public
+       surface is two methods (`text`/`subs` — `type_` and `attrlist` have no accessor), and **five
+       of seven** forms are already exactly recoverable from
+       [`RawForm`](../../parser/src/inlines/inline_node.rs) plus the node kind. A `pass:c,q[…]` body
+       defeats it twice — it folds `AsIs` just as `+++…+++` does, so the form cannot tell an
+       arbitrary group from none; and an arbitrary group needs the substitution pipeline, which a
+       fold taking a `RenderContext` rather than a `Parser` cannot reach, so the body is substituted
+       at build time and `value` holds the result where `text()` returns the input. Both facts now
+       ride inside
+       [`RawOrigin::Passthrough`](../../parser/src/inlines/inline_node.rs) (`subs`, `source_text`)
+       rather than beside it, so only the six passthrough-origin construction sites change and the
+       invariant is structural. `RawForm` stays — it is the fold's contract, and the two
+       deliberately disagree where the bare `+…+` form folds `AsIs` under a `Verbatim` group.
+       Two forms record nothing where the pass records an entry (an inline STEM body, and the `x-`
+       compatibility marker's subtree), pinned by their own test. Audit: 36 rows either side, 0 new
+       and 0 closed; coverage diff-neutral. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -833,7 +833,10 @@ mod tests {
         let raw = InlineNode::Raw {
             value: CowStr::from(location.data()),
             form: RawForm::AsIs,
-            origin: RawOrigin::Passthrough,
+            origin: RawOrigin::Passthrough {
+                subs: crate::content::SubstitutionGroup::None,
+                source_text: None,
+            },
             location,
         };
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2639,7 +2639,10 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from("raw"),
                 form: RawForm::AsIs,
-                origin: RawOrigin::Passthrough,
+                origin: RawOrigin::Passthrough {
+                    subs: crate::content::SubstitutionGroup::None,
+                    source_text: None,
+                },
                 location: root,
             },
             InlineNode::Stem(crate::inlines::Stem {

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -757,7 +757,7 @@ mod tests {
                 .iter()
                 .filter_map(|node| match node {
                     InlineNode::Raw { origin, value, .. } => {
-                        Some((*origin, value.as_ref().to_string()))
+                        Some((origin.clone(), value.as_ref().to_string()))
                     }
 
                     _ => None,
@@ -785,10 +785,34 @@ mod tests {
         assert_eq!(
             by_spelling,
             vec![
-                ("+++<b>x</b>+++", vec![RawOrigin::Passthrough]),
-                ("++a < b++", vec![RawOrigin::Passthrough]),
-                ("$$<i>$$", vec![RawOrigin::Passthrough]),
-                ("pass:[<b>]", vec![RawOrigin::Passthrough]),
+                (
+                    "+++<b>x</b>+++",
+                    vec![RawOrigin::Passthrough {
+                        subs: crate::content::SubstitutionGroup::None,
+                        source_text: None
+                    }]
+                ),
+                (
+                    "++a < b++",
+                    vec![RawOrigin::Passthrough {
+                        subs: crate::content::SubstitutionGroup::Verbatim,
+                        source_text: None
+                    }]
+                ),
+                (
+                    "$$<i>$$",
+                    vec![RawOrigin::Passthrough {
+                        subs: crate::content::SubstitutionGroup::Verbatim,
+                        source_text: None
+                    }]
+                ),
+                (
+                    "pass:[<b>]",
+                    vec![RawOrigin::Passthrough {
+                        subs: crate::content::SubstitutionGroup::None,
+                        source_text: None
+                    }]
+                ),
             ]
         );
 

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -662,7 +662,16 @@ fn build_bare_unconstrained_match<'src>(
             node: Box::new(InlineNode::Raw {
                 value: CowStr::from(value),
                 form,
-                origin: RawOrigin::Passthrough,
+                // The bare `+…+` form is `Verbatim` like its delimited
+                // siblings; `substitute_and_restore` has already applied it,
+                // so `value` is the author's body (or, for a body enclosing an
+                // already-extracted construct, that body with each inner
+                // node's own fold bytes spliced in — which is what the string
+                // pipeline's own restore produces there too).
+                origin: RawOrigin::Passthrough {
+                    subs: SubstitutionGroup::Verbatim,
+                    source_text: None,
+                },
                 location,
             }),
         },
@@ -795,7 +804,10 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::AsIs,
-            origin: RawOrigin::Passthrough,
+            origin: RawOrigin::Passthrough {
+                subs: SubstitutionGroup::None,
+                source_text: None,
+            },
             location,
         };
     }
@@ -814,7 +826,10 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::Escaped,
-            origin: RawOrigin::Passthrough,
+            origin: RawOrigin::Passthrough {
+                subs: SubstitutionGroup::Verbatim,
+                source_text: None,
+            },
             location,
         };
     }
@@ -835,17 +850,24 @@ fn build_passthrough_node<'src>(
     let raw = content.data();
     let unescaped = raw.contains("\\]").then(|| raw.replace("\\]", "]"));
 
-    let value = if let Some(subs_list) = caps.get(14) {
+    // The explicit-list form is the one place `value` is not the author's own
+    // bytes, so it is also the one place the node records a `source_text`: an
+    // arbitrary group needs the substitution pipeline, which a fold has no
+    // `Parser` to reach, so the body is substituted here and the input kept
+    // beside the result.
+    let (value, subs, source_text) = if let Some(subs_list) = caps.get(14) {
         let text = unescaped.as_deref().unwrap_or(raw);
-        CowStr::from(build_pass_macro_subs_value(
-            text,
-            subs_list.as_str(),
-            parser,
-        ))
+        let (subs, _invalid) = SubstitutionGroup::from_custom_string(None, subs_list.as_str());
+
+        (
+            CowStr::from(passthrough_text(text, &subs, parser)),
+            subs,
+            Some(text.to_string()),
+        )
     } else if let Some(unescaped) = unescaped {
-        CowStr::from(unescaped)
+        (CowStr::from(unescaped), SubstitutionGroup::None, None)
     } else {
-        CowStr::from(raw)
+        (CowStr::from(raw), SubstitutionGroup::None, None)
     };
 
     // Either the body under `SubstitutionGroup::None` (nothing applied, so the
@@ -855,7 +877,7 @@ fn build_passthrough_node<'src>(
     InlineNode::Raw {
         value,
         form: RawForm::AsIs,
-        origin: RawOrigin::Passthrough,
+        origin: RawOrigin::Passthrough { subs, source_text },
         location,
     }
 }
@@ -979,7 +1001,18 @@ fn build_attrlisted_passthrough_node<'src>(
         vec![InlineNode::Raw {
             value: CowStr::from(body_span.data()),
             form,
-            origin: RawOrigin::Passthrough,
+            // This `Raw` is the *body* of an attribute-list-prefixed
+            // passthrough, whose `Styled` wrapper is what the extraction pass
+            // records as one entry; the group here is the body's own, read off
+            // the delimiters exactly as the unprefixed forms above read theirs.
+            origin: RawOrigin::Passthrough {
+                subs: if form == RawForm::AsIs {
+                    SubstitutionGroup::None
+                } else {
+                    SubstitutionGroup::Verbatim
+                },
+                source_text: None,
+            },
             location: body_span,
         }]
     };
@@ -1062,7 +1095,10 @@ fn build_bare_attrlisted_passthrough_node<'src>(
         vec![InlineNode::Raw {
             value: CowStr::from(body_span.data()),
             form: RawForm::Escaped,
-            origin: RawOrigin::Passthrough,
+            origin: RawOrigin::Passthrough {
+                subs: SubstitutionGroup::Verbatim,
+                source_text: None,
+            },
             location: body_span,
         }]
     };
@@ -1150,7 +1186,7 @@ mod tests {
 
     use super::{
         super::test_support::{
-            assert_raw, assert_styled, build_src, fold_html, golden_passthroughs, seed,
+            assert_raw, assert_styled, build_src, fold_html, golden_passthroughs, passthrough, seed,
         },
         apply_pass_macro_level, apply_passthroughs,
     };
@@ -1344,7 +1380,7 @@ mod tests {
     #[test]
     fn a_bare_plus_body_is_literal_text_unless_it_restores_something() {
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::{RawForm, RawOrigin};
+        use crate::inlines::RawForm;
 
         // A bare `+…+` body is `SubstitutionGroup::Verbatim` like `++…++`, so
         // by rights it is the author's literal text too. It could not say so
@@ -1357,7 +1393,12 @@ mod tests {
         // detected rather than assumed: with nothing restorable inside the
         // body, the value is the author's bytes and the fold escapes them.
         let nodes = build_src(Span::new("+a < b+"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "a < b");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::Escaped,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
+            "a < b",
+        );
 
         // The mixture keeps `AsIs`, since part of its value is another node's
         // rendering rather than anything an escape could reproduce.
@@ -1365,7 +1406,7 @@ mod tests {
         assert_raw_form(
             &nodes[0],
             RawForm::AsIs,
-            RawOrigin::Passthrough,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
             "a &lt;b&gt; c",
         );
     }
@@ -1414,7 +1455,7 @@ mod tests {
     #[test]
     fn a_specialcharacters_body_is_literal_text_the_fold_escapes() {
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::{RawForm, RawOrigin};
+        use crate::inlines::RawForm;
 
         // The shape this increment exists for. `SubstitutionGroup` decides
         // which form a passthrough body takes, and the two are not the same
@@ -1429,29 +1470,54 @@ mod tests {
         // Both stay opaque to every later step — that is what keeps them one
         // node kind — so this pins the distinction the kind alone cannot.
         let nodes = build_src(Span::new("+++<b>+++"));
-        assert_raw_form(&nodes[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::AsIs,
+            passthrough(crate::content::SubstitutionGroup::None),
+            "<b>",
+        );
 
         let nodes = build_src(Span::new("pass:[<b>]"));
-        assert_raw_form(&nodes[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::AsIs,
+            passthrough(crate::content::SubstitutionGroup::None),
+            "<b>",
+        );
 
         let nodes = build_src(Span::new("++<b>++"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "<b>");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::Escaped,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
+            "<b>",
+        );
 
         let nodes = build_src(Span::new("$$<b>$$"));
-        assert_raw_form(&nodes[0], RawForm::Escaped, RawOrigin::Passthrough, "<b>");
+        assert_raw_form(
+            &nodes[0],
+            RawForm::Escaped,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
+            "<b>",
+        );
 
         // The attribute-listed forms carry theirs as the `Styled` wrapper's
         // one child, and split the same way.
         let nodes = build_src(Span::new("[.role]+++<b>+++"));
         let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
-        assert_raw_form(&children[0], RawForm::AsIs, RawOrigin::Passthrough, "<b>");
+        assert_raw_form(
+            &children[0],
+            RawForm::AsIs,
+            passthrough(crate::content::SubstitutionGroup::None),
+            "<b>",
+        );
 
         let nodes = build_src(Span::new("[.role]++<b>++"));
         let children = assert_styled(&nodes[0], StyleVariant::Unquoted, SpanForm::Unconstrained);
         assert_raw_form(
             &children[0],
             RawForm::Escaped,
-            RawOrigin::Passthrough,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
             "<b>",
         );
     }
@@ -1588,7 +1654,7 @@ mod tests {
         }
 
         use super::super::test_support::assert_raw_form;
-        use crate::inlines::{RawForm, RawOrigin};
+        use crate::inlines::RawForm;
 
         let parser =
             Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
@@ -1599,7 +1665,7 @@ mod tests {
         assert_raw_form(
             &nodes[0],
             RawForm::AsIs,
-            RawOrigin::Passthrough,
+            passthrough(crate::content::SubstitutionGroup::Verbatim),
             "a b [1] c d",
         );
         assert_eq!(nodes[0].span().data(), "+a $$b < c$$ d+");

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -1020,7 +1020,10 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from(location.data()),
                 form: RawForm::AsIs,
-                origin: RawOrigin::Passthrough,
+                origin: RawOrigin::Passthrough {
+                    subs: crate::content::SubstitutionGroup::None,
+                    source_text: None,
+                },
                 location,
             },
         ]);

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -154,6 +154,20 @@ pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'sr
 /// the parse's — and that both are
 /// [`Passthrough`](RawOrigin::Passthrough)-origin, unlike the `Raw` leaves a
 /// substitution leaves behind in place.
+/// A [`Passthrough`](RawOrigin::Passthrough) origin carrying `subs` and no
+/// `source_text` — the shape every form but `pass:c,q[…]` takes.
+///
+/// Spelled out at each call site rather than defaulted, so a test states the
+/// group it expects instead of letting it be inferred from the
+/// [`RawForm`](crate::inlines::RawForm) beside it. The two deliberately
+/// disagree for the bare `+…+` form, which is `Verbatim` but folds `AsIs`.
+pub(super) fn passthrough(subs: crate::content::SubstitutionGroup) -> RawOrigin {
+    RawOrigin::Passthrough {
+        subs,
+        source_text: None,
+    }
+}
+
 pub(super) fn assert_raw_form(
     node: &InlineNode<'_>,
     form: crate::inlines::RawForm,

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -1,5 +1,6 @@
 use crate::{
     HasSpan, Span,
+    content::SubstitutionGroup,
     inlines::{Anchor, Callout, CharRef, Footnote, Image, IndexTerm, Ref, Stem, Styled, Ui},
     strings::CowStr,
 };
@@ -329,13 +330,46 @@ mod tests {
 /// [`Substitution`](Self::Substitution) node's bytes sees exactly what the
 /// replacer saw. Recording it on the node is what lets a recognition gate tell
 /// the two apart without having to know which pass it is running in.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+///
+/// A [`Passthrough`](Self::Passthrough) additionally carries the two facts the
+/// extraction pass resolved for it, which nothing else in the tree records: the
+/// substitution group its body is restored under, and — for the one form whose
+/// [`value`](InlineNode::Raw) is *not* the author's own bytes — that body. See
+/// the variant's own documentation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum RawOrigin {
     /// An explicit passthrough the extraction pass pulled out before any step
     /// ran: `+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, or an inline STEM body.
     ///
     /// The author asked for this text to be off limits.
-    Passthrough,
+    Passthrough {
+        /// The substitution group this body is restored under, as the
+        /// extraction pass resolved it — `None` for `+++…+++` and a bare
+        /// `pass:[…]`, `Verbatim` for `++…++` and `$$…$$`, and whatever list a
+        /// `pass:c,q[…]` spelled out.
+        ///
+        /// [`RawForm`] is the *fold's* two-valued view of this: a group that
+        /// applies nothing renders [`AsIs`](RawForm::AsIs), one that applies
+        /// special characters and nothing else renders
+        /// [`Escaped`](RawForm::Escaped). The two agree for every group the
+        /// fold can carry out by itself, and the group says more than the fold
+        /// needs precisely so that a consumer asking *what the author wrote*
+        /// does not have to infer it back from what the fold did.
+        subs: SubstitutionGroup,
+
+        /// The author's body **before** its group was applied, when
+        /// [`value`](InlineNode::Raw) is not it.
+        ///
+        /// For every form the fold can restore by itself, `value` *is* the
+        /// author's body and this is `None`. The exception is a `pass:` macro
+        /// carrying an explicit substitution list (`pass:c,q[…]`): an arbitrary
+        /// group needs the substitution pipeline, and a fold takes a renderer
+        /// and a [`RenderContext`](crate::parser::RenderContext) rather than a
+        /// `Parser`, so that body is substituted at **build** time and `value`
+        /// holds the result. Recording the input beside it is what keeps the
+        /// author's own text answerable from the tree.
+        source_text: Option<String>,
+    },
 
     /// Raw output a substitution produced **in place**, with no extraction
     /// involved: a literal `<`, `>`, or `&` from an expanded attribute value

--- a/parser/src/tests/inline_builder_passthrough_record_parity.rs
+++ b/parser/src/tests/inline_builder_passthrough_record_parity.rs
@@ -1,0 +1,194 @@
+//! A differential harness for the passthrough facts a
+//! [`Raw`](crate::inlines::InlineNode::Raw) node records.
+//!
+//! Design §5.2's survey named [`Content::passthroughs`] as one of the six
+//! things `run_pipeline` still solely owns, and called it the one where
+//! *deleting* the API was as live an option as building a tree-backed view.
+//! The view is the chosen path, and this is its first prerequisite: the tree
+//! did not hold enough to answer either of the two things a
+//! [`Passthrough`](crate::content::Passthrough) exposes.
+//!
+//! [`RawForm`](crate::inlines::RawForm) is the fold's *two-valued* view — emit
+//! or escape — and five of the seven passthrough forms are exactly recoverable
+//! from it. The two that are not are what
+//! [`RawOrigin::Passthrough`](crate::inlines::RawOrigin) now carries:
+//!
+//!   * **`subs`.** A `pass:c,q[…]` body folds `AsIs` exactly as a `+++…+++`
+//!     body does, so the form cannot tell the two apart, and the group is what
+//!     [`Passthrough::subs`](crate::content::Passthrough::subs) returns.
+//!   * **`source_text`.** An arbitrary group needs the substitution pipeline,
+//!     which a fold — taking a renderer and a
+//!     [`RenderContext`](crate::parser::RenderContext), not a `Parser` — has no
+//!     way to reach. So a `pass:c,q[…]` body is substituted at *build* time and
+//!     `value` holds the result, where
+//!     [`Passthrough::text`](crate::content::Passthrough::text) returns the
+//!     input. Recording the input beside the result is what keeps the author's
+//!     own bytes answerable from the tree.
+//!
+//! Nothing reads either field yet — the view itself is a later increment — so
+//! this corpus is what pins them, by comparing every record the tree holds
+//! against the entry the string pipeline extracted for the same source.
+
+use crate::{
+    Parser, Span,
+    content::{Content, SubstitutionGroup},
+    inlines::{InlineNode, RawOrigin},
+};
+
+/// One passthrough as either side describes it: the author's body, and the
+/// group it is restored under.
+type Record = (String, SubstitutionGroup);
+
+/// What the string pipeline extracted, in extraction order.
+fn golden(content: &Content<'_>) -> Vec<Record> {
+    content
+        .passthroughs()
+        .iter()
+        .map(|pt| (pt.text().to_string(), pt.subs().clone()))
+        .collect()
+}
+
+/// What the tree records, in document order.
+///
+/// A [`Raw`](InlineNode::Raw) node of
+/// [`Passthrough`](RawOrigin::Passthrough) origin is one entry; its body is
+/// `source_text` where the build-time substitution moved `value` away from the
+/// author's bytes, and `value` itself everywhere else.
+fn derived(nodes: &[InlineNode<'_>], out: &mut Vec<Record>) {
+    for node in nodes {
+        match node {
+            InlineNode::Raw {
+                value,
+                origin: RawOrigin::Passthrough { subs, source_text },
+                ..
+            } => {
+                let text = source_text
+                    .clone()
+                    .unwrap_or_else(|| value.as_ref().to_string());
+
+                out.push((text, subs.clone()));
+            }
+
+            InlineNode::Styled(styled) => derived(&styled.children, out),
+            InlineNode::Ref(reference) => derived(&reference.children, out),
+            InlineNode::Footnote(footnote) => derived(&footnote.children, out),
+            InlineNode::IndexTerm(index_term) => derived(&index_term.children, out),
+
+            _ => {}
+        }
+    }
+}
+
+/// The forms whose extraction entry and tree node correspond one-to-one.
+///
+/// The two that do not are deferred to the view's own increment and pinned by
+/// [`the_two_forms_the_tree_records_nothing_for`] below.
+const CORPUS: &[&str] = &[
+    // `+++…+++` and a bare `pass:[…]` — group `None`, body verbatim.
+    "a +++<b>raw</b>+++ x",
+    "a pass:[bare<b>] x",
+    "+++ leading +++ and +++ trailing +++",
+    // `++…++` and `$$…$$` — group `Verbatim`.
+    "a ++lit<b>++ x",
+    "a $$dollar<b>$$ x",
+    "a ++one++ and $$two$$ and ++three++",
+    // An explicit substitution list: the form whose `value` is *not* the
+    // author's body, and whose group no `RawForm` can express.
+    "a pass:c,q[c and *q* <b>] x",
+    "a pass:q[just *quotes*] x",
+    "a pass:n[normal <b> subs] x",
+    "a pass:[plain] and pass:c[<escaped>] together",
+    // An escaped closing bracket, which unescapes before either side records
+    // the body.
+    r"a pass:[br\]acket] x",
+    r"a pass:c,q[*q* br\]acket] x",
+    // Several forms in one content, so the *order* is compared too.
+    "+++A+++ then ++B++ then $$C$$ then pass:[D]",
+    "++B++ and pass:c,q[*E*] and +++A+++",
+    // An **attribute-list-prefixed** passthrough, whose body is a `Raw` inside
+    // the `Styled` wrapper the extraction pass records — the two still agree,
+    // because the group the wrapper resolves is the body's own.
+    "a [.role]++attr++ x",
+    "a [.role]+++raw+++ x",
+    // Inside containers the walk has to descend into.
+    "*bold with ++lit++ inside*",
+    "link:x.html[text with ++lit++ in it]",
+    "footnote:[a note with +++<b>++++ inside]",
+];
+
+#[test]
+fn a_raw_node_records_the_passthrough_it_came_from() {
+    let parser = Parser::default();
+    let mut seen = 0usize;
+
+    for source in CORPUS {
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+        let mut tree = vec![];
+        derived(content.inlines(), &mut tree);
+
+        seen += tree.len();
+
+        assert_eq!(
+            tree,
+            golden(&content),
+            "the tree's passthrough records diverged from the extraction pass for {source:?}"
+        );
+    }
+
+    // Guards against a corpus that stopped extracting anything, which would
+    // otherwise compare empty against empty and report success.
+    assert!(
+        seen >= 25,
+        "the corpus stopped exercising passthrough records: {seen}"
+    );
+}
+
+#[test]
+fn the_two_forms_the_tree_records_nothing_for() {
+    // Two forms are deliberately outside the corpus above, and in both the tree
+    // records *nothing* where the extraction pass records an entry — so this is
+    // the view's problem rather than the record's, since the fact this
+    // increment adds lives on a `Raw` node and neither form builds one.
+    let parser = Parser::default();
+
+    let records = |source: &str| -> (Vec<Record>, Vec<Record>) {
+        let mut content = Content::from(Span::new(source));
+        SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+        let mut tree = vec![];
+        derived(content.inlines(), &mut tree);
+
+        (golden(&content), tree)
+    };
+
+    // The `x-` **compatibility marker** sends the body through the normal
+    // substitutions as a node subtree rather than holding it as one opaque
+    // `Raw`, which is why its entry's group is `Normal` — the one
+    // attribute-list-prefixed spelling that differs from its siblings above.
+    let (golden_records, tree) = records("a [x-]++attr++ x");
+
+    assert_eq!(
+        golden_records,
+        [("attr".to_string(), SubstitutionGroup::Normal)]
+    );
+
+    assert!(
+        tree.is_empty(),
+        "the compat marker's body must not record a Raw: {tree:?}"
+    );
+
+    // An inline **STEM** body is a `Stem` node, not a `Raw` one.
+    let (golden_records, tree) = records("a stem:[x^2] x");
+
+    assert_eq!(
+        golden_records,
+        [("x^2".to_string(), SubstitutionGroup::Stem)]
+    );
+
+    assert!(
+        tree.is_empty(),
+        "a STEM body must not record a Raw: {tree:?}"
+    );
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod block_nesting_depth;
 pub(crate) mod fixtures;
 mod hash;
 mod inline_builder_document_parity;
+mod inline_builder_passthrough_record_parity;
 mod inline_builder_recorder_parity;
 mod inline_builder_side_effect_parity;
 mod inline_builder_xref_segment_parity;


### PR DESCRIPTION
#1282's survey named `Content::passthroughs()` as the one item that was a live **choice** rather than a task: the method is `pub` with no production consumer, so deleting it was as real an option as backing it with the tree. The choice is the **middle path** — keep the API, build the view — and this is its first prerequisite.

## Measuring first made it much smaller than the survey feared

The survey said a `Passthrough` "carries `subs`, `type_` and `attrlist`". In fact the *public* surface is two methods, `text()` and `subs()` — `type_` and `attrlist` are `pub(crate)` with no accessor. And **five of the seven forms are already exactly recoverable** from what the tree holds:

| Form | `subs()` | tree | recoverable? |
|---|---|---|---|
| `+++…+++`, `pass:[…]` | `None` | `Raw{AsIs}` | ✅ |
| `++…++`, `$$…$$` | `Verbatim` | `Raw{Escaped}` | ✅ |
| `stem:[…]` | `Stem` | `Stem` node | ✅ from node kind |
| **`pass:c,q[…]`** | `Custom([…])` | `Raw{AsIs}` | ❌ two ways |

`pass:c,q[…]` defeats `RawForm` twice. It folds `AsIs` exactly as `+++…+++` does, so the form cannot tell an arbitrary group from no group at all; and an arbitrary group needs the substitution pipeline, which a fold — taking a renderer and a `RenderContext` rather than a `Parser`, as the increment that made that change established — has no way to reach. So the body is substituted at **build** time and `value` holds `c and <strong>q</strong> &lt;b&gt;` where `text()` must return `c and *q* <b>`.

## What landed

`RawOrigin::Passthrough` gains `subs` and `source_text`. Putting them **inside** the variant rather than beside it is what keeps this small and honest:

- only the passthrough-origin construction sites change — **six in the lib**, all in `passthrough_step.rs`, which is exactly where the extraction pass already knows the answer (a `Raw`-level field would have meant 54);
- the invariant becomes structural — a group exists precisely when the origin is a passthrough, with no `Option` that could be `None` for one;
- `RawOrigin` loses `Copy` and gains no lifetime, `source_text` being an owned `String` present for one rare form.

`RawForm` **stays**. It is the fold's contract — emit or escape — and the two deliberately disagree where the bare `+…+` form folds `AsIs` under a `Verbatim` group. Two of this module's own tests now state the group rather than inferring it from the form beside it.

## Evidence

- **Corpus:** `inline_builder_passthrough_record_parity` compares every record the tree holds against the entry the extraction pass made for the same source, **in order** — the delimited forms, both `pass:` spellings, four explicit substitution lists, an escaped closing bracket on each, several forms in one content, the attribute-list-prefixed spelling, and three containers the walk descends into. A vacuity guard keeps a corpus that stopped extracting from passing.
- **Falsifiable, both fields, verified by sabotage:** dropping `source_text` fails it; reporting `None` for a resolved list fails it.
- **Two forms record nothing** where the pass records an entry, and both are the *view's* problem rather than the record's: an inline STEM body is a `Stem` node, not a `Raw` one, and the `x-` compatibility marker sends its body through the normal substitutions as a subtree (which is why its entry's group is `Normal` — the one attribute-list-prefixed spelling that differs from its siblings). Their own test pins both.
- **Audit:** 36 rows either side, 0 new and 0 closed — no rendered byte moves, the fold reading `form` exactly as before.
- **Coverage:** diff-neutral (`passthrough_step.rs` 22 missed regions / 10 missed lines either side; `inline_node.rs` 100%).
- Full preflight green, **with no existing expectation edited**: nightly `fmt --check`, `clippy --all-targets`, `test --workspace` (5,462 passing), nightly `doc --document-private-items`.

## What the view still needs

The two forms above reached from wherever the tree *does* hold them, and then the walk itself. One thing owed to that increment rather than assumed here: this one compared **document** order against extraction order and found them equal for every fixture, but the bare `+…+` form is extracted in a *second* pass, so the two orders are not equal by construction and the view needs its own corpus for that.

---
_Generated by [Claude Code](https://claude.ai/code/session_019XerthjcmSs8HirHXrbHDo)_