### PR TITLE
feat: Close the authoritative pass (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -7970,6 +7970,86 @@ Each phase is a reviewable unit with a clear exit gate.
   `inline_recorder` corpus that tests it, which the finding above says goes with the pass rather than
   outliving it.
 
+  *Step 6 landed as (the authoritative-pass closure):* the last item on the survey's list that is
+  not test-side, and the production blocker the deletion has been waiting on. It is a **four-line
+  change**, which is the surprise worth recording.
+
+  The blocker, as the survey stated it: `run_pipeline` has two production callers in `apply_inner`.
+  The first is the oracle, whose output the fold overwrites three statements later. The second is
+  the `tree_seed == None` branch, which is *authoritative* — a passthrough body re-entering
+  `SubstitutionGroup::apply` from inside a build takes no tree seed (the `in_inline_build` guard), so
+  its string pipeline is that body's real pass. Nothing could answer for it "while a body folds to
+  one `Raw` value rather than to nodes".
+
+  *The obstacle was misidentified, and the increment is mostly finding that out.* The reasoning above
+  descends from the deleted `build_pass_macro_subs_value` helper, whose doc comment argued that a
+  body cannot be threaded through this module's transducers because
+  [`build`](../../parser/src/content/inline_builder/mod.rs) runs a fixed *normal* order, so any
+  structural node the body's own resolved subset produced would be visited again by whichever steps
+  come after — and a macro's display text is not idempotent under a second pass. Every word of that
+  is true, and none of it applies: **it is an argument about splicing the body's nodes into the
+  enclosing level, not about computing the body's string.** Folding the body's own tree and wrapping
+  the result in one `Raw` leaf keeps it exactly as opaque as `subs.apply` did.
+
+  And the capability was already there. [`build_for_group`](../../parser/src/content/inline_builder/mod.rs)
+  has taken a `SubstitutionGroup` since the cutover began, runs `group.steps()` **in the group's own
+  order**, and already handles the orders no built-in group has — a `Custom` list that puts the
+  escaping step *after* a step that produced markup, which is what `flatten_prior_markup` and
+  `SplicedSpecials` exist for. So `passthrough_text` needed only to build and fold rather than
+  substitute.
+
+  *The measurement is the increment's evidence, and it is unambiguous.* Instrumenting the `None`
+  branch across the whole suite: **112 hits before, 1 after.** The 111 that went were all
+  `in_inline_build=true` — the passthrough-body re-entry, every one of them. The single hit that
+  remains is `build_inline_tree=false`, the crate test that turns the flag off deliberately
+  (`a_parse_that_builds_no_tree_keeps_the_string_pipelines_warnings`). Production no longer reaches
+  the string pipeline at all.
+
+  *What a body's rendering now costs, measured before the change:* `passthrough_text` is reached 378
+  times in the suite — `Stem` 218, `Verbatim` 63, `Normal` 2, and 95 across **fifteen distinct
+  `Custom` spellings**, among them `Custom([Quotes, SpecialCharacters])` and
+  `Custom([AttributeReferences, Quotes])`. The out-of-order pairs are the ones that say this is not a
+  fixed-order problem in disguise, and
+  [`a_passthrough_body_renders_under_every_order_its_own_list_can_name`](../../parser/src/tests/inline_recorder.rs)
+  pins both orders of both pairs — `pass:c,q[*x* < y]` renders `<strong>x</strong> &lt; y` where
+  `pass:q,c[*x* < y]` renders `&lt;strong&gt;x&lt;/strong&gt; &lt; y`, so the fixture discriminates
+  order rather than merely exercising it.
+
+  *Three explanations elsewhere in the crate became false and were corrected rather than left to rot.*
+  `Parser::in_inline_build`'s reentrancy guard no longer has a re-entry to guard: the property
+  [`a_passthrough_body_is_substituted_once_per_apply`](../../parser/src/tests/inline_recorder.rs)
+  measures still holds and is still worth pinning, but it holds *structurally* now rather than by the
+  guard, which is why removing the guard's check no longer moves those counts.
+  [`passthrough_body_warnings_survive_the_builds_own_discard`](../../parser/src/content/passthroughs.rs)
+  passes unchanged, but by a different route — the body's `attribute-missing` diagnostic goes through
+  the build's own `record_builder_diagnostic` and is carried across by the enclosing seam, instead of
+  being raised into the discarded range and rescued by `Parser::nested_authoritative_warnings`. And
+  the `Raw`/`source_text` notes that said "an arbitrary group needs the substitution pipeline" now
+  say what is actually true: it needs a `Parser`, which a fold does not have, so the body is rendered
+  at build time.
+
+  Audit: **63 rows either side, 0 new and 0 closed** — a production change that moves no divergence
+  at all, which is the strongest form the bar takes.
+
+  Coverage is **not** diff-neutral, and the exception is the point, exactly as it was for the
+  inversion. `passthrough_step.rs` stays at 22/10 (missed regions / missed lines) and `passthroughs.rs`
+  at 3/3; `substitution_group.rs` goes from 0/0 to 6/6, and those six lines are precisely the
+  `nested_authoritative_warnings` block inside the branch this increment just made unreachable.
+  `Parser::nested_authoritative_warnings` and `in_inline_build`'s reentrancy half are **vestigial** as
+  of here. Both are left standing on purpose — the same call the inversion made for
+  `suppress_recognition_side_effects`, and for the same reason: they are two-ended mechanisms that go
+  whole with `run_pipeline`, and removing one end while leaving the other would be worse than removing
+  neither.
+
+  *What still defers* is the deletion, and only the deletion: `run_pipeline`, `apply_string_pipeline`,
+  the escaping pass, the three sentinel systems (§4.2), the `suppress_recognition_side_effects`
+  window, `Parser::nested_authoritative_warnings`, `Parser::in_inline_build`,
+  `Parser::build_inline_tree`, and the Strategy-A recorder (`content/inline_tree.rs`,
+  `RecordingRenderer`) with the `inline_recorder` corpus that tests it. Every corpus that used to
+  depend on the string pipeline for its golden is frozen; nothing in production calls it. The one
+  test that still does — the `build_inline_tree=false` parse — is what the deletion has to decide
+  about, and it is a decision about a flag rather than a blocker.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -9700,6 +9780,26 @@ Each phase is a reviewable unit with a clear exit gate.
        comes from `RECORDER_ENTITY_TABLE`, already drift-guarded against production's
        `classify_entity`. Nothing in production moved: audit 63 rows either side, 0 new and 0 closed,
        and coverage byte-identical. See the step's own "landed as" note above.
+
+     - ✅ **the authoritative-pass closure — the last production blocker.** `run_pipeline`'s second
+       production caller, the `tree_seed == None` branch, was authoritative for one content: a
+       passthrough body re-entering `apply` from inside a build. It closes in four lines, because the
+       obstacle was misidentified. The argument inherited from the deleted `build_pass_macro_subs_value`
+       — that a body cannot be threaded through this module's transducers, since `build` runs a fixed
+       normal order and would revisit any structural node the body's own subset produced — is about
+       **splicing** the body's nodes into the enclosing level, not about computing its string; folding
+       the body's own tree and wrapping it in one `Raw` leaf keeps it exactly as opaque as
+       `subs.apply` did. And `build_for_group` already runs an arbitrary group's steps in that group's
+       own order, including the `Custom` orders that put the escaping step after a step that produced
+       markup. Measured: the branch goes from **112 hits to 1** across the suite, the 111 that went
+       all being the passthrough re-entry, the one that remains being the crate test that turns
+       `build_inline_tree` off. The body's rendering was reached 378 times under fifteen distinct
+       `Custom` spellings including out-of-order pairs, and
+       `a_passthrough_body_renders_under_every_order_its_own_list_can_name` pins both orders of two of
+       them. Audit: 63 rows either side, 0 new and 0 closed. Coverage deliberately *not* diff-neutral:
+       `substitution_group.rs` gains six uncovered lines, exactly the `nested_authoritative_warnings`
+       block this makes unreachable — vestigial as of here, and left standing to go whole with
+       `run_pipeline`. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     Parser, Span,
-    content::{Content, INLINE_PASS, INLINE_PASS_MACRO, SubstitutionGroup},
+    content::{INLINE_PASS, INLINE_PASS_MACRO, SubstitutionGroup},
     inlines::{InlineNode, PassthroughWrapper, RawForm, RawOrigin, SpanForm, StyleVariant, Styled},
     strings::CowStr,
 };
@@ -893,9 +893,10 @@ fn build_passthrough_node<'src>(
     //
     // That opacity is also why the explicit-list form is the one place `value`
     // is not the author's own bytes, and so the one place the node records a
-    // `source_text`: an arbitrary group needs the substitution pipeline, which
-    // a fold has no `Parser` to reach, so the body is substituted here and the
-    // input kept beside the result.
+    // `source_text`. Rendering an arbitrary group needs a `Parser` — to build
+    // the body's own tree under that group (`passthrough_text`) — and a fold
+    // takes a renderer and a `RenderContext` rather than a `Parser`, so the
+    // body is rendered here and the input kept beside the result.
     let (value, subs, source_text) = if let Some(subs_list) = caps.get(14) {
         let text = unescaped.as_deref().unwrap_or(raw);
         let (subs, invalid) = SubstitutionGroup::from_custom_string(None, subs_list.as_str());
@@ -1203,51 +1204,56 @@ fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<
     super::build(text, parser, None)
 }
 
-/// Runs `text` through the real substitution pipeline under `subs`, returning
-/// the resulting owned string. Used to compute a [`Raw`](InlineNode::Raw)
-/// passthrough's `value` under [`SubstitutionGroup::Verbatim`] — mirroring
-/// `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call in the string
-/// pipeline's restore step — so the result honors whatever
+/// Renders `text` under `subs` **through the tree**, returning the resulting
+/// owned string. Used to compute a [`Raw`](InlineNode::Raw) passthrough's
+/// `value` — for [`SubstitutionGroup::Verbatim`], for a `stem:` body, and for
+/// the explicit substitution list a `pass:c,q[…]` carries — so the result
+/// honors whatever
 /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
 /// `parser` carries rather than a hand-rolled, always-default escaping.
 ///
+/// **This is the authoritative-pass closure** (design §5.2's step 6). Until
+/// now this ran `subs.apply`, which re-entered
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) for the
+/// body; that re-entry took no tree seed (the `in_inline_build` guard), so its
+/// *string* pipeline was the body's authoritative pass. It was the last thing
+/// in production keeping `run_pipeline` alive, and the survey named it the
+/// only remaining blocker to the deletion that is not test-side.
+///
+/// It closes because [`build_for_group`](super::build_for_group) already runs
+/// **an arbitrary group's steps in that group's own order** — including a
+/// `Custom` order that puts the escaping step after a step that produced
+/// markup, which is what `flatten_prior_markup` and `SplicedSpecials` are for.
+/// So the body needs no string pipeline of its own: it is built as a tree and
+/// folded, exactly as every other content is, and the enclosing level goes on
+/// wrapping the result in one opaque `Raw` leaf.
+///
+/// *The obvious objection does not apply here, which is why this works.* A
+/// passthrough's body cannot be built as *nodes spliced into the enclosing
+/// level* — the enclosing [`build`](super::build) runs its own fixed normal
+/// order over that level, so any structural node the body's own resolved
+/// subset produced would be visited again by whichever steps come after, and
+/// a macro's display text is not idempotent under a second pass. That
+/// objection is about **splicing**, not about computing: folding the body's
+/// own tree to a string and wrapping it in a `Raw` leaf keeps it opaque to
+/// every later step, which is the same containment `subs.apply` bought.
+///
 /// `text` is a [`Span`] rather than a `&str` so that a warning this body's
 /// substitution records lands on the reference's **own** position in the
-/// document. A body carrying `AttributeReferences` (`pass:a[{missing}]`) is
-/// the case that matters: this call is that body's authoritative pass — no
-/// tree is seeded for it, so it is the one place its `attribute-missing`
-/// diagnostic is raised — and its warnings are carried out through
-/// `Parser::nested_authoritative_warnings` rather than discarded. Seeded from
-/// an unanchored `Span::new`, every one of them resolved to offset 0, however
-/// far into the document the passthrough sat.
-///
-/// The per-line spans are what make the location *precise* rather than merely
-/// in the right neighborhood: without them `apply_attributes` falls back to
-/// the whole-body span and every reference in the body reports at the body's
-/// start. They are built here the way block construction builds them (see
-/// [`Content::from_filtered_lines`](crate::content::Content::from_filtered_lines)),
-/// which is safe for a body that is not one: a retained span is only used when
-/// its text still equals the matched reference, so a body whose rendered lines
-/// have drifted from its source lines falls back rather than mislocating.
+/// document — the answer #1301 settled. It stays true through the tree: the
+/// span is the build's `location`, so the reference's node carries it and the
+/// diagnostic is raised against it. The per-line spans that call needed are
+/// gone with it; they existed because `apply_attributes` scanned a *string*
+/// and had only the whole-body span to fall back on, and a tree has each
+/// reference's own node instead.
 pub(super) fn passthrough_text(
     text: Span<'_>,
     subs: &SubstitutionGroup,
     parser: &Parser,
 ) -> String {
-    let lines: Vec<&str> = text.data().split('\n').collect();
-    let mut line_spans = Vec::with_capacity(lines.len());
-    let mut offset = 0;
+    let nodes = super::build_for_group(subs, CowStr::from(text.data()), text, parser, None);
 
-    for line in &lines {
-        line_spans.push(text.slice(offset..offset + line.len()));
-
-        // Advance past the line and the '\n' that `split` consumed.
-        offset += line.len() + 1;
-    }
-
-    let mut content = Content::from_filtered_lines(text, &lines, line_spans);
-    subs.apply(&mut content, parser, None);
-    content.rendered_str().to_string()
+    super::fold::fold_html(&nodes, &*parser.renderer, &parser.render_context())
 }
 
 /// Reports whether `c` is one of the three characters the special-characters

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -138,11 +138,11 @@ fn collect_from_tree(nodes: &[InlineNode<'_>], out: &mut Vec<Passthrough>) {
             } => {
                 out.push(Passthrough {
                     // `value` is the author's body for every form but one: a
-                    // `pass:c,q[…]` body is substituted at build time, because
-                    // an arbitrary group needs the substitution pipeline and a
-                    // fold cannot reach it. `source_text` is the input that
-                    // produced it, and is `None` wherever the group changed
-                    // nothing.
+                    // `pass:c,q[…]` body is substituted at build time, since
+                    // its group is resolved there and the resulting value is
+                    // what the enclosing level's `Raw` leaf carries.
+                    // `source_text` is the input that produced it, and is
+                    // `None` wherever the group changed nothing.
                     text: source_text
                         .clone()
                         .unwrap_or_else(|| value.as_ref().to_string()),
@@ -1037,19 +1037,25 @@ mod tests {
         // of the distinction.
         //
         // A passthrough carrying its own substitution list has its body
-        // substituted by a re-entrant `SubstitutionGroup::apply`, which — since
-        // the inversion — happens *inside* the enclosing inline-tree build, on
-        // the real parser. That nested pass takes no tree seed, so it is the
-        // body's authoritative pass and its warnings are real, located in the
-        // document source like any other.
+        // rendered by `passthrough_text`, which builds the body's own tree and
+        // folds it. A reference the body carries is therefore recognized by
+        // that build, and its `attribute-missing` diagnostic is recorded the
+        // way every build records one — through `record_builder_diagnostic`,
+        // which the enclosing seam drains and carries across.
         //
-        // The enclosing build discards everything it records into the
-        // substitution-warning buffer, because a build's deliberate diagnostics
-        // go through `record_builder_diagnostic` and what lands in the other
-        // buffer is incidental — the mislocated `Attrlist` warning the test
-        // above pins. These warnings sit in that same range and are *not*
-        // incidental, so `Parser::nested_authoritative_warnings` carries them
-        // across it. Without that, every fixture here reports nothing at all.
+        // The distinction this pins is against the test above: the enclosing
+        // build discards everything it records into the *substitution-warning*
+        // buffer, because what lands there during a build is incidental (the
+        // mislocated `Attrlist` warning). A body's own diagnostics are not
+        // incidental, and they survive because they never go into that buffer
+        // in the first place.
+        //
+        // Before the authoritative-pass closure the route was different — the
+        // body re-entered `SubstitutionGroup::apply`, whose string pipeline
+        // raised the warning into the discarded range, and
+        // `Parser::nested_authoritative_warnings` carried it back out. Both
+        // routes surface the same warning at the same location, which is what
+        // this test has always asserted and still does.
         for (source, mode) in [
             ("pass:a[{missing}]", "warn"),
             ("pass:a[{missing}]", "drop-line"),

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -303,24 +303,42 @@ impl SubstitutionGroup {
             Some(_) => self.run_pipeline(content, &parser.clone(), attrlist),
 
             // No tree is built here, so there is no clone and no second pass:
-            // this *is* the authoritative one. The only content that reaches it
-            // is a passthrough body re-entered from inside a build, whose
-            // constructs the enclosing tree cannot hold (the body folds to one
-            // `Raw` value, not to nodes) and so cannot replay — leaving this
-            // pass as their one registrar, which is the net effect the
-            // suppressed arrangement had too.
+            // this *is* the authoritative one.
+            //
+            // **Nothing in production reaches it any more** — the
+            // authoritative-pass closure (design §5.2's step 6). Until that
+            // increment the one content arriving here was a passthrough body
+            // re-entered from inside a build, whose own string pipeline was
+            // therefore that body's authoritative pass. `passthrough_text`
+            // builds and folds the body's own tree now, so the re-entry is
+            // gone. Measured across the suite, this branch went from 112 hits
+            // to 1, and the one that remains is the crate test that turns
+            // `build_inline_tree` off deliberately.
+            //
+            // That is what makes `run_pipeline` deletable: with the oracle
+            // above writing nothing anyone reads and this branch reaching only
+            // a test, the string pipeline has no production caller left.
             None => {
                 let before = parser.substitution_warnings_len();
 
                 self.run_pipeline(content, parser, attrlist);
 
-                // When this authoritative pass is itself running inside a
-                // build — which is exactly the passthrough-body case above —
-                // the warnings it just raised sit inside the range that build
-                // is about to discard as incidental. They are not incidental,
-                // so move them out of it now; the enclosing seam hands them
-                // back once its own discard has run. See
-                // `Parser::nested_authoritative_warnings`.
+                // Vestigial as of the authoritative-pass closure, and left
+                // standing on purpose — the same call the inversion made for
+                // `suppress_recognition_side_effects`, and for the same
+                // reason: this and its counterpart below go whole with
+                // `run_pipeline`, and removing one half of a two-ended
+                // mechanism while leaving the other would be worse than
+                // removing neither.
+                //
+                // What it was for: a nested authoritative pass running inside
+                // a build raised warnings that sat inside the range the build
+                // discards as incidental, so they had to be moved out and
+                // handed back. The passthrough body was the only content that
+                // ever reached it, and it no longer re-enters `apply` at all —
+                // its `attribute-missing` diagnostics are recorded by the
+                // build's own `record_builder_diagnostic` and carried across
+                // with the rest.
                 if parser.in_inline_build.get() {
                     let mine = parser.drain_substitution_warnings_since(before);
 

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -366,12 +366,13 @@ pub enum RawOrigin {
         ///
         /// For every form the fold can restore by itself, `value` *is* the
         /// author's body and this is `None`. The exception is a `pass:` macro
-        /// carrying an explicit substitution list (`pass:c,q[…]`): an arbitrary
-        /// group needs the substitution pipeline, and a fold takes a renderer
-        /// and a [`RenderContext`](crate::parser::RenderContext) rather than a
-        /// `Parser`, so that body is substituted at **build** time and `value`
-        /// holds the result. Recording the input beside it is what keeps the
-        /// author's own text answerable from the tree.
+        /// carrying an explicit substitution list (`pass:c,q[…]`): rendering an
+        /// arbitrary group means building the body's own tree under that group,
+        /// which needs a `Parser`, and a fold takes a renderer and a
+        /// [`RenderContext`](crate::parser::RenderContext) instead — so that
+        /// body is rendered at **build** time and `value` holds the result.
+        /// Recording the input beside it is what keeps the author's own text
+        /// answerable from the tree.
         source_text: Option<String>,
     },
 

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1005,26 +1005,30 @@ fn renderer_calls_while_applying(source: &str) -> usize {
 
 #[test]
 fn a_passthrough_body_is_substituted_once_per_apply() {
-    // `Parser::in_inline_build`, pinned.
+    // A passthrough body reaches the renderer exactly once per `apply`,
+    // pinned.
     //
-    // A passthrough carrying its own substitution list re-enters
-    // `SubstitutionGroup::apply` for its body, and that re-entry happens from
-    // *inside* the build now that the build holds the real parser. Without the
-    // guard the nested call takes a tree seed of its own, so the body is
-    // substituted a second time — once by its own string pipeline and once by
-    // its own builder — where before the inversion the seam cleared
-    // `build_inline_tree` on the owned clone to stop exactly that.
+    // This began as the guard on `Parser::in_inline_build`: a passthrough
+    // carrying its own substitution list re-entered `SubstitutionGroup::apply`
+    // for its body, and without the guard that nested call took a tree seed of
+    // its own, substituting the body twice — once by its string pipeline and
+    // once by its builder.
     //
-    // Nothing in the suite noticed: the extra pass produces the same bytes, so
-    // a stateless renderer cannot tell. A *stateful* one can, and that is the
-    // whole point — the branch already uses `OrdinalRenderer` to measure
-    // "unobservable" for the build itself. Removing the guard takes each count
-    // below from three to four, and shifts the ordinal that reaches the output
-    // (`a [3] b` becomes `a [4] b`) — a real output change for any backend
-    // whose renderer carries state.
+    // The authoritative-pass closure removed the re-entry rather than the
+    // double pass: `passthrough_text` builds and folds the body's own tree, so
+    // there is no nested `apply` left to seed. The property this measures is
+    // unchanged and still worth pinning — it is what says the closure did not
+    // quietly add a pass — but it now holds *structurally* rather than by a
+    // guard, which is why removing `in_inline_build`'s check no longer moves
+    // these counts.
     //
-    // The exact number is not the claim; that the three agree, and that
-    // dropping the guard moves all three together, is.
+    // Nothing stateless could see the difference either way: the extra pass
+    // produced the same bytes. A *stateful* renderer can, which is what
+    // `OrdinalRenderer` is for — under the old arrangement, dropping the guard
+    // took each count below from three to four and shifted the ordinal
+    // reaching the output (`a [3] b` became `a [4] b`).
+    //
+    // The exact number is not the claim; that the three agree is.
     for source in ["pass:c[a < b]", "pass:c,q[*a < b*]", "stem:[x < y]"] {
         assert_eq!(
             renderer_calls_while_applying(source),
@@ -3014,4 +3018,64 @@ fn resolved_href_in(nodes: &[InlineNode<'_>]) -> Option<String> {
         .find(|r| r.variant == RefVariant::Xref)
         .and_then(|r| r.resolved)
         .map(|resolved| resolved.href)
+}
+
+#[test]
+fn a_passthrough_body_renders_under_every_order_its_own_list_can_name() {
+    // The capability the authoritative-pass closure rests on, pinned directly.
+    //
+    // `passthrough_text` used to hand the body to the string pipeline, which
+    // runs a resolved step list in the author's own order. It builds the body's
+    // own tree now, so the claim that has to hold is that
+    // `build_for_group` honors that order too — including the orders no
+    // built-in group has, where the escaping step comes *after* a step that
+    // already produced markup.
+    //
+    // That is not hypothetical: sweeping the suite, a passthrough body reaches
+    // its rendering under fifteen distinct `Custom` spellings, and
+    // `Custom([Quotes, SpecialCharacters])` and
+    // `Custom([AttributeReferences, Quotes])` are among them. The fixtures
+    // below name both orders of each pair explicitly, so a builder that
+    // silently normalized to the *normal* order (specialcharacters first)
+    // would fail here rather than in whichever corpus happened to carry one.
+    let parser = Parser::default().with_intrinsic_attribute(
+        "tag",
+        "<b>bold</b>",
+        crate::parser::ModificationContext::Anywhere,
+    );
+
+    for (source, expected) in [
+        // `c` alone, and `q` alone — the single-step controls.
+        ("pass:c[a < b]", "a &lt; b"),
+        ("pass:q[*x* &]", "<strong>x</strong> &"),
+        // Both orders of the escaping/quotes pair. `c,q` escapes first, so the
+        // `<` the author wrote is an entity by the time quotes runs; `q,c`
+        // runs quotes first and then escapes what it produced, which is why
+        // the `<strong>` tags come out as entities.
+        ("pass:c,q[*x* < y]", "<strong>x</strong> &lt; y"),
+        ("pass:q,c[*x* < y]", "&lt;strong&gt;x&lt;/strong&gt; &lt; y"),
+        // Both orders of the attributes/quotes pair. With `a` first the
+        // expanded value is present when quotes runs; the expansion carries
+        // markup either way, and neither order escapes it since `c` is absent.
+        (
+            "pass:a,q[{tag} and *x*]",
+            "<b>bold</b> and <strong>x</strong>",
+        ),
+        (
+            "pass:q,a[*x* and {tag}]",
+            "<strong>x</strong> and <b>bold</b>",
+        ),
+        // Attributes with escaping after it: the spliced value is escaped like
+        // any other text, which is the case `SplicedSpecials` exists for.
+        ("pass:a,c[{tag}]", "&lt;b&gt;bold&lt;/b&gt;"),
+        // And escaping before it, where the spliced value is left alone.
+        ("pass:c,a[{tag} < x]", "<b>bold</b> &lt; x"),
+        // The empty list, which renders the body untouched.
+        ("pass:[]", ""),
+    ] {
+        let mut content = crate::content::Content::from(crate::Span::new(source));
+        crate::content::SubstitutionGroup::Normal.apply(&mut content, &parser, None);
+
+        assert_eq!(content.rendered_str(), expected, "for {source:?}");
+    }
 }


### PR DESCRIPTION
The last item on the survey's list that is not test-side, and the production blocker the deletion has been waiting on. **It is a four-line change**, which is the part worth reading.

## The blocker, as stated

`run_pipeline` has two production callers in `apply_inner`. The first is the oracle, whose output the fold overwrites three statements later. The second is the `tree_seed == None` branch, which is *authoritative* — a passthrough body re-entering `SubstitutionGroup::apply` from inside a build takes no tree seed (the `in_inline_build` guard), so its string pipeline is that body's real pass. Nothing could answer for it "while a body folds to one `Raw` value rather than to nodes".

## The obstacle was misidentified

That reasoning descends from the deleted `build_pass_macro_subs_value` helper, whose doc comment argued that a body cannot be threaded through this module's transducers because `build` runs a fixed *normal* order — so any structural node the body's own resolved subset produced would be visited again by whichever steps come after, and a macro's display text is not idempotent under a second pass.

Every word of that is true, and none of it applies. **It is an argument about splicing the body's nodes into the enclosing level, not about computing the body's string.** Folding the body's own tree and wrapping the result in one `Raw` leaf keeps it exactly as opaque as `subs.apply` did.

And the capability was already there. `build_for_group` has taken a `SubstitutionGroup` since the cutover began, runs `group.steps()` **in the group's own order**, and already handles the orders no built-in group has — a `Custom` list that puts the escaping step *after* a step that produced markup, which is what `flatten_prior_markup` and `SplicedSpecials` exist for. So `passthrough_text` needed only to build and fold rather than substitute.

## The evidence

Instrumenting the `None` branch across the whole suite:

| | hits | breakdown |
|---|---|---|
| before | 112 | 111 `in_inline_build=true` + 1 test |
| after | **1** | the test only |

The 111 that went were the passthrough-body re-entry, every one of them. The survivor is `build_inline_tree=false` — the crate test that turns the flag off deliberately. **Production no longer reaches the string pipeline at all.**

Measured before the change, `passthrough_text` is reached 378 times in the suite: `Stem` 218, `Verbatim` 63, `Normal` 2, and 95 across **fifteen distinct `Custom` spellings**, among them `Custom([Quotes, SpecialCharacters])` and `Custom([AttributeReferences, Quotes])`. Those out-of-order pairs are what say this is not a fixed-order problem in disguise, so `a_passthrough_body_renders_under_every_order_its_own_list_can_name` pins both orders of both — `pass:c,q[*x* < y]` renders `<strong>x</strong> &lt; y` where `pass:q,c[*x* < y]` renders `&lt;strong&gt;x&lt;/strong&gt; &lt; y`, so the fixture **discriminates** order rather than merely exercising it.

## Three explanations that became false

Corrected rather than left to rot:

- `Parser::in_inline_build`'s reentrancy guard no longer has a re-entry to guard. The property `a_passthrough_body_is_substituted_once_per_apply` measures still holds and is still worth pinning, but it holds *structurally* now — which is why removing the guard's check no longer moves those counts.
- `passthrough_body_warnings_survive_the_builds_own_discard` passes unchanged, by a different route: the body's `attribute-missing` diagnostic goes through the build's own `record_builder_diagnostic` and is carried across by the enclosing seam, rather than being raised into the discarded range and rescued by `nested_authoritative_warnings`.
- The two `Raw`/`source_text` notes that said "an arbitrary group needs the substitution pipeline" now say what is true: it needs a `Parser`, which a fold does not have, so the body is rendered at build time.

## Preflight

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5530 passed), `cargo +nightly doc --no-deps --document-private-items` — all clean.
- **Fold-parity audit: 63 rows either side, 0 new and 0 closed** — a production change that moves no divergence at all.
- **Coverage is deliberately not diff-neutral**, exactly as it was for the inversion. `passthrough_step.rs` stays at 22/10 (missed regions / lines) and `passthroughs.rs` at 3/3; `substitution_group.rs` goes from 0/0 to 6/6, and those six lines are precisely the `nested_authoritative_warnings` block this makes unreachable. That mechanism and `in_inline_build`'s reentrancy half are **vestigial** as of here, left standing on purpose — two-ended mechanisms that go whole with `run_pipeline`, where removing one end while leaving the other would be worse than removing neither.

## What still defers

The deletion, and only the deletion: `run_pipeline`, `apply_string_pipeline`, the escaping pass, the three sentinel systems, the `suppress_recognition_side_effects` window, `nested_authoritative_warnings`, `in_inline_build`, `build_inline_tree`, and the Strategy-A recorder with the `inline_recorder` corpus that tests it.

Every corpus that depended on the string pipeline for its golden is frozen; nothing in production calls it. The one test that still does — the `build_inline_tree=false` parse — is what the deletion has to decide about, and that is a decision about a flag rather than a blocker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_