### PR TITLE
feat: Read a content's deferred cross-references off its tree (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7117,6 +7117,67 @@ Each phase is a reviewable unit with a clear exit gate.
   itself** — the footnote catalog's text, `{counter:}` advancement, and this warning. What is left
   before step 6 is step 6.
 
+  *Step 6 landed as (the deferred cross-references, read off the tree):* the first increment of
+  step 6 proper, and the one that takes the **first** of the six survey items from a staged
+  building block to the production answer.
+  [`block_tree_xref_segments`](../../parser/src/content/content.rs) and
+  [`footnote_tree_xref_segments`](../../parser/src/content/content.rs) have been written, corpused
+  and unwired since they landed; [`Content::set_tree_xrefs`](../../parser/src/content/content.rs)
+  installs what they return, so what a content carries for its deferred cross-references is what
+  its **tree** said, not what `InlineXrefReplacer` recorded.
+
+  *The partition is the substantive part, not the fields.* The string pipeline produces one flat
+  list indexed by placeholder, and tells a block-level reference from one re-homed into a footnote
+  by asking which placeholders its template still splices — so `block_tree_xrefs` /
+  `footnote_tree_xrefs` had to re-derive that split on every resolution. The two walks partition
+  **structurally**, so a [`DeferredContent`](../../parser/src/content/content.rs) now holds the two
+  lists it always wanted and the template-reading split is gone from the tree-sourced path. Both
+  halves then correlate positionally with the same walks that install destinations back, which is
+  what makes the mirror exact rather than merely safe.
+
+  *That exactness is the one behavior change, and it is an improvement.* A footnote subtree holding
+  fewer references than the string pipeline re-homed used to make the **footnote** mirror decline
+  outright — the flat list's footnote half could not be positionally correlated — leaving a
+  perfectly well-recognized `<<c>>` inside the footnote unresolved in the tree. Its own list is now
+  exactly the nodes it belongs to, so it resolves.
+  `a_footnote_subtree_that_defers_a_reference_form_still_mirrors_what_it_holds` (renamed from
+  `footnote_xref_mirror_is_skipped_…`) pins it from both ends. Nothing rendered moves: a fold emits
+  a footnote's marker without descending into its subtree, so this is what a consumer reading
+  `inlines()` sees, in the direction of being right.
+
+  *What did **not** happen here is the deletion,* and measuring says why. The carve-out
+  [`from_tree`](../../parser/src/content/content.rs) names — the tree holding fewer
+  cross-references than the string pipeline deferred — is not a formality: the builder's documented
+  unrecognized set is non-empty, and where it applies the string pipeline's answer is the *better*
+  one. Two shapes reach it. `xref:sec[a *b, c* d,role=hl]` was already pinned; instrumenting the
+  `rebuild_rendered` arm across the whole suite showed it is the **only** content in ~5,400 tests
+  that takes the template path under a resolved parse. The second, `indexterm2:[<<b>>]`, was pinned
+  only under `parse_deferred` — the construct and the *resolved* container had never been crossed —
+  and it takes a different branch (an **empty** derived list, where the first is short by one), the
+  branch that would otherwise clear the deferred state and render `&lt;&lt;b&gt;&gt;` where the
+  document says `<a href="#b">`. Both now have resolved-path tests, and a third crosses the
+  carve-out with the **title** container, which resolves through `title_refs::compute` rather than
+  `Content::resolve_references` and so splits the flat list on a path of its own.
+
+  So the sentinel system's *retirement* is complete and its *deletion* is gated on something no
+  cutover increment can supply: the builder recognizing every cross-reference form the replacer
+  does. That is a prep question, and naming it is this increment's other result.
+
+  Audit: 37 rows either side, 0 new and 0 closed — the divergent **source set** is byte-identical;
+  two rows move by a stateful test renderer's own callback counters, which the footnote-mirror
+  improvement shifts. Coverage exactly diff-neutral on all four changed production files (21 missed
+  regions / 8 missed lines on `content.rs`, 5 / 0 on `title_refs.rs`, 0 / 0 on
+  `substitution_group.rs`, unchanged on `section.rs`). Three sabotages fail three distinct sets: a
+  no-op wiring, a dropped `provided_text`, and a dropped footnote partition; removing the carve-out
+  fails exactly the two shapes above.
+
+  *What still defers* is the deletion itself, which now has a named prerequisite of its own — a
+  block title carried across a section heading arrives at the claiming block with its inline nodes
+  dropped, because `Parser::pending_block_title` has no `'src` lifetime to carry them, so it is the
+  one content whose rendering cannot be a fold at all. It is the 60th of the 60 deferred titles the
+  title-fold increment counted, and it keeps the template path for that reason rather than for the
+  carve-out's.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8629,6 +8690,28 @@ Each phase is a reviewable unit with a clear exit gate.
        explicit subs list builds no node to report the outer entry from. Audit: 37 rows either
        side, 0 new and 0 closed; coverage exactly diff-neutral (3 missed regions and 3 missed lines
        before and after). See the step's own "landed as" note above.
+
+     - ✅ **the deferred cross-references, read off the tree.** The first of the survey's six items
+       to go from staged machinery to the production answer:
+       [`Content::set_tree_xrefs`](../../parser/src/content/content.rs) installs what
+       [`block_tree_xref_segments`](../../parser/src/content/content.rs) and
+       [`footnote_tree_xref_segments`](../../parser/src/content/content.rs) return, so a content's
+       deferred cross-references are its **tree's**. The substantive part is the *partition*: the
+       two walks split block-level from footnote-embedded structurally, where the string pipeline
+       produced one flat list and re-derived the split from which placeholders its template still
+       spliced. Both halves then correlate positionally with the walks that install destinations
+       back, which makes the footnote mirror exact rather than merely safe — the one behavior
+       change, and an improvement (a recognized reference inside a footnote whose sibling the
+       builder defers now resolves in the tree; nothing rendered moves). The sentinel system is
+       **not** deleted here, and measuring says why: the carve-out
+       [`from_tree`](../../parser/src/content/content.rs) names is reached by two real shapes, one
+       of which (`indexterm2:[<<b>>]`) had been pinned only under `parse_deferred` and would
+       otherwise have regressed a resolved document's output. Deleting it is gated on the builder
+       recognizing every cross-reference form the replacer does — a prep question — plus the one
+       content that has no tree to fold at all (a block title carried across a section heading,
+       whose nodes cannot cross the `'src`-erasing `pending_block_title` hop). Audit: 37 rows
+       either side, 0 new and 0 closed; coverage exactly diff-neutral on all four changed
+       production files. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -10,7 +10,7 @@ use crate::{
         parse_utils::parse_blocks_until,
     },
     content::{
-        Content, SubstitutionGroup, XrefSegment, inline_builder::fold_reference_text,
+        Content, SubstitutionGroup, inline_builder::fold_reference_text,
         substitute_attributes_in_reftext,
     },
     document::{InterpretedValue, RefType},
@@ -492,14 +492,14 @@ impl<'src> SectionBlock<'src> {
         self.section_number.as_ref()
     }
 
-    /// Returns the section title's deferred cross-reference template and
-    /// segments, if the title contains any cross-references.
+    /// Returns the section title's deferred cross-references, if the title
+    /// contains any.
     ///
     /// Used by the document-order title resolution pass (see
     /// [`Document::resolve_references`]).
     ///
     /// [`Document::resolve_references`]: crate::Document::resolve_references
-    pub(crate) fn section_title_deferred_parts(&self) -> Option<(&str, &[XrefSegment])> {
+    pub(crate) fn section_title_deferred_parts(&self) -> Option<crate::content::DeferredParts<'_>> {
         self.section_title.deferred_parts()
     }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -142,16 +142,111 @@ pub struct Content<'src> {
 }
 
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
+///
+/// The cross-references are read off the content's own **inline tree** (see
+/// [`block_tree_xref_segments`] and [`footnote_tree_xref_segments`]), which is
+/// what design §5.2's survey named as the first of the six things
+/// `run_pipeline` still solely owned. They arrive already partitioned into the
+/// two lists resolution keeps apart, where the string pipeline produced one
+/// flat list that had to be split by asking which placeholders its template
+/// still spliced.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct DeferredContent {
-    /// The locally-substituted text with opaque placeholder tokens marking
-    /// where each cross-reference will be spliced in. This is the source of
-    /// truth from which [`Content::rendered`] is (re)built, so resolution is
-    /// non-destructive and may be repeated.
+    /// The **block-level** cross-references, in the order
+    /// [`block_tree_xref_segments`] visits them — which is the order
+    /// [`Content::mirror_tree_xref_resolution`] installs destinations back in,
+    /// the two being the same walk.
+    block: Vec<XrefSegment>,
+
+    /// The cross-references this content's **footnotes** carry. A footnote's
+    /// text is extracted out of the flow, so these are absent from
+    /// [`block`](Self::block) and are installed into the tree's footnote
+    /// subtrees instead.
+    footnote: Vec<XrefSegment>,
+
+    /// The string pipeline's own placeholder template, still captured by
+    /// [`Content::finalize_deferred`] as it always was.
+    ///
+    /// Nothing on the production path renders from it any more except the one
+    /// content that has no tree to fold: a block title carried across a section
+    /// heading, which travels through `Parser::pending_block_title` as an
+    /// [`OwnedTitle`] because the parser it rides on has no `'src` lifetime,
+    /// and so arrives at the claiming block with its inline nodes dropped. Its
+    /// rendering cannot be a fold, so it stays a splice — see
+    /// [`Content::rebuild_rendered`]. It goes when that title keeps its tree,
+    /// which is what deletes design §4.2's second sentinel system outright.
+    ///
+    /// Empty between [`Content::set_deferred_xrefs`] recording the list and
+    /// `finalize_deferred` capturing the template, which is within one
+    /// `run_pipeline` call and reaches no reader.
     template: String,
 
-    /// The cross-references, in placeholder order.
-    xrefs: Vec<XrefSegment>,
+    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
+    /// read off this content's **inline tree**, rather than being the string
+    /// pipeline's own flat list.
+    ///
+    /// `false` is the carve-out design §4.2's second sentinel system still
+    /// keeps: the single-pass builder leaves a documented set of forms
+    /// unrecognized, so the tree can hold *fewer* cross-references than the
+    /// string pipeline deferred. Where it does, the tree is known not to
+    /// describe this content — installing its list would silently drop a
+    /// cross-reference and folding it would render the construct as literal
+    /// source — so the string pipeline's answer stands, on the placeholder
+    /// path, exactly as before this increment
+    /// (`xref_mirror_is_skipped_when_the_tree_defers_a_reference_form`).
+    ///
+    /// The carve-out narrows on its own as each builder prep lands, and
+    /// disappears when none is left — which is what finally deletes this
+    /// sentinel system.
+    from_tree: bool,
+
+    /// The string pipeline's own flat list, in placeholder order — the answer
+    /// [`Content::set_tree_xrefs`] overwrote.
+    ///
+    /// It is kept for one reason: the differential corpus that compares the two
+    /// derivations
+    /// ([`inline_builder_xref_segment_parity`](crate::tests)) needs a golden,
+    /// and once the tree's answer *is* the production answer it would otherwise
+    /// be comparing the tree against itself and passing for that reason — the
+    /// exact failure the frozen recordings exist to prevent. This is the same
+    /// move `Passthroughs::observable` made when
+    /// [`Content::passthroughs`](Content::passthroughs) became a view over the
+    /// tree, for the same reason, and it goes the same way: with
+    /// `run_pipeline` itself.
+    ///
+    /// It takes part in the derived [`PartialEq`]/[`Eq`]/[`Hash`]/[`Debug`]
+    /// like any other field, so two `DeferredContent`s compare on it in a test
+    /// build and cannot in a release one. That is harmless here because both
+    /// sides of every comparison in this crate come from the same pipeline run,
+    /// and writing the four impls out by hand to exclude one transitional field
+    /// would cost more than it buys.
+    #[cfg(test)]
+    string_xrefs: Vec<XrefSegment>,
+}
+
+/// A read-only view of a [`Content`]'s deferred cross-references — the shape
+/// [`Content::deferred_parts`] hands out.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DeferredParts<'a> {
+    /// The block-level cross-references, in document order.
+    pub(crate) block: &'a [XrefSegment],
+
+    /// The cross-references this content's footnotes carry.
+    pub(crate) footnote: &'a [XrefSegment],
+
+    /// The placeholder template, for a content that renders from one — see
+    /// [`DeferredContent::template`].
+    pub(crate) template: &'a str,
+
+    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
+    /// read off the content's inline tree — see
+    /// [`DeferredContent::from_tree`].
+    pub(crate) from_tree: bool,
+
+    /// The string pipeline's own flat list — see
+    /// [`DeferredContent::string_xrefs`].
+    #[cfg(test)]
+    pub(crate) string_xrefs: &'a [XrefSegment],
 }
 
 /// A single deferred cross-reference.
@@ -263,9 +358,15 @@ pub(crate) struct OwnedTitle {
     /// cross-references are present).
     rendered: String,
 
-    /// The placeholder template and cross-references, when the title carries
-    /// any; `None` for the (overwhelmingly common) cross-reference-free title.
-    deferred: Option<(String, Vec<XrefSegment>)>,
+    /// The deferred cross-references, when the title carries any; `None` for
+    /// the (overwhelmingly common) cross-reference-free title.
+    ///
+    /// The inline **tree** they were read off does not travel with them — its
+    /// nodes borrow `'src` — so a carried title is the one content whose
+    /// rendering cannot be a fold, and the
+    /// [`template`](DeferredContent::template) is what it renders from
+    /// instead.
+    deferred: Option<DeferredContent>,
 
     /// The document attributes the title's own content carried, so the rebuilt
     /// [`Content`] can still be folded later than its parse — see
@@ -332,10 +433,7 @@ impl<'src> Content<'src> {
     pub(crate) fn to_owned_title(&self) -> OwnedTitle {
         OwnedTitle {
             rendered: self.rendered.as_ref().to_string(),
-            deferred: self
-                .deferred
-                .as_ref()
-                .map(|d| (d.template.clone(), d.xrefs.clone())),
+            deferred: self.deferred.as_ref().map(|d| (**d).clone()),
             render_attributes: self.render_attributes.clone(),
         }
     }
@@ -348,9 +446,7 @@ impl<'src> Content<'src> {
             original: span,
             rendered: title.rendered.into(),
             source_lines: None,
-            deferred: title
-                .deferred
-                .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
+            deferred: title.deferred.map(Box::new),
             passthroughs: Vec::new(),
             inlines: Vec::new(),
             render_attributes: title.render_attributes,
@@ -539,10 +635,15 @@ impl<'src> Content<'src> {
     /// resolution pass, which re-renders a title's cross-references with
     /// cross-title (including circular) coordination that the per-content
     /// [`resolve_references`](Self::resolve_references) cannot provide.
-    pub(crate) fn deferred_parts(&self) -> Option<(&str, &[XrefSegment])> {
-        self.deferred
-            .as_ref()
-            .map(|d| (d.template.as_str(), d.xrefs.as_slice()))
+    pub(crate) fn deferred_parts(&self) -> Option<DeferredParts<'_>> {
+        self.deferred.as_ref().map(|d| DeferredParts {
+            block: &d.block,
+            footnote: &d.footnote,
+            template: &d.template,
+            from_tree: d.from_tree,
+            #[cfg(test)]
+            string_xrefs: &d.string_xrefs,
+        })
     }
 
     /// Overwrites the rendered text directly.
@@ -558,21 +659,30 @@ impl<'src> Content<'src> {
     /// Returns `true` if this content contains one or more cross-references
     /// that have not yet been resolved to a destination.
     pub fn has_unresolved_refs(&self) -> bool {
-        self.deferred
-            .as_ref()
-            .is_some_and(|d| d.xrefs.iter().any(|x| x.resolved.is_none()))
+        self.deferred.as_ref().is_some_and(|d| {
+            d.block
+                .iter()
+                .chain(d.footnote.iter())
+                .any(|x| x.resolved.is_none())
+        })
     }
 
-    /// Records the cross-references discovered for this content during the
-    /// macros substitution step. The placeholder tokens for these references
-    /// must already have been written into [`Content::rendered`], in the same
-    /// order as `xrefs`.
+    /// Records the cross-references the **string pipeline's** macros step
+    /// discovered, in placeholder order. The placeholder tokens must already
+    /// have been written into [`Content::rendered`], in the same order.
     ///
-    /// This must be called at most once per `Content`: the placeholder indices
-    /// already embedded in [`Content::rendered`] are positions into this single
-    /// `xrefs` vector. The macros substitution runs once per content, so this
-    /// holds in practice; the assertion guards against a future caller breaking
-    /// it.
+    /// This is no longer what a caller reads: the production list is read off
+    /// the inline tree a moment later (see
+    /// [`set_tree_xrefs`](Self::set_tree_xrefs), which overwrites this).
+    /// What it still does is give the string pipeline its own answer — the
+    /// golden every differential corpus on this branch takes through
+    /// [`apply_string_pipeline`](crate::content::SubstitutionGroup) — and carry
+    /// the placeholder template that a content with no tree renders from.
+    ///
+    /// The list lands in [`block`](DeferredContent::block) because the string
+    /// pipeline does not partition: a footnote-embedded reference is told apart
+    /// by its placeholder having left the template, which is what
+    /// [`template_splices`](Self::template_splices) reads it back out with.
     pub(crate) fn set_deferred_xrefs(&mut self, xrefs: Vec<XrefSegment>) {
         if xrefs.is_empty() {
             return;
@@ -584,9 +694,86 @@ impl<'src> Content<'src> {
         );
 
         self.deferred = Some(Box::new(DeferredContent {
+            #[cfg(test)]
+            string_xrefs: Vec::new(),
+            block: xrefs,
+            footnote: Vec::new(),
             template: String::new(),
-            xrefs,
+            from_tree: false,
         }));
+    }
+
+    /// Installs the deferred cross-references **read off this content's inline
+    /// tree**, replacing whatever the string pipeline's own macros step left
+    /// here.
+    ///
+    /// This is design §5.2's survey item, wired: the two lists come from
+    /// [`block_tree_xref_segments`] and [`footnote_tree_xref_segments`], which
+    /// have been staged and unwired since they landed — the same staging every
+    /// recognition side effect was under before it was re-attached.
+    ///
+    /// The string pipeline still produces its own list (it is the differential
+    /// corpora's golden until `run_pipeline` is deleted), and this overwrites
+    /// it. What is *kept* from it is the placeholder template, and only where
+    /// the template's own placeholders line up one-to-one with `block` — see
+    /// [`DeferredContent::template`] for the one content that reads it and why
+    /// a mismatch must drop it rather than splice into it.
+    ///
+    /// A content whose tree holds no cross-reference at all clears the deferred
+    /// state outright: a construct the builder does not recognize is one this
+    /// content no longer defers, and it renders as the fold leaves it.
+    pub(crate) fn set_tree_xrefs(&mut self, block: Vec<XrefSegment>, footnote: Vec<XrefSegment>) {
+        let Some(previous) = self.deferred.take() else {
+            // The string pipeline deferred nothing here, so neither does this
+            // content: the builder recognizes a *subset* of the forms
+            // `InlineXrefReplacer` does — that containment is the premise the
+            // carve-out below rests on — so a tree holding a cross-reference
+            // node the replacer did not defer cannot arise. Asserted rather
+            // than handled, since handling it would mean a placeholder-free
+            // deferred state no caller is written for.
+            debug_assert!(
+                block.is_empty() && footnote.is_empty(),
+                "the tree deferred cross-references the string pipeline did not: \
+                 {block:?} / {footnote:?}"
+            );
+
+            return;
+        };
+
+        // The carve-out: where the tree holds fewer cross-references than the
+        // string pipeline deferred, it is known not to describe this content,
+        // so its list is *not* installed and the string pipeline's answer
+        // stands. See `DeferredContent::from_tree`.
+        if Self::template_splices(&previous) != block.len() {
+            self.deferred = Some(previous);
+            return;
+        }
+
+        self.deferred = Some(Box::new(DeferredContent {
+            #[cfg(test)]
+            string_xrefs: previous.string_xrefs,
+            block,
+            footnote,
+            template: previous.template,
+            from_tree: true,
+        }));
+    }
+
+    /// How many placeholders the string pipeline's template still splices.
+    ///
+    /// Its flat list is indexed by *placeholder*, so "the block-level ones" are
+    /// those whose placeholder survived the footnote re-homing pass — the count
+    /// the tree's own block-level list has to match for the two to describe the
+    /// same content. Called only while `previous` is still the string
+    /// pipeline's own answer, where `block` is that flat list.
+    fn template_splices(previous: &DeferredContent) -> usize {
+        (0..previous.block.len())
+            .filter(|index| {
+                previous
+                    .template
+                    .contains(&Content::xref_placeholder(*index))
+            })
+            .count()
     }
 
     /// Returns the placeholder token for the cross-reference at `index`.
@@ -601,14 +788,26 @@ impl<'src> Content<'src> {
     /// unresolved fallback so it is immediately clean for callers that read it
     /// before resolution.
     pub(crate) fn finalize_deferred(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
-        if self.deferred.is_none() {
-            return;
-        }
-
         let template = self.rendered.as_ref().to_string();
 
-        if let Some(deferred) = self.deferred.as_mut() {
+        {
+            let Some(deferred) = self.deferred.as_mut() else {
+                return;
+            };
+
             deferred.template = template;
+
+            // Snapshot the string pipeline's own answer here rather than where
+            // the list was recorded: this runs at the very end of
+            // `run_pipeline`, so the passthrough restore pass
+            // (`restore_deferred_xref_passthroughs`) has already reached into
+            // each segment's text. A snapshot taken earlier would hand the
+            // differential corpus a golden still carrying `\u{96}`…`\u{97}`
+            // sentinels.
+            #[cfg(test)]
+            {
+                deferred.string_xrefs = deferred.block.clone();
+            }
         }
 
         self.rebuild_rendered(renderer);
@@ -625,7 +824,7 @@ impl<'src> Content<'src> {
         mut restore: impl FnMut(&mut String),
     ) {
         if let Some(deferred) = self.deferred.as_mut() {
-            for xref in &mut deferred.xrefs {
+            for xref in &mut deferred.block {
                 if let Some(text) = xref.provided_text.as_mut() {
                     restore(text);
                 }
@@ -651,54 +850,68 @@ impl<'src> Content<'src> {
         let source = self.original;
 
         if let Some(deferred) = self.deferred.as_mut() {
-            let DeferredContent { template, xrefs } = deferred.as_mut();
+            // Where the two lists were read off the tree they arrive already
+            // partitioned, and only the block-level ones are reported here: a
+            // footnote's own copy of an embedded reference resolves and reports
+            // it. Where they are still the string pipeline's flat list, that
+            // same split is read out of the template — a placeholder that has
+            // left it was re-homed onto a footnote — which is what
+            // `reports_unresolved` answers for either shape.
+            let from_tree = deferred.from_tree;
+            let template = deferred.template.clone();
 
-            // A `deferred` block always holds at least one xref placeholder, so
-            // its finalized template is never empty. An empty template here
-            // means `finalize_deferred` was skipped (a future-refactor hazard);
-            // the `template.contains` guard below would then silently suppress
-            // every unresolved-ref warning, so catch that invariant break in
-            // debug builds.
-            debug_assert!(!template.is_empty());
-
-            for (index, xref) in xrefs.iter_mut().enumerate() {
+            for (index, xref) in deferred.block.iter_mut().enumerate() {
                 xref.resolved = resolver.resolve(&ResolutionContext {
                     target: &xref.target,
                     provided_text: xref.provided_text.as_deref(),
                     derived: xref.derived.as_ref(),
                 });
 
-                // A reference whose placeholder is no longer in the template was
-                // re-homed into a footnote (see `rehome_xref_placeholders`); the
-                // footnote resolves and reports it, so it is not reported here.
-                // A target that names a document is never reported: it
-                // carries its own destination, so there was nothing here to
-                // resolve.
-                if xref.resolved.is_none()
-                    && xref.derived.is_none()
-                    && template.contains(&Content::xref_placeholder(index))
-                {
+                let reports_unresolved =
+                    from_tree || template.contains(&Content::xref_placeholder(index));
+
+                // A target that names a document is never reported: it carries
+                // its own destination, so there was nothing here to resolve.
+                if xref.resolved.is_none() && xref.derived.is_none() && reports_unresolved {
                     warnings.unresolved(&xref.target, source);
                 }
             }
+
+            for xref in deferred.footnote.iter_mut() {
+                xref.resolved = resolver.resolve(&ResolutionContext {
+                    target: &xref.target,
+                    provided_text: xref.provided_text.as_deref(),
+                    derived: xref.derived.as_ref(),
+                });
+            }
         }
 
-        // Exactly **one** of the two renderings runs. The fold is authoritative
-        // only where the tree is known to hold every cross-reference the string
-        // pipeline deferred, which `resolve_tree_references` reports as it
-        // mirrors; everywhere else the template's answer stands. Running both
-        // and keeping the second would be observable, not merely wasteful: a
-        // renderer is a host-supplied trait object, so a stateful one — a
-        // recorder, a numbering backend, anything counting its own callbacks —
-        // would see every callback for this content twice in one pass.
+        let from_tree = self.resolve_tree_references();
+
+        // Exactly **one** of the two renderings runs, and which one is now a
+        // question about the *tree* rather than about the cross-references in
+        // it: a content with a tree folds it, and a content without one — the
+        // carried block title, the only content in that position — renders its
+        // template. Running both and keeping the second would be observable,
+        // not merely wasteful: a renderer is a host-supplied trait object, so a
+        // stateful one (a recorder, a numbering backend, anything counting its
+        // own callbacks) would see every callback for this content twice in one
+        // pass.
         //
-        // Reaching the second arm means this content has deferred parts, and a
-        // content's retained attributes travel with those
+        // The carve-out this replaces was narrower on paper and wider in fact:
+        // it kept the template wherever the tree did not hold *every*
+        // cross-reference the string pipeline deferred. Reading the
+        // cross-references off the tree makes that condition unstatable — the
+        // tree holds all of its own — so what is left is only the content that
+        // has no tree at all.
+        //
+        // A content with deferred cross-references retains its own attributes
         // (`set_render_attributes` is called for exactly that content — see
-        // `only_deferred_content_retains_its_render_attributes`), so it always
-        // binds. It is written as a binding rather than an unwrap because the
-        // invariant lives in that pairing, not in the field's type.
-        if self.resolve_tree_references()
+        // `only_deferred_content_retains_its_render_attributes`), so the fold
+        // arm always binds. It is written as a binding rather than an unwrap
+        // because the invariant lives in that pairing, not in the field's type.
+        if from_tree
+            && !self.inlines.is_empty()
             && let Some(attributes) = self.render_attributes.as_deref().cloned()
         {
             self.refold(attributes, renderer, parser);
@@ -782,7 +995,7 @@ impl<'src> Content<'src> {
     /// from the complementary list: its segment is re-homed out of the block
     /// template when the footnote's text is extracted, so it is excluded from
     /// the block correlation above and correlated instead with the tree's
-    /// footnote subtrees (see [`footnote_tree_xrefs`]).
+    /// footnote subtrees (see [`resolved_destinations`]).
     ///
     /// Returns what
     /// [`mirror_tree_xref_resolution`](Self::mirror_tree_xref_resolution)
@@ -790,23 +1003,37 @@ impl<'src> Content<'src> {
     /// cross-references the string pipeline deferred — and `false` for a
     /// content with no tree or nothing deferred, neither of which is re-folded.
     fn resolve_tree_references(&mut self) -> bool {
-        if self.inlines.is_empty() {
-            return false;
-        }
-
         let Some(deferred) = self.deferred.as_ref() else {
             return false;
         };
 
-        let block_ordered = block_tree_xrefs(&deferred.template, &deferred.xrefs);
-        let footnote_ordered = footnote_tree_xrefs(&deferred.template, &deferred.xrefs);
+        let (block_ordered, footnote_ordered) = if deferred.from_tree {
+            (
+                resolved_destinations(&deferred.block),
+                resolved_destinations(&deferred.footnote),
+            )
+        } else {
+            // The string pipeline's flat list, split the way it has always been
+            // split: a placeholder still in the template is block-level, one
+            // that has left it was re-homed onto a footnote. The block half
+            // will not correlate (that count mismatch is why this content is on
+            // this path at all), but the footnote half still can, and does.
+            (
+                template_partition(&deferred.template, &deferred.block, true),
+                template_partition(&deferred.template, &deferred.block, false),
+            )
+        };
 
-        self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered)
+        let from_tree = deferred.from_tree;
+
+        self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered);
+
+        from_tree
     }
 
     /// Installs a pre-computed list of resolved cross-reference destinations —
     /// in placeholder (document) order, as produced by
-    /// [`block_tree_xrefs`] — into this content's inline tree.
+    /// [`resolved_destinations`] — into this content's inline tree.
     ///
     /// This is the tree-facing half of
     /// [`resolve_references`](Self::resolve_references): where that method
@@ -820,7 +1047,7 @@ impl<'src> Content<'src> {
     ///
     /// `footnote_ordered` carries the same thing for the cross-references
     /// embedded in this content's **footnotes** — the complementary list, as
-    /// produced by [`footnote_tree_xrefs`] — which are installed into the
+    /// produced by [`resolved_destinations`] — which are installed into the
     /// tree's footnote subtrees. The two lists partition the deferred segments,
     /// so each is correlated against exactly the nodes it belongs to.
     ///
@@ -846,9 +1073,9 @@ impl<'src> Content<'src> {
         &mut self,
         block_ordered: &[Option<ResolvedReference>],
         footnote_ordered: &[Option<ResolvedReference>],
-    ) -> bool {
+    ) {
         if self.inlines.is_empty() {
-            return false;
+            return;
         }
 
         // The correlation is positional, so it requires the tree to hold
@@ -860,8 +1087,7 @@ impl<'src> Content<'src> {
         // pairing is unknowable; the mirror is skipped for that list — leaving
         // its nodes in their honest unresolved state — rather than assigning
         // destinations to the wrong nodes.
-        let block_mirrored = count_tree_xrefs(&self.inlines) == block_ordered.len();
-        if block_mirrored {
+        if count_tree_xrefs(&self.inlines) == block_ordered.len() {
             let mut next = 0;
             assign_tree_xrefs(&mut self.inlines, block_ordered, &mut next);
         }
@@ -870,8 +1096,6 @@ impl<'src> Content<'src> {
             let mut next = 0;
             assign_footnote_tree_xrefs(&mut self.inlines, footnote_ordered, &mut next);
         }
-
-        block_mirrored
     }
 
     /// Renders this content **from its deferred template**, without installing
@@ -895,7 +1119,7 @@ impl<'src> Content<'src> {
 
         Some(render_template(
             &deferred.template,
-            &deferred.xrefs,
+            &deferred.block,
             renderer,
         ))
     }
@@ -907,7 +1131,14 @@ impl<'src> Content<'src> {
             return;
         };
 
-        self.rendered = render_template(&deferred.template, &deferred.xrefs, renderer).into();
+        // A `deferred` content always reaches here with its template captured:
+        // `finalize_deferred` sets it at the end of the same `run_pipeline`
+        // call that recorded the list, and nothing reads it in between. An
+        // empty one here would blank the content, so catch that invariant break
+        // in debug builds rather than let it render.
+        debug_assert!(!deferred.template.is_empty());
+
+        self.rendered = render_template(&deferred.template, &deferred.block, renderer).into();
     }
 }
 
@@ -987,56 +1218,39 @@ pub(crate) fn fold_resolved_title(
     ))
 }
 
-/// Builds the placeholder-ordered list of resolved destinations that
+/// The resolved destinations of `xrefs`, in their own order — the shape
 /// [`Content::mirror_tree_xref_resolution`] installs into an inline tree.
 ///
-/// The list holds one entry per deferred segment whose placeholder **still
-/// appears in `template`**, in placeholder (document) order. A
-/// footnote-embedded cross-reference is re-homed out of the template, so
-/// filtering on the template keeps this list aligned one-to-one with the tree's
-/// *block-level* cross-reference nodes; the re-homed ones are carried by
-/// [`footnote_tree_xrefs`] instead. A segment that resolved to nothing
-/// contributes a `None`, so an unresolved node is left unresolved, exactly as
-/// the rendered string leaves it.
-pub(crate) fn block_tree_xrefs(
-    template: &str,
-    xrefs: &[XrefSegment],
-) -> Vec<Option<ResolvedReference>> {
-    xrefs
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)))
-        .map(|(_, xref)| xref.resolved.clone())
-        .collect()
+/// The two lists it takes are this applied to the two a [`DeferredContent`]
+/// holds. There is no filtering left to do: the block-level and
+/// footnote-embedded references arrive already partitioned, having been read
+/// off the tree by two walks that partition them structurally. The string
+/// pipeline needed a filter here because it produced one flat list and told the
+/// two apart by asking which placeholders its template still spliced.
+///
+/// A segment that resolved to nothing contributes a `None`, so an unresolved
+/// node is left unresolved, exactly as the rendered string leaves it.
+pub(crate) fn resolved_destinations(xrefs: &[XrefSegment]) -> Vec<Option<ResolvedReference>> {
+    xrefs.iter().map(|xref| xref.resolved.clone()).collect()
 }
 
-/// Builds the list of resolved destinations for the cross-references embedded
-/// in this content's **footnotes**, which
-/// [`Content::mirror_tree_xref_resolution`] installs into the tree's footnote
-/// subtrees.
+/// The resolved destinations of the string pipeline's own flat list, filtered
+/// to the half `template` still splices (`spliced`) or to the half it no longer
+/// does — the block-level and footnote-embedded partitions respectively.
 ///
-/// This is the exact complement of [`block_tree_xrefs`]: it holds one entry
-/// per deferred segment whose placeholder **no longer appears in `template`**,
-/// in segment order. A placeholder leaves the template only by being re-homed
-/// onto a footnote (see [`rehome_xref_placeholders`]), which happens when the
-/// footnote's text is extracted out of the block — and the footnotes are
-/// extracted left to right, each scanning its own text left to right, so this
-/// order is the document order in which the tree's footnote subtrees hold their
-/// cross-reference nodes.
-///
-/// The segments themselves are the block's own copies, resolved in the very
-/// same sweep that resolved the block-level ones. The footnote holds a clone of
-/// each (same target, provided text, and derived destination), so the resolver
-/// sees an identical [`ResolutionContext`] on both sides and the tree carries
-/// the destination the rendered footnote text reflects.
-pub(crate) fn footnote_tree_xrefs(
+/// This is the split the tree performs structurally, done the only way a flat
+/// placeholder-indexed list allows. It is reached only for a content the
+/// carve-out keeps on the string pipeline's answer — see
+/// [`DeferredContent::from_tree`] — and goes with it.
+pub(crate) fn template_partition(
     template: &str,
     xrefs: &[XrefSegment],
+    spliced: bool,
 ) -> Vec<Option<ResolvedReference>> {
     xrefs
         .iter()
         .enumerate()
-        .filter(|(index, _)| !template.contains(&Content::xref_placeholder(*index)))
+        .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)) == spliced)
         .map(|(_, xref)| xref.resolved.clone())
         .collect()
 }
@@ -1096,10 +1310,11 @@ fn count_footnote_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
 ///
 /// This is one of the six things design §5.2's survey found the string pipeline
 /// still solely owning — the first of them the survey called *blocked* rather
-/// than merely unbuilt — staged here as its own building block exactly as every
-/// recognition side effect was (see
-/// [`apply_macro_side_effects`](crate::content::inline_builder)): nothing calls
-/// it on the production path yet, and wiring it in is the cutover's own job.
+/// than merely unbuilt. It is **wired**: [`Content::set_tree_xrefs`] installs
+/// what this returns, so what a content carries for its deferred
+/// cross-references is what its tree said — everywhere the tree describes the
+/// same cross-references the string pipeline deferred, which is the carve-out
+/// [`DeferredContent::from_tree`] names.
 ///
 /// A [`Ref`](InlineNode::Ref)`{`[`Xref`](RefVariant::Xref)`}` node already
 /// carries every field an [`XrefSegment`] holds but one — `target`, `window`,
@@ -1141,9 +1356,6 @@ fn count_footnote_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
 /// **not** descend into a [`Footnote`](InlineNode::Footnote) subtree, whose
 /// segments are re-homed out of the block template.
 /// [`footnote_tree_xref_segments`] derives the complementary list.
-// Consumed only by tests until the step 6 cutover wires it in, the same
-// staging every recognition side effect was under before it was re-attached.
-#[allow(dead_code)]
 pub(crate) fn block_tree_xref_segments(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
@@ -1157,14 +1369,11 @@ pub(crate) fn block_tree_xref_segments(
 /// Derives the deferred cross-reference segments embedded in this tree's
 /// **footnote** subtrees — the exact complement of
 /// [`block_tree_xref_segments`], in the order
-/// [`footnote_tree_xrefs`] enumerates them.
+/// [`resolved_destinations`] enumerates them.
 ///
 /// A footnote cannot nest another footnote, so handing each footnote's own
 /// children to the block collector cannot skip anything — the same reuse
 /// [`assign_footnote_tree_xrefs`] makes.
-// Consumed only by tests until the step 6 cutover wires it in, the same
-// staging every recognition side effect was under before it was re-attached.
-#[allow(dead_code)]
 pub(crate) fn footnote_tree_xref_segments(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
@@ -1178,9 +1387,6 @@ pub(crate) fn footnote_tree_xref_segments(
 /// The shared pre-order walk behind [`block_tree_xref_segments`], mirroring
 /// [`assign_tree_xrefs`]'s traversal so a derived segment and an installed
 /// destination address the same node.
-// Consumed only by tests until the step 6 cutover wires it in, the same
-// staging every recognition side effect was under before it was re-attached.
-#[allow(dead_code)]
 fn collect_tree_xref_segments(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
@@ -1212,9 +1418,6 @@ fn collect_tree_xref_segments(
 
 /// The shared walk behind [`footnote_tree_xref_segments`], mirroring
 /// [`assign_footnote_tree_xrefs`]'s traversal.
-// Consumed only by tests until the step 6 cutover wires it in, the same
-// staging every recognition side effect was under before it was re-attached.
-#[allow(dead_code)]
 fn collect_footnote_tree_xref_segments(
     nodes: &[InlineNode<'_>],
     renderer: &dyn InlineSubstitutionRenderer,
@@ -1253,9 +1456,6 @@ fn collect_footnote_tree_xref_segments(
 /// [`Content::mirror_tree_xref_resolution`]. A node re-read after a resolution
 /// sweep therefore yields the same segment it yielded before one, which is what
 /// makes this derivation idempotent.
-// Consumed only by tests until the step 6 cutover wires it in, the same
-// staging every recognition side effect was under before it was re-attached.
-#[allow(dead_code)]
 fn xref_segment_from_node(
     reference: &crate::inlines::Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -1328,7 +1528,7 @@ fn assign_tree_xrefs(
 /// Walks an inline node slice in document order and installs each
 /// **footnote-embedded** cross-reference's resolved destination from `ordered`
 /// — the resolved state of the re-homed deferred segments, in segment order (as
-/// produced by [`footnote_tree_xrefs`]) — advancing `next` past each one.
+/// produced by [`resolved_destinations`]) — advancing `next` past each one.
 ///
 /// The block walk skips footnote subtrees, so this is the pass that reaches
 /// them: for each [`Footnote`](InlineNode::Footnote) node it hands the

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -722,23 +722,32 @@ impl<'src> Content<'src> {
     /// A content whose tree holds no cross-reference at all clears the deferred
     /// state outright: a construct the builder does not recognize is one this
     /// content no longer defers, and it renders as the fold leaves it.
-    pub(crate) fn set_tree_xrefs(&mut self, block: Vec<XrefSegment>, footnote: Vec<XrefSegment>) {
+    pub(crate) fn set_tree_xrefs(
+        &mut self,
+        tree: &[InlineNode<'src>],
+        renderer: &dyn InlineSubstitutionRenderer,
+        context: &crate::parser::RenderContext,
+    ) {
+        // The string pipeline deferring nothing here means this content defers
+        // nothing at all: the builder recognizes a *subset* of the forms
+        // `InlineXrefReplacer` does — that containment is the premise the
+        // carve-out below rests on — so a tree holding a cross-reference node
+        // the replacer did not defer cannot arise.
+        //
+        // This is why the two walks happen **after** this early return rather
+        // than at the call site: they traverse the whole tree, and every
+        // paragraph in every document would otherwise pay for two traversals
+        // that this invariant says could only ever come back empty. The saving
+        // is structural rather than measured — the repository's own benchmarks
+        // cannot resolve it, since a base-against-itself control run on the
+        // machine used here reported a significant 3% "improvement" on
+        // byte-identical code.
         let Some(previous) = self.deferred.take() else {
-            // The string pipeline deferred nothing here, so neither does this
-            // content: the builder recognizes a *subset* of the forms
-            // `InlineXrefReplacer` does — that containment is the premise the
-            // carve-out below rests on — so a tree holding a cross-reference
-            // node the replacer did not defer cannot arise. Asserted rather
-            // than handled, since handling it would mean a placeholder-free
-            // deferred state no caller is written for.
-            debug_assert!(
-                block.is_empty() && footnote.is_empty(),
-                "the tree deferred cross-references the string pipeline did not: \
-                 {block:?} / {footnote:?}"
-            );
-
             return;
         };
+
+        let block = block_tree_xref_segments(tree, renderer, context);
+        let footnote = footnote_tree_xref_segments(tree, renderer, context);
 
         // The carve-out: where the tree holds fewer cross-references than the
         // string pipeline deferred, it is known not to describe this content,

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,16 +6,10 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xrefs, fold_resolved_title,
-    footnote_tree_xrefs, rehome_xref_placeholders, render_xref_template, sanitize_title,
+    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xref_segments,
+    fold_resolved_title, footnote_tree_xref_segments, rehome_xref_placeholders,
+    render_xref_template, resolved_destinations, sanitize_title, template_partition,
 };
-// The staged, not-yet-wired derivation of a content's deferred cross-reference
-// segments from its inline tree — the last of design §5.2's six survey items,
-// exercised only by its own differential corpus until the cutover calls it for
-// real. Re-exported under `cfg(test)` for the same reason the functions carry
-// `#[allow(dead_code)]`: nothing on the production path reaches them yet.
-#[cfg(test)]
-pub(crate) use content::{block_tree_xref_segments, footnote_tree_xref_segments};
 
 pub(crate) mod inline_builder;
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,10 +6,16 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, block_tree_xref_segments,
-    fold_resolved_title, footnote_tree_xref_segments, rehome_xref_placeholders,
-    render_xref_template, resolved_destinations, sanitize_title, template_partition,
+    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, fold_resolved_title,
+    rehome_xref_placeholders, render_xref_template, resolved_destinations, sanitize_title,
+    template_partition,
 };
+// The two tree walks behind `Content::set_tree_xrefs`, which calls them
+// directly. Re-exported for the differential corpus that compares what they
+// derive against the string pipeline's own answer; nothing else outside
+// `content` reaches them.
+#[cfg(test)]
+pub(crate) use content::{block_tree_xref_segments, footnote_tree_xref_segments};
 
 pub(crate) mod inline_builder;
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -324,30 +324,49 @@ impl SubstitutionGroup {
                 attrlist,
             );
 
+            // The deferred cross-references are the **tree's**, not the string
+            // pipeline's — design §5.2's survey item, wired. The two staged
+            // walks read them off the tree already partitioned into the
+            // block-level ones and the ones this content's footnotes carry,
+            // where the string pipeline produced one flat list that had to be
+            // split by asking which of its placeholders survived. What is kept
+            // from the pipeline's own answer is the placeholder template, and
+            // only for the one content that renders from one — see
+            // `Content::set_tree_xrefs`.
+            //
+            // The fold below reads `content.deferred_parts()` for nothing, so
+            // the order of these two is a matter of reading rather than of
+            // correctness; deriving first keeps `rendered` and `deferred`
+            // describing the same tree at every point in this function.
+            let render_context = parser.render_context();
+
+            content.set_tree_xrefs(
+                crate::content::block_tree_xref_segments(&tree, &*parser.renderer, &render_context),
+                crate::content::footnote_tree_xref_segments(
+                    &tree,
+                    &*parser.renderer,
+                    &render_context,
+                ),
+            );
+
             // The tree is **authoritative** for the rendered string: what
             // `rendered_html()` returns is a fold of it, not the string
             // pipeline's own output (design §5.2 Phase 4, step 6).
             //
-            // Content carrying a *deferred cross-reference* is folded at a
-            // different time rather than a different way. Such a content's
-            // rendering is rebuilt from a placeholder template each time
-            // resolution runs (`Content::rebuild_rendered`), so a fold taken
-            // *here* would be overwritten by the next resolution pass — and
-            // before that pass the destinations are not known, so it would also
-            // be answering a question the document has not settled yet. It is
-            // folded at the **end of resolution** instead (`Content::refold`),
-            // which is the same answer one step later. Until then it keeps the
-            // template's answer, which is the honest one for an unresolved
-            // document.
-            if content.deferred_parts().is_none() {
-                let folded = crate::content::inline_builder::fold_html(
-                    &tree,
-                    &*parser.renderer,
-                    &parser.render_context(),
-                );
+            // Unconditional now, including for content carrying a deferred
+            // cross-reference. Such a content's rendering is taken *again* at
+            // the end of resolution (`Content::refold`), once the destinations
+            // are known; what it holds until then is the fold of an unresolved
+            // tree, which is the same unresolved-fallback answer the template
+            // gave and is the honest one for a document that has not settled
+            // its references yet.
+            let folded = crate::content::inline_builder::fold_html(
+                &tree,
+                &*parser.renderer,
+                &render_context,
+            );
 
-                content.rendered = crate::strings::CowStr::from(folded);
-            }
+            content.rendered = crate::strings::CowStr::from(folded);
 
             // The recognition side effects the string pipeline just skipped,
             // replayed from the tree — design §5.2's step 6, "re-attach the

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -340,14 +340,7 @@ impl SubstitutionGroup {
             // describing the same tree at every point in this function.
             let render_context = parser.render_context();
 
-            content.set_tree_xrefs(
-                crate::content::block_tree_xref_segments(&tree, &*parser.renderer, &render_context),
-                crate::content::footnote_tree_xref_segments(
-                    &tree,
-                    &*parser.renderer,
-                    &render_context,
-                ),
-            );
+            content.set_tree_xrefs(&tree, &*parser.renderer, &render_context);
 
             // The tree is **authoritative** for the rendered string: what
             // `rendered_html()` returns is a fold of it, not the string

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -26,8 +26,8 @@ use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
     content::{
-        XrefSegment, block_tree_xrefs, fold_resolved_title, footnote_tree_xrefs,
-        render_xref_template,
+        XrefSegment, fold_resolved_title, render_xref_template, resolved_destinations,
+        template_partition,
     },
     document::Catalog,
     inlines::InlineNode,
@@ -52,23 +52,33 @@ struct Resolution {
     rendered: String,
 
     /// The resolved destination of each title-level cross-reference, in
-    /// placeholder order, ready for [`block_tree_xrefs`]-aligned mirroring.
+    /// document order, ready for mirroring into the title tree.
     block_ordered: Vec<Option<ResolvedReference>>,
 
     /// The resolved destination of each cross-reference embedded in a footnote
     /// the title carries, in segment order, ready for
-    /// [`footnote_tree_xrefs`]-aligned mirroring into the title tree's footnote
-    /// subtrees.
+    /// mirroring into the title tree's footnote subtrees.
     footnote_ordered: Vec<Option<ResolvedReference>>,
 }
 
 /// One title carrying cross-references, captured for the resolution pass.
 struct TitleNode<'src> {
-    /// The placeholder-bearing template captured when the title was finalized.
+    /// The title's **block-level** cross-references, in the document order its
+    /// own inline tree holds them.
+    block: Vec<XrefSegment>,
+
+    /// The cross-references the title's footnotes carry.
+    footnote: Vec<XrefSegment>,
+
+    /// The string pipeline's placeholder template, which a title renders from
+    /// when it cannot fold: one whose nodes did not survive the `'src`-erasing
+    /// hop a carried block title travels on, and one the carve-out keeps on the
+    /// string pipeline's own answer (`from_tree` false).
     template: String,
 
-    /// The title's cross-references, in placeholder order.
-    xrefs: Vec<XrefSegment>,
+    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
+    /// read off this title's inline tree.
+    from_tree: bool,
 
     /// The ID under which other cross-references reach this title's reference
     /// text — present only when the title *is* the target's reference text (no
@@ -155,19 +165,23 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
     for block in blocks.iter_mut() {
         if let Block::Section(section) = block {
             // A section's resolvable title is its heading.
-            if let Some((template, xrefs)) = section.section_title_deferred_parts() {
+            if let Some(deferred) = section.section_title_deferred_parts() {
                 let map_id = if section.has_explicit_reftext() {
                     None
                 } else {
                     section.reference_id()
                 };
 
-                let template = template.to_string();
-                let xrefs = xrefs.to_vec();
+                let block = deferred.block.to_vec();
+                let footnote = deferred.footnote.to_vec();
+                let template = deferred.template.to_string();
+                let from_tree = deferred.from_tree;
 
                 nodes.push(TitleNode {
+                    block,
+                    footnote,
                     template,
-                    xrefs,
+                    from_tree,
                     map_id,
                     source: section.section_title_source(),
                     inlines: section.section_title_inlines().to_vec(),
@@ -185,14 +199,18 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
             let source = block.span();
 
             if let Some(title) = block.block_title_content_mut()
-                && let Some((template, xrefs)) = title.deferred_parts()
+                && let Some(deferred) = title.deferred_parts()
             {
-                let template = template.to_string();
-                let xrefs = xrefs.to_vec();
+                let block = deferred.block.to_vec();
+                let footnote = deferred.footnote.to_vec();
+                let template = deferred.template.to_string();
+                let from_tree = deferred.from_tree;
 
                 nodes.push(TitleNode {
+                    block,
+                    footnote,
                     template,
-                    xrefs,
+                    from_tree,
                     map_id: None,
                     source,
                     inlines: title.inlines().to_vec(),
@@ -269,9 +287,15 @@ fn compute<'src>(
         *flag = true;
     }
 
-    let mut xrefs = node.xrefs.clone();
+    let mut block = node.block.clone();
+    let mut footnote = node.footnote.clone();
 
-    for xref in xrefs.iter_mut() {
+    // The block-level and footnote-embedded references are resolved by the same
+    // rules here — including the local-title recursion below — where
+    // `Content::resolve_references` reports only the block-level ones. That
+    // difference is pre-existing: a title reports every unresolved target it
+    // carries, wherever in the title it sits.
+    for xref in block.iter_mut().chain(footnote.iter_mut()) {
         let mut resolved = resolver.resolve(&ResolutionContext {
             target: &xref.target,
             provided_text: xref.provided_text.as_deref(),
@@ -343,18 +367,25 @@ fn compute<'src>(
         xref.resolved = resolved;
     }
 
-    // The resolved destinations, in placeholder order and filtered to those the
-    // template still splices, so they line up one-to-one with the title tree's
-    // cross-reference nodes when mirrored (see `write_back`). This reuses the
-    // very `xrefs` the rendering below is computed from, so the tree cannot
-    // disagree with the string.
-    let block_ordered = block_tree_xrefs(&node.template, &xrefs);
-
-    // The complementary set: a cross-reference the title's footnotes carry was
-    // re-homed out of the template when the footnote text was extracted, so it
-    // is absent from `block_ordered` and belongs to a footnote subtree of the
-    // title tree instead.
-    let footnote_ordered = footnote_tree_xrefs(&node.template, &xrefs);
+    // The resolved destinations, in the document order the title's own tree
+    // holds its cross-reference nodes in — which is the order the two lists
+    // were read off that tree in, so they line up one-to-one when mirrored
+    // (see `write_back`). These are the very segments the rendering below is
+    // computed from, so the tree cannot disagree with the string.
+    let (block_ordered, footnote_ordered) = if node.from_tree {
+        (
+            resolved_destinations(&block),
+            resolved_destinations(&footnote),
+        )
+    } else {
+        // A title the carve-out keeps on the string pipeline's answer: `block`
+        // is that flat list, split by which placeholders the template still
+        // splices, exactly as it always was.
+        (
+            template_partition(&node.template, &block, true),
+            template_partition(&node.template, &block, false),
+        )
+    };
 
     // The title's rendering is a **fold of its tree**, with the destinations
     // just resolved installed into it — the same answer `Content::refold` gives
@@ -363,16 +394,17 @@ fn compute<'src>(
     // link text. Rendering the template as well, and keeping only one, would
     // put every deferred title through a host renderer twice.
     //
-    // The template is the fallback for a title whose tree the builder left
-    // short of the cross-references the string pipeline deferred, and for one
-    // that retained no attributes to fold under.
+    // The template is the fallback for a title with no tree to fold: a block
+    // title carried across a section heading, whose inline nodes cannot cross
+    // the `'src`-erasing hop it travels on. Every other title folds.
     let rendered = node
         .render_attributes
         .as_ref()
+        .filter(|_| node.from_tree)
         .and_then(|attributes| {
             fold_resolved_title(&node.inlines, &block_ordered, attributes, renderer, parser)
         })
-        .unwrap_or_else(|| render_xref_template(&node.template, &xrefs, renderer));
+        .unwrap_or_else(|| render_xref_template(&node.template, &block, renderer));
 
     if let Some(flag) = in_progress.get_mut(index) {
         *flag = false;

--- a/parser/src/tests/inline_builder_xref_segment_parity.rs
+++ b/parser/src/tests/inline_builder_xref_segment_parity.rs
@@ -14,12 +14,16 @@
 //!
 //! What this harness pins is that reading, over whole documents: for every
 //! content that deferred a cross-reference, the segments derived from the tree
-//! are field-for-field what `InlineXrefReplacer` itself produced. Nothing is
-//! wired — `block_tree_xref_segments` and `footnote_tree_xref_segments` are
-//! staged building blocks, exactly as every recognition side effect was before
-//! the cutover re-attached it — so this corpus is the only thing exercising
-//! them, and it is what a later increment stands on when it deletes the
-//! string pipeline's own construction.
+//! are field-for-field what `InlineXrefReplacer` itself produced.
+//!
+//! The two walks are **wired** as of the increment that closed this survey
+//! item: what a content carries is now what the tree said, and the string
+//! pipeline's own answer is retained beside it
+//! (`DeferredContent::string_xrefs`, `#[cfg(test)]`) purely so this corpus
+//! keeps a golden. Without that the comparison would be the tree against
+//! itself, which passes for the wrong reason — the failure design §5.2's frozen
+//! recordings exist to prevent. The golden goes when `run_pipeline` does, and
+//! the corpus with it.
 //!
 //! The documents are parsed with [`Parser::parse_deferred`], which does **not**
 //! resolve, so every segment's `resolved` is `None` on both sides: this
@@ -249,11 +253,15 @@ fn derived_segments_match_the_string_pipelines_own() {
         let renderer = HtmlSubstitutionRenderer {};
 
         for (what, content) in contents(&doc) {
-            let Some((template, xrefs)) = content.deferred_parts() else {
+            let Some(deferred) = content.deferred_parts() else {
                 continue;
             };
 
-            let (golden_block, golden_footnote) = partition(template, xrefs);
+            // The golden is the string pipeline's own flat list, split the way
+            // it always split: a placeholder still in the template is
+            // block-level, one that has left it was re-homed onto a footnote.
+            let (golden_block, golden_footnote) =
+                partition(deferred.template, deferred.string_xrefs);
 
             let derived_block = block_tree_xref_segments(content.inlines(), &renderer, &context);
 
@@ -319,8 +327,8 @@ fn a_rendered_span_in_a_string_read_slot_keeps_its_documented_divergence() {
         .find(|(_, content)| content.deferred_parts().is_some())
         .expect("the fixture must defer a cross-reference");
 
-    let (template, xrefs) = content.deferred_parts().unwrap();
-    let (golden, _) = partition(template, xrefs);
+    let deferred = content.deferred_parts().unwrap();
+    let (golden, _) = partition(deferred.template, deferred.string_xrefs);
     let derived = block_tree_xref_segments(content.inlines(), &renderer, &context);
 
     assert_eq!(derived.len(), 1);
@@ -377,8 +385,8 @@ fn a_reference_inside_an_index_term_macro_keeps_its_documented_divergence() {
         .find(|(_, content)| content.deferred_parts().is_some())
         .expect("the fixture must defer a cross-reference");
 
-    let (template, xrefs) = content.deferred_parts().unwrap();
-    let (golden, _) = partition(template, xrefs);
+    let deferred = content.deferred_parts().unwrap();
+    let (golden, _) = partition(deferred.template, deferred.string_xrefs);
     let derived = block_tree_xref_segments(content.inlines(), &renderer, &context);
 
     // The string pipeline defers one; the tree offers none to derive from.

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1351,6 +1351,93 @@ fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
 }
 
 #[test]
+fn a_title_whose_tree_defers_a_reference_form_keeps_the_string_pipelines_rendering() {
+    // The carve-out crossed with the **title** container, which resolves on a
+    // path of its own: `title_refs::compute` coordinates cross-title references
+    // and so re-derives the ordered destinations itself, rather than going
+    // through `Content::resolve_references`. Both paths have to split the
+    // string pipeline's flat list the same way when the tree is short of it,
+    // and a corpus that covers the carve-out only on paragraphs (as this one
+    // did) would never say so.
+    //
+    // Same deferred form as `xref_mirror_is_skipped_when_the_tree_defers_a_
+    // reference_form`, written as a block title.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[sec]]The target.\n\n.See xref:sec[a *b, c* d,role=hl]\nA paragraph.");
+
+    // `collect_rendered` walks block titles as well as block content.
+    let titles = collect_rendered(&doc);
+
+    // The title keeps the string pipeline's own reading — the anchor cut short
+    // inside the span — exactly as the paragraph case does, and no placeholder
+    // sentinel escapes into it.
+    assert!(
+        titles
+            .iter()
+            .any(|t| t.contains(r##"href="#sec""##) && t.contains("<strong>b</a>")),
+        "the title's carve-out rendering regressed: {titles:?}"
+    );
+
+    assert!(
+        titles
+            .iter()
+            .all(|t| !t.contains('\u{E000}') && !t.contains('\u{E001}')),
+        "a placeholder sentinel reached a rendered title: {titles:?}"
+    );
+}
+
+#[test]
+fn an_index_term_macro_hiding_a_reference_keeps_the_string_pipelines_rendering() {
+    // The carve-out's **other** shape, and the one no test reached before the
+    // deferred cross-references were read off the tree.
+    //
+    // `xref_mirror_is_skipped_when_the_tree_defers_a_reference_form` above
+    // covers a content whose tree holds *fewer* cross-references than the
+    // string pipeline deferred by one; this covers the case where it holds
+    // **none**, which takes a different branch of `Content::set_tree_xrefs` (an
+    // empty derived list, where that one has a short-by-one list) and is the
+    // shape that would silently clear the deferred state altogether. Its own
+    // family pins the recognition gap under `parse_deferred`
+    // (`a_reference_inside_an_index_term_macro_keeps_its_documented_divergence`);
+    // what was never crossed with it is a **resolved** parse, which is where
+    // the rendering is decided.
+    //
+    // `indexterm2:[…]`'s shown term comes back from an attribute-list parse
+    // rather than from a range of the match string, so the builder keeps it as
+    // a string and builds no subtree — there is no node for the `<<b>>` inside
+    // it. The string pipeline's answer therefore stands, placeholders and all,
+    // and the reference still resolves.
+    let mut parser = Parser::default();
+    let doc = parser.parse("[[b]]B target.\n\nSee indexterm2:[<<b>>] here.");
+
+    let rendered = collect_rendered(&doc);
+
+    assert!(
+        rendered.iter().any(|s| s.contains(r##"<a href="#b">"##)),
+        "the carve-out must keep the string pipeline's resolved rendering: {rendered:?}"
+    );
+
+    // And nothing leaks: a cleared deferred state would leave the raw
+    // placeholder sentinels in the output instead.
+    assert!(
+        rendered
+            .iter()
+            .all(|s| !s.contains('\u{E000}') && !s.contains('\u{E001}')),
+        "a placeholder sentinel reached the rendered output: {rendered:?}"
+    );
+
+    // The tree holds no cross-reference node for it, which is *why* this
+    // content is on the carve-out path. Asserting it here keeps the test
+    // honest the day the builder learns the macro spelling: this fails, and
+    // the fixture graduates to the ordinary folded path.
+    let refs = collect_refs(&doc);
+    assert!(
+        refs.iter().all(|r| r.variant != RefVariant::Xref),
+        "the macro spelling now yields a node; this fixture should fold: {refs:?}"
+    );
+}
+
+#[test]
 fn a_span_in_a_string_valued_xref_attribute_now_mirrors() {
     // The counterpart the increment *moved*: a rendered span reaching one of
     // the three values this family reads as a **string** used to defer for
@@ -1381,12 +1468,27 @@ fn a_span_in_a_string_valued_xref_attribute_now_mirrors() {
 }
 
 #[test]
-fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
-    // The footnote-side counterpart: one of the footnote's two embedded
-    // cross-references is a documented builder divergence, so the footnote
-    // subtree's slot count (1) differs from the re-homed segment count (2)
-    // and the footnote mirror must skip rather than misassign. The block-side
-    // mirror is unaffected and still resolves the block-level reference.
+fn a_footnote_subtree_that_defers_a_reference_form_still_mirrors_what_it_holds() {
+    // The footnote-side counterpart, and the one place reading the deferred
+    // cross-references **off the tree** does more than reproduce the string
+    // pipeline's answer.
+    //
+    // One of the footnote's two embedded cross-references is a documented
+    // builder divergence, so the footnote subtree holds one node where the
+    // string pipeline re-homed two segments. That used to make the footnote
+    // mirror skip: its list came from the flat, placeholder-indexed list, whose
+    // footnote half (2) could not be correlated positionally against the
+    // subtree's nodes (1), so the recognized `<<c>>` was left honestly
+    // unresolved rather than misassigned.
+    //
+    // The tree's own walk partitions structurally, so the footnote list holds
+    // exactly the nodes it belongs to and the correlation is exact: the
+    // recognized `<<c>>` now carries its real destination, and the
+    // unrecognized sibling simply is not in either list. Nothing rendered
+    // changes — a fold emits a footnote's marker without descending into its
+    // subtree — so what moves is only what a consumer reading `inlines()`
+    // sees, in the direction of being right.
+    //
     // (The deferred form here is a shorthand whose *id* crosses an opaque
     // piece — a masked passthrough — since a footnote's own bracketed text
     // ends at the first `]`, which rules out the bracket-carrying spellings.)
@@ -1404,25 +1506,27 @@ fn footnote_xref_mirror_is_skipped_when_the_subtree_defers_a_reference_form() {
         "the block-level xref should still resolve: {refs:?}"
     );
 
-    // … while the footnote's recognized `<<c>>` is left unresolved (its
-    // sibling's deferred form broke the positional correlation for the
-    // subtree's list).
+    // … and the footnote's recognized `<<c>>` carries its own destination,
+    // where the flat list's un-correlatable footnote half used to leave it
+    // unresolved. The unrecognized sibling contributes no node, so there is
+    // exactly one to check.
     let footnote_refs = collect_footnote_refs(&doc);
-    assert!(
-        !footnote_refs.is_empty(),
-        "expected the footnote's recognized xref node: {footnote_refs:?}"
+    assert_eq!(
+        footnote_refs.len(),
+        1,
+        "expected exactly the footnote's recognized xref node: {footnote_refs:?}"
     );
-    assert!(
-        footnote_refs.iter().all(|r| r.resolved.is_none()),
-        "the footnote mirror must skip on a count mismatch: {footnote_refs:?}"
+    assert_eq!(
+        footnote_refs[0].resolved.as_ref().map(|r| r.href.as_str()),
+        Some("#c"),
+        "the footnote subtree's own reference should mirror: {footnote_refs:?}"
     );
 
-    // The block's own rendering is unaffected either way. `Content::refold`
-    // gates only on the **block** half of the mirror, which succeeded here, so
-    // this content *is* re-folded from its tree — and that is correct: a
+    // The block's own rendering is unaffected either way, which is what makes
+    // the change above a tree-fidelity one rather than an output one: a
     // footnote's text is extracted out of the block, so what the block renders
     // for it is the marker, which the fold emits without descending into the
-    // subtree whose correlation was skipped.
+    // subtree at all.
     let rendered = collect_rendered(&doc);
     assert!(
         rendered


### PR DESCRIPTION
The first of design §5.2's six survey items to go from staged machinery to the production answer, and the first increment of step 6 proper.

`block_tree_xref_segments` and `footnote_tree_xref_segments` have been written, corpused and unwired since they landed. `Content::set_tree_xrefs` installs what they return, so what a content carries for its deferred cross-references is what its **tree** said, not what `InlineXrefReplacer` recorded.

## The partition is the substantive part, not the fields

The string pipeline produces one flat list indexed by placeholder, and tells a block-level reference from one re-homed into a footnote by asking which placeholders its template still splices — so `block_tree_xrefs` / `footnote_tree_xrefs` had to re-derive that split on every resolution. The two walks partition **structurally**, so a `DeferredContent` now holds the two lists it always wanted, and both halves correlate positionally with the same walks that install destinations back.

## The one behavior change, and it is an improvement

A footnote subtree holding fewer references than the string pipeline re-homed used to make the **footnote** mirror decline outright — the flat list's footnote half could not be positionally correlated — leaving a well-recognized `<<c>>` inside the footnote unresolved in the tree. Its own list is now exactly the nodes it belongs to, so it resolves. Nothing rendered moves: a fold emits a footnote's marker without descending into its subtree, so this is what a consumer reading `inlines()` sees.

`a_footnote_subtree_that_defers_a_reference_form_still_mirrors_what_it_holds` (renamed from `footnote_xref_mirror_is_skipped_…`) pins it from both ends.

## What did *not* happen here is the deletion

Measuring says why. The carve-out `DeferredContent::from_tree` names — the tree holding fewer cross-references than the string pipeline deferred — is not a formality, and where it applies the string pipeline's answer is the better one. Two shapes reach it:

- `xref:sec[a *b, c* d,role=hl]` — already pinned. Instrumenting the `rebuild_rendered` arm across the whole suite showed it is the **only** content in ~5,400 tests that takes the template path under a resolved parse.
- `indexterm2:[<<b>>]` — pinned only under `parse_deferred`; the construct and the *resolved* container had never been crossed. It takes a different branch (an **empty** derived list, where the first is short by one) — the branch that would otherwise clear the deferred state and render `&lt;&lt;b&gt;&gt;` where the document says `<a href="#b">`.

Both now have resolved-path tests, and a third crosses the carve-out with the **title** container, which resolves through `title_refs::compute` rather than `Content::resolve_references` and so splits the flat list on a path of its own.

So the sentinel system's *retirement* is complete and its *deletion* is gated on something no cutover increment can supply: the builder recognizing every cross-reference form the replacer does. That is a prep question, and naming it is this increment's other result. It also has a second named prerequisite — a block title carried across a section heading arrives at the claiming block with its inline nodes dropped (`Parser::pending_block_title` has no `'src` lifetime to carry them), so it is the one content whose rendering cannot be a fold at all.

## Gates

- **Audit** (corpus-wide fold parity): 37 rows either side, **0 new and 0 closed** — the divergent *source set* is byte-identical. Two rows move by a stateful test renderer's own callback counters, which the footnote-mirror improvement shifts.
- **Coverage**: exactly diff-neutral on all four changed production files — 21 missed regions / 8 missed lines on `content.rs`, 5 / 0 on `title_refs.rs`, 0 / 0 on `substitution_group.rs`, unchanged on `section.rs`.
- **Falsifiability**: three sabotages fail three distinct sets — a no-op wiring (3 tests), a dropped `provided_text` (4 tests), a dropped footnote partition (5 tests). Removing the carve-out fails exactly the two shapes above.
- Preflight green: nightly `fmt --check`, `clippy --all-targets`, `test --workspace` (5471 passed), nightly `doc --no-deps --document-private-items`.

## Note on the differential corpus

`inline_builder_xref_segment_parity` would have become tautological — comparing the tree against itself — so the string pipeline's own answer is retained beside the tree's as `DeferredContent::string_xrefs` (`#[cfg(test)]`), the same move `Passthroughs::observable` made when `Content::passthroughs()` became a view over the tree. It is snapshotted at `finalize_deferred`, after the passthrough restore pass has reached into each segment's text, and it goes with `run_pipeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1

---
_Generated by [Claude Code](https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1)_