### PR TITLE
feat: Record the fifth recognition diagnostic where it is recognized

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7313,6 +7313,80 @@ Each phase is a reviewable unit with a clear exit gate.
   genuinely needs freezing is the recorder-versus-builder structural cross-check, whose oracle is
   the Strategy-A recorder §5.4 retires. That is its own increment.
 
+  *Step 6 landed as (the fifth diagnostic, and the last one):* the increment that closes the set
+  the diagnostics increment opened, and it landed for a reason worth recording: **it is a
+  prerequisite for the cutover's remaining swap, not a tidy-up after it.**
+
+  The prompt for it was a throwaway probe of the *inversion* — giving the string pipeline the
+  counter-safe clone and the builder the real parser, which is what makes `run_pipeline` a pure
+  oracle and lets three sentinel systems go. That probe fails **27 tests of 5,474** (against 218 for
+  a naive `run_pipeline` removal), and they collapse into exactly **two** root causes: the footnote
+  catalog entry, and this diagnostic. Neither is unblocked *by* the inversion; both block it. The
+  order in the plan was backwards, and the probe is what said so. Worth noting too is what did
+  **not** appear: `{counter:}`, which had been carried as a blocker on the strength of an audit
+  measurement, is a non-issue — the counter-safe clone seeds both passes from the same
+  pre-substitution state whichever way round they run.
+
+  `SkippingReferenceToMissingAttribute` was held back from the diagnostics increment for three
+  stated reasons, and each turned out to be answerable rather than deep. *It belongs to the
+  attributes step, not to a macro family* — so it is recorded in
+  [`apply_attribute_references`](../../parser/src/content/inline_builder/attribute_refs.rs) rather
+  than at a macro's recognition site, which changes where the code lives and nothing else. *It is
+  located per line* — but only because that is how the string pipeline recovers a span it has
+  otherwise lost (`warning_source` matches a per-line byte range back against the line's text, and
+  degrades to the whole content when there are no source lines). The tree needs none of that:
+  [`source_slice`](../../parser/src/content/inline_builder/quotes.rs) maps the match's own range
+  back to `'src` directly, which is the same mapping every node's `location` already takes. *And it
+  is the very diagnostic whose incidental recording was that increment's first bug* — which is
+  precisely why it is landable now: the two-buffer split that fixed that bug is what keeps an
+  `Attrlist` parse's own `attribute-missing` warning (recorded through
+  `record_substitution_warning`, over a match string, unmappable) apart from this one (recorded
+  through `record_builder_diagnostic`, deliberately). The earlier increment paid for this one.
+
+  *Two things in the design are load-bearing, and both were found by sabotage rather than by
+  reading.*
+
+  **The diagnostic is decided by the document's mode, not by
+  [`MissingHandling`](../../parser/src/content/inline_builder/attribute_refs.rs).** That enum
+  answers what a missing reference *renders* as, and it collapses distinctions this needs: `skip`
+  and `warn` are both `Literal` because they emit the same bytes, and both `for_content` and
+  `nested` fall back to `Literal` for the two shapes whose line correspondence the transducer
+  cannot reproduce. None of that is a reason to stop diagnosing — the string pipeline scans a flat
+  rendered string in which a span's contents are ordinary text, so it warns for a nested reference
+  and for a line-straddling span alike. Reading `AttributeMissing` directly keeps the deferrals
+  about output bytes, where they belong. It also means the `drop-line` divergence this transducer
+  documents is a divergence in **bytes only**: the diagnostic agrees.
+
+  **The order has to be restored, not kept.** The splicing recursion visits a `Styled` child's
+  content *before* its own level, so `{alpha} *bold {beta}*` finds `beta` first while the string
+  pipeline's line scan sees `alpha` first — the same hazard `resolve_counters` exists to correct
+  for counter directives. A stable sort by source offset fixes it, and the sort is *the* thing
+  nothing pinned: removing it left the whole suite green. So the increment's real test is a new
+  configured pair in
+  [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+  sweeping both diagnosing modes over ten fixtures, four of them straddling a span, with a
+  non-vacuity guard per fixture. That harness compares warnings **in order**, which is exactly the
+  question.
+
+  Audit: 37 rows either side, 0 new and 0 closed. Coverage exactly diff-neutral on both changed
+  production files (`attribute_refs.rs` 11/6, `substitution_step.rs` 2/0 — missed regions / missed
+  lines, identical on both sides). Three sabotages fail three distinct sets: dropping the builder's
+  recording fails the same **eight** tests the inversion probe named as this cause, un-suppressing
+  the string pipeline's copy fails the same eight on the double, and removing the sort fails only
+  the new parity sweep.
+
+  *What still defers is the footnote catalog entry* — the other root cause the probe named, and the
+  last thing between here and the inversion.
+  [`register_footnote_number`](../../parser/src/content/inline_builder/footnotes.rs) registers
+  `normalize_footnote_text(raw_content)`, the *unrendered* text, and threads no cross-reference
+  placeholders through, so `define_footnote` never builds a `FootnoteDeferred` for a tree-built
+  footnote. Both are invisible today because the registration lands on the discarded clone; invert,
+  and they become the catalog (`footnotes[0].text` empty where the string pipeline registers
+  `<a href="…">GitHub</a>`, and a footnote's own `<<tgt>>` no longer resolving). The entry's `text`
+  has to become a fold of the footnote's own subtree, and the entry has to carry the deferred
+  segments. It is testable ahead of the inversion through the same side-effect parity harness,
+  which drives the builder directly and so can see what the clone registers.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8889,6 +8963,35 @@ Each phase is a reviewable unit with a clear exit gate.
        **structural** half: the three `parser/src/tests/` corpora that compare trees and records
        rather than HTML, which need an `InlineNode` serialization rather than a wider sweep of this
        mechanism. See the step's own "landed as" note above.
+
+     - ✅ **the fifth diagnostic, and the last one.** `SkippingReferenceToMissingAttribute` — the
+       `attribute-missing` `warn` and `drop-line` diagnostic — recorded at the builder's own
+       recognition site and carried across, with the string pipeline's copy joining the existing
+       [`suppress_recognition_side_effects`](../../parser/src/parser/parser.rs) window. It landed
+       **because a probe of the inversion said it had to**: giving the string pipeline the
+       counter-safe clone and the builder the real parser fails 27 tests of 5,474, collapsing into
+       exactly two root causes — this diagnostic and the footnote catalog entry. Neither is
+       unblocked by the inversion; both block it, which is the reverse of how the plan had them.
+       (`{counter:}`, carried as a third blocker, does not appear at all: the clone seeds both
+       passes from the same pre-substitution state whichever way round they run.) Each of the three
+       reasons this was held back turned out to be answerable: it lives in the attributes step
+       rather than a macro family, which only moves the code; its per-line location is the string
+       pipeline *recovering* a span the tree never loses
+       ([`source_slice`](../../parser/src/content/inline_builder/quotes.rs) maps the match's range
+       to `'src` directly); and the incidental-recording hazard it is the subject of is exactly what
+       the previous increment's two-buffer split already fixed. Two things are load-bearing: the
+       diagnostic reads [`AttributeMissing`](../../parser/src/content/substitution_step.rs) directly rather than
+       `MissingHandling`, which collapses `skip` with `warn` and falls back to `Literal` for shapes
+       whose *bytes* it cannot reproduce — so the `drop-line` divergence stays a divergence in bytes
+       only; and the order must be **restored** by a stable sort, since the splicing recursion
+       visits a span's content before its own level. The sort was the one thing nothing pinned
+       (removing it left the whole suite green), so the increment's real test is a new configured
+       pair in
+       [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+       sweeping both diagnosing modes over ten fixtures, four straddling a span. Audit: 37 rows
+       either side, 0 new and 0 closed; coverage exactly diff-neutral on both changed production
+       files. What still defers is the footnote catalog entry — the probe's other root cause, and
+       the last thing before the inversion. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -14,6 +14,7 @@ use crate::{
     inlines::{InlineNode, RawForm, RawOrigin},
     parser::attribute_lookup_name,
     strings::CowStr,
+    warnings::WarningType,
 };
 
 /// The attribute-references substitution, as a node transducer: descends into
@@ -130,7 +131,12 @@ pub(super) fn apply_attribute_references<'src>(
         Vec::new()
     };
 
-    apply_attribute_references_recursive(
+    // The `attribute-missing` diagnostic, collected across every level and
+    // raised **after** the recursion — see `record_missing_reference_warnings`
+    // for why it cannot be raised where it is found.
+    let mut diagnostics: Vec<(Span<'src>, String)> = Vec::new();
+
+    let nodes = apply_attribute_references_recursive(
         nodes,
         root,
         parser,
@@ -138,7 +144,65 @@ pub(super) fn apply_attribute_references<'src>(
         missing,
         &span_drops,
         specials,
-    )
+        &mut diagnostics,
+    );
+
+    record_missing_reference_warnings(diagnostics, parser);
+
+    nodes
+}
+
+/// Raises the `attribute-missing` diagnostic — Asciidoctor's "skipping
+/// reference to missing attribute", and under `drop-line` its "dropping line
+/// containing reference to missing attribute" — for every missing reference
+/// the levels found, in **source order**.
+///
+/// # Why the mode is read here rather than from [`MissingHandling`]
+///
+/// [`MissingHandling`] answers what a missing reference *renders* as, and it
+/// deliberately collapses distinctions the diagnostic needs: `skip` and `warn`
+/// both become [`Literal`](MissingHandling::Literal) because they emit the same
+/// bytes, and [`for_content`](MissingHandling::for_content) and
+/// [`nested`](MissingHandling::nested) both fall back to `Literal` for the two
+/// shapes whose *line* correspondence this transducer cannot reproduce. None of
+/// that is a reason to stop diagnosing: the string pipeline scans a flat
+/// rendered string in which a span's contents are ordinary text, so it warns
+/// for a nested reference and for a line-straddling span alike. Reading
+/// [`AttributeMissing`] directly keeps the deferrals about output bytes, where
+/// they belong.
+///
+/// # Why the order is restored here rather than kept as found
+///
+/// The splicing recursion visits a [`Styled`](crate::inlines::Styled) child's
+/// content *before* its own level, so a reference nested in an earlier span is
+/// found before one that sits earlier still at the top level. That is the same
+/// hazard [`resolve_counters`] exists to correct for counter directives, and it
+/// matters here for the same reason: a warning list is compared in order (see
+/// `inline_builder_side_effect_parity`). Sorting by source offset restores the
+/// document order the string pipeline's own left-to-right line scan produces.
+/// The sort is **stable**, so two references that snap to one coarse span
+/// (design §4.4 — both inside a single expanded value) keep the order they were
+/// found in rather than being reordered arbitrarily.
+fn record_missing_reference_warnings(mut diagnostics: Vec<(Span<'_>, String)>, parser: &Parser) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    if !matches!(
+        AttributeMissing::from_parser(parser),
+        AttributeMissing::Warn | AttributeMissing::DropLine
+    ) {
+        return;
+    }
+
+    diagnostics.sort_by_key(|(source, _)| source.byte_offset());
+
+    for (source, name) in diagnostics {
+        parser.record_builder_diagnostic(
+            source,
+            WarningType::SkippingReferenceToMissingAttribute(name),
+        );
+    }
 }
 
 /// Whether a
@@ -187,6 +251,7 @@ fn apply_attribute_references_recursive<'src>(
     missing: MissingHandling,
     span_drops: &[usize],
     specials: SplicedSpecials,
+    diagnostics: &mut Vec<(Span<'src>, String)>,
 ) -> Vec<InlineNode<'src>> {
     let nodes: Vec<InlineNode<'src>> = nodes
         .into_iter()
@@ -200,6 +265,7 @@ fn apply_attribute_references_recursive<'src>(
                     missing.nested(),
                     &[],
                     specials,
+                    diagnostics,
                 );
                 InlineNode::Styled(styled)
             }
@@ -208,7 +274,16 @@ fn apply_attribute_references_recursive<'src>(
         })
         .collect();
 
-    attribute_references_level(nodes, root, parser, counters, missing, span_drops, specials)
+    attribute_references_level(
+        nodes,
+        root,
+        parser,
+        counters,
+        missing,
+        span_drops,
+        specials,
+        diagnostics,
+    )
 }
 
 /// How a level treats a reference to a **missing** attribute — this module's
@@ -465,6 +540,7 @@ fn attribute_references_level<'src>(
     missing: MissingHandling,
     span_drops: &[usize],
     specials: SplicedSpecials,
+    diagnostics: &mut Vec<(Span<'src>, String)>,
 ) -> Vec<InlineNode<'src>> {
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
@@ -488,7 +564,23 @@ fn attribute_references_level<'src>(
     }
 
     let matches = if s.contains('{') {
-        find_attribute_matches(&s, parser, missing)
+        let scan = find_attribute_matches(&s, parser, missing);
+
+        // Each level's own missing references, located against `'src` exactly
+        // as every other node this step builds is (design §4.4's coarse
+        // fallback where a reference has no honest source of its own). Every
+        // reference is seen at exactly one level — a `Styled` span is a single
+        // opaque piece in its parent's match string, so its interior is only
+        // ever scanned by its own level's call — which is what keeps this from
+        // double-counting. `styled_drop_indices`' separate pre-scan reads
+        // `find_attribute_matches` too and deliberately reports nothing.
+        diagnostics.extend(
+            scan.missing
+                .into_iter()
+                .map(|m| (source_slice(&pieces, m.full, root), m.name)),
+        );
+
+        scan.matches
     } else {
         Vec::new()
     };
@@ -558,6 +650,7 @@ fn subtree_has_missing_reference(nodes: &[InlineNode<'_>], parser: &Parser) -> b
 
     if s.contains('{')
         && find_attribute_matches(&s, parser, MissingHandling::DropLine)
+            .matches
             .iter()
             .any(|m| matches!(m.kind, AttributeMatchKind::DropMissing))
     {
@@ -757,20 +850,47 @@ fn counter_value<'c>(
         .unwrap_or_default()
 }
 
+/// One reference to a **missing** attribute, as this level's match string
+/// holds it — the subject of the `attribute-missing` diagnostic, which is
+/// decided separately from what the reference *renders* as.
+///
+/// Kept apart from [`AttributeMatch`] on purpose. A match says what the
+/// rebuild emits, and under [`MissingHandling::Literal`] a missing reference
+/// emits nothing at all (the surrounding gap logic carries its source text
+/// through unchanged), so there is no match to hang a diagnostic on — while
+/// the string pipeline warns in exactly that case. The two questions have
+/// different answers and so travel separately.
+struct MissingReference {
+    /// The whole `{name}` match, in match-string offsets.
+    full: std::ops::Range<usize>,
+
+    /// The attribute's name **as written**, which is what the warning names
+    /// (the case-folded lookup name is an implementation detail).
+    name: String,
+}
+
+/// What one pass of [`find_attribute_matches`] found.
+struct AttributeScan {
+    matches: Vec<AttributeMatch>,
+
+    /// Every missing reference the level holds, whatever the handling —
+    /// see [`MissingReference`].
+    missing: Vec<MissingReference>,
+}
+
 /// Finds every non-overlapping [`ATTRIBUTE_REFERENCE`] match in the escaped
 /// match string `s`, left to right, exactly as the string pipeline's
 /// `replace_all` does. A `counter`/`counter2` directive is recorded as a
 /// match here but not yet resolved (see [`AttributeMatchKind::Counter`]); a
 /// reference to a missing attribute becomes a
 /// [`DropMissing`](AttributeMatchKind::DropMissing) match under a
-/// line-dropping `missing` handling, and is left out of the returned list
-/// entirely under [`MissingHandling::Literal`].
-fn find_attribute_matches(
-    s: &str,
-    parser: &Parser,
-    missing: MissingHandling,
-) -> Vec<AttributeMatch> {
+/// line-dropping `missing` handling, and is left out of the returned
+/// **matches** entirely under [`MissingHandling::Literal`] — but is reported
+/// either way in [`AttributeScan::missing`], which is what the diagnostic
+/// reads.
+fn find_attribute_matches(s: &str, parser: &Parser, missing: MissingHandling) -> AttributeScan {
     let mut matches = Vec::new();
+    let mut missing_refs = Vec::new();
 
     for caps in ATTRIBUTE_REFERENCE.captures_iter(s) {
         // `unwrap` on group 0 is safe: a capture always has an overall match.
@@ -825,6 +945,14 @@ fn find_attribute_matches(
         if !parser.has_attribute(&lookup_name)
             || matches!(interpreted_value, InterpretedValue::Unset)
         {
+            // Reported whatever the handling: whether the reference is dropped
+            // or left literal decides its *bytes*, not whether the document's
+            // `attribute-missing` mode diagnoses it.
+            missing_refs.push(MissingReference {
+                full: full.clone(),
+                name: attr_name.to_string(),
+            });
+
             if missing.drops_missing() {
                 matches.push(AttributeMatch {
                     full,
@@ -854,7 +982,10 @@ fn find_attribute_matches(
         });
     }
 
-    matches
+    AttributeScan {
+        matches,
+        missing: missing_refs,
+    }
 }
 
 /// Rebuilds a level's node list from its attribute-reference matches: each gap

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -50,13 +50,25 @@ use crate::{
 /// [`MissingHandling`] and [`surviving_lines`] for how this transducer
 /// reproduces it, and for the two shapes it defers.
 ///
-/// The `DropLine` mode's own diagnostic (Asciidoctor's "dropping line
-/// containing reference to missing attribute", recorded as a
-/// [`SkippingReferenceToMissingAttribute`] warning) is **not** raised here: it
-/// does not change the fold's output bytes, so — like every macro family's own
-/// catalog/warning side effect — it is deferred to the cutover (design §5.2
-/// Phase 4, step 6). The same applies to `Warn` mode's warning, whose output
-/// this step already reproduces.
+/// Both diagnosing modes' own diagnostic — Asciidoctor's "skipping reference to
+/// missing attribute" under `Warn`, and "dropping line containing reference to
+/// missing attribute" under `DropLine`, each recorded as a
+/// [`SkippingReferenceToMissingAttribute`] warning — **is** raised here, by
+/// [`record_missing_reference_warnings`]. It is the fifth and last of the
+/// recognition diagnostics the tree-walk replay cannot carry (design §5.2 Phase
+/// 4, step 6): a dropped or warned-about reference leaves no node to hang a
+/// diagnostic on, so it is recorded where it is *recognized* and carried onto
+/// the real parser afterwards, with the string pipeline's own copy suppressed
+/// for the duration of that window.
+///
+/// Two things about it are easy to get wrong, and both have their reasons on
+/// [`record_missing_reference_warnings`]: the mode is read from
+/// [`AttributeMissing`] directly rather than through [`MissingHandling`] (which
+/// deliberately collapses `Skip` with `Warn`, and falls back to `Literal` for
+/// the two shapes above — deferrals about output *bytes*, which are no reason
+/// to stop diagnosing), and the diagnostics are ordered by source offset rather
+/// than raised where they are found (the splicing recursion visits a `Styled`
+/// child's content before its own level).
 ///
 /// A literal `<`, `>`, or `&` **in the expanded value** is classified by
 /// design §3.4.1 — "the kind a fragment becomes is decided by which

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -712,6 +712,33 @@ impl<'p> AttributeReplacer<'p> {
     /// retained source-line match at `index` exists *and* its text equals
     /// `matched` — the text check guards against a correlation that has
     /// drifted (see the type-level docs).
+    /// Records this step's `attribute-missing` diagnostic — unless the
+    /// single-pass builder is going to record it instead.
+    ///
+    /// The fifth and last of the recognition diagnostics the tree-walk replay
+    /// cannot carry (design §5.2 Phase 4, step 6): a dropped or warned-about
+    /// reference leaves no node to hang a diagnostic on, so the builder records
+    /// it at its own recognition site (see
+    /// [`apply_attribute_references`](crate::content::inline_builder)) and it
+    /// is carried onto the real parser afterwards. This copy is suppressed
+    /// for the duration of that window, exactly as the other four are, and
+    /// is deleted along with the string pipeline itself.
+    ///
+    /// Suppression is deliberately *not* applied to a direct
+    /// [`SubstitutionStep::AttributeReferences`] call, which never opens the
+    /// window and so keeps diagnosing on its own — which is what lets this
+    /// step go on being tested in isolation.
+    fn record_missing_reference(&self, index: usize, caps: &Captures<'_>, attr_name: &str) {
+        if self.parser.suppress_recognition_side_effects.get() {
+            return;
+        }
+
+        self.parser.record_substitution_warning(
+            self.warning_source(index, &caps[0]),
+            WarningType::SkippingReferenceToMissingAttribute(attr_name.to_string()),
+        );
+    }
+
     fn warning_source(&self, index: usize, matched: &str) -> Span<'p> {
         if let Some(line) = self.source_line
             && let Some(range) = self.source_matches.get(index)
@@ -810,17 +837,11 @@ impl Replacer for AttributeReplacer<'_> {
                     // attribute") for each reference that triggers a drop, so
                     // record the matching diagnostic here.
                     self.missing_on_line = true;
-                    self.parser.record_substitution_warning(
-                        self.warning_source(match_index, &caps[0]),
-                        WarningType::SkippingReferenceToMissingAttribute(attr_name.to_string()),
-                    );
+                    self.record_missing_reference(match_index, caps, attr_name);
                 }
                 AttributeMissing::Warn => {
                     dest.push_str(&caps[0]);
-                    self.parser.record_substitution_warning(
-                        self.warning_source(match_index, &caps[0]),
-                        WarningType::SkippingReferenceToMissingAttribute(attr_name.to_string()),
-                    );
+                    self.record_missing_reference(match_index, caps, attr_name);
                 }
             }
             return;

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -379,6 +379,75 @@ fn the_sweep_reaches_every_list_a_recognition_pass_writes_to() {
     assert!(warnings > 0, "no fixture recorded a warning");
 }
 
+/// The `attribute-missing` diagnostic's own configured pair: the mode is
+/// parser state rather than source text, and the default (`skip`) diagnoses
+/// nothing at all.
+fn missing_mode_side_effects(source: &str, mode: &str) -> (SideEffects, SideEffects) {
+    side_effects_with(source, || {
+        corpus_parser().with_intrinsic_attribute(
+            "attribute-missing",
+            mode,
+            ModificationContext::Anywhere,
+        )
+    })
+}
+
+#[test]
+fn the_attribute_missing_diagnostic_agrees_in_number_and_in_order() {
+    // The fifth recognition diagnostic, and the only one whose *order* is not
+    // already fixed by the pass that raises it. The splicing recursion visits a
+    // `Styled` child's content before its own level, so a reference nested in a
+    // span is found before one that sits earlier at the top level — while the
+    // string pipeline, scanning a flat rendered string in which the span is
+    // already `<strong>…</strong>`, sees them in source order. The straddling
+    // fixtures below are what pin the correction; without it they compare
+    // `[beta, alpha]` against `[alpha, beta]`.
+    //
+    // Both diagnosing modes are swept. `warn` leaves every reference literal,
+    // so the *only* thing it changes is the warning list; `drop-line` removes
+    // content as well, and still warns for each reference that triggered a
+    // drop — including one inside a span, whose enclosing line the tree
+    // deliberately does not drop (a documented divergence in output bytes that
+    // is **not** a divergence in the diagnostic).
+    for mode in ["warn", "drop-line"] {
+        for source in [
+            // One reference, the simplest possible case.
+            "Hello, {alpha}!",
+            // Several on one line, and across lines: source order either way.
+            "{alpha} and {beta}",
+            "first {alpha} line\nsecond {beta} line\nthird {gamma} here",
+            // A reference nested in a span, *after* a top-level one: the
+            // recursion finds it first and the sort has to put it back.
+            "{alpha} *bold {beta}* {gamma}",
+            "{alpha} _em {beta}_ and {gamma} then *{delta}*",
+            // The same shape with the span first, which is already in the
+            // order the recursion produces — the control that keeps the
+            // fixture above from passing for the wrong reason.
+            "*bold {alpha}* and {beta}",
+            // Two references inside one span, and spans nested in spans.
+            "{alpha} *a {beta} b {gamma}* c",
+            "{alpha} *outer _inner {beta}_ tail* {gamma}",
+            // An escaped reference is never a missing one, in either pipeline.
+            "\\{alpha} but {beta}",
+            // A *set* attribute beside a missing one: only the missing one is
+            // diagnosed, so this fails if recognition drifts.
+            "{logo} and {alpha}",
+        ] {
+            let (golden, builder) = missing_mode_side_effects(source, mode);
+
+            assert_eq!(
+                golden, builder,
+                "attribute-missing diagnostics diverged under {mode} for {source:?}"
+            );
+
+            assert!(
+                !golden.warnings.is_empty(),
+                "fixture diagnosed nothing under {mode}: {source:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn a_bibliography_entry_registers_the_same_way() {
     for source in [


### PR DESCRIPTION
`SkippingReferenceToMissingAttribute` — the `attribute-missing` `warn` and `drop-line` diagnostic — is now recorded at the builder's own recognition site and carried onto the real parser, with the string pipeline's copy joining the existing `suppress_recognition_side_effects` window. That closes the set the diagnostics increment opened.

## It landed because a probe said it had to

I probed the **inversion** first — giving the string pipeline the counter-safe clone and the builder the real parser, the swap that makes `run_pipeline` a pure oracle and lets three sentinel systems go. It fails **27 tests of 5,474** (against 218 for a naive `run_pipeline` removal), and they collapse into exactly **two** root causes: this diagnostic, and the footnote catalog entry.

Neither is unblocked *by* the inversion. **Both block it** — the reverse of how the plan had them. And `{counter:}`, carried as a third blocker on the strength of an earlier audit measurement, does not appear at all: the counter-safe clone seeds both passes from the same pre-substitution state whichever way round they run.

## Why this was held back, and why each reason dissolved

The diagnostics increment deferred this one with three stated reasons:

- *It belongs to the attributes step, not a macro family* → so it is recorded in `apply_attribute_references` rather than at a macro's recognition site. That changes where the code lives and nothing else.
- *It is located per line* → but only because that is how the string pipeline **recovers** a span it has otherwise lost (`warning_source` matches a per-line byte range back against the line's text, and degrades to the whole content when there are no source lines). The tree never loses it: `source_slice` maps the match's own range back to `'src` directly — the same mapping every node's `location` already takes.
- *It is the very diagnostic whose incidental recording was that increment's first bug* → which is precisely what makes it landable now. The two-buffer split that fixed that bug keeps an `Attrlist` parse's own unmappable `attribute-missing` warning (via `record_substitution_warning`) apart from this one (via `record_builder_diagnostic`). **The earlier increment paid for this one.**

## Two load-bearing design points, both found by sabotage

**The mode is read directly, not through `MissingHandling`.** That enum answers what a missing reference *renders* as, and collapses distinctions this needs: `skip` and `warn` are both `Literal` because they emit the same bytes, and both `for_content` and `nested` fall back to `Literal` for the two shapes whose line correspondence the transducer cannot reproduce. None of that is a reason to stop diagnosing — the string pipeline scans a flat rendered string in which a span's contents are ordinary text, so it warns for a nested reference and a line-straddling span alike. Reading `AttributeMissing` directly keeps the deferrals about output bytes, where they belong: **the `drop-line` divergence stays a divergence in bytes only.**

**The order must be restored, not kept.** The splicing recursion visits a `Styled` child's content *before* its own level, so `{alpha} *bold {beta}*` finds `beta` first while the string pipeline's line scan sees `alpha` first — the same hazard `resolve_counters` exists to correct for counter directives. A stable sort by source offset fixes it.

The sort was **the one thing nothing pinned**: removing it left the whole suite green. So the increment's real test is a new configured pair in `inline_builder_side_effect_parity`, sweeping both diagnosing modes over ten fixtures (four straddling a span) with a non-vacuity guard per fixture — a harness that compares warnings *in order*, which is exactly the question.

## Gates

- **Fold-parity audit: 37 rows either side, 0 new, 0 closed.**
- **Coverage exactly diff-neutral** on both changed production files: `attribute_refs.rs` 11/6, `substitution_step.rs` 2/0 (missed regions / missed lines), identical on branch and base; totals 595/332/43 unchanged.
- **Three sabotages, three distinct failure sets:**
  - dropping the builder's recording → the same **8** tests the inversion probe named as this cause;
  - un-suppressing the string pipeline's copy → the same 8, on the double;
  - removing the sort → only the new parity sweep.
- Preflight: nightly `fmt --check`, `clippy --all-targets`, `test --workspace`, nightly `doc --no-deps --document-private-items` — all clean.

## What still defers

The **footnote catalog entry** — the probe's other root cause, and the last thing between here and the inversion. `register_footnote_number` registers `normalize_footnote_text(raw_content)`, the *unrendered* text, and threads no cross-reference placeholders through, so `define_footnote` never builds a `FootnoteDeferred` for a tree-built footnote. Both are invisible today because the registration lands on the discarded clone; invert, and they become the catalog (`footnotes[0].text` empty where the string pipeline registers `<a href="…">GitHub</a>`, and a footnote's own `<<tgt>>` no longer resolving). Testable ahead of the inversion through this same harness, which drives the builder directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_0146FMLXCi5iRt7xEYfcgHr1)_