### PR TITLE
chore: Retire build_inline_tree, the with_inline_tree remnant (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8334,6 +8334,45 @@ Each phase is a reviewable unit with a clear exit gate.
   reading what each case *is* beats counting the cases. Here it took instrumenting the leaf function
   and nothing above it.
 
+  *Step 6 landed as (`build_inline_tree` retired, and the seam's two "otherwise" causes told
+  apart):* the first of the vestigial mechanisms the deletion survey enumerated, removed on its own.
+
+  `Parser::build_inline_tree` is what remained of the `with_inline_tree` opt-in after that switch was
+  retired. It was `true` for every parser a caller can construct, and its only surviving consumer was
+  a crate test that set it to `false` in order to exercise the field. Measured across the suite it is
+  false for **1 of 13,299** parses reaching the seam — that one test.
+
+  So the field is gone, and `SubstitutionGroup::apply`'s seed condition drops from
+  `parser.build_inline_tree && !parser.in_inline_build.get()` to the reentrancy guard alone. No
+  production parse changes: the conjunct removed was true in every one of the other 13,298.
+
+  *What the increment actually turned up*, and the reason it is worth a note rather than a line in a
+  commit message: **the seam's two "otherwise" causes were never equivalent, and the retired one was
+  carrying the test.** The `None` branch is taken when no tree is built, which had two causes — a
+  parse configured to build none, and a pass re-entered under the reentrancy guard — and the obvious
+  move was to re-point the test from the first cause at the second. That fails, and the failure is
+  the interesting part:
+
+  - A **tree-less parse** must *keep* the string pipeline's warnings where they are raised. Nothing
+    encloses it, so there is nobody to hand them back.
+  - A pass under the **reentrancy guard** must *stash* them in `nested_authoritative_warnings`, for
+    the enclosing build to restore.
+
+  The `None` branch does the second (`if parser.in_inline_build.get()`), so a test that sets the
+  guard with no build around it sees the warnings stashed and dropped. That is not a bug — it is a
+  state production cannot construct — but it means the warning half of the old test belonged to the
+  cause being retired, and asserting it from the surviving cause would have pinned the behavior of an
+  impossible parser. The replacement asserts only what the guard actually contracts: **a pass under it
+  builds no tree.**
+
+  *What this does not do.* It leaves `in_inline_build` and `nested_authoritative_warnings` in place.
+  They are the two ends of one mechanism — the guard stashes, the enclosing build restores — and the
+  seam's own comment already says removing one end while leaving the other is worse than removing
+  neither. `in_inline_build` is true for **0 of 13,299** parses at this seam, so the pair is dead in
+  practice and is the next increment; but it is dead by *measurement*, and the guard is what stands
+  between a re-entry and a nested tree build, so retiring it is a deliberate step rather than a
+  side effect of this one.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10161,6 +10200,18 @@ Each phase is a reviewable unit with a clear exit gate.
        render goes with `run_pipeline`, and what remains is `Footnote::render` plus a single carried
        block title whose `inlines` are empty because they cannot cross the `'src`-erasing hop. See
        the step's own "landed as" note above.
+
+     - ✅ **`build_inline_tree` retired — the last remnant of the `with_inline_tree` opt-in.** The
+       field was `true` for every parser the public API can construct (measured false for 1 of 13,299
+       parses reaching the seam: the one crate test that set it), so the seed condition drops to the
+       reentrancy guard alone and no production parse changes. The increment turned up that the
+       seam's two "otherwise" causes are **not** equivalent — a tree-less parse must *keep* the
+       string pipeline's warnings, a pass under the reentrancy guard must *stash* them for the
+       enclosing build — so the old test's warning assertion belonged to the retired cause and the
+       replacement pins what the guard actually contracts: a pass under it builds no tree.
+       `in_inline_build` and `nested_authoritative_warnings` stay: they are the two ends of one
+       mechanism, dead by measurement (0 of 13,299) but not by construction. See the step's own
+       "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -268,12 +268,13 @@ impl SubstitutionGroup {
         // are seeded from it, so the authoritative one sees exactly what the
         // oracle does.
         //
-        // `build_inline_tree` is no longer an opt-in switch — every parse
-        // builds the tree — but it is still the *configuration* half of "does
-        // this call build one". The reentrancy half moved to
-        // `Parser::in_inline_build`, because the parser the build runs on is
-        // the real one now and cannot have a field cleared on it.
-        let tree_seed = if parser.build_inline_tree && !parser.in_inline_build.get() {
+        // Every parse builds the tree, so the only question left is
+        // reentrancy: `Parser::in_inline_build` is set for the duration of a
+        // build, because the parser the build runs on is the real one now and
+        // cannot have a configuration field cleared on it. The `with_inline_tree`
+        // opt-in that used to gate this as well is retired, and so is the
+        // `build_inline_tree` field that outlived it.
+        let tree_seed = if !parser.in_inline_build.get() {
             Some(content.rendered.clone())
         } else {
             None
@@ -312,8 +313,9 @@ impl SubstitutionGroup {
             // therefore that body's authoritative pass. `passthrough_text`
             // builds and folds the body's own tree now, so the re-entry is
             // gone. Measured across the suite, this branch went from 112 hits
-            // to 1, and the one that remains is the crate test that turns
-            // `build_inline_tree` off deliberately.
+            // to 1, and the one that remains is the crate test that sets the
+            // reentrancy guard deliberately — `in_inline_build` is true for
+            // 0 of the 13,299 parses the suite reaches this seam with.
             //
             // That is what makes `run_pipeline` deletable: with the oracle
             // above writing nothing anyone reads and this branch reaching only

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -470,20 +470,6 @@ pub struct Parser {
     /// with only a shared reference).
     datetime_context: RefCell<Option<DatetimeContext>>,
 
-    /// Whether each [`Content`](crate::content::Content) built with this parser
-    /// also builds its inline AST (see `content::inline_builder`) and stores it
-    /// for [`Content::inlines`](crate::content::Content::inlines).
-    ///
-    /// `true` for every parser a caller can construct — the opt-in
-    /// `with_inline_tree` switch this used to carry is retired, and every parse
-    /// now builds the tree. What survives is the **recursion guard** that
-    /// switch's plumbing also served: `SubstitutionGroup::apply` clears it on
-    /// the clone it hands the builder, because building a tree re-enters
-    /// `apply` for a passthrough body whose own substitution list must run
-    /// (`passthrough_step::passthrough_text`), and that nested content needs no
-    /// tree of its own. Nothing else sets it, and no public API exposes it.
-    pub(crate) build_inline_tree: bool,
-
     /// Whether the **string pipeline's** recognition side effects — an image
     /// target, a link target, an inline anchor's or bibliography entry's id,
     /// the image family's dangerous-`link=`-scheme warning, and a callout
@@ -523,12 +509,13 @@ pub struct Parser {
     /// body while the builder is running (via `passthrough_text`), and that
     /// nested content needs no tree.
     ///
-    /// This used to ride on [`build_inline_tree`](Self::build_inline_tree),
-    /// which the seam could clear because the parser driving the build was an
-    /// owned clone. It is the **real** parser now, held by shared reference, so
-    /// the guard needs a cell of its own — and the two questions it was
-    /// answering come apart cleanly: `build_inline_tree` is *configuration*
-    /// (does this parse build trees at all), this is *reentrancy*.
+    /// This used to ride on a `build_inline_tree` configuration field, which
+    /// the seam could clear because the parser driving the build was an owned
+    /// clone. It is the **real** parser now, held by shared reference, so the
+    /// guard needs a cell of its own — and once the `with_inline_tree` opt-in
+    /// was retired, configuration had no question left to answer (every parse
+    /// builds the tree) while reentrancy still did. That field is gone; this
+    /// cell is the whole of what the seam reads.
     pub(crate) in_inline_build: std::cell::Cell<bool>,
 
     /// Substitution warnings raised by an **authoritative** pass that ran
@@ -666,7 +653,6 @@ impl Default for Parser {
             reference_time: None,
             input_mtime: None,
             datetime_context: RefCell::new(None),
-            build_inline_tree: true,
             suppress_recognition_side_effects: std::cell::Cell::new(false),
             in_inline_build: std::cell::Cell::new(false),
             nested_authoritative_warnings: RefCell::new(vec![]),

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1098,51 +1098,38 @@ fn inline_tree_is_built_by_default() {
 }
 
 #[test]
-fn a_parse_that_builds_no_tree_keeps_the_string_pipelines_warnings() {
-    // The other half of `build_inline_tree`, and the branch the inversion made
-    // reachable in a second way.
+fn a_pass_under_the_reentrancy_guard_builds_no_tree() {
+    // The branch the inversion left behind, and the one reason it still exists.
     //
     // Since the inversion the seam sends `run_pipeline` to a *clone* whenever a
-    // tree is being built, and to the real parser otherwise. "Otherwise" now
-    // has two causes: a passthrough body re-entered from inside a build (the
-    // reentrancy guard), and a parse configured to build no tree at all —
-    // this one. The first runs inside a build whose blanket warning discard it
-    // has to be carried across; the second does not, and must not be, or the
-    // warnings would be stashed with nothing to hand them back.
+    // tree is being built, and to the real parser otherwise. "Otherwise" had two
+    // causes: a parse configured to build no tree at all, and a passthrough body
+    // re-entered from inside a build. The first is gone — `with_inline_tree` is
+    // retired, every parse builds the tree, and the `build_inline_tree` field
+    // that outlived that switch is retired with it. What is left is the
+    // reentrancy guard, and its contract is this: a pass reaching the seam under
+    // it builds no tree of its own.
     //
-    // `with_inline_tree` is retired, so `build_inline_tree` is `true` for every
-    // parse the public API can produce and only a crate test reaches this. It
-    // is still the configuration the seam reads, and the branch it selects is
-    // real, so it is exercised here rather than left to be assumed.
-    let mut parser = Parser::default().with_intrinsic_attribute(
-        "attribute-missing",
-        "warn",
-        crate::parser::ModificationContext::Anywhere,
-    );
+    // Only that half is asserted here. The warning half belonged to the cause
+    // that is gone: a *tree-less parse* had to keep the string pipeline's
+    // warnings where they were raised, because nothing would hand them back,
+    // whereas a pass under this guard stashes them in
+    // `nested_authoritative_warnings` for the enclosing build to restore. That
+    // is correct precisely because the guard is only ever set by a build — so
+    // pinning it from a test that sets the guard with no build around it would
+    // assert the behavior of a state production cannot construct. Setting the
+    // guard directly is still the only way in (`in_inline_build` is true for 0
+    // of the 13,299 parses the suite reaches this seam with), which is why the
+    // branch is worth pinning at all rather than leaving to be assumed.
+    let mut parser = Parser::default();
 
-    parser.build_inline_tree = false;
+    parser.in_inline_build.set(true);
 
-    let doc = parser.parse("A paragraph with {missing} in it.");
+    let doc = parser.parse("A paragraph with *bold* in it.");
 
-    let warnings: Vec<_> = doc
-        .warnings()
-        .map(|warning| warning.warning.clone())
-        .collect();
-
-    assert_eq!(
-        warnings,
-        [
-            crate::warnings::WarningType::SkippingReferenceToMissingAttribute(
-                "missing".to_string()
-            )
-        ],
-        "a tree-less parse lost the string pipeline's own warning"
-    );
-
-    // And no tree, which is what the configuration says.
     assert!(
         first_simple_inlines(&doc).is_empty(),
-        "a parse with `build_inline_tree` off must build no tree"
+        "a pass under the reentrancy guard must build no tree"
     );
 }
 


### PR DESCRIPTION
The first of the vestigial mechanisms the deletion survey enumerated, removed on its own.

## What goes

`Parser::build_inline_tree` is what remained of the `with_inline_tree` opt-in after that switch was retired. It was `true` for every parser a caller can construct, and its only surviving consumer was a crate test that set it to `false` in order to exercise the field.

Measured across the suite, it is false for **1 of 13,299** parses reaching the seam — that one test.

So the field is gone and `SubstitutionGroup::apply`'s seed condition drops from

```rust
let tree_seed = if parser.build_inline_tree && !parser.in_inline_build.get() {
```

to the reentrancy guard alone. **No production parse changes**: the conjunct removed was true in every one of the other 13,298.

## What the increment turned up

The obvious move was to re-point the old test from the retired cause at the surviving one. That fails, and the failure is the interesting part — **the seam's two "otherwise" causes were never equivalent, and the retired one was carrying the test.**

The `None` branch is taken when no tree is built, which had two causes:

| cause | what it must do with the string pipeline's warnings |
|---|---|
| a parse configured to build no tree | **keep** them where raised — nothing encloses it to hand them back |
| a pass under the reentrancy guard | **stash** them in `nested_authoritative_warnings` for the enclosing build to restore |

The branch does the second (`if parser.in_inline_build.get()`), so a test that sets the guard with no build around it sees the warnings stashed and dropped. That isn't a bug — it's a state production cannot construct — but it means the warning assertion in the old test belonged to the cause being retired. Asserting it from the surviving cause would pin the behavior of an impossible parser.

The replacement asserts only what the guard actually contracts: **a pass under it builds no tree.**

## What this deliberately does not do

`in_inline_build` and `nested_authoritative_warnings` stay. They are the two ends of one mechanism — the guard stashes, the enclosing build restores — and the seam's own comment already says removing one end while leaving the other is worse than removing neither. The pair is dead in practice (`in_inline_build` is true for **0 of 13,299** parses at this seam), but dead by *measurement*, not by construction, and the guard is what stands between a re-entry and a nested tree build. Retiring it is the next increment, deliberately, rather than a side effect of this one.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5530 passed
- `cargo +nightly doc --no-deps --document-private-items` — clean

**Fold-parity audit** (rebuilt as a throwaway patch, run on this branch and on `origin/inline-ast`, both single-threaded): 62 distinct divergences on each side — **zero new, zero closed**. Expected exactly, for a change that removes an always-true conjunct.

**Coverage** — this one *improves*, rather than being diff-neutral:

| file | missed regions | missed lines |
|---|---|---|
| `content/substitution_group.rs` before | 6 | 6 |
| `content/substitution_group.rs` after | **1** | **0** |

`parser/parser.rs` is unchanged (90 / 76). The gain is the same finding as above: the old test took the `None` branch with `in_inline_build` false, so the stash was never entered; the new test sets the guard, so it is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_