### PR TITLE
feat: A STEM body keeps its own nodes (inline-ast step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -6932,6 +6932,52 @@ Each phase is a reviewable unit with a clear exit gate.
   commit messages rather than hand-edited — that increment's own commit message is what has to carry
   the ordering change into the release notes.
 
+  *Step 6 landed as (a `Stem` keeps its body's own nodes):* the increment before this one closed six
+  of the seven passthrough forms and left one shape short of an entry — a STEM expression
+  **embedding** an already-extracted passthrough, where the pass records two entries and the tree
+  recorded one. This is the structural half of closing it, landed on its own so that the view's
+  increment can be purely about the walk.
+
+  The fix turned out narrower than the note predicting it. That note named the *outer* entry's text
+  as an obstacle — the pass keeps the `\u{96}0\u{97}` sentinel where the inner body was lifted out,
+  while [`stem_expression_value`](../../parser/src/content/inline_builder/stem_step.rs) splices it
+  back — and the decision taken was that the view should report the **restored** body. Probing the
+  tree said it already does: once a `Stem` carries its own group and source (the increment above),
+  the outer entry reads `("x <b> y", Stem)` on both sides. So only the **inner** entry was ever
+  missing, and the whole change is to stop folding the body's nodes away. Measuring before building
+  turned a structural redesign into one field.
+
+  [`Stem`](../../parser/src/inlines/stem.rs) gains `children`. `value` is the *rendering* of those
+  nodes, which is what the fold emits; `children` is what they **are**. The two are redundant for
+  the overwhelmingly common flat body — a single `Text` run — and differ exactly when the body
+  embeds a passthrough, which is the case the field exists for. Nothing reads it yet, so this moves
+  no rendered byte: the fold still reads `value`, and the suite is green with no expectation edited.
+
+  A second test pins the invariant that keeps the change from spreading. `apply_stem` runs
+  immediately after `apply_passthroughs`, whose output is `Text` / `Raw` only, so a STEM body can
+  never hold a cross-reference, a macro or a span — and therefore no *other* walk in the crate is
+  now obliged to descend into `Stem::children`. `a_stem_bodys_nodes_are_only_text_and_raw` asserts
+  it over five bodies that each try to smuggle one in. Asserted rather than assumed, because this
+  branch has twice shipped a walk that missed a container it should have descended into — the
+  `IndexTerm` children, and this same nested passthrough — and both times the corpus had covered the
+  construct and the container separately but never crossed. If a later step ever moves `apply_stem`
+  ahead of the extraction pass, that test fails and names the walks that then need revisiting.
+
+  Audit: 37 rows either side, 0 new and 0 closed. (One row more than the previous increment
+  reported, from this session's rebuild of the throwaway patch rather than from anything on the
+  branch — `origin/inline-ast` measures 37 under the same patch. What carries across increments is
+  the *difference*, never the absolute count.) Coverage diff-neutral outside the new tests' own
+  `panic!` arms. Two sabotages: dropping the body's nodes, and keeping only its `Text` runs. The
+  second is the one that matters, since it is the `Raw` leaf that carries the record and a corpus
+  that only counted children would have passed it.
+
+  *What the view still needs:* the walk, and one narrower shape than before. A STEM macro carrying
+  an **explicit non-local substitution list** over an embedded passthrough
+  (`stem:c,q[x +++<b>+++ y]`) is declined by `build_stem_node` outright — the list cannot be applied
+  run-by-run around the embedded body without risking a construct that spans the boundary — so
+  there is no `Stem` node at all to hold `children`, and the tree records only the inner
+  passthrough where the pass records both. That is the view increment's to answer, not this one's.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8389,6 +8435,22 @@ Each phase is a reviewable unit with a clear exit gate.
        limitation rather than a regression, since a `Stem` carried neither fact before; pinned by
        its own test and owed to the view's increment. Audit: 36 rows either side, 0 new and 0
        closed; coverage diff-neutral on all three files. See the step's own "landed as" note above.
+
+     - ✅ **prep (a `Stem` keeps its body's own nodes).** The structural half of the one shape the
+       entry above left short of a record: a STEM expression **embedding** an already-extracted
+       passthrough, where the pass makes two entries and the tree made one.
+       [`Stem`](../../parser/src/inlines/stem.rs) gains `children` — the body's own nodes, where
+       `value` is their *rendering* — so the inner `Raw` leaf and the record it carries survive
+       instead of being folded into the value. Nothing reads the field yet, so no rendered byte
+       moves. Measuring first narrowed the increment to that one field: the outer entry, which the
+       note predicting this work named as the harder half, already agrees once a `Stem` carries its
+       own group and source. A second test pins the invariant that keeps the change from spreading —
+       `apply_stem` runs immediately after `apply_passthroughs`, so a STEM body holds only
+       `Text` / `Raw` and no *other* walk is obliged to descend into it. Still short of a record is
+       the explicit **non-local** substitution list (`stem:c,q[x +++<b>+++ y]`), which
+       `build_stem_node` declines outright, leaving no node to hold anything; that is the view
+       increment's to answer. Audit: 37 rows either side, 0 new and 0 closed; coverage diff-neutral
+       outside the new tests' own `panic!` arms. See the step's own "landed as" note above.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2650,6 +2650,7 @@ mod tests {
                 value: CowStr::from("x"),
                 subs: crate::content::SubstitutionGroup::Stem,
                 source_text: None,
+                children: vec![],
                 location: root,
             }),
         ];

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -248,6 +248,10 @@ fn build_stem_node<'src>(
 
     Some(InlineNode::Stem(Stem {
         notation,
+        // The body's own nodes, kept rather than folded away: an embedded
+        // passthrough is its own extraction entry, and `value` alone gives a
+        // walk no way to reach it.
+        children: emitted,
         // The author's expression is recorded only where the group changed it,
         // the same rule `RawOrigin::Passthrough`'s own `source_text` follows.
         source_text: (source != value).then_some(source),
@@ -722,5 +726,88 @@ mod tests {
             fold_html(&nodes, &HtmlSubstitutionRenderer {}),
             golden_passthroughs(source)
         );
+    }
+
+    #[test]
+    fn a_stem_node_keeps_its_bodys_own_nodes() {
+        // `children` is the body as it *is*, where `value` is its rendering.
+        // They are redundant for a flat body and differ exactly when one
+        // embeds a passthrough — the case the field exists for, since an
+        // embedded passthrough is its own extraction entry and folding it into
+        // `value` left a walk no way to reach it.
+        use crate::inlines::{InlineNode, RawOrigin};
+
+        // A flat body: one `Text` run, and `value` says the same thing.
+        let nodes = build_src(Span::new("stem:[x^2]"));
+        let InlineNode::Stem(stem) = &nodes[0] else {
+            panic!("expected a Stem, got {:?}", nodes[0]);
+        };
+
+        assert_eq!(stem.children.len(), 1);
+        assert!(matches!(stem.children[0], InlineNode::Text { .. }));
+        assert_eq!(stem.value.as_ref(), "x^2");
+
+        // An embedded passthrough: three nodes, the middle one the `Raw` leaf
+        // carrying its own record — which is the whole point.
+        let nodes = build_src(Span::new("stem:[x +++<b>+++ y]"));
+        let InlineNode::Stem(stem) = &nodes[0] else {
+            panic!("expected a Stem, got {:?}", nodes[0]);
+        };
+
+        assert_eq!(stem.children.len(), 3, "{:?}", stem.children);
+
+        let InlineNode::Raw { value, origin, .. } = &stem.children[1] else {
+            panic!("expected a Raw, got {:?}", stem.children[1]);
+        };
+
+        assert_eq!(value.as_ref(), "<b>");
+        assert_eq!(
+            *origin,
+            RawOrigin::Passthrough {
+                subs: crate::content::SubstitutionGroup::None,
+                source_text: None,
+            }
+        );
+
+        // The rendering is unchanged by keeping them — this increment moves no
+        // byte, which is what lets the whole suite stay green.
+        assert_eq!(stem.value.as_ref(), "x <b> y");
+    }
+
+    #[test]
+    fn a_stem_bodys_nodes_are_only_text_and_raw() {
+        // The invariant every *other* walk in the crate relies on without
+        // saying so: `apply_stem` runs immediately after `apply_passthroughs`,
+        // whose output is `Text`/`Raw` only, so no cross-reference, macro or
+        // span can ever be nested inside a `Stem`'s body. That is why adding
+        // `children` here obliges no other walk to descend into it.
+        //
+        // Asserted rather than assumed, because this branch has twice shipped a
+        // walk that missed a container it should have descended into. If a
+        // later step ever moves ahead of this one, this fails and names the
+        // walks that then need revisiting.
+        use crate::inlines::InlineNode;
+
+        for source in [
+            "stem:[x +++<b>+++ y]",
+            "stem:[a $$lit$$ b]",
+            "stem:[see *bold* and <<ref>> and image:i.png[]]",
+            "stem:[{attr} and link:x.html[t]]",
+            "latexmath:[e ++f++ g]",
+        ] {
+            let nodes = build_src(Span::new(source));
+
+            let InlineNode::Stem(stem) = &nodes[0] else {
+                panic!("{source:?} did not build a Stem; got {:?}", nodes[0]);
+            };
+
+            for child in &stem.children {
+                assert!(
+                    matches!(child, InlineNode::Text { .. } | InlineNode::Raw { .. }),
+                    "{source:?} put a {child:?} in a STEM body; every walk that \
+                     skips `Stem::children` now needs revisiting"
+                );
+            }
+        }
     }
 }

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -895,6 +895,7 @@ fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
                     value: CowStr::from(value),
                     subs: crate::content::SubstitutionGroup::Stem,
                     source_text: None,
+                    children: vec![],
                     location: span,
                 })
             }

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -232,6 +232,7 @@ mod tests {
                 value: CowStr::from("x^2"),
                 subs: crate::content::SubstitutionGroup::Stem,
                 source_text: None,
+                children: vec![],
                 location,
             }),
             InlineNode::LineBreak { location },

--- a/parser/src/inlines/stem.rs
+++ b/parser/src/inlines/stem.rs
@@ -1,4 +1,4 @@
-use crate::{HasSpan, Span, content::SubstitutionGroup, strings::CowStr};
+use crate::{HasSpan, Span, content::SubstitutionGroup, inlines::InlineNode, strings::CowStr};
 
 /// Inline STEM content (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`).
 ///
@@ -46,6 +46,24 @@ pub struct Stem<'src> {
     /// `source_text` does for a `pass:c,q[…]` body, and is `None` when the
     /// group changed nothing.
     pub source_text: Option<String>,
+
+    /// The expression body's own nodes — the [`Text`](InlineNode::Text) runs it
+    /// is written from, and any [`Raw`](InlineNode::Raw) passthrough the
+    /// extraction pass had already pulled out of it before this macro was
+    /// recognized (`stem:[x +++<b>+++ y]`).
+    ///
+    /// [`value`](Self::value) is the *rendering* of these, which is what the
+    /// fold emits; this is what they **are**. The two are redundant for the
+    /// overwhelmingly common flat body — one `Text` run — and differ exactly
+    /// when the body embeds a passthrough, which is the case they exist for: an
+    /// embedded one is a [`Passthrough`](crate::content::Passthrough) entry in
+    /// its own right, and folding it into `value` (as this node used to) left a
+    /// walk no way to reach it.
+    ///
+    /// A body whose expression this module declined to recognize builds no
+    /// `Stem` at all, so there is no partial state here: a node either holds
+    /// its whole body or does not exist.
+    pub children: Vec<InlineNode<'src>>,
 
     /// The source location of the whole STEM macro.
     pub location: Span<'src>,


### PR DESCRIPTION
The increment before this one ([#1288](https://github.com/asciidoc-rs/asciidoc-parser/pull/1288))
closed six of the seven passthrough forms and left one shape short of an entry: a STEM expression
**embedding** an already-extracted passthrough, where the extraction pass records **two** entries
and the tree recorded **one**. This is the structural half of closing that, landed on its own so
the view increment (`Content::passthroughs()` reading off the tree) can be purely about the walk.

## What changed

`Stem` gains one field:

```rust
pub children: Vec<InlineNode<'src>>,
```

`value` is the *rendering* of those nodes, which is what the fold emits; `children` is what they
**are**. The two are redundant for the overwhelmingly common flat body — a single `Text` run — and
differ exactly when the body embeds a passthrough, which is the case the field exists for.

Nothing reads it yet, so **this moves no rendered byte**: `build_stem_node` still computes `value`
the same way and the fold still reads `value`. The suite is green with no expectation edited.

## Measuring first narrowed it to one field

The note predicting this work named the *outer* entry's text as the harder half: the pass keeps the
`\u{96}0\u{97}` sentinel where the inner body was lifted out, while `stem_expression_value` splices
it back, so the two sides were expected to disagree on the outer entry too. The decision taken was
that the view should report the **restored** body — and probing the tree said it already does. Once
a `Stem` carries its own group and source (which #1288 gave it), the outer entry reads
`("x <b> y", Stem)` on both sides. Only the **inner** entry was ever missing, so the whole change is
to stop folding the body's nodes away.

## The invariant that keeps this from spreading

`apply_stem` runs immediately after `apply_passthroughs`, whose output is `Text`/`Raw` only, so a
STEM body can never hold a cross-reference, a macro or a span — and therefore **no other walk in
the crate is now obliged to descend into `Stem::children`**.

`a_stem_bodys_nodes_are_only_text_and_raw` asserts that over five bodies that each try to smuggle
one in (`*bold*`, `<<ref>>`, `image:i.png[]`, `{attr}`, `link:x.html[t]`). Asserted rather than
assumed, because this branch has twice shipped a walk that missed a container it should have
descended into — the `IndexTerm` children (#1286) and this same nested passthrough (#1288) — and
both times the corpus had covered the construct and the container separately but never crossed. If
a later step ever moves `apply_stem` ahead of the extraction pass, that test fails and names the
walks that then need revisiting.

## What is still short of a record

A STEM macro carrying an **explicit non-local substitution list** over an embedded passthrough
(`stem:c,q[x +++<b>+++ y]`) is declined by `build_stem_node` outright — the list cannot be applied
run-by-run around the embedded body without risking a construct that spans the boundary — so there
is no `Stem` node at all to hold `children`, and the tree records only the inner passthrough where
the pass records both. Unchanged by this increment and the view increment's to answer; the existing
`a_non_local_explicit_subs_list_beside_a_nested_passthrough_is_a_documented_divergence` still pins
it.

## Gates

- **Fold-parity audit:** 37 rows either side, **0 new and 0 closed**. (One row more than #1288
  reported, from this session's rebuild of the throwaway patch rather than from anything on the
  branch — `origin/inline-ast` measures 37 under the same patch. What carries across increments is
  the *difference*, never the absolute count.)
- **Coverage:** diff-neutral outside the new tests' own `panic!` arms —
  `stem_step.rs` goes 3→13 missed regions and 2→7 missed lines, and every one of the five new
  uncovered lines is an assertion-failure arm (`panic!("expected a Stem, …")` and one `assert!`
  false branch). `stem.rs` stays at 3 regions / 100%.
- **Sabotages:** dropping the body's nodes (`children: vec[]`), and keeping only its `Text` runs.
  Each fails `a_stem_node_keeps_its_bodys_own_nodes`. The second is the one that matters, since it
  is the `Raw` leaf that carries the record — a corpus that only counted children would have passed
  it.
- Full preflight (nightly `fmt --check`, `clippy --all-targets`, `test --workspace`, nightly
  `doc --no-deps --document-private-items`) clean.

## Design doc

A new *Step 6 landed as (a `Stem` keeps its body's own nodes)* narrative paragraph and its Phase 4
checklist entry, in the style of every prior increment on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_019XerthjcmSs8HirHXrbHDo)_