### PR TITLE
chore: Run CI on pushes to inline-ast so CodSpeed has a base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,16 @@ on:
       - synchronize
       - labeled
   push:
-    branches: main
+    # `inline-ast` is here for the benchmarks. CodSpeed compares a pull
+    # request against the most recent successful run on its **base** branch,
+    # and without one it silently falls back to an unrelated commit and
+    # reports that fallback's differences as the pull request's own. The
+    # long-running `inline-ast` branch had no such run — nothing triggered CI
+    # on a push to it — so every pull request into it was measured against a
+    # stale `main`, which reported the whole branch's cost as a regression.
+    branches:
+      - main
+      - inline-ast
 
 # Every job below is gated on the same condition: run automatically for
 # pushes, for pull requests whose head branch lives in this repository


### PR DESCRIPTION
CodSpeed compares a pull request against the most recent successful run on its **base** branch. Nothing triggered CI on a push to `inline-ast` — `ci.yml` fired on `pull_request` and `push: branches: main` only — so no such run existed, and CodSpeed silently fell back to an unrelated commit, reporting *that fallback's* differences as the pull request's own. Its report says so in a footnote:

> No successful run was found on `inline-ast` (9667eaf) during the generation of this report, so 11d76fa was used instead as the comparison base. There might be some changes unrelated to this pull request in this report.

## What it cost

[#1293](https://github.com/asciidoc-rs/asciidoc-parser/pull/1293) was reported as a **-52% performance regression** across four benchmarks (e.g. `2 blocks + title` 153.4 µs → 358.9 µs). Measured locally against the branch's *actual* base:

| benchmark | CodSpeed claim | vs. real base |
|---|---|---|
| `inline macro` | 2.0× slower | −1.3%, p = 0.13 (no change) |
| `2 blocks + title` | 2.3× slower | +5.0%, p = 0.00 |

…and a **base-against-itself control** on the same machine reported a *significant* −3.1% "improvement" on byte-identical code, so neither figure is distinguishable from that box's noise. The report was really measuring the whole `inline-ast` branch against `main` — and that branch builds an inline tree for every parse *on top of* the string pipeline, which is roughly where a 2× comes from.

It self-corrected once a PR-context run existed ("Merging this PR will not alter performance"), but only after the misleading version had already been posted, and the same footnote reappeared on #1294.

## The fix

Add `inline-ast` to the `push:` branch list. The benchmark job has no branch condition of its own — its `if:` only guards fork PRs, and `github.event_name != 'pull_request'` is true for a push — so a push to `inline-ast` runs it and gives every PR into that branch a real comparison base.

Cost is one extra CI run per merge into `inline-ast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1

---
_Generated by [Claude Code](https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1)_