### PR TITLE
doc: Measure the template — it is two named cases, not a majority path

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8076,9 +8076,10 @@ Each phase is a reviewable unit with a clear exit gate.
   | tree segments installed, `template` still the pipeline's | 436 | 3.3% |
   | **carve-out** — the pipeline's whole answer stands | 6 | 0.05% |
 
-  So the template is the larger debt by volume. (The 436 here is a count of `set_tree_xrefs` calls
-  that installed a tree answer, not of contents rendering from a template — a later note measures the
-  arm itself and corrects this.) The carve-out is six hits over five
+  So the template looks like the larger debt by volume. (The 436 here is a count of `set_tree_xrefs`
+  calls that installed a tree answer, not of contents rendering from a template. A later note
+  measures `render_template` itself and finds the debt is *smaller* than this suggests, not larger.)
+  The carve-out is six hits over five
   sources — and reading what each one *is* matters more than the count, because the five are **two
   different kinds**, and only one of them is a gap.
 
@@ -8271,44 +8272,67 @@ Each phase is a reviewable unit with a clear exit gate.
   call sites and `run_pipeline` itself, the vestigial mechanisms (now including the carve-out), and
   the Strategy-A recorder with `inline_recorder`.
 
-  *Step 6 landed as (the template, measured — and the survey's figure corrected):* a scoping note
-  rather than a change, and it exists because the deletion survey's own number for this item was
-  measuring the wrong population.
+  *Step 6 landed as (the template, measured — it is two named cases, not a majority path):* a
+  scoping note rather than a change, and it exists because the deletion survey's own number for this
+  item was measuring the wrong population.
 
   That survey called the template "the larger debt by volume (436 contents)". **436 is a count of
   calls to `set_tree_xrefs` that installed a tree answer, not a count of contents that render from a
-  template** — different populations, and the smaller one. Measuring the arm that actually renders
-  says so directly. `Content::resolve_references` chooses between
-  [`refold`](../../parser/src/content/content.rs), which folds the tree and needs no template, and
-  `rebuild_rendered`, which renders one; instrumenting both across the suite:
+  template** — different populations. The first attempt to correct it made the same class of mistake
+  one step further in: it instrumented the *arm choice* in `Content::resolve_references` — `refold`,
+  which folds the tree, against `rebuild_rendered`, which renders a template — and read 330 calls
+  over 210 distinct sources for the fold against 5,944 over 2,437 for the template. That reads as a
+  template-majority path. It is not one. **`rebuild_rendered` opens with an early return on
+  `self.deferred.is_none()`, and every one of those 5,944 calls took it.** They are no-ops on
+  contents that never deferred anything. Counting an arm is not counting a render.
 
-  | arm | calls | distinct sources |
+  Instrumenting `render_template` itself — the single function every template render funnels through
+  — gives the population the item is actually about:
+
+  | production call site | calls | distinct templates |
   |---|---|---|
-  | `refold` (tree-backed) | 330 | **210** |
-  | `rebuild_rendered` (template) | 5,944 | **2,437** |
+  | `finalize_deferred` → `rebuild_rendered` | 794 | 170 |
+  | `Footnote::render` | 225 | 24 |
+  | `title_refs`'s fold fallback | **1** | **1** |
+  | `resolve_references` → `rebuild_rendered` | **0** | — |
 
-  The distinct counts are the ones that matter, and they rule out the obvious innocent explanation:
-  this is not one content re-resolved many times. Roughly **eight percent** of the contents that
-  defer a cross-reference are rendered from the tree; the rest still go through the template. The
-  template is not a residue to be tidied away after the oracle goes — on this measurement it is the
-  majority path.
+  So the two headline claims inverted together. Not eight percent of deferring contents fold their
+  tree — **all of them do**: the 330 fold calls over 210 distinct sources are exactly the contents
+  carrying deferred state, and no content with deferred state reaches `resolve_references`'s template
+  arm at all. And the template is not the majority path; from the resolution pass it renders **zero
+  times**.
 
-  *One thing the measurement settles, and one it opens.* Settled: the fold arm never falls through.
-  Every call with `from_tree` true took `refold` — 330 of 330 — so where the tree's answer is
-  installed it is always the one that renders. Open: why `from_tree` is false for ~2,227 distinct
-  contents that *do* carry deferred state by resolution time. The obvious orderings do not explain it
-  — `set_deferred_xrefs` is called from `apply_macros`, inside the string pipeline's own macros step,
-  which runs *before* `set_tree_xrefs` in `apply_inner`, so a content the oracle deferred on should
-  have its deferred state visible when the tree answer is offered. Whatever accounts for the gap
-  (titles resolving on `title_refs`'s separate path is the first candidate, since it has a template
-  reader of its own) is the question the template increment has to answer first.
+  *What is left is therefore two named cases and one line of bookkeeping,* which is a much smaller
+  and much more specific item than either the survey or its first correction implied:
 
-  *What this does to the decomposition.* The item is unchanged in its position — still gated behind
-  nothing, still the last thing `set_tree_xrefs` takes from the string pipeline's `deferred` state —
-  but it is bigger than the survey implied, and the question is now sharper: not "can the tree
-  produce a placeholder template" but **"why does the tree's answer reach only one content in twelve,
-  and is that a gap or a boundary?"** The carve-out taught the same lesson one scale down: what looked
-  like one number was two kinds, and reading what each case *is* mattered more than counting them.
+  - **`finalize_deferred`'s render (794 calls, 170 templates) is not separate scope.** It runs at the
+    end of `run_pipeline`, rebuilding `rendered` as the *unresolved fallback* so the string is clean
+    for a caller that reads it before resolution. It is the string pipeline's own answer to its own
+    question, and it goes when `run_pipeline` goes — an increment already enumerated in the
+    decomposition, not a new one.
+  - **`Footnote::render` (225 calls, 24 distinct templates) is the one genuinely separate consumer.**
+    A footnote holds its own template and its own segment list and re-renders from them, on a path
+    `refold` never touches. This is the real remaining template work, and it is footnote-shaped
+    rather than content-shaped.
+  - **`title_refs`'s fallback fires exactly once in the whole suite.** One call, one template,
+    `"See \u{e000}0\u{e001}"` — and its shape is precisely what the code comment beside it predicts:
+    `from_tree` true and `render_attributes` present, but `inlines` **empty**. It is the carried block
+    title whose inline nodes cannot cross the `'src`-erasing hop across a section heading, so there is
+    no tree to fold and the template is the only answer available. One source is a boundary, not a
+    gap.
+
+  *What this does to the decomposition.* The item keeps its position — still gated behind nothing —
+  but it shrinks and splits. The question is not "can the tree produce a placeholder template", and
+  not "why does the tree's answer reach only one content in twelve" (it reaches all of them); it is
+  **"can a footnote fold its own tree, and can a carried block title keep one across the `'src` hop?"**
+  Two concrete questions with two concrete subjects, where there was one vague volume estimate.
+
+  *And the methodological point, which cost two rounds to learn.* Both wrong numbers were proxies
+  measured one seam away from the thing they were supposed to describe — first a `set_tree_xrefs`
+  call count standing in for a render, then an arm choice standing in for a render, when the arm's
+  `else` branch is overwhelmingly a no-op. The carve-out taught the same lesson at a smaller scale:
+  reading what each case *is* beats counting the cases. Here it took instrumenting the leaf function
+  and nothing above it.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -10124,21 +10148,19 @@ Each phase is a reviewable unit with a clear exit gate.
        the mirror image of the divergence increment before it. Coverage diff-neutral. See the step's
        own "landed as" note above.
 
-     - ℹ️ **the template is the majority path, not a residue — and the survey's figure was the
+     - ℹ️ **the template is two named cases, not a majority path — and both prior figures were the
        wrong population.** The deletion survey called it "the larger debt by volume (436 contents)";
-       436 counts `set_tree_xrefs` calls that installed a tree answer, not contents that render from
-       a template. Instrumenting the arm that actually renders — `refold` (folds the tree, no
-       template) against `rebuild_rendered` — gives 330 calls over **210 distinct sources** for the
-       fold and 5,944 over **2,437 distinct** for the template. The distinct counts rule out
-       re-resolution: roughly **8%** of contents that defer a cross-reference render from the tree.
-       The measurement settles that the fold arm never falls through (330 of 330 with `from_tree`
-       true took it), and opens why `from_tree` is false for ~2,227 distinct contents that do carry
-       deferred state by resolution — not an ordering problem on the face of it, since
-       `set_deferred_xrefs` runs in `apply_macros` ahead of `set_tree_xrefs`. `title_refs`'s separate
-       path, which has a template reader of its own, is the first candidate. So the question is not
-       "can the tree produce a placeholder template" but "why does the tree's answer reach one
-       content in twelve, and is that a gap or a boundary?" See the step's own "landed as" note
-       above.
+       436 counts `set_tree_xrefs` calls that installed a tree answer. Instrumenting the *arm choice*
+       in `resolve_references` corrected that with a worse number — 330 fold calls over 210 distinct
+       sources against 5,944 over 2,437 for `rebuild_rendered` — because `rebuild_rendered` early-
+       returns on `deferred.is_none()` and **all 5,944 took that return**. Instrumenting
+       `render_template` itself gives the real population: `finalize_deferred` 794 calls / 170
+       templates, `Footnote::render` 225 / 24, `title_refs`'s fallback **1 / 1**, and
+       `resolve_references` **0**. So every content that defers a cross-reference folds its tree (not
+       8% of them), the template renders zero times from the resolution pass, `finalize_deferred`'s
+       render goes with `run_pipeline`, and what remains is `Footnote::render` plus a single carried
+       block title whose `inlines` are empty because they cannot cross the `'src`-erasing hop. See
+       the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8076,7 +8076,9 @@ Each phase is a reviewable unit with a clear exit gate.
   | tree segments installed, `template` still the pipeline's | 436 | 3.3% |
   | **carve-out** — the pipeline's whole answer stands | 6 | 0.05% |
 
-  So the template is the larger debt by volume (436 contents). The carve-out is six hits over five
+  So the template is the larger debt by volume. (The 436 here is a count of `set_tree_xrefs` calls
+  that installed a tree answer, not of contents rendering from a template — a later note measures the
+  arm itself and corrects this.) The carve-out is six hits over five
   sources — and reading what each one *is* matters more than the count, because the five are **two
   different kinds**, and only one of them is a gap.
 
@@ -8268,6 +8270,45 @@ Each phase is a reviewable unit with a clear exit gate.
   *What still defers:* the **template**, then the oracle call, the ~28 `apply_string_pipeline` test
   call sites and `run_pipeline` itself, the vestigial mechanisms (now including the carve-out), and
   the Strategy-A recorder with `inline_recorder`.
+
+  *Step 6 landed as (the template, measured — and the survey's figure corrected):* a scoping note
+  rather than a change, and it exists because the deletion survey's own number for this item was
+  measuring the wrong population.
+
+  That survey called the template "the larger debt by volume (436 contents)". **436 is a count of
+  calls to `set_tree_xrefs` that installed a tree answer, not a count of contents that render from a
+  template** — different populations, and the smaller one. Measuring the arm that actually renders
+  says so directly. `Content::resolve_references` chooses between
+  [`refold`](../../parser/src/content/content.rs), which folds the tree and needs no template, and
+  `rebuild_rendered`, which renders one; instrumenting both across the suite:
+
+  | arm | calls | distinct sources |
+  |---|---|---|
+  | `refold` (tree-backed) | 330 | **210** |
+  | `rebuild_rendered` (template) | 5,944 | **2,437** |
+
+  The distinct counts are the ones that matter, and they rule out the obvious innocent explanation:
+  this is not one content re-resolved many times. Roughly **eight percent** of the contents that
+  defer a cross-reference are rendered from the tree; the rest still go through the template. The
+  template is not a residue to be tidied away after the oracle goes — on this measurement it is the
+  majority path.
+
+  *One thing the measurement settles, and one it opens.* Settled: the fold arm never falls through.
+  Every call with `from_tree` true took `refold` — 330 of 330 — so where the tree's answer is
+  installed it is always the one that renders. Open: why `from_tree` is false for ~2,227 distinct
+  contents that *do* carry deferred state by resolution time. The obvious orderings do not explain it
+  — `set_deferred_xrefs` is called from `apply_macros`, inside the string pipeline's own macros step,
+  which runs *before* `set_tree_xrefs` in `apply_inner`, so a content the oracle deferred on should
+  have its deferred state visible when the tree answer is offered. Whatever accounts for the gap
+  (titles resolving on `title_refs`'s separate path is the first candidate, since it has a template
+  reader of its own) is the question the template increment has to answer first.
+
+  *What this does to the decomposition.* The item is unchanged in its position — still gated behind
+  nothing, still the last thing `set_tree_xrefs` takes from the string pipeline's `deferred` state —
+  but it is bigger than the survey implied, and the question is now sharper: not "can the tree
+  produce a placeholder template" but **"why does the tree's answer reach only one content in twelve,
+  and is that a gap or a boundary?"** The carve-out taught the same lesson one scale down: what looked
+  like one number was two kinds, and reading what each case *is* mattered more than counting them.
 
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
@@ -10082,6 +10123,22 @@ Each phase is a reviewable unit with a clear exit gate.
        62 rows against 63, 0 new and 1 closed — the pipeline was right here and the tree caught up,
        the mirror image of the divergence increment before it. Coverage diff-neutral. See the step's
        own "landed as" note above.
+
+     - ℹ️ **the template is the majority path, not a residue — and the survey's figure was the
+       wrong population.** The deletion survey called it "the larger debt by volume (436 contents)";
+       436 counts `set_tree_xrefs` calls that installed a tree answer, not contents that render from
+       a template. Instrumenting the arm that actually renders — `refold` (folds the tree, no
+       template) against `rebuild_rendered` — gives 330 calls over **210 distinct sources** for the
+       fold and 5,944 over **2,437 distinct** for the template. The distinct counts rule out
+       re-resolution: roughly **8%** of contents that defer a cross-reference render from the tree.
+       The measurement settles that the fold arm never falls through (330 of 330 with `from_tree`
+       true took it), and opens why `from_tree` is false for ~2,227 distinct contents that do carry
+       deferred state by resolution — not an ordering problem on the face of it, since
+       `set_deferred_xrefs` runs in `apply_macros` ahead of `set_tree_xrefs`. `title_refs`'s separate
+       path, which has a template reader of its own, is the first candidate. So the question is not
+       "can the tree produce a placeholder template" but "why does the tree's answer reach one
+       content in twelve, and is that a gap or a boundary?" See the step's own "landed as" note
+       above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a


### PR DESCRIPTION
A scoping note rather than a change, and it exists because the deletion survey's own number for this item was measuring the wrong population.

Documentation only; nothing in production moved.

## Two wrong numbers, and what they had in common

#1307 called the template *"the larger debt by volume (436 contents)"*. **436 counts calls to `set_tree_xrefs` that installed a tree answer — not contents that render from a template.**

The first commit on this branch corrected that with a *worse* number. It instrumented the **arm choice** in `Content::resolve_references` — `refold`, which folds the tree, against `rebuild_rendered`, which renders a template — and read:

| arm | calls | distinct sources |
|---|---|---|
| `refold` | 330 | 210 |
| `rebuild_rendered` | 5,944 | 2,437 |

…and concluded the template was the majority path and the tree's answer reached one content in twelve. **It is not, and it does not.** `rebuild_rendered` opens with an early return on `self.deferred.is_none()`, and **all 5,944 of those calls took it**. They are no-ops on contents that never deferred anything.

Counting an arm is not counting a render. Both figures were proxies measured one seam away from the thing they described.

## The actual measurement

Instrumenting `render_template` itself — the single function every template render funnels through:

| production call site | calls | distinct templates |
|---|---|---|
| `finalize_deferred` → `rebuild_rendered` | 794 | 170 |
| `Footnote::render` | 225 | 24 |
| `title_refs`'s fold fallback | **1** | **1** |
| `resolve_references` → `rebuild_rendered` | **0** | — |

Both headline claims invert:

- **Every** content that defers a cross-reference folds its tree — the 330 calls over 210 distinct sources are exactly that population, and no content with deferred state reaches the template arm at all. Not 8%.
- From the resolution pass the template renders **zero times**.

## What is left: two named cases and one line of bookkeeping

- **`finalize_deferred`'s render (794 / 170) is not separate scope.** It runs at the end of `run_pipeline`, rebuilding `rendered` as the *unresolved fallback* so the string is clean for a caller reading it before resolution. It is the string pipeline's own answer to its own question, and it goes when `run_pipeline` goes — an increment already enumerated in the decomposition.
- **`Footnote::render` (225 / 24) is the one genuinely separate consumer.** A footnote holds its own template and segment list and re-renders from them, on a path `refold` never touches. This is the real remaining work, and it is footnote-shaped rather than content-shaped.
- **The `title_refs` fallback fires exactly once in the whole suite** — one call, one template — and its shape is precisely what the code comment beside it predicts: `from_tree` true, `render_attributes` present, `inlines` **empty**. It is the carried block title whose inline nodes cannot cross the `'src`-erasing hop across a section heading. One source is a boundary, not a gap.

So the item **shrinks and splits**. The question is not *"can the tree produce a placeholder template"*, and not *"why does the tree's answer reach only one content in twelve"* (it reaches all of them), but:

> **"Can a footnote fold its own tree, and can a carried block title keep one across the `'src` hop?"**

Two concrete questions with two concrete subjects, where there was one vague volume estimate.

## Shape of the change

Two commits, deliberately. The second **rewrites** the first's note rather than appending a correction to it, so the design doc ends correct — a wrong paragraph plus a right one would leave the wrong one in the artifact forever. The commit message keeps the path visible.

The `436` in the original survey paragraph is annotated in place rather than rewritten, so the reasoning that produced it stays legible; the annotation now says the debt is *smaller* than 436 suggests, not larger.

## Preflight

`cargo +nightly fmt --all -- --check` and `cargo test --workspace` clean. No audit or coverage claim: a design-doc note plus a Phase 4 checklist entry, with no production line touched. All instrumentation was reverted before committing (verified — `git status` clean against the two Rust files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_