### PR TITLE
feat: Take the deferral divergence (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8155,6 +8155,63 @@ Each phase is a reviewable unit with a clear exit gate.
   Nothing in production moved in this increment — it is a measurement and a decomposition — so there
   is no audit or coverage claim to make beyond the suite staying green.
 
+  *Step 6 landed as (the deferral divergence, taken):* the survey's item (2), decided by the
+  maintainer and now implemented. `tokened_split_agrees` is gone, with `restored_markup_text` (its
+  only helper) and the image family's `bracket_is_recognizable` (which became always-`true`), and all
+  three call sites — xref, links, image — with them.
+
+  *What the gate actually cost is clearer from its removal than from its presence.* It deferred a
+  match whenever the tokened split and the replacer's markup split disagreed, which meant **a comma
+  inside a span decided whether the macro was recognized at all**. Before this increment
+  `xref:sec[a *b, c* d,role=hl]` folded to the literal text `xref:sec[a <strong>b, c</strong>
+  d,role=hl]`; the identical fixture without the comma, `xref:sec[a *b* d,role=hl]`, folded to a
+  proper anchor. The gate was not choosing between two readings of a construct — it was refusing the
+  construct.
+
+  Now all three families read it the way they already read the comma-free case:
+
+  | source | before | after |
+  |---|---|---|
+  | `xref:sec[a *b, c* d,role=hl]` | literal text | `<a href="#sec" class="hl">a <strong>b, c</strong> d</a>` |
+  | `link:index.html[a *b, c* d,role=hl]` | literal text | `<a href="index.html" class="hl">a <strong>b, c</strong> d</a>` |
+  | `image:x.png[a *b, c* d,title=hl]` | literal text | `alt="a <strong>b, c</strong> d" title="hl"` |
+
+  The image row is the one worth checking rather than assuming, and it was: the baseline already
+  renders `alt="a <strong>b</strong> d"` for the comma-free `image:x.png[a *b* d,title=hl]`, so
+  markup reaching an `alt` is this family's **existing** behavior and the change only stops the comma
+  from suppressing recognition. Nothing new leaks into an attribute.
+
+  *The audit reads differently here than on any previous increment, and the difference is the
+  increment.* **63 rows either side, 61 distinct sources either side, and the two source sets are
+  identical** — no divergent source appeared or disappeared. What moved is the *tree's* column on
+  exactly four rows: the `(source, rendered)` pairs are byte-identical either side (a set comparison
+  over those two columns differs in nothing at all), while `folded` goes from the literal text to the
+  anchor. The divergence against the string pipeline **persists** on those four, because the pipeline
+  still writes the cut-short `a <strong>b`; what changed is that the tree's answer went from *absent*
+  to *right*. Reporting this as "four rows closed" would have been wrong, and it is worth saying so:
+  the bar this branch uses ("no new row") is a proxy for "no unintended behavior change", and an
+  intended one shows up as a row whose fold moved rather than as a row that left.
+
+  Five tests asserted the deferral and now assert the reading; each keeps its own subject.
+  `an_attribute_list_delimiter_inside_a_span_is_the_trees_to_read` and
+  `a_span_whose_markup_splits_the_attribute_list_is_the_trees_to_read` pin the fold and, with
+  `assert_ne!` against the golden, pin the divergence itself as bytes.
+  `the_xref_mirror_correlates_the_form_that_used_to_defer` is the carve-out closing from resolution's
+  side — the counts agree, the positional mirror correlates instead of skipping, and the content
+  leaves the template path — with `a_title_resolves_the_form_that_used_to_defer_on_its_own_path`
+  saying the same for `title_refs::compute`'s separate path.
+  `a_resolved_destination_holding_a_sentinel_survives_the_template_path` keeps its sentinel subject
+  and simply carries the new bytes.
+
+  Coverage is neutral in total (578 missed regions / 329 missed lines either side) and improves where
+  the dead code went: `image.rs` drops from 5/2 to 4/1. `xref.rs` goes from 16/7 to 17/8, and the one
+  added line is the `let … else { panic!(…) }` in the rewritten test — the test-assertion fallback
+  this repository's conventions already exclude.
+
+  *What still defers* is the survey's list with items (1) and (2) struck: the `indexterm2:` gap, the
+  **template**, then the oracle call, the test call sites and `run_pipeline`, the vestigial
+  mechanisms, and the Strategy-A recorder with `inline_recorder`.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -9931,6 +9988,24 @@ Each phase is a reviewable unit with a clear exit gate.
        `tokened_split_agrees`'s decline, scope settled against the audit's set), the template, the
        oracle call, the test call sites and `run_pipeline`, the vestigial mechanisms, then the
        Strategy-A recorder with `inline_recorder`. See the step's own "landed as" note above.
+
+     - ✅ **the deferral divergence, taken.** The survey's item (2), decided by the maintainer and
+       implemented: `tokened_split_agrees` is gone, with `restored_markup_text` and the image
+       family's now-always-true `bracket_is_recognizable`, and all three call sites. What the gate
+       cost is clearer from its removal — it deferred whenever the tokened split and the replacer's
+       markup split disagreed, which meant **a comma inside a span decided whether the macro was
+       recognized at all**: `xref:sec[a *b, c* d,role=hl]` folded to literal text where
+       `xref:sec[a *b* d,role=hl]` folded to an anchor. All three families now read the comma case
+       the way they already read the comma-free one. The image row was checked rather than assumed —
+       the baseline already renders `alt="a <strong>b</strong> d"` without the comma, so markup in an
+       `alt` is pre-existing behavior and nothing new leaks into an attribute. The audit reads
+       differently here than anywhere else on this branch: 63 rows and 61 sources either side with
+       **identical source sets** and identical `(source, rendered)` pairs, while `folded` moves on
+       exactly four rows from the literal text to the anchor. The divergence persists — the pipeline
+       still writes the cut-short `a <strong>b` — so this is not "four rows closed"; the tree's answer
+       went from absent to right, which is what an *intended* behavior change looks like under a bar
+       written to catch unintended ones. Coverage neutral in total, improving where the dead code
+       went. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2,10 +2,7 @@
 
 use std::borrow::Cow;
 
-use super::{
-    MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level,
-    tokened_split_agrees,
-};
+use super::{MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
@@ -128,20 +125,6 @@ fn find_image_matches<'src>(
         // macro name and the two square brackets need no gate of their own:
         // those bytes are literal, and no atomic piece — a placeholder, or an
         // entity delimited by `&` and `;` — can supply them.
-        let bracket = caps
-            .get(2)
-            .map_or(full.end..full.end, |m| m.start()..m.end());
-
-        if !bracket_is_recognizable(
-            caps.get(2).map_or("", |m| m.as_str()),
-            &bracket,
-            nodes,
-            pieces,
-            parser,
-        ) {
-            continue;
-        }
-
         if let Some(target) = caps.get(1)
             && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
@@ -876,81 +859,6 @@ fn masked_default_alt(
 
     out.push_str(rest);
     out
-}
-
-/// Whether this family may recognize a macro whose bracket covers `range`.
-///
-/// A bracket comes back from a **parse** — [`bracket_attrlist`] reads its bytes
-/// as content — so an opaque piece there is read as literal text unless
-/// something puts the piece's own bytes back first. [`range_is_restorable`]
-/// names the pieces that always can: a masked passthrough or STEM expression,
-/// whose body [`Passthroughs::restore_to`](crate::content::Passthroughs)
-/// splices into the string pipeline's own finished string, so restoring one
-/// into a parsed value is faithful wherever that value goes.
-///
-/// A **rendered span** is admitted too, and this is where that rule was first
-/// drawn; [`text_attrlist`](super::links) now draws the same one, so the three
-/// [`Attrlist`]-bearing families agree.
-///
-/// *Necessary*, because it is the only way an image reaches parity at all.
-/// Every value an image's bracket holds is one `render_image` writes out — an
-/// `alt`, a `title`, a `width` — so a rule refusing a token in such a slot
-/// would defer *every* such bracket, and
-/// `image:pause.png[title=*Pause* and Resume]` (a fixture from the AsciiDoc
-/// language docs) would lose its whole macro. The link families had somewhere
-/// else to put a rendered span — a display text becomes the node's children —
-/// and drew that per-slot rule for a while; it cost them the same macro for
-/// `link:index.html[Docs,title=*Pause*]`, so they dropped it.
-///
-/// *Safe*, in two senses. The frozen bytes are the bytes: the string replacer
-/// reads its own bracket out of a haystack the quotes step has already
-/// rendered **with this same renderer**, so
-/// `title="<strong>Pause</strong> and Resume"` is what it writes too, and
-/// freezing the span's build-time fold here reproduces that exactly rather
-/// than approximating it. It is the same trade this very function's masked
-/// branch already makes for a [`Stem`](crate::inlines::Stem), whose "body" is
-/// likewise a build-time fold ([`restorable_body`]). And the markup cannot
-/// escape the attribute it is carried into: every value the image, icon and
-/// link renderers interpolate is escaped for the `"` delimiter where it lands
-/// (`encode_attribute_value`), so a span rendering a quote of its own —
-/// `[.r"z]#b#` — closes nothing.
-///
-/// What a frozen value cannot survive is being folded again through a
-/// *different* renderer — [`render_with`](crate::Parser) (design §3.3.1,
-/// step 7), which does not exist yet and which every other frozen value on
-/// this branch owes the same debt to. §4.6 reshapes the renderer seam in Phase
-/// 5 so a `*RenderParams` struct becomes the node type itself, which is where
-/// a fold-**materialized** attribute value belongs; until then this is parity,
-/// and parity is what the cutover needs.
-///
-/// The one thing a rendered piece must still satisfy is the *split*: a token
-/// carries none of the `,` / `=` / `"` an attribute list splits on and a
-/// span's markup may (`image:x.png[a *b, c* d,title=hl]`), so the two parses
-/// are compared attribute by attribute and a disagreement defers the whole
-/// match — the same check the link families make, for the same reason.
-fn bracket_is_recognizable(
-    bracket_text: &str,
-    range: &std::ops::Range<usize>,
-    nodes: &[InlineNode<'_>],
-    pieces: &[Piece],
-    parser: &Parser,
-) -> bool {
-    if range_is_restorable(nodes, pieces, range) {
-        return true;
-    }
-
-    let (tokened, masked) = tokened_bracket(
-        bracket_text,
-        range,
-        nodes,
-        pieces,
-        parser,
-        Tokened::MaskedOrRendered,
-    );
-
-    let carried: Vec<InlineNode<'_>> = masked.iter().map(|piece| piece.node.clone()).collect();
-
-    tokened_split_agrees(&tokened, &carried, parser)
 }
 
 /// Parses the macro's bracket into the [`Attrlist`]`<'src>` its node carries.

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -8,7 +8,7 @@ use super::computed_value_children;
 use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind,
     image::{Tokened, range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
-    macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
+    macro_text_children, rebuild_macro_level, restored_value_children,
 };
 use crate::{
     Parser, Span,
@@ -1633,9 +1633,10 @@ struct TextAttrlist<'src> {
 /// rather than per family so that a masked piece in the display text beside a
 /// plain subject still restores.
 ///
-/// Returns `None` for those two shapes alone: a `pre_restore` slot holding a
-/// token, and a list whose two parses disagree about the match's own extent
-/// ([`tokened_split_agrees`]).
+/// Returns `None` for that one shape alone: a `pre_restore` slot holding a
+/// token. A list whose two parses disagree about the match's own extent used to
+/// return `None` here too; the tree's own split is what stands now (design
+/// §5.2's deferral divergence).
 fn text_attrlist<'src>(
     raw_text: &str,
     text_range: std::ops::Range<usize>,
@@ -1679,12 +1680,9 @@ fn text_attrlist<'src>(
     // the *split* must land where the string replacer's own parse of the
     // markup lands. A token carries none of the `,` / `=` / `"` the split
     // reads, and the replacer's markup may (`link:x[a *b, c* d,role=hl]`), so
-    // the two are compared parse against parse — see [`tokened_split_agrees`].
-    let carried: Vec<InlineNode<'src>> = masked.iter().map(|piece| piece.node.clone()).collect();
-
-    if !tokened_split_agrees(&tokened, &carried, parser) {
-        return None;
-    }
+    // the tree's own split is the one that stands (design §5.2's deferral
+    // divergence).
+    let _carried: Vec<InlineNode<'src>> = masked.iter().map(|piece| piece.node.clone()).collect();
 
     if masked.is_empty() {
         return Some(TextAttrlist {
@@ -5237,12 +5235,17 @@ mod tests {
     }
 
     #[test]
-    fn a_span_whose_markup_splits_the_attribute_list_defers_the_match() {
-        // The other half of the two checks the rendered-piece token used to
-        // face, and the one that stays: a span whose own markup carries a
-        // character the split reads, so the string replacer's list divides
-        // where the token cannot. The match's very extent differs, so it is
-        // deferred rather than recognized — `tokened_split_agrees`.
+    fn a_span_whose_markup_splits_the_attribute_list_is_the_trees_to_read() {
+        // The link family's half of the deferral divergence (design §5.2's
+        // step 6) — the same decision the xref family's own test records, for
+        // the same reason and by the same mechanism.
+        //
+        // A span whose markup carries a character the split reads used to make
+        // the two readings disagree about the match's extent, and the match was
+        // deferred. That made a comma inside a span decide whether the macro
+        // was recognized at all: these fixtures came out as literal text. The
+        // tree's split sees a token carrying no delimiter, reads a display text
+        // and a role, and is now the reading that stands.
         for source in [
             "link:index.html[a *b, c* d,role=hl]",
             "https://example.org[a *b, c* d,role=hl]",
@@ -5250,15 +5253,29 @@ mod tests {
             let nodes = build_src(Span::new(source));
 
             assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "a split the two readings disagree on must stay literal: {nodes:?}"
+                nodes.iter().any(|n| matches!(n, InlineNode::Ref(_))),
+                "the tree must now recognize the macro: {nodes:?}"
             );
 
-            // The string pipeline, by contrast, *does* build a link here.
-            assert!(golden_macros(source).contains("<a href"));
+            let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
+
+            // The role landed as a class rather than being swallowed into the
+            // display text, and the span survives whole inside it.
+            assert!(
+                folded.contains(r#"class="hl""#),
+                "{source:?} lost its role: {folded:?}"
+            );
+
+            assert!(
+                folded.contains("<strong>b, c</strong>"),
+                "{source:?} lost its span: {folded:?}"
+            );
+
+            // The divergence, stated as bytes: the replacer builds a link too,
+            // but cuts it short inside the tag it just wrote.
+            assert_ne!(folded, golden_macros(source), "{source:?}");
         }
     }
-
     #[test]
     fn a_span_whose_markup_perturbs_the_string_pipeline_is_a_documented_divergence() {
         // What the structural recovery cannot do is make the *recognition*

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -22,7 +22,6 @@ use super::{
 };
 use crate::{
     HasSpan, Parser, Span,
-    attributes::{Attrlist, AttrlistContext},
     content::restored_entity_pattern,
     inlines::{CharRef, InlineNode},
     strings::CowStr,
@@ -73,7 +72,7 @@ pub(super) enum ComputedSpecials {
 /// (`doc@example.org`), replacing each with an
 /// [`Image`](InlineNode::Image), [`Ui`](InlineNode::Ui), or
 /// [`Ref`](InlineNode::Ref) node. An image node carries its own owned
-/// [`Attrlist`] — the step that makes a macro node
+/// [`Attrlist`](crate::attributes::Attrlist) — the step that makes a macro node
 /// *self-describing*, so the fold reconstructs the render parameters and calls
 /// the same `render_image`/`render_icon` the string step calls; a UI node
 /// carries the keys / label / menu path the string replacer computed, so its
@@ -148,7 +147,7 @@ pub(super) enum ComputedSpecials {
 /// its own child with no gate at all. What keeps
 /// the stricter gate is never a *family* now, only the one **capture** that
 /// must ride on the node as a real
-/// [`Attrlist`]`<'src>`, parsed from the source's
+/// [`Attrlist`](crate::attributes::Attrlist)`<'src>`, parsed from the source's
 /// own bytes: a link's attribute-list-bearing display text and an image's
 /// non-empty bracket (a cross-reference's own attribute list is parsed from a
 /// normalized *copy*, so it takes both lifts). The auto-link family
@@ -800,94 +799,6 @@ pub(super) fn tokened_text<'src>(
     (tokened, carried)
 }
 
-/// The bytes the **string replacer's own haystack** holds for a text
-/// [`tokened_text`] tokened: each token replaced by what the fold of the node
-/// it stands for emits, with the parser's own renderer — the renderer the
-/// string pipeline ran. A **masked** construct's token is left alone: the
-/// replacer's own haystack holds a sentinel there too.
-///
-/// This is the other half of the token's contract. Tokening is what makes the
-/// attribute-list *split* reproducible: a bracket's `,` / `=` / `"` are the
-/// only bytes it reads, and an opaque piece's placeholder carries none of
-/// them. But the replacer splits over the piece's own **markup**, which may:
-/// `xref:sec[a *b, c* d,role=hl]` renders `a <strong>b, c</strong> d`, and its
-/// list splits at the comma *inside* the tag. A caller compares the two
-/// parses to find out (see [`tokened_split_agrees`]).
-pub(super) fn restored_markup_text(
-    tokened: &str,
-    carried: &[InlineNode<'_>],
-    parser: &Parser,
-) -> String {
-    let mut out = tokened.to_string();
-
-    for (n, node) in carried.iter().enumerate() {
-        // A **masked** construct is left as its token. The replacer's haystack
-        // holds its own `\u{96}`*n*`\u{97}` sentinel there — not the body,
-        // which `Passthroughs::restore_to` splices only after every step has
-        // run — so the two sides already agree on those bytes, and expanding
-        // one here would compare the tokened split against a string the
-        // replacer never split.
-        if image::node_is_restorable(node) {
-            continue;
-        }
-
-        let markup = super::fold::fold_html(
-            std::slice::from_ref(node),
-            parser.renderer.as_ref(),
-            &parser.render_context(),
-        );
-
-        out = out.replace(&format!("\u{96}{n}\u{97}"), &markup);
-    }
-
-    out
-}
-
-/// Whether an attribute list parsed from a [`tokened_text`] text splits the
-/// same way the string replacer's own parse of the **markup** does.
-///
-/// A token stands in for markup the replacer really sees, so the two parses
-/// agree exactly when no character the split reads is hidden inside a piece.
-/// Rather than guess at that from the bytes — an ordinary `*bold*` hides
-/// nothing, while `[.r]#x#` renders a `"` and an `=` that the split
-/// nonetheless reads harmlessly — this asks the parser: it compares the two
-/// lists attribute by attribute, expanding the tokened side's tokens first, so
-/// a split that moved shows up as a value that differs.
-///
-/// It answers only the *split*, not what the caller then does with each value.
-/// A token reaching a value the caller reads as a **string** — a
-/// cross-reference's `window=` / `role=` / `xrefstyle=` — splits identically
-/// on both sides and still has no bytes of its own the caller can read, so
-/// such a slot takes [`untranslated_value`] of it instead.
-pub(super) fn tokened_split_agrees(
-    tokened: &str,
-    carried: &[InlineNode<'_>],
-    parser: &Parser,
-) -> bool {
-    let restored = restored_markup_text(tokened, carried, parser);
-
-    let tokened_attrs = Attrlist::parse(Span::new(tokened), parser, AttrlistContext::Inline)
-        .item
-        .item;
-
-    let restored_attrs = Attrlist::parse(Span::new(&restored), parser, AttrlistContext::Inline)
-        .item
-        .item;
-
-    let tokened_list: Vec<_> = tokened_attrs.attributes().collect();
-    let restored_list: Vec<_> = restored_attrs.attributes().collect();
-
-    tokened_list.len() == restored_list.len()
-        && tokened_list
-            .iter()
-            .zip(restored_list.iter())
-            .all(|(tokened_attr, restored_attr)| {
-                tokened_attr.name() == restored_attr.name()
-                    && restored_markup_text(tokened_attr.value(), carried, parser)
-                        == restored_attr.value()
-            })
-}
-
 /// Rebuilds a computed value a family reads as a **string** — an `xref`'s
 /// `role`, `window` or `xrefstyle`, and the link and image families'
 /// equivalents — replacing each [`tokened_text`] token with the *untranslated*
@@ -1003,7 +914,7 @@ pub(super) fn restored_value_children<'src>(
 ///
 /// A computed value is the one thing this step reads as *bytes* rather than
 /// carrying structurally: it comes back from an
-/// [`Attrlist`] parse, so there is no range of
+/// [`Attrlist`](crate::attributes::Attrlist) parse, so there is no range of
 /// nodes to rebuild it from and its classification has to be re-derived from
 /// the bytes themselves. What those bytes are worth is exactly what
 /// [`ComputedSpecials`] answers — see its two halves,

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -9,8 +9,8 @@ use super::{
     ComputedSpecials, MacroMatch, MacroMatchKind,
     image::{range_has_no_opaque_piece, range_is_substitution_restorable},
     links::restore_masked_passthroughs,
-    macro_text_children, rebuild_macro_level, restored_value_children, tokened_split_agrees,
-    tokened_text, untranslated_value,
+    macro_text_children, rebuild_macro_level, restored_value_children, tokened_text,
+    untranslated_value,
 };
 use crate::{
     Parser, Span,
@@ -405,9 +405,6 @@ fn find_xref_matches<'src>(
 /// [`range_has_no_opaque_piece`] has already refused, so the tokening below
 /// always produces at least one token; a text carrying none would answer
 /// `true` here, which is what that caller already decided for itself.
-///
-/// It also refuses a match whose two readings disagree about its extent — see
-/// [`tokened_split_agrees`].
 fn attrlist_text_carries_its_opaque_pieces(
     raw_text: &str,
     text_range: &std::ops::Range<usize>,
@@ -421,13 +418,7 @@ fn attrlist_text_carries_its_opaque_pieces(
         return false;
     }
 
-    let (tokened, carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
-
-    // The split must land where the string replacer's own parse of the markup
-    // lands — otherwise the two disagree about the match's very extent.
-    if !tokened_split_agrees(&tokened, &carried, parser) {
-        return false;
-    }
+    let (tokened, _carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
 
     let attrlist = Attrlist::parse(Span::new(&tokened), parser, AttrlistContext::Inline)
         .item
@@ -1990,37 +1981,72 @@ mod tests {
     }
 
     #[test]
-    fn an_attribute_list_delimiter_inside_a_span_defers_the_match() {
-        // The token is what makes the split reproducible — a bracket's `,` /
-        // `=` / `"` are the only bytes it reads, and a placeholder carries
-        // none of them. But the string replacer splits over the piece's own
-        // **markup**, which may: `a *b, c* d` renders `a <strong>b, c</strong>
-        // d`, whose list splits at the comma *inside* the tag, ending the
-        // anchor there. Where the two readings differ about the match's own
-        // extent the match is **deferred** rather than recognized, so the tree
-        // never claims a construct the rendered document does not agree with.
-        for source in [
-            "xref:sec[a *b, c* d,role=hl]",
-            "xref:sec[a `b, c` d,role=hl]",
+    fn an_attribute_list_delimiter_inside_a_span_is_the_trees_to_read() {
+        // The deferral divergence (design §5.2's step 6), decided in favor of
+        // the tree.
+        //
+        // A token carries none of the `,` / `=` / `"` a bracket split reads, so
+        // the tree's split sees `a ␖ d,role=hl` — a display text and a role.
+        // The string replacer splits over the piece's own **markup**: `a *b, c*
+        // d` renders `a <strong>b, c</strong> d`, whose list splits at the
+        // comma *inside the tag*, ending the anchor at `a <strong>b` and
+        // leaving it unbalanced. Asciidoctor does the same.
+        //
+        // This used to defer where the two readings disagreed, which made the
+        // presence of a comma inside a span decide whether the macro was
+        // recognized **at all** — the fixtures below came out as literal text.
+        // Emitting the replacer's split is the wrong answer and reproducing it
+        // was never on the table, so the tree's reading stands and this crate
+        // diverges from both the replacer and Asciidoctor here.
+        for (source, expected) in [
+            (
+                "xref:sec[a *b, c* d,role=hl]",
+                "<a href=\"#sec\" class=\"hl\">a <strong>b, c</strong> d</a>",
+            ),
+            (
+                "xref:sec[a `b, c` d,role=hl]",
+                "<a href=\"#sec\" class=\"hl\">a <code>b, c</code> d</a>",
+            ),
         ] {
             let nodes = build_src(Span::new(source));
 
-            assert!(
-                nodes.iter().all(|n| !matches!(n, InlineNode::Ref(_))),
-                "a hidden attribute-list delimiter must defer the match: {nodes:?}"
+            let Some(InlineNode::Ref(ref_)) = nodes.first() else {
+                panic!("the tree must now recognize the macro: {nodes:?}");
+            };
+
+            // The role landed as a role rather than being swallowed into the
+            // display text, which is the half the replacer's split loses.
+            assert_eq!(
+                ref_.roles.iter().map(|r| r.as_ref()).collect::<Vec<_>>(),
+                ["hl"],
+                "for {source:?}"
             );
 
-            // The string pipeline does build one — cut short inside the span.
-            assert!(golden_xref(source).contains("<a href"));
+            // And the span survives whole inside the display text.
+            assert!(
+                ref_.children
+                    .iter()
+                    .any(|child| matches!(child, InlineNode::Styled(_))),
+                "the display text must keep its span: {:?}",
+                ref_.children
+            );
+
+            assert_eq!(
+                fold_html(&nodes, &HtmlSubstitutionRenderer {}),
+                expected,
+                "for {source:?}"
+            );
+
+            // The divergence, stated as bytes: the replacer cuts the anchor
+            // short inside the tag it just wrote.
+            assert_ne!(golden_xref(source), expected, "for {source:?}");
         }
 
-        // The boundary of the class, from both sides. Without a *named*
-        // attribute to split off there is no attribute list at all, so the
-        // same comma is at parity through the plain-text path; and a span
-        // whose markup carries no delimiter is recognized however many
-        // quotes and equals signs its own rendering holds
-        // (`[.r]#x#` renders a `"` and an `=` the split reads harmlessly),
-        // which is why the test is the two parses rather than the bytes.
+        // The boundary of the class, unchanged: without a *named* attribute to
+        // split off there is no attribute list at all, so the same comma is at
+        // parity through the plain-text path, and a span whose markup carries
+        // no delimiter was never affected (`[.r]#x#` renders a `"` and an `=`
+        // the split reads harmlessly).
         for source in ["xref:sec[a *b, c* d]", "xref:sec[[.r]#x# here,role=hl]"] {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlSubstitutionRenderer {}),
@@ -2029,7 +2055,6 @@ mod tests {
             );
         }
     }
-
     #[test]
     fn an_author_written_token_byte_defers_the_match() {
         // The bytes a token is built from are `\u{96}` and `\u{97}`, and an

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -204,14 +204,19 @@
 //!   reaching the `window=` / `role=` / `xrefstyle=` this family reads as a
 //!   *string* has no bytes to be read as, and that shape alone defers. The
 //!   token is what makes the *split* reproducible — a bracket's `,` / `=` / `"`
-//!   are the only bytes it read, and a placeholder carries none of them — but
-//!   the replacer splits over the piece's own **markup**, which may
-//!   (`xref:sec[a *b, c* d,role=hl]` renders `a <strong>b, c</strong> d`,
-//!   whose list splits at the comma inside the tag). So the gate asks the
-//!   parser rather than the bytes: it parses the tokened text *and* the
-//!   restored markup and compares them attribute by attribute
-//!   ([`tokened_split_agrees`](macros::tokened_split_agrees)), deferring the
-//!   match whenever the two readings differ about its extent. The two **link**
+//!   are the only bytes it reads, and a placeholder carries none of them. The
+//!   replacer, by contrast, splits over the piece's own **markup**, which may
+//!   carry them: `xref:sec[a *b, c* d,role=hl]` renders
+//!   `a <strong>b, c</strong> d`, whose list splits at the comma inside the tag
+//!   and leaves the anchor's text as `a <strong>b`, unbalanced. The two
+//!   readings therefore disagree about the match's own extent, and this used to
+//!   defer the match — which made a comma inside a span decide whether the
+//!   macro was recognized **at all**. Emitting the replacer's split is the
+//!   wrong answer, so **the tree's split is the one that stands** and this
+//!   crate diverges from both the replacer and Asciidoctor for that shape
+//!   (design §5.2's deferral divergence). The principle it rests on: a bracket
+//!   split must not read bytes that a markup-producing step introduced, and the
+//!   tokened side is exactly the side that holds to it. The two **link**
 //!   families take the same move through
 //!   [`tokened_bracket`](macros::image::tokened_bracket), which under
 //!   [`Tokened::MaskedOrRendered`](macros::image::Tokened) admits a rendered

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1468,69 +1468,74 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 }
 
 #[test]
-fn xref_mirror_is_skipped_when_the_tree_defers_a_reference_form() {
-    // `xref:sec[a *b, c* d,role=hl]` is a documented builder divergence: the
-    // string replacer splits the attribute list over the span's **markup**,
-    // whose `<strong>b, c</strong>` hides a comma the split reads, so the two
-    // readings disagree about the match's own extent and the builder defers
-    // rather than claim a construct the rendered document contradicts. The
-    // tree therefore holds *fewer* cross-reference nodes than the string
-    // pipeline deferred. The positional resolution mirror must detect the
-    // count mismatch and skip — leaving the tree in its honest unresolved
-    // state — rather than assign destinations to the wrong nodes (or panic).
+fn the_xref_mirror_correlates_the_form_that_used_to_defer() {
+    // The counterpart of the deferral divergence (design §5.2's step 6), seen
+    // from resolution.
+    //
+    // `xref:sec[a *b, c* d,role=hl]` used to be deferred by the builder,
+    // because the string replacer splits the attribute list over the span's
+    // **markup** and the `<strong>b, c</strong>` it writes hides a comma the
+    // split reads. The tree then held *fewer* cross-reference nodes than the
+    // pipeline deferred, the positional mirror detected the count mismatch and
+    // skipped, and this content stayed on the template path carrying the
+    // replacer's own answer — an anchor cut short inside the tag.
+    //
+    // The tree's reading stands now, so the counts agree, the mirror
+    // correlates, and the rendering is the fold's: a whole anchor with the span
+    // intact inside it and the role where the author put it.
     let mut parser = Parser::default();
     let doc = parser.parse("[[sec]]The target.\n\nSee xref:sec[a *b, c* d,role=hl].");
 
-    // The rendered output is the string pipeline's own — anchor cut short
-    // inside the span, which is precisely the reading the builder refused to
-    // claim. That count mismatch is also what keeps this content on the
-    // **template** path: a deferred content is re-folded from its tree once
-    // resolution has installed its destinations (`Content::refold`), and the
-    // mirror's own success is the gate. Here the mirror skipped, so the tree
-    // is known not to describe this content and folding it would drop the
-    // cross-reference outright.
     let rendered = collect_rendered(&doc);
     assert!(
         rendered
             .iter()
-            .any(|s| s.contains("href=\"#sec\"") && s.contains("<strong>b</a>")),
-        "the rendered xref regressed: {rendered:?}"
+            .any(|s| s.contains(r##"<a href="#sec" class="hl">a <strong>b, c</strong> d</a>"##)),
+        "the xref did not resolve through the tree: {rendered:?}"
     );
 
-    // … and the tree simply carries no node for the deferred form.
+    // The malformed shape the replacer produces, pinned as *absent* — this is
+    // the divergence, and it is the whole reason the deferral went.
+    assert!(
+        !rendered.iter().any(|s| s.contains("<strong>b</a>")),
+        "the replacer's cut-short anchor came back: {rendered:?}"
+    );
+
+    // And the tree carries the node the mirror correlated against.
     let refs = collect_refs(&doc);
     assert!(
-        refs.iter().all(|r| r.variant != RefVariant::Xref),
-        "expected the deferred xref form to stay unrecognized in the tree: {refs:?}"
+        refs.iter().any(|r| r.variant == RefVariant::Xref),
+        "expected the form to be recognized in the tree: {refs:?}"
     );
 }
-
 #[test]
-fn a_title_whose_tree_defers_a_reference_form_keeps_the_string_pipelines_rendering() {
-    // The carve-out crossed with the **title** container, which resolves on a
-    // path of its own: `title_refs::compute` coordinates cross-title references
-    // and so re-derives the ordered destinations itself, rather than going
-    // through `Content::resolve_references`. Both paths have to split the
-    // string pipeline's flat list the same way when the tree is short of it,
-    // and a corpus that covers the carve-out only on paragraphs (as this one
-    // did) would never say so.
+fn a_title_resolves_the_form_that_used_to_defer_on_its_own_path() {
+    // The deferral divergence crossed with the **title** container, which
+    // resolves on a path of its own: `title_refs::compute` coordinates
+    // cross-title references and re-derives the ordered destinations itself,
+    // rather than going through `Content::resolve_references`. Both paths have
+    // to agree about this form, and a corpus covering it only on paragraphs (as
+    // this one did) would never say so.
     //
-    // Same deferred form as `xref_mirror_is_skipped_when_the_tree_defers_a_
-    // reference_form`, written as a block title.
+    // Same form as `the_xref_mirror_correlates_the_form_that_used_to_defer`,
+    // written as a block title. It used to keep the replacer's cut-short anchor
+    // through the carve-out; the tree's reading stands on this path too.
     let mut parser = Parser::default();
     let doc = parser.parse("[[sec]]The target.\n\n.See xref:sec[a *b, c* d,role=hl]\nA paragraph.");
 
     // `collect_rendered` walks block titles as well as block content.
     let titles = collect_rendered(&doc);
 
-    // The title keeps the string pipeline's own reading — the anchor cut short
-    // inside the span — exactly as the paragraph case does, and no placeholder
-    // sentinel escapes into it.
     assert!(
         titles
             .iter()
-            .any(|t| t.contains(r##"href="#sec""##) && t.contains("<strong>b</a>")),
-        "the title's carve-out rendering regressed: {titles:?}"
+            .any(|t| t.contains(r##"<a href="#sec" class="hl">a <strong>b, c</strong> d</a>"##)),
+        "the title did not resolve through the tree: {titles:?}"
+    );
+
+    assert!(
+        titles.iter().all(|t| !t.contains("<strong>b</a>")),
+        "the replacer's cut-short anchor came back in a title: {titles:?}"
     );
 
     assert!(
@@ -1540,7 +1545,6 @@ fn a_title_whose_tree_defers_a_reference_form_keeps_the_string_pipelines_renderi
         "a placeholder sentinel reached a rendered title: {titles:?}"
     );
 }
-
 #[test]
 fn an_index_term_macro_hiding_a_reference_keeps_the_string_pipelines_rendering() {
     // The carve-out's **other** shape, and the one no test reached before the

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -259,6 +259,11 @@ fn a_resolved_destination_holding_a_sentinel_survives_the_template_path() {
     // and must not be decoded. Decoding the finished rendering in one pass did
     // decode it, turning `#a\u{e004}b` into `#a\u{e001}`; the template's own
     // literal runs leave escaped form as they are spliced instead.
+    //
+    // The second anchor is whole rather than cut short inside its span since
+    // the deferral divergence (design §5.2's step 6) — the sentinel handling
+    // this test is about is unchanged by that, and the expected bytes simply
+    // carry the tree's reading now.
     let (rendered, warnings) = last_paragraph_and_warnings(CARVE_OUT_SOURCE);
 
     assert_eq!(warnings, 0, "reference did not resolve: {rendered:?}");
@@ -267,7 +272,7 @@ fn a_resolved_destination_holding_a_sentinel_survives_the_template_path() {
         rendered,
         concat!(
             "See <a href=\"#a\u{e004}b\">[a\u{e004}b]</a> and ",
-            "<a href=\"#a\u{e004}b\" class=\"hl\">a <strong>b</a>."
+            "<a href=\"#a\u{e004}b\" class=\"hl\">a <strong>b, c</strong> d</a>."
         ),
         "the id reaches the output as the document wrote it"
     );


### PR DESCRIPTION
The survey's item (2), decided by the maintainer in #1307 and now implemented. `tokened_split_agrees` is gone, with `restored_markup_text` (its only helper) and the image family's `bracket_is_recognizable` (which became always-`true`), and all three call sites — xref, links, image.

> Anchor markup is described rather than quoted below: GitHub rewrites a literal anchor tag in a PR body (it drops `class` and adds `rel`), which silently falsified an earlier revision of this table.

## What the gate actually cost

Clearer from its removal than from its presence. It deferred a match whenever the tokened split and the replacer's markup split disagreed, which meant **a comma inside a span decided whether the macro was recognized at all**:

| source | before |
|---|---|
| `xref:sec[a *b* d,role=hl]` | an anchor to `#sec` carrying `class="hl"`, text `a <strong>b</strong> d` |
| `xref:sec[a *b, c* d,role=hl]` | `xref:sec[a <strong>b, c</strong> d,role=hl]` — **literal text, macro not recognized** |

The gate was not choosing between two readings of a construct. It was refusing the construct.

## After

All three families read the comma case the way they already read the comma-free one:

| source | after |
|---|---|
| `xref:sec[a *b, c* d,role=hl]` | anchor to `#sec`, `class="hl"`, text `a <strong>b, c</strong> d` |
| `link:index.html[a *b, c* d,role=hl]` | anchor to `index.html`, `class="hl"`, same text |
| `image:x.png[a *b, c* d,title=hl]` | `alt="a <strong>b, c</strong> d"`, `title="hl"` |

**The image row was checked rather than assumed.** The baseline already renders `alt="a <strong>b</strong> d"` for the comma-free `image:x.png[a *b* d,title=hl]`, so markup reaching an `alt` is that family's existing behavior; this only stops the comma from suppressing recognition. Nothing new leaks into an attribute.

## The audit reads differently here, and that is the increment

**63 rows either side, 61 distinct sources either side, and the two source sets are identical** — no divergent source appeared or disappeared. The `(source, rendered)` pairs are byte-identical either side too; a set comparison over those two columns differs in nothing at all.

What moved is the **tree's** column, on exactly four rows, for `See xref:sec[a *b, c* d,role=hl]`:

- **folded, before:** `See xref:sec[a <strong>b, c</strong> d,role=hl]` — literal.
- **folded, after:** an anchor to `#sec` with `class="hl"`, whose text is `a <strong>b, c</strong> d`.
- **rendered (both, the string pipeline):** an anchor whose text ends at `a <strong>b` — cut short inside the tag, leaving it unbalanced.

The divergence against the string pipeline **persists** on those four, because the pipeline still writes that cut-short text. What changed is that the tree's answer went from *absent* to *right*.

Reporting this as "four rows closed" would have been wrong, and it is worth saying plainly: the bar this branch uses ("no new row") is a proxy for "no unintended behavior change", and an *intended* one shows up as a row whose fold moved rather than as a row that left. I predicted closed rows before running it; that prediction was wrong.

## Tests

Five asserted the deferral and now assert the reading, each keeping its own subject:

- `an_attribute_list_delimiter_inside_a_span_is_the_trees_to_read` and `a_span_whose_markup_splits_the_attribute_list_is_the_trees_to_read` — pin the fold, and with `assert_ne!` against the golden, pin the divergence itself as bytes.
- `the_xref_mirror_correlates_the_form_that_used_to_defer` — the carve-out closing from resolution's side: counts agree, the positional mirror correlates instead of skipping, the content leaves the template path.
- `a_title_resolves_the_form_that_used_to_defer_on_its_own_path` — the same for `title_refs::compute`'s separate path.
- `a_resolved_destination_holding_a_sentinel_survives_the_template_path` — keeps its sentinel subject, carries the new bytes.

## Preflight

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo test --workspace` (5530 passed), `cargo +nightly doc --no-deps --document-private-items` — all clean. Several stale intra-doc links to the removed items were fixed; `cargo doc` is the only step that catches those.
- **Coverage neutral in total** — 578 missed regions / 329 missed lines either side — and improving where the dead code went: `image.rs` drops from 5/2 to 4/1. `xref.rs` goes 16/7 → 17/8, the one added line being a rewritten test's `let … else { panic!(…) }`.

## What still defers

The survey's list with (1) and (2) struck: the `indexterm2:` gap, the **template**, then the oracle call, the test call sites and `run_pipeline`, the vestigial mechanisms, and the Strategy-A recorder with `inline_recorder`.