### PR TITLE
feat: Record four recognition diagnostics where they are recognized (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7178,6 +7178,71 @@ Each phase is a reviewable unit with a clear exit gate.
   title-fold increment counted, and it keeps the template path for that reason rather than for the
   carve-out's.
 
+  *Step 6 landed as (four recognition diagnostics, recorded where they are recognized):* the second
+  increment of step 6 proper, and the first to move a side effect the tree-walk **replay cannot
+  carry**. `apply_macro_side_effects` works because a registration has a node to hang on; these four
+  have none. A `link:` macro with a dangerous scheme stays *literal*, an invalid substitution name
+  in a `pass:`/`stem:` list is *skipped*, a `footnoteref:` builds the same node its modern spelling
+  does, and a reference to an undefined footnote looks exactly like a forward one mid-parse. So they
+  are recorded at the **recognition site** — the sites that already hold `parser` — and carried
+  across afterwards.
+
+  *Carrying them across is the mechanism, and it is where the increment's two real bugs were.* The
+  builder runs against the counter-safe clone, whose warning buffer is discarded with it, so the
+  obvious move is to drain that buffer after the build and push it onto the real parser
+  ([`push_substitution_warnings`](../../parser/src/parser/parser.rs)). That is wrong twice over, and
+  the suite caught both.
+
+  First, the clone's warning buffer also collects what the builder records **incidentally**, through
+  machinery it shares with the string pipeline: an
+  [`Attrlist`](../../parser/src/attributes/attrlist.rs) parse expands attribute references over the
+  list's own text, and where that text is a *match string* rather than document source, the
+  resulting `attribute-missing` warning carries an offset that cannot be mapped back. The string
+  pipeline discards exactly those at its own site; carrying the whole buffer surfaced them
+  mislocated against the document root, which
+  `passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning` fails on. The fix is to keep
+  the two apart at the source: a diagnostic the builder *means* to report goes to its own buffer
+  ([`record_builder_diagnostic`](../../parser/src/parser/parser.rs)), and only that buffer is
+  transplanted.
+
+  Second, a build **nests**. `passthrough_text` re-enters `SubstitutionGroup::apply` for a
+  passthrough body, and that call clones the parser it is given — copying the new buffer along with
+  everything else — so a nested drain that took the whole buffer carried the *outer* build's pending
+  diagnostics across a second time. `pass:bogus[…]` reported twice. So the drain takes a **mark**,
+  exactly as [`drain_substitution_warnings_since`](../../parser/src/parser/parser.rs) does, and each
+  build leaves with exactly its own.
+
+  *The string pipeline's four copies are suppressed*, not deleted — the same
+  [`suppress_recognition_side_effects`](../../parser/src/parser/parser.rs) window every registration
+  already rides, and deleting the replacers is what the increment that removes `run_pipeline` does.
+  The transplant happens **before** `apply_macro_side_effects`, because the string pipeline raised
+  these during its own pass and ahead of the registrations the replay performs, and that relative
+  order is what [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+  compares.
+
+  *That harness had to be taught the new channel,* which is worth recording because it is the shape
+  a corpus goes quiet in: it drives the builder side directly rather than through `apply`, so
+  without its own transplant every fixture exercising one of these four would have compared a
+  warning against nothing and passed. Seven fixtures were added — one per class, one crossing two
+  classes to pin their order against each other, and one crossing a diagnostic with a registration
+  to pin the order between the two kinds.
+
+  Audit: 37 rows either side, 0 new and 0 closed. Coverage exactly diff-neutral on all **eight**
+  changed files (`parser.rs` 87/73, `links.rs` 18/9, `passthrough_step.rs` 32/14, `stem_step.rs`
+  13/6, `footnotes.rs` 5/3, `macros.rs` 2/1, `passthroughs.rs` 3/3, `substitution_group.rs` 0/0 —
+  missed regions / missed lines, identical on both sides). Three sabotages fail three distinct sets:
+  dropping the transplant fails five tests, one per class; un-suppressing the string pipeline's link
+  copy fails `rejected_scheme_records_a_warning` on the double; and draining without the mark fails
+  the parity harness on the nested re-transplant.
+
+  *What still defers is the fifth,* `SkippingReferenceToMissingAttribute` — the `attribute-missing`
+  `warn` and `drop-line` diagnostic — and it is held back for a reason rather than for room. It is
+  not a macro family: it belongs to the **attributes step**, it is located per *line* through
+  `Content::source_lines` rather than against the content's span, and it is the very diagnostic
+  whose incidental recording the first bug above is about. Giving it the same treatment means
+  deciding which of the two buffers each of its sites writes to, which is its own increment's
+  question.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8712,6 +8777,26 @@ Each phase is a reviewable unit with a clear exit gate.
        whose nodes cannot cross the `'src`-erasing `pending_block_title` hop). Audit: 37 rows
        either side, 0 new and 0 closed; coverage exactly diff-neutral on all four changed
        production files. See the step's own "landed as" note above.
+
+     - ✅ **four recognition diagnostics, recorded where they are recognized.** The first side
+       effects the tree-walk replay **cannot** carry: a rejected `link:` macro stays literal, an
+       invalid substitution name in a `pass:`/`stem:` list is skipped, a `footnoteref:` builds the
+       same node its modern spelling does, and an undefined footnote reference looks exactly like a
+       forward one — so none of them leaves a node to replay from. Each is recorded at its own
+       recognition site and carried onto the real parser afterwards, with the string pipeline's copy
+       joining the existing
+       [`suppress_recognition_side_effects`](../../parser/src/parser/parser.rs) window. The
+       mechanism is where the work was: the builder's deliberate diagnostics need a buffer of their
+       own ([`record_builder_diagnostic`](../../parser/src/parser/parser.rs)), because the clone's
+       warning buffer also collects what an `Attrlist` parse records *incidentally* over a match
+       string — warnings the string pipeline discards and which would otherwise surface mislocated —
+       and the drain needs a **mark**, because `passthrough_text` re-enters `apply` and the nested
+       clone would carry the outer build's diagnostics across twice. Both were caught by the suite,
+       not by inspection. Audit: 37 rows either side, 0 new and 0 closed; coverage exactly
+       diff-neutral on all eight changed files. What still defers is the fifth diagnostic,
+       `SkippingReferenceToMissingAttribute`, which belongs to the attributes *step* rather than to
+       a macro family, is located per line, and is the very diagnostic the incidental-recording
+       hazard is about. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -474,17 +474,25 @@ fn build_footnote_node<'src>(
                 }))
             }
 
-            // A reference to an id that was never defined. The string replacer
-            // warns here (`InvalidFootnoteReference`); this pass, like every
-            // other diagnostic the additive builder skips, leaves that to the
-            // cutover.
-            None => Some(InlineNode::Footnote(Footnote {
-                id: Some(id),
-                number: None,
-                is_reference: true,
-                children: vec![],
-                location,
-            })),
+            // A reference to an id that was never defined, reported exactly
+            // where the string replacer reports it. Recorded rather than
+            // replayed: the node is a reference with no number, which is also
+            // what a *forward* reference looks like mid-parse, so the tree
+            // cannot tell the two apart after the fact.
+            None => {
+                parser.record_builder_diagnostic(
+                    root,
+                    crate::warnings::WarningType::InvalidFootnoteReference(id.to_string()),
+                );
+
+                Some(InlineNode::Footnote(Footnote {
+                    id: Some(id),
+                    number: None,
+                    is_reference: true,
+                    children: vec![],
+                    location,
+                }))
+            }
         };
     }
 
@@ -525,12 +533,9 @@ fn build_footnote_node<'src>(
 /// first comma and never normalizes what precedes it, so an id carrying a `\]`
 /// keeps its backslash — as the id [`footnote_id_text`] recovers does.
 ///
-/// The one thing this increment does **not** yet do is the deprecation
-/// warning `InlineFootnoteMacroReplacer` records outside `compat-mode`: like
-/// every other macro family's own catalog/warning side effect, that is a
-/// diagnostic that does not change the fold's output bytes, so — unlike the
-/// footnote number itself — it is left to the cutover (design §5.2 Phase 4,
-/// step 6) rather than performed here.
+/// The deprecation warning `InlineFootnoteMacroReplacer` records outside
+/// `compat-mode` is raised here too, from the whole match's own text, exactly
+/// as that replacer raises it.
 fn build_footnoteref_node<'src>(
     raw: regex::Match<'_>,
     full: &std::ops::Range<usize>,
@@ -541,6 +546,20 @@ fn build_footnoteref_node<'src>(
     parser: &Parser,
 ) -> Option<InlineNode<'src>> {
     let location = source_slice(pieces, full.clone(), root);
+
+    // The `footnoteref:` macro is deprecated outside compatibility mode.
+    // Recorded rather than replayed because the node this builds is an
+    // ordinary `Footnote`, indistinguishable from the `footnote:` spelling's —
+    // the deprecation is a fact about the *source*, which only the recognition
+    // site sees.
+    if !parser.is_attribute_set("compat-mode")
+        && let Some(matched) = s.get(full.clone())
+    {
+        parser.record_builder_diagnostic(
+            root,
+            crate::warnings::WarningType::DeprecatedFootnoterefMacro(matched.to_string()),
+        );
+    }
 
     // Split on the first comma: `id` is everything before it (the whole raw
     // text when there is no comma at all), `content` is everything after it
@@ -594,17 +613,23 @@ fn build_footnoteref_node<'src>(
             }))
         }
 
-        // A reference to an id that was never defined. The string replacer
-        // warns here (`InvalidFootnoteReference`); this pass, like every
-        // other diagnostic the additive builder skips, leaves that to the
-        // cutover.
-        None => Some(InlineNode::Footnote(Footnote {
-            id: Some(id),
-            number: None,
-            is_reference: true,
-            children: vec![],
-            location,
-        })),
+        // A reference to an id that was never defined — see the sibling site
+        // in `build_footnote_node` for why this is recorded rather than
+        // replayed.
+        None => {
+            parser.record_builder_diagnostic(
+                root,
+                crate::warnings::WarningType::InvalidFootnoteReference(id.to_string()),
+            );
+
+            Some(InlineNode::Footnote(Footnote {
+                id: Some(id),
+                number: None,
+                is_reference: true,
+                children: vec![],
+                location,
+            }))
+        }
     }
 }
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1265,6 +1265,17 @@ pub(super) fn build_link_node<'src>(
     // increment chooses the safe reading over byte parity — see
     // `a_dangerous_scheme_inside_a_passthrough_is_a_documented_divergence`.
     if !is_mailto && has_dangerous_scheme(&target) {
+        // Reported where `InlineLinkMacroReplacer` reports it. This is the
+        // recognition diagnostic design §5.2's survey singled out as needing "a
+        // node-level fact the way `RawOrigin` was one": a rejected macro stays
+        // literal, so there is no `Ref` node to hang it on and nothing for a
+        // tree walk to replay. Recording it at the rejection site — the site
+        // that already holds `parser` — is what that fact would have been for.
+        parser.record_builder_diagnostic(
+            root,
+            crate::warnings::WarningType::UnsafeLinkSchemeRejected(target),
+        );
+
         return None;
     }
 

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -857,7 +857,22 @@ fn build_passthrough_node<'src>(
     // beside the result.
     let (value, subs, source_text) = if let Some(subs_list) = caps.get(14) {
         let text = unescaped.as_deref().unwrap_or(raw);
-        let (subs, _invalid) = SubstitutionGroup::from_custom_string(None, subs_list.as_str());
+        let (subs, invalid) = SubstitutionGroup::from_custom_string(None, subs_list.as_str());
+
+        // An unrecognized name in the list (`pass:bogus[…]`) is skipped while
+        // the recognized ones are still honored — and reported, exactly as
+        // `InlinePassMacroReplacer` reports it, against the content's own span.
+        // Recorded here rather than replayed from the tree because the node
+        // carries no trace of it: an invalid name leaves the value it produces
+        // indistinguishable from a valid list's.
+        if !invalid.is_empty() {
+            parser.record_builder_diagnostic(
+                root,
+                crate::warnings::WarningType::InvalidSubstitutionTypeForPassthroughMacro(
+                    invalid.join(", "),
+                ),
+            );
+        }
 
         (
             CowStr::from(passthrough_text(text, &subs, parser)),

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -26,10 +26,32 @@ use crate::{
 /// string pipeline's own `InvalidSubstitutionTypeForStemMacro` warning for
 /// an invalid name, deferring that side effect to the cutover (design §5.2
 /// Phase 4, step 6), since it does not change the fold's output bytes.
-fn resolve_stem_subs(subs_list: Option<&str>) -> SubstitutionGroup {
+fn resolve_stem_subs(
+    subs_list: Option<&str>,
+    root: Span<'_>,
+    parser: &Parser,
+) -> SubstitutionGroup {
     match subs_list {
         None => SubstitutionGroup::Stem,
-        Some(subs_list) => SubstitutionGroup::from_custom_string(None, subs_list).0,
+
+        Some(subs_list) => {
+            let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs_list);
+
+            // Reported exactly where `InlineStemMacroReplacer` reports it, and
+            // recorded rather than replayed for the same reason its `pass:`
+            // sibling is: an invalid name is skipped, so the node it produces
+            // carries no trace of one.
+            if !invalid.is_empty() {
+                parser.record_builder_diagnostic(
+                    root,
+                    crate::warnings::WarningType::InvalidSubstitutionTypeForStemMacro(
+                        invalid.join(", "),
+                    ),
+                );
+            }
+
+            group
+        }
     }
 }
 
@@ -230,7 +252,7 @@ fn build_stem_node<'src>(
     let mut emitted = Vec::new();
     emit_range(nodes, pieces, expr_range, &mut emitted);
 
-    let subs = resolve_stem_subs(caps.get(3).map(|m| m.as_str()));
+    let subs = resolve_stem_subs(caps.get(3).map(|m| m.as_str()), root, parser);
 
     // An explicit substitution list naming a step that needs more than one
     // `Text` run of context (Quotes, AttributeReferences,

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1300,10 +1300,17 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
         // macro is handled elsewhere. `mailto:` targets carry their own safe
         // scheme and are exempt.
         if mailto.is_none() && has_dangerous_scheme(&target) {
-            self.parser.record_substitution_warning(
-                self.source,
-                WarningType::UnsafeLinkSchemeRejected(target),
-            );
+            // Suppressed for content whose tree raises this itself — see
+            // `Parser::suppress_recognition_side_effects`. This was the one
+            // recognition side effect the replay did not carry, because a
+            // rejected macro leaves no node; the builder records it at its own
+            // rejection site instead (`build_link_node`).
+            if !self.parser.suppress_recognition_side_effects.get() {
+                self.parser.record_substitution_warning(
+                    self.source,
+                    WarningType::UnsafeLinkSchemeRejected(target),
+                );
+            }
             dest.push_str(&caps[0]);
             return;
         }
@@ -2067,7 +2074,12 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
             };
 
             // The `footnoteref:` macro is deprecated outside compatibility mode.
-            if !parser.is_attribute_set("compat-mode") {
+            // Suppressed for content whose tree raises this itself — see
+            // `Parser::suppress_recognition_side_effects`; `build_footnoteref_node`
+            // records it at its own recognition site.
+            if !parser.is_attribute_set("compat-mode")
+                && !parser.suppress_recognition_side_effects.get()
+            {
                 parser.record_substitution_warning(
                     self.source,
                     WarningType::DeprecatedFootnoterefMacro(caps[0].to_string()),
@@ -2118,10 +2130,14 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
                 );
             } else {
                 // A reference to an ID that was never defined.
-                parser.record_substitution_warning(
-                    self.source,
-                    WarningType::InvalidFootnoteReference(id.clone()),
-                );
+                // Suppressed for the same reason the deprecation warning above
+                // is: the builder records it where it recognizes the reference.
+                if !parser.suppress_recognition_side_effects.get() {
+                    parser.record_substitution_warning(
+                        self.source,
+                        WarningType::InvalidFootnoteReference(id.clone()),
+                    );
+                }
                 parser.renderer.render_footnote(
                     &FootnoteRenderParams {
                         index: None,

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -386,7 +386,13 @@ impl Replacer for InlinePassMacroReplacer<'_> {
                 Some(subs_list) => {
                     let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs_list);
 
-                    if !invalid.is_empty() {
+                    // Suppressed for content whose tree raises this itself —
+                    // see `Parser::suppress_recognition_side_effects`. One of
+                    // the two diagnostics this pass owns that the builder now
+                    // records at its own recognition site
+                    // (`build_passthrough_node`), so recognizing the construct
+                    // twice would report it twice.
+                    if !invalid.is_empty() && !self.parser.suppress_recognition_side_effects.get() {
                         self.parser.record_substitution_warning(
                             self.source,
                             WarningType::InvalidSubstitutionTypeForPassthroughMacro(
@@ -755,7 +761,10 @@ impl Replacer for InlineStemMacroReplacer<'_> {
             Some(subs_list) => {
                 let (group, invalid) = SubstitutionGroup::from_custom_string(None, subs_list);
 
-                if !invalid.is_empty() {
+                // Suppressed for the same reason its `pass:` sibling above is:
+                // `resolve_stem_subs` records this at the builder's own
+                // recognition site.
+                if !invalid.is_empty() && !self.parser.suppress_recognition_side_effects.get() {
                     self.parser.record_substitution_warning(
                         self.source,
                         WarningType::InvalidSubstitutionTypeForStemMacro(invalid.join(", ")),

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -316,12 +316,41 @@ impl SubstitutionGroup {
             // its own.
             tree_parser.build_inline_tree = false;
 
+            // Where this build's own diagnostics start — see
+            // `Parser::drain_builder_diagnostics_since` for why a mark rather
+            // than the whole buffer.
+            let diagnostics_before_build = tree_parser.builder_diagnostics_len();
+
             let tree = crate::content::inline_builder::build_for_group(
                 self,
                 value,
                 content.original(),
                 &tree_parser,
                 attrlist,
+            );
+
+            // The recognition **diagnostics** the string pipeline just skipped,
+            // moved onto the real parser — the warning half of "re-attach the
+            // recognition side effects" (design §5.2's step 6).
+            //
+            // A registration has a node to hang on, so it is replayed from the
+            // tree below. These five do not: `attribute-missing` drops a
+            // reference and leaves nothing behind, a `link:` macro with a
+            // dangerous scheme stays literal, and an invalid substitution name
+            // in a `pass:`/`stem:` list is simply skipped. So they are recorded
+            // where they are *recognized*, on the clone, and carried across
+            // here — which is what `Parser::record_builder_diagnostic` and
+            // `push_substitution_warnings` are for. The builder's own buffer is
+            // used rather than the clone's warning buffer, so a warning it
+            // records only *incidentally* (an `Attrlist` parse over a match
+            // string) is not swept up with them.
+            //
+            // Before `apply_macro_side_effects`, deliberately: the string
+            // pipeline raised these during its own pass, ahead of the
+            // registrations the replay performs, and that relative order is
+            // what `inline_builder_side_effect_parity` compares.
+            parser.push_substitution_warnings(
+                tree_parser.drain_builder_diagnostics_since(diagnostics_before_build),
             );
 
             // The deferred cross-references are the **tree's**, not the string

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -418,6 +418,13 @@ pub struct Parser {
     /// spanned [`Warning`]s once the document's owned source is available.
     substitution_warnings: RefCell<Vec<DeferredWarning>>,
 
+    /// Recognition diagnostics the single-pass builder raised, awaiting
+    /// transplant onto the real parser — see
+    /// [`record_builder_diagnostic`](Self::record_builder_diagnostic) for why
+    /// these are kept apart from
+    /// [`substitution_warnings`](Self::substitution_warnings).
+    builder_diagnostics: RefCell<Vec<DeferredWarning>>,
+
     /// An optional fixed reference time that pins the clock used to compute the
     /// time-dependent document attributes (`docdate`, `doctime`, `docdatetime`,
     /// `docyear`, and their `local*` siblings), for reproducible output.
@@ -617,6 +624,7 @@ impl Default for Parser {
             owned_cell_warnings: RefCell::new(vec![]),
             callouts: RefCell::new(CalloutCatalog::default()),
             substitution_warnings: RefCell::new(vec![]),
+            builder_diagnostics: RefCell::new(vec![]),
             reference_time: None,
             input_mtime: None,
             datetime_context: RefCell::new(None),
@@ -2036,6 +2044,80 @@ impl Parser {
     /// held `len` entries.
     pub(crate) fn drain_substitution_warnings_since(&self, len: usize) -> Vec<DeferredWarning> {
         self.substitution_warnings.borrow_mut().split_off(len)
+    }
+
+    /// Records a recognition **diagnostic** the single-pass builder raises,
+    /// into a buffer of its own.
+    ///
+    /// Deliberately *not*
+    /// [`record_substitution_warning`](Self::record_substitution_warning)'s
+    /// buffer. The builder runs against a counter-safe clone whose warning
+    /// buffer is discarded, so its diagnostics have to be carried across to the
+    /// real parser — but that clone's buffer also collects warnings the builder
+    /// records **incidentally**, through machinery it shares with the string
+    /// pipeline: an [`Attrlist`](crate::attributes::Attrlist) parse expands
+    /// attribute references over the list's own text, and where that text is a
+    /// match string rather than document source, the resulting
+    /// `attribute-missing` warning carries an offset that cannot be mapped
+    /// back. The string pipeline discards exactly those at its own site (see
+    /// `PassthroughRestoreReplacer`); carrying the clone's whole buffer across
+    /// would surface them mislocated against the document root
+    /// (`passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning`
+    /// catches it).
+    ///
+    /// So the two are kept apart at the source: this buffer holds only what the
+    /// builder means to report, and only it is transplanted.
+    pub(crate) fn record_builder_diagnostic(&self, source: crate::Span<'_>, warning: WarningType) {
+        self.builder_diagnostics.borrow_mut().push(DeferredWarning {
+            offset: source.byte_offset(),
+            len: source.len(),
+            warning,
+            origin: None,
+        });
+    }
+
+    /// The number of builder diagnostics recorded so far — the mark
+    /// [`drain_builder_diagnostics_since`](Self::drain_builder_diagnostics_since)
+    /// drains from.
+    pub(crate) fn builder_diagnostics_len(&self) -> usize {
+        self.builder_diagnostics.borrow().len()
+    }
+
+    /// Removes and returns the builder diagnostics recorded since the buffer
+    /// held `len` entries — see
+    /// [`record_builder_diagnostic`](Self::record_builder_diagnostic).
+    ///
+    /// Taken from a **mark** rather than wholesale, for the same reason
+    /// [`drain_substitution_warnings_since`](Self::drain_substitution_warnings_since)
+    /// is: a build can nest. `passthrough_text` re-enters
+    /// `SubstitutionGroup::apply` for a passthrough body, and that call clones
+    /// the parser it is given — copying this buffer along with everything else
+    /// — so a nested drain that took the whole buffer would carry the *outer*
+    /// build's pending diagnostics across a second time. Marking before each
+    /// build and draining back to that mark leaves each build with exactly its
+    /// own.
+    pub(crate) fn drain_builder_diagnostics_since(&self, len: usize) -> Vec<DeferredWarning> {
+        self.builder_diagnostics.borrow_mut().split_off(len)
+    }
+
+    /// Appends already-built warnings to this parser's buffer, in order.
+    ///
+    /// This is the counterpart to
+    /// [`drain_substitution_warnings_since`](Self::drain_substitution_warnings_since),
+    /// and it exists for one caller: the single-pass builder records its
+    /// diagnostics against the counter-safe *clone*
+    /// `SubstitutionGroup::apply` hands it, whose buffer is discarded with the
+    /// clone, so they are drained from there and pushed here to reach the real
+    /// parser. A [`DeferredWarning`] is plain data — an offset, a length, a
+    /// [`WarningType`] and an origin — so moving one between parsers loses
+    /// nothing.
+    ///
+    /// A recognition diagnostic that *has* a node to hang on is replayed from
+    /// the tree instead (see `apply_macro_side_effects`); this carries the ones
+    /// that do not, which is why they are recorded where they are recognized
+    /// rather than after the fact.
+    pub(crate) fn push_substitution_warnings(&self, warnings: Vec<DeferredWarning>) {
+        self.substitution_warnings.borrow_mut().extend(warnings);
     }
 
     /// Takes the substitution warnings recorded during parsing, leaving the

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -138,6 +138,15 @@ fn side_effects_with(source: &str, configure: impl Fn() -> Parser) -> (SideEffec
 
     let builder_parser = configure();
     let nodes = build(Span::new(source), &builder_parser, None);
+
+    // The recognition **diagnostics** the builder recorded while recognizing,
+    // moved onto the parser exactly as `SubstitutionGroup::apply` moves them:
+    // before the replay, since the string pipeline raises them during its own
+    // pass and ahead of the registrations. Without this the builder side would
+    // report no warnings for the four classes it now owns, and every fixture
+    // exercising one would compare something against nothing.
+    builder_parser.push_substitution_warnings(builder_parser.drain_builder_diagnostics_since(0));
+
     apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
 
     (snapshot(&golden_parser), snapshot(&builder_parser))
@@ -174,6 +183,28 @@ const CORPUS: &[&str] = &[
     //
     // The image family, alone and in company.
     "an image:photo.png[Alt Text] inline",
+    //
+    // The four recognition **diagnostics** the builder records at its own
+    // recognition site rather than replaying from the tree, because each
+    // leaves nothing on the tree to replay from: a rejected `link:` stays
+    // literal, an invalid substitution name is skipped, a `footnoteref:` builds
+    // the same node its modern spelling does, and an undefined reference looks
+    // exactly like a forward one.
+    "a pass:bogus[dangerous] macro",
+    "a stem:bogus,q[x + y] macro",
+    "a link:javascript:alert(1)[click me] macro",
+    "a footnoteref:[fnid,some text] macro",
+    "a footnote:never-defined[] macro",
+    //
+    // Two diagnostics in one content, which is what pins their **order**: the
+    // warnings ride in one list, so a builder that recognized these families in
+    // a different order from the string pipeline would still record both and
+    // only this fixture would notice.
+    "a pass:bogus[x] and a link:javascript:alert(1)[click] together",
+    // A diagnostic beside a registration, which pins the other order: the
+    // string pipeline raises its warnings during the pass, ahead of what the
+    // replay registers afterwards.
+    "a link:javascript:alert(1)[bad] and an image:photo.png[Alt] together",
     "image:a.png[] and image:b.png[] and image:c.png[]",
     "image:a&b.png[Query] with a special in the target",
     "image:{logo}[Logo] from an expanded target",


### PR DESCRIPTION
The second increment of step 6 proper, and the first to move side effects the tree-walk **replay cannot carry**.

`apply_macro_side_effects` works because a registration has a node to hang on. These four have none:

| diagnostic | why there is no node |
|---|---|
| `UnsafeLinkSchemeRejected` (link family) | a rejected `link:` macro stays **literal** |
| `InvalidSubstitutionTypeForPassthroughMacro` | an invalid name is **skipped**; the value is indistinguishable from a valid list's |
| `InvalidSubstitutionTypeForStemMacro` | same |
| `DeprecatedFootnoterefMacro` | `footnoteref:` builds the same node its modern spelling does |
| `InvalidFootnoteReference` | an undefined reference looks exactly like a **forward** one mid-parse |

So each is recorded at its own recognition site — the sites that already hold `parser` — and carried onto the real parser afterwards. The string pipeline's copies join the existing `suppress_recognition_side_effects` window rather than being deleted; deleting the replacers is what the increment that removes `run_pipeline` does.

## The mechanism is where the work was, and both bugs

The builder runs against the counter-safe clone, whose warning buffer is discarded with it — so the obvious move is to drain that buffer after the build. That is wrong twice over, and **the suite caught both**, not inspection.

**1. The clone's buffer also collects incidental warnings.** An `Attrlist` parse expands attribute references over the list's own text, and where that text is a *match string* rather than document source, the resulting `attribute-missing` warning carries an offset that cannot be mapped back. The string pipeline discards exactly those at its own site; carrying the whole buffer surfaced them mislocated against the document root, failing `passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning`. Fix: a diagnostic the builder *means* to report goes to a buffer of its own (`record_builder_diagnostic`), and only that buffer is transplanted.

**2. A build nests.** `passthrough_text` re-enters `SubstitutionGroup::apply` for a passthrough body, and that call clones the parser it is given — copying the new buffer with it — so a nested drain that took the whole buffer carried the *outer* build's pending diagnostics across a second time (`pass:bogus[…]` reported twice). Fix: the drain takes a **mark**, exactly as `drain_substitution_warnings_since` does.

The transplant runs **before** `apply_macro_side_effects`: the string pipeline raised these during its own pass, ahead of the registrations the replay performs, and that relative order is what the parity harness compares.

## The harness had to be taught the new channel

Worth calling out, because it is the shape a corpus goes quiet in. `inline_builder_side_effect_parity` drives the builder side directly rather than through `apply`, so without its own transplant every fixture exercising one of these four would have compared a warning against **nothing** and passed. Seven fixtures added: one per class, one crossing two classes to pin their order against each other, and one crossing a diagnostic with a registration to pin the order between the two kinds.

## Gates

- **Audit** (corpus-wide fold parity): 37 rows either side, **0 new and 0 closed**.
- **Coverage**: exactly diff-neutral on all **eight** changed files — `parser.rs` 87/73, `links.rs` 18/9, `passthrough_step.rs` 32/14, `stem_step.rs` 13/6, `footnotes.rs` 5/3, `macros.rs` 2/1, `passthroughs.rs` 3/3, `substitution_group.rs` 0/0 (missed regions / missed lines, identical on both sides).
- **Falsifiability**: three sabotages fail three distinct sets — dropping the transplant fails 5 tests, one per class; un-suppressing the string pipeline's link copy fails `rejected_scheme_records_a_warning` on the double; draining without the mark fails the parity harness on the nested re-transplant.
- Preflight green: nightly `fmt --check`, `clippy --all-targets`, `test --workspace` (5471 passed), nightly `doc --no-deps --document-private-items`.

## What still defers

The fifth diagnostic, `SkippingReferenceToMissingAttribute` (the `attribute-missing` `warn` / `drop-line` diagnostic), is held back for a reason rather than for room: it is not a macro family. It belongs to the **attributes step**, it is located per *line* through `Content::source_lines` rather than against the content's span, and it is the very diagnostic whose incidental recording bug 1 above is about — so deciding which of the two buffers each of its sites writes to is its own increment's question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1

---
_Generated by [Claude Code](https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1)_