### PR TITLE
feat: Fold a footnote's catalog entry from its own subtree (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7387,6 +7387,100 @@ Each phase is a reviewable unit with a clear exit gate.
   segments. It is testable ahead of the inversion through the same side-effect parity harness,
   which drives the builder directly and so can see what the clone registers.
 
+  *Step 6 landed as (the footnote catalog entry, folded from its own subtree):* the probe's other
+  root cause, and the last thing between here and the inversion.
+
+  [`register_footnote_number`](../../parser/src/content/inline_builder/footnotes.rs) now takes the
+  footnote's `children` instead of its raw bracket text, and builds the catalog entry by **folding
+  that subtree**. What it registered before was the *match string*, in which an already-recognized
+  construct is one opaque `SPAN_PLACEHOLDER` codepoint: `footnote:[see https://github.com[GitHub]]`
+  registered `"see \u{e0f0}"` where the string pipeline registers
+  `"see <a href=\"https://github.com\">GitHub</a>"`. Invisible today only because the registration
+  lands on the discarded clone.
+
+  **The mechanism is a second mode axis on the fold.** `fold.rs` already threads
+  `Footnotes::Marked`/`Stripped` — "does this fold write a footnote's in-flow marker?" — for the
+  same underlying reason: a tree is folded to more than one string, and which one is wanted is a
+  question about node kinds rather than about bytes. `Xrefs::Rendered`/`Deferred(&mut Vec<XrefSegment>)`
+  is the same shape for cross-references. Under `Deferred`, `fold_xref` writes
+  `Content::xref_placeholder(n)` and pushes `xref_segment_from_node(...)` instead of rendering, so
+  the new entry point [`fold_deferring_xrefs`](../../parser/src/content/inline_builder/fold.rs)
+  yields the placeholder **template** and the segment list **in one pass**, in matching order, which
+  is exactly the pair `define_footnote` turns into a `FootnoteDeferred`. The string replacer reaches
+  the same pair from the other direction — it re-homes the block template's placeholders out of the
+  already-substituted text it cut the footnote from — so a footnote's own `<<tgt>>` now resolves on
+  either side. Reusing `xref_segment_from_node`, which the block-level walk already uses, is what
+  keeps the two readings of "what does this node defer?" from drifting.
+
+  Refolding the subtree *after* resolution was considered and rejected: `Footnote::resolve_references`
+  runs on the **catalog entry**, driven from the catalog, with no access to the tree — it would need
+  whole new plumbing. Registration is also the last moment the subtree is final;
+  `apply_post_replacements` descends into a `Styled`/`Ref` child but not into a `Footnote`'s, and the
+  string pipeline agrees because the footnote's text is out of the flat string by then.
+
+  **The cost is a documented exception to an invariant, and it is not optional.** Building the tree
+  is otherwise unobservable — `inline_recorder`'s
+  `building_the_tree_does_not_consult_the_documents_renderer` measures that with a stateful
+  renderer — and this is the first fold that runs *during* a build. It cannot be avoided: a
+  footnote's catalog entry is a **required** recognition side effect (the same reason its number is;
+  a second `footnote:id[]` in the same content has to find the first one's id already registered),
+  and the entry's payload is a rendered string, so registering it and rendering it are one act. The
+  string pipeline does exactly the same thing at exactly the same moment. It adds no *second*
+  rendering: `fold_footnote` writes only the in-flow marker, never the children, so a footnote's
+  subtree is folded exactly once per parse either way. `footnote:[a < b]` moves out of
+  `RENDERER_FREE_CONSTRUCTS` into a new pinned test that also asserts the complement
+  (`footnote:[plain text]` still consults nothing), so the exception is a decision rather than a gap.
+
+  **The harness found a bug nothing else could see.** Extending `SideEffects` in
+  [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+  to carry the footnote catalog — compared *whole*, including `location`, which `Footnote`'s own
+  `Debug` omits — failed immediately on a fixture whose text matched byte-for-byte: the builder was
+  anchoring the entry at the **macro's** span where the string replacer anchors it at the enclosing
+  **content's**. That location is what a footnote's unresolved-reference warning is reported
+  against, so it was inert only while tree-built footnotes never carried a `FootnoteDeferred`. It
+  now passes `root`, the same span this pass already hands
+  `record_builder_diagnostic`. The sweep adds 32 footnote fixtures plus a `compat-mode` pair for the
+  deprecated `footnoteref:` spelling, and guards reachability of the deferred half specifically (a
+  corpus registering footnotes but none carrying a cross-reference would compare `None` against
+  `None`).
+
+  **Two entry-level divergences survive, both pinned.** A passthrough or a STEM expression inside a
+  footnote: the string pipeline restores a passthrough *after* the macros step, over the whole block
+  string, by which time the footnote's text has been cut out of it — so its entry keeps a raw
+  passthrough sentinel that nothing will ever replace (`\u{96}0\u{97}` reaching public API, one of
+  §4.2's three sentinel systems leaking). The tree has no sentinels and folds the restored text, so
+  here the **tree is right and the string pipeline is wrong**, which is why it is pinned as a
+  divergence rather than matched. And a cross-reference inside a *link's display text*, which the
+  builder does not recognize at all — a pre-existing gap in the link family that shows identically
+  outside any footnote, and which the entry is merely where it becomes visible in a side effect. A
+  third, kept out of the corpus rather than pinned: outside compat mode a construct-bearing
+  `footnoteref:` raises a deprecation warning quoting the matched macro, and each pipeline quotes
+  its own placeholder alphabet — a divergence in the warning's payload that the tree cannot close
+  from its side, since it has no string haystack to quote.
+
+  Audit: 37 rows either side, 0 new and 0 closed. Five rows differ only in the test-only Strategy-A
+  recorder's PUA event-index digits, which shift because the build-time fold records events through
+  that renderer too; normalizing those digits away collapses both sets to the same 36 lines with
+  nothing added or removed. Coverage exactly diff-neutral on all three changed production files
+  (`content.rs` 21/8, `fold.rs` 3/3, `footnotes.rs` 5/3 — missed regions / missed lines, identical
+  on both sides). Six sabotages, each failing a distinct set: discarding the captured segments,
+  shifting the placeholder index by one (which reaches a `debug_assert!` in `render_template` and
+  fails twelve suites), dropping the `trim`, dropping the newline collapse, re-anchoring at the
+  macro span, and folding the deferred reference's children into the flow after its placeholder.
+  Removing the fold entirely fails all four new or extended tests at once. A seventh could not be
+  written: `fold_anchor` takes no sink at all, so an anchor's reference text — which reaches
+  `render_anchor` rather than `out`, and would therefore contribute a segment with no placeholder —
+  is structurally prevented from deferring rather than merely told not to.
+
+  *What still defers is the inversion itself* — giving the string pipeline the counter-safe clone
+  and the builder the real parser. Both of the probe's root causes are now closed, so re-running it
+  is the next increment's first act. After that: deleting `run_pipeline`, the three sentinel
+  systems, and the `with_inline_tree` flag; and the structural freeze the recording increment left
+  owed — the three corpora that compare **trees and records** rather than HTML
+  (`inline_recorder`, `inline_builder_recorder_parity`,
+  `inline_builder_passthrough_record_parity`), which needs an `InlineNode` serialization rather than
+  a wider sweep of the HTML recording mechanism.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -8992,6 +9086,29 @@ Each phase is a reviewable unit with a clear exit gate.
        either side, 0 new and 0 closed; coverage exactly diff-neutral on both changed production
        files. What still defers is the footnote catalog entry — the probe's other root cause, and
        the last thing before the inversion. See the step's own "landed as" note above.
+
+     - ✅ **the footnote catalog entry, folded from its own subtree.** The probe's other root
+       cause, and the last thing before the inversion.
+       [`register_footnote_number`](../../parser/src/content/inline_builder/footnotes.rs) takes the
+       footnote's `children` rather than its raw bracket text and folds them, so the entry stops
+       being the *match string* (in which an already-recognized construct is one opaque
+       `SPAN_PLACEHOLDER` codepoint) and becomes the same bytes the string replacer captures out of
+       its already-substituted haystack. The mechanism is a **second mode axis** on the fold —
+       `Xrefs::Rendered`/`Deferred`, alongside the existing `Footnotes::Marked`/`Stripped` — under
+       which `fold_xref` writes a placeholder and pushes `xref_segment_from_node(...)` instead of
+       rendering, so one pass yields the template *and* the segment list in matching order: exactly
+       the pair `define_footnote` turns into a `FootnoteDeferred`, which a tree-built footnote never
+       had. The cost is a documented exception to "building the tree consults no renderer": the
+       entry is a required recognition side effect whose payload is a rendered string, so
+       registering it and rendering it are one act (and `fold_footnote` never folds a footnote's
+       children into the flow, so nothing is rendered twice). Extending
+       [`inline_builder_side_effect_parity`](../../parser/src/tests/inline_builder_side_effect_parity.rs)
+       to compare the footnote catalog *whole* immediately caught a second bug — the entry was
+       anchored at the macro's span where the string pipeline anchors it at the enclosing content's,
+       which is where a footnote's unresolved-reference warning is reported. Audit: 37 rows either
+       side, 0 new and 0 closed (five rows shift only in the test-only recorder's PUA index digits);
+       coverage exactly diff-neutral on all three changed production files. What still defers is the
+       inversion itself. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -1218,7 +1218,10 @@ Each phase is a reviewable unit with a clear exit gate.
     The registered catalog `text` is a best-effort normalized rendering of the raw bracket content, not
     a fold (building the tree must not itself invoke a renderer), so — like every other deferred
     registration in this module — a tree-built footnote's `Document::catalog().footnotes()` entry is
-    not yet byte-faithful; only the returned *number* is relied on.
+    not yet byte-faithful; only the returned *number* is relied on. Both halves of that — the
+    approximate `text` and the premise behind it — held at the time and were closed by a step 6 prep
+    below, which finds the entry is a *required* side effect whose payload is a rendered string, so
+    it is the one thing a build has to fold.
 
   Two forms are deferred, each documented and pinned by a divergence test: the deprecated
   `footnoteref:[id,text]` / `footnoteref:[id]` form (which packs its id and text into one bracket, split

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1459,13 +1459,19 @@ fn collect_footnote_tree_xref_segments(
 /// Reads one [`XrefSegment`] off a cross-reference node — see
 /// [`block_tree_xref_segments`] for why each field reads the way it does.
 ///
+/// Shared with the placeholder-emitting fold
+/// ([`fold_deferring_xrefs`](crate::content::inline_builder::fold_deferring_xrefs)),
+/// which captures a footnote's own segments as it writes that footnote's
+/// template: both readings of "what does this node defer?" are this one
+/// function, so the block-level list and a footnote's own cannot drift.
+///
 /// [`resolved`](XrefSegment::resolved) is deliberately **not** carried across:
 /// it is resolution's *output*, filled in later by
 /// [`Content::resolve_references`] and mirrored back onto the node by
 /// [`Content::mirror_tree_xref_resolution`]. A node re-read after a resolution
 /// sweep therefore yields the same segment it yielded before one, which is what
 /// makes this derivation idempotent.
-fn xref_segment_from_node(
+pub(crate) fn xref_segment_from_node(
     reference: &crate::inlines::Ref<'_>,
     renderer: &dyn InlineSubstitutionRenderer,
     context: &crate::parser::RenderContext,

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -391,8 +391,11 @@ impl MissingHandling {
 ///
 /// The check is on the span's *source* span rather than on what it renders to,
 /// which is sound in the direction that matters: a span whose source carries
-/// no `\n` cannot render one, and building the tree must not invoke a renderer
-/// to find out.
+/// no `\n` cannot render one, and building the tree does not fold a span to
+/// find out. (The build runs exactly one fold, and it is not an inspection: a
+/// footnote's catalog entry, which is a required recognition side effect whose
+/// payload is a rendered string — see
+/// [`fold_deferring_xrefs`](super::fold_deferring_xrefs).)
 fn line_structure_is_faithful(nodes: &[InlineNode<'_>]) -> bool {
     !nodes.iter().any(|node| match node {
         InlineNode::Styled(styled) => styled.location.data().contains('\n'),

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -3,6 +3,7 @@
 use super::{callouts::replacement_type_of, quotes::quote_type_of};
 use crate::{
     attributes::Attrlist,
+    content::{Content, XrefSegment, xref_segment_from_node},
     inlines::{
         Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm,
         Ref, RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
@@ -42,7 +43,14 @@ pub(crate) fn fold_html(
     context: &RenderContext,
 ) -> String {
     let mut out = String::new();
-    fold_into_html(nodes, renderer, context, Footnotes::Marked, &mut out);
+    fold_into_html(
+        nodes,
+        renderer,
+        context,
+        Footnotes::Marked,
+        &mut Xrefs::Rendered,
+        &mut out,
+    );
     out
 }
 
@@ -56,6 +64,95 @@ pub(crate) enum Footnotes {
     /// Omit it, marker and all, leaving the surrounding text as though the
     /// footnote had not been written — see [`fold_reference_text`].
     Stripped,
+}
+
+/// Whether a fold *renders* a cross-reference or *defers* it.
+///
+/// The fold's second mode axis, alongside [`Footnotes`]. Both exist for the
+/// same reason: a tree is folded to more than one string, and which string is
+/// wanted is a question about node kinds rather than about bytes.
+///
+/// [`Deferred`](Self::Deferred) is the placeholder-emitting mode — see
+/// [`fold_deferring_xrefs`], which is the only way to reach it.
+pub(crate) enum Xrefs<'a> {
+    /// Render each cross-reference in place, through `render_xref`: the
+    /// ordinary fold, which is what a block's flow shows.
+    Rendered,
+
+    /// Write a placeholder where each cross-reference stands, appending the
+    /// segment that will fill it to this list. The placeholder's index is the
+    /// segment's position in the list, so a template and its list are built in
+    /// one pass and cannot fall out of order.
+    Deferred(&'a mut Vec<XrefSegment>),
+}
+
+/// Folds `nodes` into a **placeholder template** plus the cross-reference
+/// segments that fill it, in placeholder order — the pair
+/// [`FootnoteDeferred`](crate::content::FootnoteDeferred) is built from.
+///
+/// A footnote's text is lifted out of the block it was written in, so a
+/// cross-reference inside it is never reached by the document-order pass that
+/// resolves the block's own references; the footnote has to carry its
+/// references itself, as a template plus a segment list, and resolve them from
+/// the catalog later ([`Footnote::resolve_references`]). The string pipeline
+/// reaches that pair by *re-homing* the block template's own placeholders,
+/// which are already sitting in the footnote's captured text
+/// ([`rehome_xref_placeholders`](crate::content::rehome_xref_placeholders)).
+/// The tree has no such placeholders to re-home — a cross-reference is a node
+/// — so it writes its own: this fold emits one per
+/// [`Xref`](RefVariant::Xref) node and records that node's segment as it goes.
+///
+/// # Why the template is built at *registration* time
+///
+/// A footnote's catalog entry is registered when the footnote is recognized,
+/// which is the same moment the string replacer registers its own. That is not
+/// a convenience: `Footnote::resolve_references` runs on the **catalog entry**,
+/// driven from the catalog, with no access to the tree the footnote came from,
+/// so nothing later in the parse can go back and derive the pair. Recognition
+/// is also the last moment the subtree is still final —
+/// [`apply_post_replacements`](super::apply_post_replacements) descends into a
+/// [`Styled`](crate::inlines::Styled)/[`Ref`](InlineNode::Ref) child but not
+/// into a [`Footnote`](InlineNode::Footnote)'s, exactly as the string pipeline
+/// has the footnote's text out of the flat string by then.
+///
+/// # This is a *build-time* fold, and the only one
+///
+/// Building the tree is otherwise unobservable — it consults no renderer, a
+/// property `inline_recorder`'s own
+/// `building_the_tree_does_not_consult_the_documents_renderer` measures with a
+/// stateful renderer. A footnote is the documented exception, and not by
+/// choice: its catalog entry is a **required** recognition side effect (the
+/// same reason its number is), and that entry's payload is a *rendered
+/// string*, so registering it and rendering it are one act. The string
+/// pipeline does exactly the same thing at exactly the same moment — its
+/// footnote replacer cuts already-rendered bytes out of the flat string it is
+/// substituting.
+///
+/// This adds no second rendering of the subtree. `fold_footnote` writes only
+/// the in-flow **marker**, never the footnote's children, so the block's own
+/// fold does not re-render what this one rendered: a footnote's subtree is
+/// folded exactly once per parse, here — the same once the string pipeline
+/// spends on it.
+///
+/// [`Footnote::resolve_references`]: crate::document::Footnote::resolve_references
+pub(crate) fn fold_deferring_xrefs(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &RenderContext,
+) -> (String, Vec<XrefSegment>) {
+    let mut out = String::new();
+    let mut segments = Vec::new();
+
+    fold_into_html(
+        nodes,
+        renderer,
+        context,
+        Footnotes::Marked,
+        &mut Xrefs::Deferred(&mut segments),
+        &mut out,
+    );
+
+    (out, segments)
 }
 
 /// The fold a **section title** contributes as its reference text and as the
@@ -92,7 +189,14 @@ pub(crate) fn fold_reference_text(
     context: &RenderContext,
 ) -> String {
     let mut out = String::new();
-    fold_into_html(nodes, renderer, context, Footnotes::Stripped, &mut out);
+    fold_into_html(
+        nodes,
+        renderer,
+        context,
+        Footnotes::Stripped,
+        &mut Xrefs::Rendered,
+        &mut out,
+    );
     out
 }
 
@@ -110,6 +214,7 @@ fn fold_into_html(
     renderer: &dyn InlineSubstitutionRenderer,
     context: &RenderContext,
     footnotes: Footnotes,
+    xrefs: &mut Xrefs<'_>,
     out: &mut String,
 ) {
     for node in nodes {
@@ -193,11 +298,11 @@ fn fold_into_html(
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Link => {
-                fold_link(reference, renderer, context, footnotes, out);
+                fold_link(reference, renderer, context, footnotes, xrefs, out);
             }
 
             InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => {
-                fold_xref(reference, renderer, context, footnotes, out);
+                fold_xref(reference, renderer, context, footnotes, xrefs, out);
             }
 
             InlineNode::Anchor(anchor) => {
@@ -205,7 +310,7 @@ fn fold_into_html(
             }
 
             InlineNode::IndexTerm(index_term) => {
-                fold_index_term(index_term, renderer, context, footnotes, out);
+                fold_index_term(index_term, renderer, context, footnotes, xrefs, out);
             }
 
             InlineNode::Footnote(footnote) => {
@@ -232,7 +337,14 @@ fn fold_into_html(
                 // string pipeline's quotes step did: the same `QuoteType`,
                 // attribute list, and id it recognized, so the bytes match.
                 let mut body = String::new();
-                fold_into_html(&styled.children, renderer, context, footnotes, &mut body);
+                fold_into_html(
+                    &styled.children,
+                    renderer,
+                    context,
+                    footnotes,
+                    xrefs,
+                    &mut body,
+                );
 
                 let scope = match styled.form {
                     SpanForm::Constrained => QuoteScope::Constrained,
@@ -405,6 +517,7 @@ fn fold_link(
     renderer: &dyn InlineSubstitutionRenderer,
     context: &RenderContext,
     footnotes: Footnotes,
+    xrefs: &mut Xrefs<'_>,
     out: &mut String,
 ) {
     let mut link_text = String::new();
@@ -413,6 +526,7 @@ fn fold_link(
         renderer,
         context,
         footnotes,
+        xrefs,
         &mut link_text,
     );
 
@@ -466,14 +580,28 @@ fn fold_xref(
     renderer: &dyn InlineSubstitutionRenderer,
     context: &RenderContext,
     footnotes: Footnotes,
+    xrefs: &mut Xrefs<'_>,
     out: &mut String,
 ) {
+    // A deferring fold writes a placeholder here instead of a rendering, and
+    // captures the segment that will fill it — see [`Xrefs::Deferred`]. The
+    // children are *not* folded into `out`: they are this reference's own
+    // display text, which the segment carries (rendered, by
+    // [`xref_segment_from_node`]) rather than the flow.
+    if let Xrefs::Deferred(segments) = xrefs {
+        let index = segments.len();
+        segments.push(xref_segment_from_node(reference, renderer, context));
+        out.push_str(&Content::xref_placeholder(index));
+        return;
+    }
+
     let mut provided = String::new();
     fold_into_html(
         &reference.children,
         renderer,
         context,
         footnotes,
+        xrefs,
         &mut provided,
     );
 
@@ -548,7 +676,23 @@ fn fold_anchor(
     } else {
         anchor.reftext.as_ref().map(|children| {
             let mut s = String::new();
-            fold_into_html(children, renderer, context, footnotes, &mut s);
+
+            // Always a *rendering*, even under a deferring fold, which is
+            // why this function takes no sink to pass along: an anchor's
+            // reference text reaches `render_anchor`, not `out`, so a
+            // placeholder written here would join the segment list without
+            // ever appearing in the template, shifting every later
+            // placeholder onto the wrong segment. Not descending is the same
+            // call `collect_tree_xref_segments` makes, for the same reason.
+            fold_into_html(
+                children,
+                renderer,
+                context,
+                footnotes,
+                &mut Xrefs::Rendered,
+                &mut s,
+            );
+
             s
         })
     };
@@ -588,6 +732,7 @@ fn fold_index_term(
     renderer: &dyn InlineSubstitutionRenderer,
     context: &RenderContext,
     footnotes: Footnotes,
+    xrefs: &mut Xrefs<'_>,
     out: &mut String,
 ) {
     let mut folded_children = String::new();
@@ -601,6 +746,7 @@ fn fold_index_term(
                 renderer,
                 context,
                 footnotes,
+                xrefs,
                 &mut folded_children,
             );
             Some(folded_children.as_str())

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -143,6 +143,11 @@ pub(crate) fn fold_deferring_xrefs(
     let mut out = String::new();
     let mut segments = Vec::new();
 
+    // The footnote axis is inert here whichever way it is set: `nodes` is one
+    // footnote's own children, and footnotes do not nest (the string
+    // pipeline's lazy bracket match cannot recognize one inside another's
+    // content either), so no `Footnote` node can be reached. `Marked` is the
+    // ordinary fold, which is the honest default for a mode nothing consults.
     fold_into_html(
         nodes,
         renderer,

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1,13 +1,14 @@
 //! The footnote substitution step.
 
 use super::{
+    fold_deferring_xrefs,
     macros::{emit_range_unescaping_brackets, image::range_has_no_opaque_piece},
     quotes::{Piece, build_match_string, source_slice, text_slice},
     special_chars::Masked,
 };
 use crate::{
     Parser, Span,
-    content::{INLINE_FOOTNOTE_MACRO, normalize_footnote_text},
+    content::INLINE_FOOTNOTE_MACRO,
     inlines::{Footnote, InlineNode},
     strings::CowStr,
 };
@@ -400,17 +401,16 @@ fn build_candidate_node<'src>(
 /// numbers footnotes over the same source in the same left-to-right order),
 /// so this never double-counts a registration; see the module's test helpers.
 ///
-/// The registered catalog `text` is a best-effort rendering of the raw
-/// bracket content (normalized, but not folded through a renderer — building
-/// the tree must not itself invoke one), so — like every other deferred
-/// registration in this module — a tree-built footnote's
-/// `Document::catalog().footnotes()` entry is not yet byte-faithful; only the
-/// returned *number*, this pass's one load-bearing side effect, is relied on.
+/// The registered catalog `text` is the footnote's **own subtree, folded** —
+/// see [`register_footnote_number`], which is where the entry a
+/// `Document::catalog().footnotes()` reader sees is now built, and why it can
+/// only be built here.
 ///
 /// # Content carrying an escaped closing bracket
 ///
 /// A content bracket may carry an escaped closing bracket (`\]`), which the
-/// string replacer unescapes to a literal `]` ([`normalize_footnote_text`]).
+/// string replacer unescapes to a literal `]`
+/// ([`normalize_footnote_text`](crate::content::macros::normalize_footnote_text)).
 /// The subtree carries it the same way: [`footnote_children`] emits the
 /// content through the reference-bearing families' own
 /// [`emit_range_unescaping_brackets`], which drops each backslash as a *gap*
@@ -458,12 +458,7 @@ fn build_footnote_node<'src>(
             Some(content) => {
                 // A defining occurrence that also carries an id.
                 let children = footnote_children(content.range(), s, pieces, nodes);
-                let number = register_footnote_number(
-                    parser,
-                    Some(id.as_ref()),
-                    &s[content.range()],
-                    location,
-                );
+                let number = register_footnote_number(parser, Some(id.as_ref()), &children, root);
 
                 Some(InlineNode::Footnote(Footnote {
                     id: Some(id),
@@ -500,7 +495,7 @@ fn build_footnote_node<'src>(
     let content = content_match?;
 
     let children = footnote_children(content.range(), s, pieces, nodes);
-    let number = register_footnote_number(parser, None, &s[content.range()], location);
+    let number = register_footnote_number(parser, None, &children, root);
 
     Some(InlineNode::Footnote(Footnote {
         id: None,
@@ -600,9 +595,8 @@ fn build_footnoteref_node<'src>(
     match content_range {
         Some(content_range) => {
             // A defining occurrence that also carries an id.
-            let children = footnote_children(content_range.clone(), s, pieces, nodes);
-            let number =
-                register_footnote_number(parser, Some(id.as_ref()), &s[content_range], location);
+            let children = footnote_children(content_range, s, pieces, nodes);
+            let number = register_footnote_number(parser, Some(id.as_ref()), &children, root);
 
             Some(InlineNode::Footnote(Footnote {
                 id: Some(id),
@@ -686,17 +680,17 @@ fn footnote_id_text<'src>(
 /// # The `\]` unescape
 ///
 /// A bracket's content may carry an **escaped closing bracket** (`\]`), which
-/// [`normalize_footnote_text`] — the string replacer's own normalization, and
-/// the one this pass registers the catalog `text` through — turns back into a
-/// literal `]`. The subtree must carry the same text, so the shared
-/// [`emit_range_unescaping_brackets`] drops each backslash as a *gap* in the
-/// ranges it emits: `footnote:[a \] b]` becomes the two `'src`-borrowing
-/// [`Text`](InlineNode::Text) children `a ` and `] b`, never an owned rebuild.
-/// Sharing the reference-bearing families' own helper is what keeps the two
-/// readings of "which backslashes pair off" from drifting; it is also why this
-/// form is no longer deferred (recognizing it once meant splicing a literal
-/// `]` into the middle of a `Text` piece, which nothing here could then
-/// express).
+/// [`normalize_footnote_text`](crate::content::macros::normalize_footnote_text)
+/// — the string replacer's own normalization, and the one this pass registers
+/// the catalog `text` through — turns back into a literal `]`. The subtree must
+/// carry the same text, so the shared [`emit_range_unescaping_brackets`] drops
+/// each backslash as a *gap* in the ranges it emits: `footnote:[a \] b]`
+/// becomes the two `'src`-borrowing [`Text`](InlineNode::Text) children `a `
+/// and `] b`, never an owned rebuild. Sharing the reference-bearing families'
+/// own helper is what keeps the two readings of "which backslashes pair off"
+/// from drifting; it is also why this form is no longer deferred (recognizing
+/// it once meant splicing a literal `]` into the middle of a `Text` piece,
+/// which nothing here could then express).
 fn footnote_children<'src>(
     range: std::ops::Range<usize>,
     s: &str,
@@ -713,21 +707,63 @@ fn footnote_children<'src>(
 /// Registers a footnote's defining occurrence with the parser, advancing the
 /// `footnote-number` counter and returning the assigned number — the one
 /// recognition side effect [`build_footnote_node`]'s doc comment explains this
-/// pass must perform. `raw_content` is normalized exactly as the string
-/// replacer normalizes it ([`normalize_footnote_text`]: trimmed, embedded
-/// newlines collapsed) before being registered as the catalog's best-effort
-/// `text`; no cross-reference placeholders are threaded through (the additive
-/// builder has none to give it — a `Ref{Xref}` is a node, not a placeholder),
-/// so `define_footnote` never builds a `FootnoteDeferred` for a tree-built
-/// footnote.
+/// pass must perform.
+///
+/// The catalog entry is built from the footnote's own `children`, folded
+/// through [`fold_deferring_xrefs`]: that fold yields, in one pass, the
+/// placeholder **template** the entry stores and the cross-reference
+/// **segments** that fill it, which is exactly the pair `define_footnote`
+/// turns into a
+/// [`FootnoteDeferred`](crate::content::FootnoteDeferred). The string
+/// replacer reaches the same pair from the other direction — it re-homes the
+/// block template's placeholders out of the already-substituted text it cut
+/// the footnote from
+/// ([`rehome_xref_placeholders`](crate::content::rehome_xref_placeholders)) —
+/// so a footnote's own `<<tgt>>` resolves on either side.
+///
+/// Folding the subtree is also what makes the entry's `text` byte-faithful at
+/// all: the raw bracket content this used to register is the *match string*,
+/// in which an already-recognized construct is one opaque `SPAN_PLACEHOLDER`
+/// codepoint, so `footnote:[see https://github.com[GitHub\]]` registered
+/// `"see \u{e0f0}"` where the string pipeline registers
+/// `"see <a href=\"https://github.com\">GitHub</a>"`.
+///
+/// # Why the anchor is `root`, not the macro's own span
+///
+/// `define_footnote` records where the *enclosing content* was written, not
+/// where the macro sits: the entry's location anchors an unresolved-reference
+/// warning raised much later, when the catalog resolves the footnote's own
+/// cross-references, and the string replacer passes its whole `self.source`
+/// there (paragraph granularity, matching how a non-footnote reference is
+/// anchored at its `Content` — see the field's own docs). `root` is that same
+/// span; it is what this pass already passes to
+/// [`Parser::record_builder_diagnostic`] for the two diagnostics it raises.
+/// The macro's own span is the *node's* `location`, a different question with
+/// a different answer.
+///
+/// # Normalization
+///
+/// [`normalize_footnote_text`](crate::content::macros::normalize_footnote_text)
+/// does three things to the string replacer's raw content: trims it, collapses
+/// each embedded newline to a space, and unescapes `\]` to `]`. The first two
+/// apply here unchanged — they are about the *text*, whichever pipeline
+/// produced it. The third does **not**: [`footnote_children`] already dropped
+/// each such backslash while emitting the subtree (see its doc comment), so
+/// re-applying the unescape here would be a second pass over an
+/// already-unescaped string.
 fn register_footnote_number(
     parser: &Parser,
     id: Option<&str>,
-    raw_content: &str,
-    location: Span<'_>,
+    children: &[InlineNode<'_>],
+    root: Span<'_>,
 ) -> String {
-    let text = normalize_footnote_text(raw_content);
-    parser.define_footnote(id, text, vec![], location)
+    let (template, xrefs) =
+        fold_deferring_xrefs(children, &*parser.renderer, &parser.render_context());
+
+    // Trim and collapse, but do not unescape — see the doc comment above.
+    let template = template.trim().replace('\n', " ");
+
+    parser.define_footnote(id, template, xrefs, root)
 }
 
 #[cfg(test)]

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -681,9 +681,9 @@ fn footnote_id_text<'src>(
 ///
 /// A bracket's content may carry an **escaped closing bracket** (`\]`), which
 /// [`normalize_footnote_text`](crate::content::macros::normalize_footnote_text)
-/// — the string replacer's own normalization, and the one this pass registers
-/// the catalog `text` through — turns back into a literal `]`. The subtree must
-/// carry the same text, so the shared [`emit_range_unescaping_brackets`] drops
+/// — the string replacer's own normalization — turns back into a literal `]`.
+/// The subtree must carry the same text, so the shared
+/// [`emit_range_unescaping_brackets`] drops
 /// each backslash as a *gap* in the ranges it emits: `footnote:[a \] b]`
 /// becomes the two `'src`-borrowing [`Text`](InlineNode::Text) children `a `
 /// and `] b`, never an owned rebuild. Sharing the reference-bearing families'
@@ -691,6 +691,12 @@ fn footnote_id_text<'src>(
 /// from drifting; it is also why this form is no longer deferred (recognizing
 /// it once meant splicing a literal `]` into the middle of a `Text` piece,
 /// which nothing here could then express).
+///
+/// Unescaping *here* is also why [`register_footnote_number`] applies only the
+/// other two halves of that normalization (the trim and the newline collapse)
+/// to the template it folds out of these children: the backslash is already
+/// gone by then, and a second pass would unescape a string that was never
+/// escaped.
 fn footnote_children<'src>(
     range: std::ops::Range<usize>,
     s: &str,

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -276,7 +276,7 @@
 //!   families' own
 //!   [`emit_range_unescaping_brackets`](macros::emit_range_unescaping_brackets),
 //!   so the subtree carries the literal `]` the string replacer's
-//!   [`normalize_footnote_text`](crate::content::normalize_footnote_text)
+//!   [`normalize_footnote_text`](crate::content::macros::normalize_footnote_text)
 //!   produces. The deprecated `footnoteref:[id,text]` / `footnoteref:[id]` form
 //!   (`build_footnoteref_node`) is recognized too, splitting its one bracket on
 //!   the first comma rather than taking an id from the macro target (an id, the
@@ -428,7 +428,7 @@ use char_replacements::apply_character_replacements;
 // Consumed only by `cfg(test)` callers and future external callers until the
 // authoritative-fold half of the cutover wires it into `Content`.
 #[allow(unused_imports)]
-pub(crate) use fold::{fold_html, fold_reference_text};
+pub(crate) use fold::{fold_deferring_xrefs, fold_html, fold_reference_text};
 use footnotes::apply_footnotes;
 pub(crate) use macros::apply_macro_side_effects;
 use macros::{ComputedSpecials, apply_macros};

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -8,7 +8,7 @@ pub use content::Content;
 pub(crate) use content::{
     DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, fold_resolved_title,
     rehome_xref_placeholders, render_xref_template, resolved_destinations, sanitize_title,
-    template_partition,
+    template_partition, xref_segment_from_node,
 };
 // The two tree walks behind `Content::set_tree_xrefs`, which calls them
 // directly. Re-exported for the differential corpus that compares what they
@@ -33,8 +33,8 @@ pub(crate) use macros::{
     INLINE_ANCHOR, INLINE_BIBLIO_ANCHOR, INLINE_EMAIL, INLINE_FOOTNOTE_MACRO, INLINE_IMAGE_MACRO,
     INLINE_INDEXTERM, INLINE_KBD_BTN_MACRO, INLINE_LINK, INLINE_LINK_MACRO, INLINE_MENU_MACRO,
     INLINE_XREF, NormalizedCaps, URI_SNIFF, basename, document_xrefstyle, encode_uri_component,
-    extract_attributes_from_text, normalize_footnote_text, normalize_index_text,
-    normalize_text_lf_escaped_bracket, split_kbd_keys, strip_see_and_seealso,
+    extract_attributes_from_text, normalize_index_text, normalize_text_lf_escaped_bracket,
+    split_kbd_keys, strip_see_and_seealso,
 };
 
 mod xref_target;

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -1,16 +1,27 @@
 //! A corpus-wide differential harness for the builder's recognition **side
 //! effects**.
 //!
-//! Recognizing a construct is not only about the bytes it renders. Four
+//! Recognizing a construct is not only about the bytes it renders. Five
 //! passes of the string pipeline also *write down* what they saw: an
 //! `image:` macro records its target in the asset catalog, a `link:`/`mailto:`
 //! macro and every auto-linked URL or address record theirs, an inline anchor
-//! (and a bibliography entry) registers its id in the reference catalog, and
-//! an image whose `link=` names a dangerous scheme records a warning. Design
-//! §5.2's step 6 has to replay all four from the tree, exactly once per parse
-//! and in the string pipeline's own pass order, which is what
+//! (and a bibliography entry) registers its id in the reference catalog, an
+//! image whose `link=` names a dangerous scheme records a warning, and a
+//! `footnote:`/`footnoteref:` macro registers its numbered entry — text and
+//! deferred cross-references included — in the footnote catalog. Design
+//! §5.2's step 6 has to replay the first four from the tree, exactly once per
+//! parse and in the string pipeline's own pass order, which is what
 //! [`apply_macro_side_effects`](crate::content::inline_builder::apply_macro_side_effects)
 //! is staged to do.
+//!
+//! The **footnote** catalog is the one that cannot be staged, and the builder
+//! has always written it during the build: a footnote's number *is* its
+//! rendered marker, and a second `footnote:id[]` in the same content has to
+//! find the first one's id already registered. What the entry carried was
+//! another matter — until this increment it was the raw match string, in which
+//! an already-recognized construct is one opaque placeholder codepoint. It is
+//! compared here for the same reason the other four are (it is what the
+//! pipeline wrote down), but against the build itself rather than a replay.
 //!
 //! Until now it was pinned only by hand-written fixtures inside its own
 //! module — one per ordering rule it has to honor. The blast-radius
@@ -35,7 +46,7 @@ use crate::{
         Content, SubstitutionGroup,
         inline_builder::{apply_macro_side_effects, build},
     },
-    document::RefType,
+    document::{Footnote, RefType},
     parser::ModificationContext,
     warnings::WarningType,
 };
@@ -55,6 +66,11 @@ struct SideEffects {
 
     /// Substitution warnings, in the order the one shared list received them.
     warnings: Vec<WarningType>,
+
+    /// Footnote catalog entries, in registration (document) order. Compared
+    /// whole — index, id, text, deferred cross-references and location — since
+    /// every field of one is written by the recognizing pass.
+    footnotes: Vec<Footnote>,
 }
 
 /// Snapshots everything `parser` has had written into it, draining the
@@ -64,7 +80,7 @@ fn snapshot(parser: &Parser) -> SideEffects {
     // warnings buffer), so they do not conflict; the catalog's is scoped
     // anyway, since its `Ref` outliving the read would be a hazard for any
     // later caller.
-    let (images, links, refs) = {
+    let (images, links, refs, footnotes) = {
         let catalog = parser.catalog();
 
         (
@@ -84,6 +100,7 @@ fn snapshot(parser: &Parser) -> SideEffects {
                     )
                 })
                 .collect(),
+            catalog.footnotes().to_vec(),
         )
     };
 
@@ -91,6 +108,7 @@ fn snapshot(parser: &Parser) -> SideEffects {
         images,
         links,
         refs,
+        footnotes,
         warnings: parser
             .drain_substitution_warnings_since(0)
             .into_iter()
@@ -164,6 +182,7 @@ impl SideEffects {
             && self.links.is_empty()
             && self.refs.is_empty()
             && self.warnings.is_empty()
+            && self.footnotes.is_empty()
     }
 }
 
@@ -308,7 +327,183 @@ const CORPUS: &[&str] = &[
     "anchor:a[see image:t.png[T]] and image:u.png[U]",
     "anchor:a[see link:t.html[T]] and link:u.html[U]",
     "[[[b,see image:t.png[T]]]] and image:u.png[U]",
+    //
+    // The **footnote** catalog. Unlike the four staged lists, an entry here is
+    // written by the build itself, and it carries a *rendered* payload — the
+    // footnote's text, plus the placeholder template and cross-reference
+    // segments a `<<tgt>>` inside it defers. Every fixture below registers an
+    // entry, so a build that stopped rendering the subtree (registering the
+    // raw match string, in which an already-recognized construct is one opaque
+    // placeholder codepoint) fails on the first of them.
+    "A footnote:[a plain note] here.",
+    "A footnote:[  spaced\nover lines  ] here.",
+    "A footnote:[a \\] bracket] here.",
+    "A footnote:[a & b < c > d] here.",
+    "A footnote:[&copy; and \\&amp;] here.",
+    "A footnote:[a -- b (C) c] here.",
+    "A footnote:[{logo} expanded] here.",
+    // A construct already recognized when the footnote is: the whole reason
+    // the entry has to be folded rather than sliced out of the match string.
+    "A footnote:[see https://github.com[GitHub]] here.",
+    "A footnote:[an image:x.png[Alt] inline] here.",
+    "A footnote:[an icon:home[] inline] here.",
+    "A footnote:[mailto:a@b.com[write]] here.",
+    "A footnote:[bare https://example.org here] here.",
+    "A footnote:[`mono` and #hl# spans] here.",
+    "A footnote:[kbd:[Ctrl+T]] here.",
+    "A footnote:[btn:[OK] and menu:File[Save]] here.",
+    "A footnote:[an [[anchor]] inside] here.",
+    // The deferred half: a cross-reference inside a footnote is re-homed out
+    // of the block's template onto the footnote's own, so these pin the
+    // template *and* the segment list, in placeholder order.
+    "A footnote:[see <<tgt>>] here.",
+    "A footnote:[see <<tgt,the target>>] here.",
+    "A footnote:[see <<tgt,*bold* text>>] here.",
+    "A footnote:[<<a>> then <<b>> then <<c>>] here.",
+    "A footnote:[<<a>>\nand <<b>>] here.",
+    "A footnote:[*<<tgt>>*] here.",
+    "A footnote:[a ((term with <<tgt>>)) inside] here.",
+    "A footnote:[anchor:a[Ref <<tgt>>] inside] here.",
+    "A footnote:[xref:tgt[label]] here.",
+    "A footnote:[xref:doc.adoc#sec[]] here.",
+    "A footnote:[<<tgt,>>] here.",
+    "A footnote:[\\<<tgt>> escaped] here.",
+    // A footnote beside one that defers nothing, so a template spliced onto
+    // the wrong entry shows up as a mismatch rather than as a shifted index.
+    "One footnote:[<<a>>] and another footnote:[plain] here.",
+    // Ids: a defining occurrence, a later reference reusing its number, and
+    // the deprecated spelling that packs both into one bracket.
+    "First footnote:id2[<<b>>] then footnote:id2[] again.",
+    // The deprecated spelling. Its text stays plain here on purpose: outside
+    // compatibility mode this form also raises a deprecation warning quoting
+    // the *matched macro*, and the two pipelines quote two different
+    // placeholder alphabets for a construct inside it — a neighbouring gap in
+    // the warning's payload, not in the entry, which
+    // `a_compat_mode_footnoteref_registers_what_the_string_pipeline_does`
+    // steps around by turning the warning off.
+    "A footnoteref:[fid,text with a plain note] here.",
+    "A footnoteref:[fid] alone.",
 ];
+
+/// The deprecated `footnoteref:` form's own configured pair, with
+/// `compat-mode` set so the deprecation warning is not raised.
+///
+/// The warning is what keeps a construct-bearing `footnoteref:` out of
+/// [`CORPUS`]: it quotes the matched macro, and each pipeline quotes it out of
+/// its own haystack, in which an already-recognized construct is a placeholder
+/// — `\u{e000}0\u{e001}` (a deferred cross-reference) on the string side,
+/// `\u{e0f0}` (an opaque piece) on the tree's. That is a divergence in the
+/// *warning's payload*, and one the tree cannot close from its side: it has no
+/// string haystack to quote. Turning the warning off is what lets the
+/// registration underneath it be compared, which is this increment's subject.
+fn compat_mode_side_effects(source: &str) -> (SideEffects, SideEffects) {
+    side_effects_with(source, || {
+        corpus_parser().with_intrinsic_attribute("compat-mode", "", ModificationContext::Anywhere)
+    })
+}
+
+#[test]
+fn a_compat_mode_footnoteref_registers_what_the_string_pipeline_does() {
+    for source in [
+        "A footnoteref:[fid,text with <<tgt>>] here.",
+        "A footnoteref:[fid,see https://github.com[GitHub]] here.",
+        "A footnoteref:[fid,*bold* and <<a>> and <<b>>] here.",
+        // A trailing comma is an empty *defining* text, not the no-comma
+        // bare-reference shape (which registers nothing, and which `CORPUS`
+        // already covers).
+        "A footnoteref:[fid,] with an empty text.",
+        "First footnoteref:[fid,<<a>>] then footnoteref:[fid] again.",
+    ] {
+        let (golden, builder) = compat_mode_side_effects(source);
+
+        assert_eq!(
+            golden, builder,
+            "the deprecated footnote spelling diverged for {source:?}"
+        );
+
+        assert!(
+            !golden.footnotes.is_empty(),
+            "fixture registered no footnote: {source:?}"
+        );
+    }
+}
+
+#[test]
+fn two_shapes_where_a_tree_built_footnote_entry_still_diverges() {
+    // Pinned rather than left to be rediscovered. Neither is a gap this
+    // increment opened — the entry used to be the raw match string, which
+    // diverged for *every* fixture above — and neither is one it can close.
+
+    // 1. A passthrough (or a STEM expression) inside a footnote. The string
+    //    pipeline restores a passthrough *after* the macros step, over the whole
+    //    block string — by which time the footnote's text has already been cut out
+    //    of it, so the entry keeps a raw passthrough sentinel that no later pass
+    //    will ever replace. It is one of design §4.2's three sentinel systems
+    //    leaking into public API, and the tree simply has no sentinels: the
+    //    passthrough is a node, so folding the subtree yields the restored text.
+    //    The tree is *right* here and the string pipeline is wrong, which is why
+    //    this is pinned as a divergence rather than fixed on the tree's side to
+    //    match.
+    for (source, string_side, tree_side) in [
+        (
+            "A footnote:[a +++<b>raw</b>+++ passthrough] here.",
+            "a \u{96}0\u{97} passthrough",
+            "a <b>raw</b> passthrough",
+        ),
+        ("A footnote:[pass:[<x>]] here.", "\u{96}0\u{97}", "<x>"),
+        (
+            "A footnote:[stem:[x < y]] here.",
+            "\u{96}0\u{97}",
+            "\\$x &lt; y\\$",
+        ),
+    ] {
+        let (golden, builder) = side_effects(source);
+
+        assert_eq!(
+            golden.footnotes.first().map(|f| f.text.as_str()),
+            Some(string_side),
+            "the string pipeline stopped leaking a sentinel for {source:?}"
+        );
+
+        assert_eq!(
+            builder.footnotes.first().map(|f| f.text.as_str()),
+            Some(tree_side),
+            "the tree stopped restoring the passthrough for {source:?}"
+        );
+    }
+
+    // 2. A cross-reference inside a **link's display text**. The builder does not
+    //    recognize one there at all — the link family escapes its text rather than
+    //    substituting into it — so the tree holds `CharRef` leaves where the string
+    //    pipeline holds a deferred reference. That is a recognition gap in the
+    //    *link* family, which shows identically outside any footnote (`A
+    //    link:x.html[<<tgt>>] here.` renders `&lt;&lt;tgt&gt;&gt;` in the flow
+    //    either way it is reached); the footnote entry is only where it becomes
+    //    visible in a side effect.
+    let (golden, builder) = side_effects("A footnote:[link:x.html[<<tgt>>]] here.");
+
+    assert_eq!(
+        golden.footnotes.first().map(|f| f.text.as_str()),
+        Some("<a href=\"x.html\"><a href=\"#tgt\">[tgt]</a></a>")
+    );
+
+    assert_eq!(
+        builder.footnotes.first().map(|f| f.text.as_str()),
+        Some("<a href=\"x.html\">&lt;&lt;tgt&gt;&gt;</a>")
+    );
+
+    assert!(
+        golden
+            .footnotes
+            .first()
+            .is_some_and(|f| f.deferred.is_some())
+            && builder
+                .footnotes
+                .first()
+                .is_some_and(|f| f.deferred.is_none()),
+        "the link family started recognizing a cross-reference in its text"
+    );
+}
 
 /// A bibliography entry is not a plain fixture: the string pipeline recognizes
 /// `[[[id]]]` only inside a bibliography list item, which is parser state
@@ -359,9 +554,9 @@ fn the_sweep_reaches_every_list_a_recognition_pass_writes_to() {
     // that each of the four lists `apply_macro_side_effects` composes is
     // actually reached, so dropping a whole family from the corpus would fail
     // here rather than quietly narrow the sweep.
-    let (images, links, refs, warnings) = CORPUS.iter().fold(
-        (0usize, 0usize, 0usize, 0usize),
-        |(images, links, refs, warnings), source| {
+    let (images, links, refs, warnings, footnotes, deferred) = CORPUS.iter().fold(
+        (0usize, 0usize, 0usize, 0usize, 0usize, 0usize),
+        |(images, links, refs, warnings, footnotes, deferred), source| {
             let (golden, _) = side_effects(source);
 
             (
@@ -369,6 +564,13 @@ fn the_sweep_reaches_every_list_a_recognition_pass_writes_to() {
                 links + golden.links.len(),
                 refs + golden.refs.len(),
                 warnings + golden.warnings.len(),
+                footnotes + golden.footnotes.len(),
+                deferred
+                    + golden
+                        .footnotes
+                        .iter()
+                        .filter(|footnote| footnote.deferred.is_some())
+                        .count(),
             )
         },
     );
@@ -377,6 +579,16 @@ fn the_sweep_reaches_every_list_a_recognition_pass_writes_to() {
     assert!(links > 0, "no fixture registered a link");
     assert!(refs > 0, "no fixture registered an id");
     assert!(warnings > 0, "no fixture recorded a warning");
+    assert!(footnotes > 0, "no fixture registered a footnote");
+
+    // The deferred half of a footnote entry is its own reachability question:
+    // a corpus that registered footnotes but none carrying a cross-reference
+    // would compare `None` against `None` and never exercise the template or
+    // the segment list at all.
+    assert!(
+        deferred > 0,
+        "no fixture registered a footnote deferring a cross-reference"
+    );
 }
 
 /// The `attribute-missing` diagnostic's own configured pair: the mode is

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -872,7 +872,9 @@ fn first_simple_rendered<'a>(doc: &'a crate::Document<'a>) -> &'a str {
 
 /// Every construct whose tree the builder can produce without consulting a
 /// renderer — which, after the two passthrough-form increments, is everything
-/// except the two shapes that run an arbitrary substitution list.
+/// except the two shapes that run an arbitrary substitution list and the
+/// footnote, whose catalog entry the build has to *render* to register (see
+/// [`a_footnotes_catalog_entry_is_rendered_while_building`]).
 const RENDERER_FREE_CONSTRUCTS: &[&str] = &[
     "a < b",
     "++a < b++",
@@ -885,7 +887,6 @@ const RENDERER_FREE_CONSTRUCTS: &[&str] = &[
     "[x-]++a < b++",
     "image:x.png[a < b]",
     "link:x.html[a < b]",
-    "footnote:[a < b]",
     "<<tgt,a < b>>",
     "kbd:[Ctrl+T] and a < b",
     "a < b -- c (C) d",
@@ -976,6 +977,44 @@ fn the_three_non_specialcharacters_bodies_still_consult_the_renderer() {
             "expected {source:?} to still consult the renderer while building, got {calls}"
         );
     }
+}
+
+#[test]
+fn a_footnotes_catalog_entry_is_rendered_while_building() {
+    // The fourth build-time renderer consumer, and the only one that is not a
+    // frozen-value debt: a footnote's *catalog entry*.
+    //
+    // Every other recognition side effect on this branch is staged and
+    // replayed after the build, which is what lets the build stay
+    // unobservable. A footnote's cannot be. Its entry is registered at
+    // recognition — that is where the `footnote-number` counter advances, and
+    // where a later `footnote:id[]` in the same content has to find the id
+    // already registered — and the entry's payload is a *rendered* string, so
+    // registering it and rendering it are one act. The string pipeline's
+    // replacer does the same thing at the same moment, cutting already-
+    // rendered bytes out of the string it is substituting.
+    //
+    // Pinned rather than merely allowed: a build that stopped rendering here
+    // would go back to registering the raw match string, in which an
+    // already-recognized construct is one opaque placeholder codepoint — the
+    // divergence `inline_builder_side_effect_parity`'s footnote sweep exists
+    // to catch.
+    let calls = renderer_calls_while_building("footnote:[a < b]");
+
+    assert!(
+        calls > 0,
+        "expected a footnote's entry to be rendered while building, got {calls} renderer calls"
+    );
+
+    // A footnote whose text needs no escaping needs no renderer either: the
+    // fold routes only `<`, `>` and `&` through it. Without this the assertion
+    // above would pass for any footnote at all, and would keep passing if the
+    // fold were replaced by something that merely touched the renderer once.
+    assert_eq!(
+        renderer_calls_while_building("footnote:[plain text]"),
+        0,
+        "a footnote with nothing to escape must not consult the renderer"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Design §5.2 Phase 4, step 6. One increment: the **footnote catalog entry**, the last thing between here and the inversion.

## What was wrong

`register_footnote_number` registered `normalize_footnote_text(raw_content)` — the *match string*, in which an already-recognized construct is one opaque `SPAN_PLACEHOLDER` codepoint — and threaded no cross-reference placeholders, so `define_footnote` never built a `FootnoteDeferred` for a tree-built footnote:

```
source    footnote:[see https://github.com[GitHub]]
string    text: "see <a href=\"https://github.com\">GitHub</a>"
tree      text: "see \u{e0f0}"
```

Both halves are invisible today because the registration lands on the discarded counter-safe clone. They are the second of the two root causes the previous increment's inversion probe collapsed 27 failing tests into.

## The mechanism: a second mode axis on the fold

`fold.rs` already threads `Footnotes::Marked`/`Stripped` — "does this fold write a footnote's in-flow marker?" — for the same underlying reason: a tree is folded to more than one string, and which one is wanted is a question about node kinds rather than about bytes. `Xrefs::Rendered`/`Deferred(&mut Vec<XrefSegment>)` is the same shape for cross-references.

Under `Deferred`, `fold_xref` writes `Content::xref_placeholder(n)` and pushes `xref_segment_from_node(...)` instead of rendering, so the new `fold_deferring_xrefs` yields the placeholder **template** and the segment list **in one pass, in matching order** — exactly the pair `define_footnote` turns into a `FootnoteDeferred`. The string replacer reaches the same pair from the other direction (re-homing the block template's placeholders out of the text it cut the footnote from), so a footnote's own `<<tgt>>` now resolves on either side. Reusing `xref_segment_from_node`, which the block-level walk already uses, keeps the two readings of "what does this node defer?" from drifting.

`fold_anchor` deliberately takes no sink: an anchor's reference text reaches `render_anchor` rather than `out`, so a placeholder written there would join the segment list without ever appearing in the template, shifting every later placeholder onto the wrong segment.

Refolding the subtree *after* resolution was considered and rejected: `Footnote::resolve_references` runs on the catalog entry, driven from the catalog, with no access to the tree.

## The one exception this opens, and why it is not optional

This is the first fold that runs *during* a build, and building the tree is otherwise unobservable — `inline_recorder::building_the_tree_does_not_consult_the_documents_renderer` measures exactly that with a stateful renderer, and it is what failed first here.

It cannot be avoided. A footnote's catalog entry is a **required** recognition side effect — the same reason its number is; a second `footnote:id[]` in the same content has to find the first one's id already registered — and the entry's payload is a *rendered string*, so registering it and rendering it are one act. The string pipeline does the same thing at the same moment. It adds no second rendering: `fold_footnote` writes only the in-flow marker, never the children, so a footnote's subtree is folded exactly once per parse either way.

`footnote:[a < b]` therefore moves out of `RENDERER_FREE_CONSTRUCTS` into a new pinned test that also asserts the complement — `footnote:[plain text]` still consults nothing — so the exception is a decision rather than a gap.

## A second bug, found by the harness

Extending `SideEffects` in `inline_builder_side_effect_parity` to carry the footnote catalog — compared **whole**, including the `location` that `Footnote`'s own `Debug` omits — failed immediately on a fixture whose text already matched byte-for-byte: the builder anchored the entry at the **macro's** span where the string replacer anchors it at the enclosing **content's**. That span is what a footnote's unresolved-reference warning is reported against, so it was inert only while tree-built footnotes never carried a `FootnoteDeferred`. It now passes `root`, the span this pass already hands `record_builder_diagnostic`.

The sweep adds 32 footnote fixtures plus a `compat-mode` pair for the deprecated `footnoteref:` spelling, and guards reachability of the deferred half specifically (a corpus registering footnotes but none carrying a cross-reference would compare `None` against `None`).

## Divergences that survive, pinned rather than left to be rediscovered

- **A passthrough or STEM expression inside a footnote.** The string pipeline restores a passthrough *after* the macros step, over the whole block string — by which time the footnote's text has been cut out of it, so its entry keeps a raw passthrough sentinel (`\u{96}0\u{97}`) that nothing will ever replace, reaching public API. The tree has no sentinels and folds the restored text. Here the **tree is right and the string pipeline is wrong**, which is why this is pinned as a divergence rather than matched.
- **A cross-reference inside a link's display text.** The builder does not recognize one there at all — a pre-existing gap in the link family that shows identically outside any footnote. The entry is only where it becomes visible in a side effect.
- **A construct-bearing `footnoteref:` outside compat mode** is kept out of the corpus rather than pinned: its deprecation warning quotes the matched macro, and each pipeline quotes its own placeholder alphabet. That is a divergence in the warning's payload, and the tree cannot close it — it has no string haystack to quote.

## Verification

- `cargo test --workspace`: 5,478 pass, 0 fail.
- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`: all clean.
- **Fold-parity audit**: 37 rows on this branch and on `origin/inline-ast`, **0 new and 0 closed**. Five rows differ only in the test-only Strategy-A recorder's PUA event-index digits, which shift because the build-time fold records events through that renderer too; normalizing those digits away collapses both sets to the same 36 lines with nothing added or removed.
- **Coverage, judged on a diff basis**: exactly unchanged on all three changed production files — `content.rs` 21/8, `fold.rs` 3/3, `footnotes.rs` 5/3 (missed regions / missed lines), identical either side.
- **Sabotage**, six, each failing a distinct set: discarding the captured segments; shifting the placeholder index by one (reaches `render_template`'s `debug_assert!` and fails twelve suites); dropping the `trim`; dropping the newline collapse; re-anchoring at the macro span; folding the deferred reference's children into the flow after its placeholder. Removing the fold entirely fails all four new or extended tests at once. A seventh could not be written — `fold_anchor` takes no sink, so it is *structurally* prevented from deferring rather than merely told not to.

## What is next

Both of the inversion probe's root causes are now closed, so re-running that probe is the next increment's first act.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDXME9qXYjkgu5zZ7mHRYu)_