### PR TITLE
feat: Invert which pass holds the real parser (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7532,6 +7532,18 @@ Each phase is a reviewable unit with a clear exit gate.
   is the pin, and it is the complement of the mislocated-warning test above — the two together are the
   whole of the distinction.
 
+  A second review pass then asked what *location* those rescued warnings carry, which is worth
+  recording: the answer is "the wrong one, and always has been". `passthrough_text` substitutes a body
+  as **owned** text, so a warning the body raises is located against that text rather than against the
+  document and comes out at offset 0 however far in the passthrough sits. `origin/inline-ast` reports
+  byte-for-byte the same span for every fixture, so the rescue is behavior-preserving down to the
+  offset — the bug is in how a body's warnings are located, and closing it means deciding whether such
+  a warning should be *remapped* onto the body's position or *discarded* the way every other
+  owned-source substitution's is. That is its own change, and
+  [`a_rescued_passthrough_warning_keeps_the_location_it_always_had`](../../parser/src/content/passthroughs.rs)
+  pins the current answer (with a plain, non-passthrough control that *is* located exactly) so it stays
+  a decision rather than drifting.
+
   **A passthrough body's re-entry changed hands.** `passthrough_text` re-enters
   `SubstitutionGroup::apply` for a body carrying its own substitution list, and that re-entry now
   happens from inside the build, on the real parser. It takes no tree seed (the guard), so its string

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7484,6 +7484,87 @@ Each phase is a reviewable unit with a clear exit gate.
   `inline_builder_passthrough_record_parity`), which needs an `InlineNode` serialization rather than
   a wider sweep of the HTML recording mechanism.
 
+  *Step 6 landed as (the inversion):* the swap the last two increments were prep for. The string
+  pipeline and the builder have exchanged parsers.
+
+  Until now `apply_inner` ran `run_pipeline` on the **real** parser with its recognition side effects
+  suppressed, and built the tree on a **counter-safe clone** whose mutations were thrown away. That is
+  backwards for everything except history: the tree is authoritative for the rendered string, so the
+  pass that writes what the document keeps should be the one holding the parser that keeps it. Now
+  `run_pipeline` runs on the clone — its counters, its catalog registrations and its warnings are all
+  discarded with it — and `build_for_group` runs on the real parser.
+
+  **`run_pipeline` is now a pure oracle**: it computes a string and writes nothing anyone reads. That
+  is the whole point of doing this before deleting it — the deletion becomes a deletion rather than a
+  rewrite, and until then the differential corpora go on calling it through `apply_string_pipeline`
+  and go on differentiating for real.
+
+  *Three things had to move with it, and only three.*
+
+  **The recursion guard needed a cell.** `build_inline_tree` was doing two jobs: *configuration*
+  ("does this parse build trees") and *reentrancy* ("is one already building"). The seam could clear
+  the second because the parser driving the build was an owned clone; it is a shared reference now, so
+  reentrancy moved to [`Parser::in_inline_build`](../../parser/src/parser/parser.rs) and the two come
+  apart cleanly.
+
+  **The build's own warning buffer became the whole of the separation.** A build records its
+  deliberate diagnostics through `record_builder_diagnostic`. What it records *incidentally* through
+  `record_substitution_warning` — an `Attrlist` parsed out of a match string raising its own
+  `attribute-missing` warning at an offset into that string, which is not a position in the document
+  source — used to be discarded by sitting on the clone. It does not any more, so the seam discards it
+  out loud, with the same `substitution_warnings_len`/`truncate_substitution_warnings` idiom every
+  other owned-source substitution in the crate already uses. `['{missing}']++x++` is the shape, and
+  `passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning` is what caught it — the one test
+  that failed on the first green build of the inversion.
+
+  **A passthrough body's re-entry changed hands.** `passthrough_text` re-enters
+  `SubstitutionGroup::apply` for a body carrying its own substitution list, and that re-entry now
+  happens from inside the build, on the real parser. It takes no tree seed (the guard), so its string
+  pipeline *is* the authoritative pass for that body and registers directly — which is the same net
+  effect the suppressed arrangement had, reached the other way round: the enclosing tree cannot replay
+  a body's constructs, because a body folds to one `Raw` value rather than to nodes.
+
+  *That last one is where the increment's real test came from, and it took a sabotage to find.* With
+  the guard removed the whole suite stays green — the nested body is simply substituted twice, and the
+  two passes agree on every byte, so a stateless renderer cannot tell. A **stateful** one can: the
+  branch's own `OrdinalRenderer` (the device §4.2's observability tests already use) counts three
+  renderer calls for `pass:c[a < b]` with the guard and four without, and the ordinal that reaches the
+  output moves from `a [3] b` to `a [4] b` — a real output change for any backend whose renderer
+  carries state.
+  [`a_passthrough_body_is_substituted_once_per_apply`](../../parser/src/tests/inline_recorder.rs) pins
+  it, with the bare-`+` mixture body as the control that does *not* move (it reaches the renderer
+  through a different path), and it is the only test in the suite that catches either half of the
+  guard — the seed condition or the `replace(true)`.
+
+  Three further sabotages fail loudly rather than subtly, which is what says the inversion itself is
+  pinned by the existing suite: putting the string pipeline back on the real parser fails twenty-plus
+  tests (everything registers and counts twice), putting the builder back on a clone fails ten
+  (nothing advances the real counters at all), and keeping the build's incidental warnings fails the
+  mislocated-warning guard.
+
+  Audit: **37 rows either side, 0 new and 0 closed** — the inversion moves no divergence at all. The
+  raw count on the branch reads 43; all six extra rows belong to this increment's own new test, which
+  is the first in the suite to drive `SubstitutionGroup::apply` under a stateful renderer, and they
+  *are* the phenomenon it measures (the oracle and the fold reading successive ordinals off one shared
+  counter). Deleting just that test returns the count to 37 against an unchanged baseline, which is
+  how the attribution was checked rather than assumed.
+
+  Coverage is **not** diff-neutral here, and the exception is the point. `substitution_group.rs` stays
+  at 100%; `parser.rs` goes from 87/73 to 90/76 (missed regions / missed lines), and the three added
+  lines are exactly the `if self.suppress_recognition_side_effects.get() { return }` early returns in
+  `register_ref`, `register_image` and `register_link`. Nothing sets that window any more — the seam
+  was its only setter — so the mechanism is **vestigial** as of this increment. It is left standing on
+  purpose: removing three of its ten read sites while leaving the field and the other seven would be
+  worse than removing none, and the whole of it goes with `run_pipeline` in the increment that is
+  already scoped to take it.
+
+  *What still defers is the deletion itself* — `run_pipeline`, the three sentinel systems (design
+  §4.2), the `suppress_recognition_side_effects` window, and the `with_inline_tree` flag, whose
+  configuration half is now all that `build_inline_tree` carries. Separately still owed: the
+  structural freeze — the three corpora that compare **trees and records** rather than HTML
+  (`inline_recorder`, `inline_builder_recorder_parity`,
+  `inline_builder_passthrough_record_parity`), which needs an `InlineNode` serialization.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -9112,6 +9193,25 @@ Each phase is a reviewable unit with a clear exit gate.
        side, 0 new and 0 closed (five rows shift only in the test-only recorder's PUA index digits);
        coverage exactly diff-neutral on all three changed production files. What still defers is the
        inversion itself. See the step's own "landed as" note above.
+
+     - ✅ **the inversion.** `run_pipeline` moves onto the counter-safe clone and
+       `build_for_group` onto the real parser, so the pass that is authoritative for the rendered
+       string is the one holding the parser that keeps what it recognizes — and `run_pipeline`
+       becomes a pure oracle, which is what makes its deletion a deletion rather than a rewrite.
+       Three things move with it: the reentrancy half of `build_inline_tree` becomes
+       [`Parser::in_inline_build`](../../parser/src/parser/parser.rs) (a shared reference cannot have
+       a field cleared on it); the build's *incidental* `record_substitution_warning` calls, which
+       used to be discarded by sitting on the clone, are now truncated explicitly; and a passthrough
+       body's re-entry becomes the authoritative pass for that body, since the enclosing tree folds
+       it to one `Raw` value and cannot replay its constructs. The guard is the piece nothing pinned
+       — removing it leaves the suite green, the body merely substituted twice — so the increment's
+       real test measures it with the branch's own `OrdinalRenderer`, where three calls become four
+       and the ordinal reaching the output shifts. Audit: 37 rows either side, 0 new and 0 closed
+       (the branch's raw 43 is this increment's own new test, checked by deleting it). Coverage is
+       deliberately *not* diff-neutral: `parser.rs` gains three uncovered lines, the
+       `suppress_recognition_side_effects` early returns, now unreachable because the seam was that
+       window's only setter — it is vestigial as of here and goes whole with `run_pipeline`. See the
+       step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7517,6 +7517,21 @@ Each phase is a reviewable unit with a clear exit gate.
   `passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning` is what caught it — the one test
   that failed on the first green build of the inversion.
 
+  *That discard was too broad on the first pass, and review caught it.* One thing inside a build's
+  window is **not** incidental: the re-entrant `apply` a passthrough body gets, which takes no tree
+  seed and so is that body's authoritative pass. Its warnings are ordinary, located warnings — and the
+  blanket truncation ate every one of them, silently, with the whole suite green (`pass:a[{missing}]`
+  under `attribute-missing=warn` reported nothing where the base reports a
+  `SkippingReferenceToMissingAttribute`). A high-water mark cannot fix it: incidental and
+  authoritative warnings interleave within one build, so the range to discard is not a suffix. The
+  nested pass therefore moves its own warnings out of the window the moment it finishes
+  ([`Parser::nested_authoritative_warnings`](../../parser/src/parser/parser.rs)) and the seam hands
+  them back after truncating, which keeps the invariant ("a build's substitution-buffer output is
+  incidental") exactly as stated while making it true.
+  [`passthrough_body_warnings_survive_the_builds_own_discard`](../../parser/src/content/passthroughs.rs)
+  is the pin, and it is the complement of the mislocated-warning test above — the two together are the
+  whole of the distinction.
+
   **A passthrough body's re-entry changed hands.** `passthrough_text` re-enters
   `SubstitutionGroup::apply` for a body carrying its own substitution list, and that re-entry now
   happens from inside the build, on the real parser. It takes no tree seed (the guard), so its string
@@ -7540,7 +7555,16 @@ Each phase is a reviewable unit with a clear exit gate.
   pinned by the existing suite: putting the string pipeline back on the real parser fails twenty-plus
   tests (everything registers and counts twice), putting the builder back on a clone fails ten
   (nothing advances the real counters at all), and keeping the build's incidental warnings fails the
-  mislocated-warning guard.
+  mislocated-warning guard. Two more cover the correction: removing the nested pass's rescue, or
+  never handing the rescued warnings back, each fails only the new complement test.
+
+  One further branch the inversion made reachable is exercised rather than assumed. `run_pipeline`
+  goes to the real parser in two cases now — a passthrough body inside a build, and a parse that
+  builds no tree at all — and only the first must have its warnings carried across a pending
+  truncation. `with_inline_tree` is retired, so the second is reachable only from a crate test, and
+  [`a_parse_that_builds_no_tree_keeps_the_string_pipelines_warnings`](../../parser/src/tests/inline_recorder.rs)
+  is it: it is what keeps `build_inline_tree`'s remaining, configuration half from being a branch
+  nothing ever takes.
 
   Audit: **37 rows either side, 0 new and 0 closed** — the inversion moves no divergence at all. The
   raw count on the branch reads 43; all six extra rows belong to this increment's own new test, which
@@ -7550,8 +7574,8 @@ Each phase is a reviewable unit with a clear exit gate.
   how the attribution was checked rather than assumed.
 
   Coverage is **not** diff-neutral here, and the exception is the point. `substitution_group.rs` stays
-  at 100%; `parser.rs` goes from 87/73 to 90/76 (missed regions / missed lines), and the three added
-  lines are exactly the `if self.suppress_recognition_side_effects.get() { return }` early returns in
+  at 100% and `passthroughs.rs` at 3/3; `parser.rs` goes from 87/73 to 90/76 (missed regions / missed
+  lines), and the three added lines are exactly the `if self.suppress_recognition_side_effects.get() { return }` early returns in
   `register_ref`, `register_image` and `register_link`. Nothing sets that window any more — the seam
   was its only setter — so the mechanism is **vestigial** as of this increment. It is left standing on
   purpose: removing three of its ten read sites while leaving the field and the other seven would be

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -1023,6 +1023,58 @@ mod tests {
     }
 
     #[test]
+    fn passthrough_body_warnings_survive_the_builds_own_discard() {
+        // The complement of the test above, and the two together are the whole
+        // of the distinction.
+        //
+        // A passthrough carrying its own substitution list has its body
+        // substituted by a re-entrant `SubstitutionGroup::apply`, which — since
+        // the inversion — happens *inside* the enclosing inline-tree build, on
+        // the real parser. That nested pass takes no tree seed, so it is the
+        // body's authoritative pass and its warnings are real, located in the
+        // document source like any other.
+        //
+        // The enclosing build discards everything it records into the
+        // substitution-warning buffer, because a build's deliberate diagnostics
+        // go through `record_builder_diagnostic` and what lands in the other
+        // buffer is incidental — the mislocated `Attrlist` warning the test
+        // above pins. These warnings sit in that same range and are *not*
+        // incidental, so `Parser::nested_authoritative_warnings` carries them
+        // across it. Without that, every fixture here reports nothing at all.
+        for (source, mode) in [
+            ("pass:a[{missing}]", "warn"),
+            ("pass:a[{missing}]", "drop-line"),
+            ("pass:q,a[*{missing}*]", "warn"),
+            ("pass:c,a[{missing}]", "warn"),
+        ] {
+            let mut parser = Parser::default().with_intrinsic_attribute(
+                "attribute-missing",
+                mode,
+                ModificationContext::Anywhere,
+            );
+
+            let doc = parser.parse(source);
+
+            // The whole list, not a filtered count: these fixtures raise
+            // exactly this one warning, so comparing the list also says nothing
+            // *else* was surfaced — and leaves the test with no branch of its
+            // own that never runs.
+            let warnings: Vec<_> = doc
+                .warnings()
+                .map(|warning| warning.warning.clone())
+                .collect();
+
+            assert_eq!(
+                warnings,
+                [WarningType::SkippingReferenceToMissingAttribute(
+                    "missing".to_string()
+                )],
+                "the body's own missing-reference warning was lost for {source:?} under {mode}"
+            );
+        }
+    }
+
+    #[test]
     fn content_without_passthroughs_exposes_an_empty_collection() {
         // Plain content — and content whose substitution group never extracts
         // passthroughs — exposes an empty collection rather than any sentinel.

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -1075,6 +1075,67 @@ mod tests {
     }
 
     #[test]
+    fn a_rescued_passthrough_warning_keeps_the_location_it_always_had() {
+        // The rescue above carries a warning across the build's discard
+        // *unchanged*, offset included — which is worth pinning, because the
+        // offset it carries is already wrong and has been all along.
+        //
+        // `passthrough_text` substitutes a body as **owned** text, so a warning
+        // the body raises is located against that text rather than against the
+        // document: it comes out at offset 0 however far into the document the
+        // passthrough sits. That is a bug in how a body's warnings are located,
+        // not in the rescue — `origin/inline-ast` reports byte-for-byte the
+        // same span for every fixture here — and closing it means deciding
+        // whether such a warning should be *remapped* onto the body's position
+        // or *discarded* the way every other owned-source substitution's is.
+        // That is its own change; this test exists so the answer is a decision
+        // rather than a drift, and so that the rescue's own claim
+        // (behavior-preserving, offsets and all) is checked rather than
+        // asserted.
+        //
+        // The plain, non-passthrough control is what says the mislocation
+        // belongs to the body path specifically: the same reference outside a
+        // passthrough is located exactly.
+        let mut parser = Parser::default().with_intrinsic_attribute(
+            "attribute-missing",
+            "warn",
+            ModificationContext::Anywhere,
+        );
+
+        let doc = parser.parse("Intro.\n\nA later para with pass:a[{missing}] in it.");
+
+        let located: Vec<_> = doc
+            .warnings()
+            .map(|warning| (warning.source.line(), warning.source.byte_offset()))
+            .collect();
+
+        assert_eq!(
+            located,
+            [(1, 0)],
+            "a passthrough body's warning moved; it has always pointed at the document start"
+        );
+
+        let mut parser = Parser::default().with_intrinsic_attribute(
+            "attribute-missing",
+            "warn",
+            ModificationContext::Anywhere,
+        );
+
+        let doc = parser.parse("Intro.\n\nA later para with {missing} in it.");
+
+        let located: Vec<_> = doc
+            .warnings()
+            .map(|warning| (warning.source.line(), warning.source.byte_offset()))
+            .collect();
+
+        assert_eq!(
+            located,
+            [(3, 26)],
+            "a plain missing reference must still be located exactly"
+        );
+    }
+
+    #[test]
     fn content_without_passthroughs_exposes_an_empty_collection() {
         // Plain content — and content whose substitution group never extracts
         // passthroughs — exposes an empty collection rather than any sentinel.

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -264,93 +264,121 @@ impl SubstitutionGroup {
         attrlist: Option<&Attrlist<'src>>,
         term_warnings: Option<&mut Vec<crate::warnings::Warning<'src>>>,
     ) {
-        // Snapshot the pre-substitution value and the parser *before* the
-        // authoritative pass runs. The parser clone captures every document
-        // counter (footnote/callout numbers, `{counter:…}` values) at its
-        // pre-substitution value, so the single-pass builder below numbers
-        // constructs exactly as the authoritative pass does; the clone's
-        // mutations are then discarded, leaving the real parser advanced once.
+        // Snapshot the pre-substitution value *before* either pass runs: both
+        // are seeded from it, so the authoritative one sees exactly what the
+        // oracle does.
         //
         // `build_inline_tree` is no longer an opt-in switch — every parse
-        // builds the tree — but it is still the recursion guard the clone
-        // clears below, so a nested `apply` for a passthrough body skips the
-        // snapshot entirely rather than seeding a tree nothing reads.
-        let tree_seed = if parser.build_inline_tree {
-            Some((content.rendered.clone(), parser.clone()))
+        // builds the tree — but it is still the *configuration* half of "does
+        // this call build one". The reentrancy half moved to
+        // `Parser::in_inline_build`, because the parser the build runs on is
+        // the real one now and cannot have a field cleared on it.
+        let tree_seed = if parser.build_inline_tree && !parser.in_inline_build.get() {
+            Some(content.rendered.clone())
         } else {
             None
         };
 
-        // The string pipeline's own macro side effects — an image target, a link
-        // target, an anchor's or bibliography entry's id, and the image
-        // family's dangerous-`link=` warning — are suppressed for the duration
-        // of this pass, and replayed from the tree below. Both paths share one
-        // `Parser` now, so recognizing a construct twice would record it twice.
+        // **The inversion** (design §5.2 Phase 4, step 6). The string pipeline
+        // used to run on the real parser with its recognition side effects
+        // suppressed, while the builder ran on a counter-safe clone whose
+        // mutations were thrown away. The two have swapped places: the string
+        // pipeline runs on the clone — so its counters, its catalog
+        // registrations and its warnings are *all* discarded with it, and there
+        // is nothing left to suppress — and the builder runs on the real
+        // parser, where what it recognizes is simply kept.
         //
-        // Unconditional, rather than gated on a tree actually being built. The
-        // only content that reaches here without one is a passthrough body the
-        // *builder* re-enters `apply` for, and that call is handed the
-        // counter-safe clone — whose catalog is discarded with it — so nothing
-        // it records was ever going to be kept. The string pipeline's own
-        // re-entry for such a body carries the real parser and does build a
-        // tree, so it replays like any other content.
+        // That is what makes `run_pipeline` a pure oracle: it computes a string
+        // and writes nothing anyone reads. Deleting it — and with it the three
+        // sentinel systems and the now-vestigial
+        // `suppress_recognition_side_effects` window — is the next increment;
+        // this one only turns the seam around, so that deletion is a deletion
+        // rather than a rewrite.
         //
-        // Saved and restored rather than cleared. Either re-entry happens while
-        // this window is open and closes a window of its own, so clearing would
-        // leave the rest of *this* pass unsuppressed. No fixture currently
-        // distinguishes the two — the suite is green either way — because none
-        // puts a registering construct after a nested `apply` within one
-        // content; restoring is kept because it is correct by construction
-        // rather than by that absence.
-        let suppressed = parser.suppress_recognition_side_effects.replace(true);
+        // The clone is taken here, immediately before the pass it feeds, so it
+        // carries every document counter (footnote and callout numbers,
+        // `{counter:…}` values) at its pre-substitution value — the same value
+        // the builder then advances on the real parser, exactly once.
+        match &tree_seed {
+            Some(_) => self.run_pipeline(content, &parser.clone(), attrlist),
 
-        self.run_pipeline(content, parser, attrlist);
+            // No tree is built here, so there is no clone and no second pass:
+            // this *is* the authoritative one. The only content that reaches it
+            // is a passthrough body re-entered from inside a build, whose
+            // constructs the enclosing tree cannot hold (the body folds to one
+            // `Raw` value, not to nodes) and so cannot replay — leaving this
+            // pass as their one registrar, which is the net effect the
+            // suppressed arrangement had too.
+            None => self.run_pipeline(content, parser, attrlist),
+        }
 
-        parser.suppress_recognition_side_effects.set(suppressed);
-
-        if let Some((value, mut tree_parser)) = tree_seed {
+        if let Some(value) = tree_seed {
             // The builder must not recurse into tree building itself: a
             // passthrough with its own substitution list re-enters
             // `SubstitutionGroup::apply` for its body (via
             // `passthrough_text`), and that nested content needs no tree of
-            // its own.
-            tree_parser.build_inline_tree = false;
+            // its own. Saved and restored rather than cleared, so a build
+            // nested inside a build leaves the enclosing guard standing.
+            let in_build = parser.in_inline_build.replace(true);
 
             // Where this build's own diagnostics start — see
             // `Parser::drain_builder_diagnostics_since` for why a mark rather
             // than the whole buffer.
-            let diagnostics_before_build = tree_parser.builder_diagnostics_len();
+            let diagnostics_before_build = parser.builder_diagnostics_len();
+
+            // And where the *substitution* warning buffer stands, so anything
+            // the build records into it can be discarded below.
+            //
+            // The build's deliberate diagnostics go through
+            // `record_builder_diagnostic`, never here. What reaches this buffer
+            // during a build is incidental: an `Attrlist` parsed out of a match
+            // string records its own `attribute-missing` warning at an offset
+            // into that string, which is not a position in the document source
+            // — `['{missing}']++x++` is the shape, and surfacing it would
+            // anchor a warning nowhere. Before the inversion these were
+            // discarded by being recorded onto the clone; the build holds the
+            // real parser now, so the discard has to be said out loud. It is
+            // the same `substitution_warnings_len`/`truncate` idiom every other
+            // owned-source substitution in the crate already uses.
+            let warnings_before_build = parser.substitution_warnings_len();
 
             let tree = crate::content::inline_builder::build_for_group(
                 self,
                 value,
                 content.original(),
-                &tree_parser,
+                parser,
                 attrlist,
             );
 
-            // The recognition **diagnostics** the string pipeline just skipped,
-            // moved onto the real parser — the warning half of "re-attach the
-            // recognition side effects" (design §5.2's step 6).
+            parser.in_inline_build.set(in_build);
+            parser.truncate_substitution_warnings(warnings_before_build);
+
+            // The recognition **diagnostics** the string pipeline's copy of this
+            // content raised into the discarded clone, raised again here where
+            // they are kept — the warning half of "re-attach the recognition
+            // side effects" (design §5.2's step 6).
             //
             // A registration has a node to hang on, so it is replayed from the
             // tree below. These five do not: `attribute-missing` drops a
             // reference and leaves nothing behind, a `link:` macro with a
             // dangerous scheme stays literal, and an invalid substitution name
             // in a `pass:`/`stem:` list is simply skipped. So they are recorded
-            // where they are *recognized*, on the clone, and carried across
-            // here — which is what `Parser::record_builder_diagnostic` and
+            // where they are *recognized* and carried across here — which is
+            // what `Parser::record_builder_diagnostic` and
             // `push_substitution_warnings` are for. The builder's own buffer is
-            // used rather than the clone's warning buffer, so a warning it
-            // records only *incidentally* (an `Attrlist` parse over a match
-            // string) is not swept up with them.
+            // still used rather than the parser's warning buffer, and now for
+            // the only reason that was ever load-bearing: a warning the build
+            // records merely *incidentally* (an `Attrlist` parse over a match
+            // string) must not be swept up with them. Before the inversion that
+            // separation also fell out of the buffer sitting on a clone nobody
+            // read; it does not any more, so this buffer is the whole of it.
             //
             // Before `apply_macro_side_effects`, deliberately: the string
             // pipeline raised these during its own pass, ahead of the
             // registrations the replay performs, and that relative order is
             // what `inline_builder_side_effect_parity` compares.
             parser.push_substitution_warnings(
-                tree_parser.drain_builder_diagnostics_since(diagnostics_before_build),
+                parser.drain_builder_diagnostics_since(diagnostics_before_build),
             );
 
             // The deferred cross-references are the **tree's**, not the string

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -309,7 +309,27 @@ impl SubstitutionGroup {
             // `Raw` value, not to nodes) and so cannot replay — leaving this
             // pass as their one registrar, which is the net effect the
             // suppressed arrangement had too.
-            None => self.run_pipeline(content, parser, attrlist),
+            None => {
+                let before = parser.substitution_warnings_len();
+
+                self.run_pipeline(content, parser, attrlist);
+
+                // When this authoritative pass is itself running inside a
+                // build — which is exactly the passthrough-body case above —
+                // the warnings it just raised sit inside the range that build
+                // is about to discard as incidental. They are not incidental,
+                // so move them out of it now; the enclosing seam hands them
+                // back once its own discard has run. See
+                // `Parser::nested_authoritative_warnings`.
+                if parser.in_inline_build.get() {
+                    let mine = parser.drain_substitution_warnings_since(before);
+
+                    parser
+                        .nested_authoritative_warnings
+                        .borrow_mut()
+                        .extend(mine);
+                }
+            }
         }
 
         if let Some(value) = tree_seed {
@@ -351,7 +371,14 @@ impl SubstitutionGroup {
             );
 
             parser.in_inline_build.set(in_build);
+
+            // Everything this build recorded into the substitution-warning
+            // buffer is incidental (see `warnings_before_build`) — except what
+            // an authoritative nested pass moved aside, which is put back.
             parser.truncate_substitution_warnings(warnings_before_build);
+
+            let nested = std::mem::take(&mut *parser.nested_authoritative_warnings.borrow_mut());
+            parser.push_substitution_warnings(nested);
 
             // The recognition **diagnostics** the string pipeline's copy of this
             // content raised into the discarded clone, raised again here where

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -513,6 +513,23 @@ pub struct Parser {
     /// tree to replay from. It disappears when step 6 takes the string pipeline
     /// off the production path.
     pub(crate) suppress_recognition_side_effects: std::cell::Cell<bool>,
+
+    /// Whether an inline-tree build is already in progress on *this* parser —
+    /// the guard that keeps a build from recursing into building a tree of its
+    /// own.
+    ///
+    /// A passthrough carrying its own substitution list re-enters
+    /// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) for its
+    /// body while the builder is running (via `passthrough_text`), and that
+    /// nested content needs no tree.
+    ///
+    /// This used to ride on [`build_inline_tree`](Self::build_inline_tree),
+    /// which the seam could clear because the parser driving the build was an
+    /// owned clone. It is the **real** parser now, held by shared reference, so
+    /// the guard needs a cell of its own — and the two questions it was
+    /// answering come apart cleanly: `build_inline_tree` is *configuration*
+    /// (does this parse build trees at all), this is *reentrancy*.
+    pub(crate) in_inline_build: std::cell::Cell<bool>,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -630,6 +647,7 @@ impl Default for Parser {
             datetime_context: RefCell::new(None),
             build_inline_tree: true,
             suppress_recognition_side_effects: std::cell::Cell::new(false),
+            in_inline_build: std::cell::Cell::new(false),
         }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -530,6 +530,27 @@ pub struct Parser {
     /// answering come apart cleanly: `build_inline_tree` is *configuration*
     /// (does this parse build trees at all), this is *reentrancy*.
     pub(crate) in_inline_build: std::cell::Cell<bool>,
+
+    /// Substitution warnings raised by an **authoritative** pass that ran
+    /// *inside* an inline-tree build, held aside so the build's own blanket
+    /// discard cannot eat them.
+    ///
+    /// A build discards everything it records into the substitution-warning
+    /// buffer, because a build's deliberate diagnostics go through
+    /// [`record_builder_diagnostic`](Self::record_builder_diagnostic) and what
+    /// reaches the other buffer is incidental — an `Attrlist` parsed out of a
+    /// match string, warning at an offset that is not a position in the
+    /// document source. One thing inside that window is *not* incidental: the
+    /// re-entrant `SubstitutionGroup::apply` a passthrough body gets, which
+    /// takes no tree seed and so is that body's authoritative pass. Its
+    /// warnings are real, and they are moved here the moment it finishes, out
+    /// of the range the enclosing build will truncate; the seam hands them back
+    /// afterwards.
+    ///
+    /// A single high-water mark could not do this: incidental and authoritative
+    /// warnings interleave within one build, so the range to discard is not a
+    /// suffix.
+    pub(crate) nested_authoritative_warnings: RefCell<Vec<DeferredWarning>>,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -648,6 +669,7 @@ impl Default for Parser {
             build_inline_tree: true,
             suppress_recognition_side_effects: std::cell::Cell::new(false),
             in_inline_build: std::cell::Cell::new(false),
+            nested_authoritative_warnings: RefCell::new(vec![]),
         }
     }
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1094,6 +1094,55 @@ fn inline_tree_is_built_by_default() {
 }
 
 #[test]
+fn a_parse_that_builds_no_tree_keeps_the_string_pipelines_warnings() {
+    // The other half of `build_inline_tree`, and the branch the inversion made
+    // reachable in a second way.
+    //
+    // Since the inversion the seam sends `run_pipeline` to a *clone* whenever a
+    // tree is being built, and to the real parser otherwise. "Otherwise" now
+    // has two causes: a passthrough body re-entered from inside a build (the
+    // reentrancy guard), and a parse configured to build no tree at all —
+    // this one. The first runs inside a build whose blanket warning discard it
+    // has to be carried across; the second does not, and must not be, or the
+    // warnings would be stashed with nothing to hand them back.
+    //
+    // `with_inline_tree` is retired, so `build_inline_tree` is `true` for every
+    // parse the public API can produce and only a crate test reaches this. It
+    // is still the configuration the seam reads, and the branch it selects is
+    // real, so it is exercised here rather than left to be assumed.
+    let mut parser = Parser::default().with_intrinsic_attribute(
+        "attribute-missing",
+        "warn",
+        crate::parser::ModificationContext::Anywhere,
+    );
+
+    parser.build_inline_tree = false;
+
+    let doc = parser.parse("A paragraph with {missing} in it.");
+
+    let warnings: Vec<_> = doc
+        .warnings()
+        .map(|warning| warning.warning.clone())
+        .collect();
+
+    assert_eq!(
+        warnings,
+        [
+            crate::warnings::WarningType::SkippingReferenceToMissingAttribute(
+                "missing".to_string()
+            )
+        ],
+        "a tree-less parse lost the string pipeline's own warning"
+    );
+
+    // And no tree, which is what the configuration says.
+    assert!(
+        first_simple_inlines(&doc).is_empty(),
+        "a parse with `build_inline_tree` off must build no tree"
+    );
+}
+
+#[test]
 fn inline_tree_is_built_for_a_default_parser() {
     let mut parser = Parser::default();
     let doc = parser.parse("One *word* is strong.");

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -979,6 +979,69 @@ fn the_three_non_specialcharacters_bodies_still_consult_the_renderer() {
     }
 }
 
+/// Applies `source`'s whole substitution group — both passes and the fold —
+/// and returns how many times that consulted `parser`'s renderer.
+///
+/// The sibling of [`renderer_calls_while_building`], which counts the build
+/// alone. This one counts everything, which is the only way to see a body
+/// being substituted an extra *time* rather than an extra *way*.
+fn renderer_calls_while_applying(source: &str) -> usize {
+    let parser = Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
+    let mut content = crate::content::Content::from(crate::Span::new(source));
+
+    crate::content::SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+    let mut probe = String::new();
+    parser
+        .renderer
+        .render_special_character(crate::parser::SpecialCharacter::Lt, &mut probe);
+
+    probe
+        .trim_matches(|c: char| !c.is_ascii_digit())
+        .parse::<usize>()
+        .expect("the probe reports its own ordinal")
+        - 1
+}
+
+#[test]
+fn a_passthrough_body_is_substituted_once_per_apply() {
+    // `Parser::in_inline_build`, pinned.
+    //
+    // A passthrough carrying its own substitution list re-enters
+    // `SubstitutionGroup::apply` for its body, and that re-entry happens from
+    // *inside* the build now that the build holds the real parser. Without the
+    // guard the nested call takes a tree seed of its own, so the body is
+    // substituted a second time — once by its own string pipeline and once by
+    // its own builder — where before the inversion the seam cleared
+    // `build_inline_tree` on the owned clone to stop exactly that.
+    //
+    // Nothing in the suite noticed: the extra pass produces the same bytes, so
+    // a stateless renderer cannot tell. A *stateful* one can, and that is the
+    // whole point — the branch already uses `OrdinalRenderer` to measure
+    // "unobservable" for the build itself. Removing the guard takes each count
+    // below from three to four, and shifts the ordinal that reaches the output
+    // (`a [3] b` becomes `a [4] b`) — a real output change for any backend
+    // whose renderer carries state.
+    //
+    // The exact number is not the claim; that the three agree, and that
+    // dropping the guard moves all three together, is.
+    for source in ["pass:c[a < b]", "pass:c,q[*a < b*]", "stem:[x < y]"] {
+        assert_eq!(
+            renderer_calls_while_applying(source),
+            3,
+            "{source:?} was substituted more times than the seam should ask for"
+        );
+    }
+
+    // The bare-`+` mixture body is the control: it reaches the renderer through
+    // a different path (its value interleaves escaped text with an extracted
+    // construct's own fold, rather than re-entering `apply`), so it is *not*
+    // moved by the guard. Without it, this fixture alone stays at three while
+    // the three above go to four — which is what says the three are measuring
+    // the re-entry rather than something ambient.
+    assert_eq!(renderer_calls_while_applying("+a $$b < c$$ d+"), 3);
+}
+
 #[test]
 fn a_footnotes_catalog_entry_is_rendered_while_building() {
     // The fourth build-time renderer consumer, and the only one that is not a


### PR DESCRIPTION
Design §5.2 Phase 4, step 6 — **the inversion**, which the last two increments were prep for.

> Branch name is a leftover: the harness-designated branch was consumed by #1298 and re-cut from the updated `inline-ast` for this increment, per the "a merged PR cannot track new work" rule. The content is the inversion, not the footnote catalog.

## What changes

`apply_inner` ran `run_pipeline` on the **real** parser with its recognition side effects suppressed, and built the tree on a **counter-safe clone** whose mutations were thrown away. That is backwards now that the tree is authoritative for the rendered string: the pass that writes what the document keeps should be the one holding the parser that keeps it.

The two swap places. `run_pipeline` runs on the clone — its counters, its catalog registrations and its warnings all discarded with it — and `build_for_group` runs on the real parser.

**`run_pipeline` is thereby a pure oracle**: it computes a string and writes nothing anyone reads. That is the point of doing this *before* deleting it — the deletion becomes a deletion rather than a rewrite, and until then the differential corpora go on calling it through `apply_string_pipeline` and go on differentiating for real.

## Three things move with it, and only three

**The recursion guard needed a cell.** `build_inline_tree` was doing two jobs: *configuration* ("does this parse build trees") and *reentrancy* ("is one already building"). The seam could clear the second because the parser driving the build was an owned clone; it is a shared reference now, so reentrancy moves to `Parser::in_inline_build` and the two come apart cleanly.

**The build's own warning buffer became the whole of the separation.** A build records its deliberate diagnostics through `record_builder_diagnostic`. What it records *incidentally* through `record_substitution_warning` — an `Attrlist` parsed out of a match string raising `attribute-missing` at an offset into that string, which is not a position in the document source — used to be discarded by sitting on the clone. The seam now discards it explicitly, with the same `substitution_warnings_len`/`truncate_substitution_warnings` idiom every other owned-source substitution in the crate already uses. `['{missing}']++x++` is the shape, and `passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning` is the one test that failed on the first otherwise-green build of this change.

**A passthrough body's re-entry changed hands.** `passthrough_text` re-enters `SubstitutionGroup::apply` for a body carrying its own substitution list, and that re-entry now happens from inside the build, on the real parser. It takes no tree seed (the guard), so its string pipeline *is* the authoritative pass for that body and registers directly — the same net effect the suppressed arrangement had, reached the other way round: the enclosing tree cannot replay a body's constructs, because a body folds to one `Raw` value rather than to nodes.

## The test this increment exists for

That guard is the piece **nothing pinned**. Remove it and the whole suite stays green: the nested body is simply substituted twice, and both passes agree on every byte, so a stateless renderer cannot tell.

A **stateful** one can — and the branch already owns the device, the `OrdinalRenderer` its observability tests use. `pass:c[a < b]` takes three renderer calls with the guard and four without, and the ordinal reaching the output moves from `a [3] b` to `a [4] b`: a real output change for any backend whose renderer carries state. `a_passthrough_body_is_substituted_once_per_apply` pins it, with the bare-`+` mixture body as the control that does *not* move (it reaches the renderer by a different path), and it is the only test in the suite that catches either half of the guard — the seed condition or the `replace(true)`.

## Verification

- `cargo test --workspace`: 5,479 pass, 0 fail.
- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`: all clean.
- **Fold-parity audit: 37 rows either side, 0 new and 0 closed** — the inversion moves no divergence at all. The raw count on the branch reads 43; all six extra rows belong to this increment's own new test, the first in the suite to drive `SubstitutionGroup::apply` under a stateful renderer, and they *are* the phenomenon it measures (the oracle and the fold reading successive ordinals off one shared counter). Deleting just that test returns the count to 37 against an unchanged baseline — which is how the attribution was checked rather than assumed.
- **Sabotage**, four, each failing a distinct set: string pipeline back on the real parser fails twenty-plus tests (everything registers and counts twice); builder back on a clone fails ten (nothing advances the real counters); keeping the build's incidental warnings fails the mislocated-warning guard; and both halves of the reentrancy guard fail only the new test.

### Coverage is deliberately *not* diff-neutral

`substitution_group.rs` stays at 100%. `parser.rs` goes from **87/73 to 90/76** (missed regions / missed lines), and the three added lines are exactly the `if self.suppress_recognition_side_effects.get() { return }` early returns in `register_ref`, `register_image` and `register_link`.

Nothing sets that window any more — this seam was its only setter — so the mechanism is **vestigial** as of this increment. It is left standing on purpose: removing three of its ten read sites while leaving the field and the other seven would be worse than removing none, and the whole of it goes with `run_pipeline` in the increment already scoped to take it. Flagging it rather than quietly absorbing it.

## What is next

The deletion: `run_pipeline`, the three sentinel systems (§4.2), the `suppress_recognition_side_effects` window, and the `with_inline_tree` flag — whose configuration half is now all that `build_inline_tree` carries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDXME9qXYjkgu5zZ7mHRYu)_