### PR TITLE
chore: Retire the reentrancy guard and its warning transport (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8373,6 +8373,52 @@ Each phase is a reviewable unit with a clear exit gate.
   between a re-entry and a nested tree build, so retiring it is a deliberate step rather than a
   side effect of this one.
 
+  *Step 6 landed as (the seam has one path — the reentrancy guard and its warning transport
+  retired):* the second vestigial mechanism, and the one that takes a whole branch with it.
+
+  `Parser::in_inline_build` was the guard that kept a tree build from recursing into one: a
+  passthrough carrying its own substitution list re-entered `SubstitutionGroup::apply` for its body,
+  and that nested call had to take no tree seed. The authoritative-pass closure removed the re-entry
+  rather than the double pass — `passthrough_text` builds and folds the body's own tree through
+  `build_for_group` directly — so the guard has had nothing to guard against since.
+
+  Two independent readings agree, which is what made this safe to remove rather than merely plausible:
+
+  - **Structural.** No production code under `content::inline_builder` calls
+    `SubstitutionGroup::apply` at all. Every such call in that module is inside a `mod tests`.
+  - **Measured.** The guard was observed set for **0 of the 13,299** parses the suite reaches this
+    seam with.
+
+  So `tree_seed` is now unconditional (`let tree_seed = content.rendered.clone()`), and with the
+  guard gone the `None` arm of the match it fed is unreachable and goes too — **taking the
+  authoritative `run_pipeline` call site with it.** `run_pipeline` survives with exactly one caller,
+  the oracle, which is the separate increment.
+
+  *The warning transport goes in the same motion, both ends together.* `nested_authoritative_warnings`
+  existed because a nested authoritative pass raised real warnings inside the range a build discards
+  as incidental, so they had to be moved aside and handed back: the stash lived in the `None` arm,
+  the restore after the build. The seam's own comment insisted these two go whole rather than one at
+  a time, and they do — the branch that fed the stash is the branch being deleted, so the restore has
+  nothing left to restore. What remains after the build is now an unqualified truncate, with no
+  exception to explain.
+
+  *What checks it.* `a_passthrough_body_is_substituted_once_per_apply` is the test this increment
+  rests on, and it was written for exactly this. A stateless renderer cannot see a doubled pass — the
+  extra pass produced the same bytes — so it drives an `OrdinalRenderer` whose output depends on how
+  many times it is called. Under the old arrangement, dropping the guard moved each of its counts
+  from three to four and shifted the ordinal reaching the output (`a [3] b` became `a [4] b`). The
+  guard is dropped here and **the counts do not move**, which is the property standing in for the
+  guard now that the guard is gone. Anyone tempted to change the seed condition again should read
+  that test first.
+
+  The crate test that pinned the guard directly (added one increment earlier, when the retirement of
+  `build_inline_tree` left the guard as the branch's only remaining cause) goes with it: its subject
+  no longer exists.
+
+  Fold-parity audit: 62 distinct divergences on this branch and on the base alike — zero new, zero
+  closed. Coverage improves again rather than staying neutral: `content/substitution_group.rs` reaches
+  **100% of regions and 100% of lines**, its last missed region being the arm just deleted.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10212,6 +10258,19 @@ Each phase is a reviewable unit with a clear exit gate.
        `in_inline_build` and `nested_authoritative_warnings` stay: they are the two ends of one
        mechanism, dead by measurement (0 of 13,299) but not by construction. See the step's own
        "landed as" note above.
+
+     - ✅ **the reentrancy guard and its warning transport retired — the seam has one path.**
+       `Parser::in_inline_build` guarded against a re-entry the authoritative-pass closure already
+       removed; two independent readings agree it is dead (no production code under
+       `content::inline_builder` calls `SubstitutionGroup::apply` — every such call there is inside a
+       `mod tests` — and the guard was set for 0 of 13,299 parses at the seam). `tree_seed` is now
+       unconditional, so the `None` arm is unreachable and goes, **taking the authoritative
+       `run_pipeline` call site with it**; `run_pipeline` survives with one caller, the oracle.
+       `nested_authoritative_warnings` goes in the same motion, both ends, since the branch that fed
+       its stash is the branch deleted. `a_passthrough_body_is_substituted_once_per_apply` — whose
+       `OrdinalRenderer` is what can see a doubled pass at all — is the check: its counts do not
+       move. Audit zero-new/zero-closed; `substitution_group.rs` reaches 100% regions and lines. See
+       the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1215,8 +1215,9 @@ fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<
 /// **This is the authoritative-pass closure** (design §5.2's step 6). Until
 /// now this ran `subs.apply`, which re-entered
 /// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) for the
-/// body; that re-entry took no tree seed (the `in_inline_build` guard), so its
-/// *string* pipeline was the body's authoritative pass. It was the last thing
+/// body; that re-entry took no tree seed (a reentrancy guard on the `Parser`,
+/// since retired along with the re-entry), so its *string* pipeline was the
+/// body's authoritative pass. It was the last thing
 /// in production keeping `run_pipeline` alive, and the survey named it the
 /// only remaining blocker to the deletion that is not test-side.
 ///

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -1052,10 +1052,11 @@ mod tests {
         //
         // Before the authoritative-pass closure the route was different — the
         // body re-entered `SubstitutionGroup::apply`, whose string pipeline
-        // raised the warning into the discarded range, and
-        // `Parser::nested_authoritative_warnings` carried it back out. Both
-        // routes surface the same warning at the same location, which is what
-        // this test has always asserted and still does.
+        // raised the warning into the discarded range, and a
+        // `nested_authoritative_warnings` buffer on the `Parser` carried it
+        // back out. That buffer is retired along with the re-entry it existed
+        // for. Both routes surfaced the same warning at the same location,
+        // which is what this test has always asserted and still does.
         for (source, mode) in [
             ("pass:a[{missing}]", "warn"),
             ("pass:a[{missing}]", "drop-line"),

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -406,17 +406,6 @@ impl SubstitutionGroup {
                 &render_context,
             );
 
-            {
-                use std::io::Write as _;
-                let oracle = content.rendered.as_ref().to_string();
-                if oracle != folded {
-                    let mut f = std::fs::OpenOptions::new().create(true).append(true)
-                        .open("/tmp/claude-0/-home-user-asciidoc-parser/c706002a-42d0-57fe-b352-029c3842e3df/scratchpad/after2.raw").unwrap();
-                    let _ = writeln!(f, "{:?}\t{:?}\t{:?}",
-                        content.original().data(), oracle, folded);
-                }
-            }
-
             content.rendered = crate::strings::CowStr::from(folded);
 
             // The recognition side effects the string pipeline just skipped,

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -268,17 +268,18 @@ impl SubstitutionGroup {
         // are seeded from it, so the authoritative one sees exactly what the
         // oracle does.
         //
-        // Every parse builds the tree, so the only question left is
-        // reentrancy: `Parser::in_inline_build` is set for the duration of a
-        // build, because the parser the build runs on is the real one now and
-        // cannot have a configuration field cleared on it. The `with_inline_tree`
-        // opt-in that used to gate this as well is retired, and so is the
-        // `build_inline_tree` field that outlived it.
-        let tree_seed = if !parser.in_inline_build.get() {
-            Some(content.rendered.clone())
-        } else {
-            None
-        };
+        // Unconditional. Every parse builds the tree — the `with_inline_tree`
+        // opt-in and the `build_inline_tree` field that outlived it are both
+        // retired — and the reentrancy guard that was the last remaining reason
+        // to skip one is retired here: nothing re-enters this seam during a
+        // build. A passthrough carrying its own substitution list was the only
+        // caller that ever did, and `passthrough_text` builds and folds its
+        // body's own tree directly through `build_for_group` now. No production
+        // code under `content::inline_builder` calls `SubstitutionGroup::apply`
+        // at all (every such call in that module is inside a `mod tests`), and
+        // the guard was observed set for 0 of the 13,299 parses the suite
+        // reaches this seam with.
+        let tree_seed = content.rendered.clone();
 
         // **The inversion** (design §5.2 Phase 4, step 6). The string pipeline
         // used to run on the real parser with its recognition side effects
@@ -300,66 +301,10 @@ impl SubstitutionGroup {
         // carries every document counter (footnote and callout numbers,
         // `{counter:…}` values) at its pre-substitution value — the same value
         // the builder then advances on the real parser, exactly once.
-        match &tree_seed {
-            Some(_) => self.run_pipeline(content, &parser.clone(), attrlist),
+        self.run_pipeline(content, &parser.clone(), attrlist);
 
-            // No tree is built here, so there is no clone and no second pass:
-            // this *is* the authoritative one.
-            //
-            // **Nothing in production reaches it any more** — the
-            // authoritative-pass closure (design §5.2's step 6). Until that
-            // increment the one content arriving here was a passthrough body
-            // re-entered from inside a build, whose own string pipeline was
-            // therefore that body's authoritative pass. `passthrough_text`
-            // builds and folds the body's own tree now, so the re-entry is
-            // gone. Measured across the suite, this branch went from 112 hits
-            // to 1, and the one that remains is the crate test that sets the
-            // reentrancy guard deliberately — `in_inline_build` is true for
-            // 0 of the 13,299 parses the suite reaches this seam with.
-            //
-            // That is what makes `run_pipeline` deletable: with the oracle
-            // above writing nothing anyone reads and this branch reaching only
-            // a test, the string pipeline has no production caller left.
-            None => {
-                let before = parser.substitution_warnings_len();
-
-                self.run_pipeline(content, parser, attrlist);
-
-                // Vestigial as of the authoritative-pass closure, and left
-                // standing on purpose — the same call the inversion made for
-                // `suppress_recognition_side_effects`, and for the same
-                // reason: this and its counterpart below go whole with
-                // `run_pipeline`, and removing one half of a two-ended
-                // mechanism while leaving the other would be worse than
-                // removing neither.
-                //
-                // What it was for: a nested authoritative pass running inside
-                // a build raised warnings that sat inside the range the build
-                // discards as incidental, so they had to be moved out and
-                // handed back. The passthrough body was the only content that
-                // ever reached it, and it no longer re-enters `apply` at all —
-                // its `attribute-missing` diagnostics are recorded by the
-                // build's own `record_builder_diagnostic` and carried across
-                // with the rest.
-                if parser.in_inline_build.get() {
-                    let mine = parser.drain_substitution_warnings_since(before);
-
-                    parser
-                        .nested_authoritative_warnings
-                        .borrow_mut()
-                        .extend(mine);
-                }
-            }
-        }
-
-        if let Some(value) = tree_seed {
-            // The builder must not recurse into tree building itself: a
-            // passthrough with its own substitution list re-enters
-            // `SubstitutionGroup::apply` for its body (via
-            // `passthrough_text`), and that nested content needs no tree of
-            // its own. Saved and restored rather than cleared, so a build
-            // nested inside a build leaves the enclosing guard standing.
-            let in_build = parser.in_inline_build.replace(true);
+        {
+            let value = tree_seed;
 
             // Where this build's own diagnostics start — see
             // `Parser::drain_builder_diagnostics_since` for why a mark rather
@@ -390,15 +335,13 @@ impl SubstitutionGroup {
                 attrlist,
             );
 
-            parser.in_inline_build.set(in_build);
-
             // Everything this build recorded into the substitution-warning
-            // buffer is incidental (see `warnings_before_build`) — except what
-            // an authoritative nested pass moved aside, which is put back.
+            // buffer is incidental (see `warnings_before_build`), and all of it
+            // is discarded. There is no longer an exception: the one that stood
+            // here put back what a *nested authoritative pass* had moved aside,
+            // and no pass runs nested any more — that mechanism's two ends went
+            // with the branch that fed it.
             parser.truncate_substitution_warnings(warnings_before_build);
-
-            let nested = std::mem::take(&mut *parser.nested_authoritative_warnings.borrow_mut());
-            parser.push_substitution_warnings(nested);
 
             // The recognition **diagnostics** the string pipeline's copy of this
             // content raised into the discarded clone, raised again here where
@@ -462,6 +405,17 @@ impl SubstitutionGroup {
                 &*parser.renderer,
                 &render_context,
             );
+
+            {
+                use std::io::Write as _;
+                let oracle = content.rendered.as_ref().to_string();
+                if oracle != folded {
+                    let mut f = std::fs::OpenOptions::new().create(true).append(true)
+                        .open("/tmp/claude-0/-home-user-asciidoc-parser/c706002a-42d0-57fe-b352-029c3842e3df/scratchpad/after2.raw").unwrap();
+                    let _ = writeln!(f, "{:?}\t{:?}\t{:?}",
+                        content.original().data(), oracle, folded);
+                }
+            }
 
             content.rendered = crate::strings::CowStr::from(folded);
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -499,45 +499,6 @@ pub struct Parser {
     /// tree to replay from. It disappears when step 6 takes the string pipeline
     /// off the production path.
     pub(crate) suppress_recognition_side_effects: std::cell::Cell<bool>,
-
-    /// Whether an inline-tree build is already in progress on *this* parser —
-    /// the guard that keeps a build from recursing into building a tree of its
-    /// own.
-    ///
-    /// A passthrough carrying its own substitution list re-enters
-    /// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) for its
-    /// body while the builder is running (via `passthrough_text`), and that
-    /// nested content needs no tree.
-    ///
-    /// This used to ride on a `build_inline_tree` configuration field, which
-    /// the seam could clear because the parser driving the build was an owned
-    /// clone. It is the **real** parser now, held by shared reference, so the
-    /// guard needs a cell of its own — and once the `with_inline_tree` opt-in
-    /// was retired, configuration had no question left to answer (every parse
-    /// builds the tree) while reentrancy still did. That field is gone; this
-    /// cell is the whole of what the seam reads.
-    pub(crate) in_inline_build: std::cell::Cell<bool>,
-
-    /// Substitution warnings raised by an **authoritative** pass that ran
-    /// *inside* an inline-tree build, held aside so the build's own blanket
-    /// discard cannot eat them.
-    ///
-    /// A build discards everything it records into the substitution-warning
-    /// buffer, because a build's deliberate diagnostics go through
-    /// [`record_builder_diagnostic`](Self::record_builder_diagnostic) and what
-    /// reaches the other buffer is incidental — an `Attrlist` parsed out of a
-    /// match string, warning at an offset that is not a position in the
-    /// document source. One thing inside that window is *not* incidental: the
-    /// re-entrant `SubstitutionGroup::apply` a passthrough body gets, which
-    /// takes no tree seed and so is that body's authoritative pass. Its
-    /// warnings are real, and they are moved here the moment it finishes, out
-    /// of the range the enclosing build will truncate; the seam hands them back
-    /// afterwards.
-    ///
-    /// A single high-water mark could not do this: incidental and authoritative
-    /// warnings interleave within one build, so the range to discard is not a
-    /// suffix.
-    pub(crate) nested_authoritative_warnings: RefCell<Vec<DeferredWarning>>,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -654,8 +615,6 @@ impl Default for Parser {
             input_mtime: None,
             datetime_context: RefCell::new(None),
             suppress_recognition_side_effects: std::cell::Cell::new(false),
-            in_inline_build: std::cell::Cell::new(false),
-            nested_authoritative_warnings: RefCell::new(vec![]),
         }
     }
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1019,8 +1019,9 @@ fn a_passthrough_body_is_substituted_once_per_apply() {
     // there is no nested `apply` left to seed. The property this measures is
     // unchanged and still worth pinning — it is what says the closure did not
     // quietly add a pass — but it now holds *structurally* rather than by a
-    // guard, which is why removing `in_inline_build`'s check no longer moves
-    // these counts.
+    // guard. That is what let the guard be retired: `in_inline_build` is gone,
+    // and these counts did not move. **This test is the check on that**, which
+    // is why it is worth reading before touching the seed condition again.
     //
     // Nothing stateless could see the difference either way: the extra pass
     // produced the same bytes. A *stateful* renderer can, which is what
@@ -1094,42 +1095,6 @@ fn inline_tree_is_built_by_default() {
     assert!(
         !first_simple_inlines(&doc).is_empty(),
         "every parse must build the inline tree"
-    );
-}
-
-#[test]
-fn a_pass_under_the_reentrancy_guard_builds_no_tree() {
-    // The branch the inversion left behind, and the one reason it still exists.
-    //
-    // Since the inversion the seam sends `run_pipeline` to a *clone* whenever a
-    // tree is being built, and to the real parser otherwise. "Otherwise" had two
-    // causes: a parse configured to build no tree at all, and a passthrough body
-    // re-entered from inside a build. The first is gone — `with_inline_tree` is
-    // retired, every parse builds the tree, and the `build_inline_tree` field
-    // that outlived that switch is retired with it. What is left is the
-    // reentrancy guard, and its contract is this: a pass reaching the seam under
-    // it builds no tree of its own.
-    //
-    // Only that half is asserted here. The warning half belonged to the cause
-    // that is gone: a *tree-less parse* had to keep the string pipeline's
-    // warnings where they were raised, because nothing would hand them back,
-    // whereas a pass under this guard stashes them in
-    // `nested_authoritative_warnings` for the enclosing build to restore. That
-    // is correct precisely because the guard is only ever set by a build — so
-    // pinning it from a test that sets the guard with no build around it would
-    // assert the behavior of a state production cannot construct. Setting the
-    // guard directly is still the only way in (`in_inline_build` is true for 0
-    // of the 13,299 parses the suite reaches this seam with), which is why the
-    // branch is worth pinning at all rather than leaving to be assumed.
-    let mut parser = Parser::default();
-
-    parser.in_inline_build.set(true);
-
-    let doc = parser.parse("A paragraph with *bold* in it.");
-
-    assert!(
-        first_simple_inlines(&doc).is_empty(),
-        "a pass under the reentrancy guard must build no tree"
     );
 }
 


### PR DESCRIPTION
The second vestigial mechanism, and the one that takes a whole branch with it.

## What goes, and why it is safe

`Parser::in_inline_build` was the guard that kept a tree build from recursing into one: a passthrough carrying its own substitution list re-entered `SubstitutionGroup::apply` for its body, and that nested call had to take no tree seed. The authoritative-pass closure removed the **re-entry** rather than the double pass — `passthrough_text` builds and folds the body's own tree through `build_for_group` directly — so the guard has had nothing to guard against since.

Two independent readings agree, which is what made this a removal rather than a plausible-looking one:

- **Structural.** No production code under `content::inline_builder` calls `SubstitutionGroup::apply` at all. Every such call in that module is inside a `mod tests`.
- **Measured.** The guard was observed set for **0 of the 13,299** parses the suite reaches this seam with.

So `tree_seed` becomes unconditional:

```rust
let tree_seed = content.rendered.clone();
```

and with the guard gone the `None` arm of the match it fed is unreachable and goes too — **taking the authoritative `run_pipeline` call site with it.** `run_pipeline` survives with exactly one caller, the oracle, which is a separate increment (and one gated on the template question).

## The warning transport goes in the same motion, both ends

`nested_authoritative_warnings` existed because a nested authoritative pass raised real warnings inside the range a build discards as incidental, so they had to be moved aside and handed back — the stash in the `None` arm, the restore after the build.

The seam's own comment insisted these two go whole rather than one at a time, and they do: the branch that fed the stash **is** the branch being deleted, so the restore has nothing left to restore. What remains after the build is an unqualified truncate, with no exception to explain.

## What checks it

`a_passthrough_body_is_substituted_once_per_apply` is the test this increment rests on, and it was written for exactly this situation.

A *stateless* renderer cannot see a doubled pass — the extra pass produced the same bytes — so the test drives an `OrdinalRenderer` whose output depends on how many times it is called. Under the old arrangement, dropping the guard moved each of its counts from three to four and shifted the ordinal reaching the output (`a [3] b` became `a [4] b`).

The guard is dropped here and **the counts do not move.** That property is what stands in for the guard now that the guard is gone; anyone tempted to change the seed condition again should read that test first.

The crate test that pinned the guard directly — added one increment earlier, when retiring `build_inline_tree` left the guard as the branch's only remaining cause — goes with it. Its subject no longer exists.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5529 passed
- `cargo +nightly doc --no-deps --document-private-items` — clean

**Fold-parity audit** (throwaway patch, run on this branch and on the base, both single-threaded): 62 distinct divergences on each side — **zero new, zero closed**.

**Coverage** — improves again rather than being diff-neutral:

| file | missed regions | missed lines |
|---|---|---|
| `content/substitution_group.rs` before | 1 | 0 |
| `content/substitution_group.rs` after | **0** | **0** |

The file now sits at **100% of regions and 100% of lines** — its last missed region was the arm this PR deletes. `parser/parser.rs` is unchanged (90 / 76).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_