### PR TITLE
feat: Fold a footnote's own subtree at resolution (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8419,6 +8419,71 @@ Each phase is a reviewable unit with a clear exit gate.
   closed. Coverage improves again rather than staying neutral: `content/substitution_group.rs` reaches
   **100% of regions and 100% of lines**, its last missed region being the arm just deleted.
 
+  *Step 6 landed as (a footnote folds its own subtree):* the first of the two template consumers
+  the survey named, closed — and closed without the lifetime work the survey assumed it needed.
+
+  The survey framed this as blocked on one fact: a footnote's catalog entry outlives the parse
+  borrow, `InlineNode` carries a `Span<'src>`, so the entry cannot hold a tree and holds a
+  placeholder template instead. Closing it looked like a choice between threading `'src` through
+  `Footnote`/`Catalog`/`Document` and building an owned inline-node representation. **Neither is
+  needed.** The entry does not have to *hold* a tree — the tree is already somewhere else, alive, at
+  exactly the moment the entry needs re-rendering. The defining
+  [`Footnote`](../../parser/src/inlines/footnote.rs) node in the enclosing content's own tree carries
+  the footnote's children, and `Document::resolve_references` holds the blocks and the catalog
+  together in one `with_dependent_mut` closure. So the fold happens where the tree is and only a
+  `String` travels to the catalog. Nothing gains a lifetime.
+
+  Threading `'src` would in fact have been the *worse* of the two: the catalog is assembled on the
+  `Parser`, which is deliberately lifetime-free and reused across documents, so `Footnote<'src>`
+  forces `Parser<'src>` and breaks that reuse. The public-API cost the survey worried about was the
+  smaller half of that option.
+
+  *Where the fold is collected, and why not in a walker of its own.* Each content folds its own
+  defining footnotes during `Content::resolve_references` and pushes `(index, text)` onto
+  `ReferenceWarnings` — an accumulator already threaded through **exactly** the traversal that
+  reaches every content. That matters more than it looks. A parallel walker has to rediscover two
+  sub-parses the generic `child_blocks_mut()` walk misses, a Markdown-style blockquote's blocks and
+  an AsciiDoc table cell's, and the scoping measurement for this step was itself written with a
+  walker that missed the first: it reported exactly one unreachable footnote across the suite, which
+  is small enough to look like a boundary and be mistaken for one. Riding the existing traversal
+  makes that class of miss unrepresentable.
+
+  *Crossing an owned sub-parse is deliberately not automatic.* `rehome_into` carries warnings out
+  and leaves the folded texts behind, because the right answer differs by sub-parse: a Markdown
+  blockquote's blocks register their footnotes on the **document's** catalog, so its site carries
+  them out; an AsciiDoc table cell keeps a footnote list of its own, so its site installs them there
+  and carries nothing. Getting this backwards is not a lost fold but a **wrong** one — footnote
+  indices restart per catalog, so a cell's footnote `1` would overwrite the document's footnote `1`.
+
+  *One retention change was needed.* A content whose only cross-references sit *inside* a footnote
+  defers nothing itself — the replacer captures those onto the footnote's own state — so it did not
+  retain the render attributes a later fold needs. `SubstitutionGroup::apply` now retains them for a
+  content that defines a footnote as well as for one that defers a cross-reference. Both are the same
+  rule: a content whose rendering is rebuilt after the parse needs the attributes it was written
+  under.
+
+  *What still uses the template, precisely.* A footnote defined in a **section heading**. Its content
+  is resolved by the document-order title pass rather than by `Content::resolve_references`, so no
+  fold is collected for it and `Footnote::resolve_references` falls back to its placeholder template.
+  Measured across the suite: **49 of 55** resolved footnotes fold; the 6 that do not are that case.
+  So the fallback arm is not speculative — it has a real, named user, which is a better position than
+  the survey's "no such footnote is known".
+
+  *What checks it.* Nothing in the differential corpora can: the fold and the template produce the
+  same bytes, which is the point of the step and why all 5,529 existing tests stayed green the moment
+  the fold was wired in. `a_footnotes_rendering_is_refolded_from_its_subtree_at_resolution` is the
+  test that can, and it uses the same instrument as the reentrancy step before it — a renderer with
+  *state*. `OrdinalRenderer` stamps an increasing ordinal into every special character, so a `<`
+  inside a footnote carries one ordinal if it was rendered once at parse time and spliced ever after,
+  and a higher one if the subtree was folded again at resolution. It caught a real gap on its first
+  run: the retention change above exists because that test failed without it, while every other test
+  passed.
+
+  Fold-parity audit: 62 distinct divergences on the base, 63 on this branch — the one new row is this
+  step's own new fixture, whose source does not exist in the base corpus; no pre-existing source
+  changed. Coverage diff-neutral (`content/content.rs` 30 missed regions and 20 missed lines, both
+  unchanged).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10271,6 +10336,21 @@ Each phase is a reviewable unit with a clear exit gate.
        `OrdinalRenderer` is what can see a doubled pass at all — is the check: its counts do not
        move. Audit zero-new/zero-closed; `substitution_group.rs` reaches 100% regions and lines. See
        the step's own "landed as" note above.
+
+     - ✅ **a footnote folds its own subtree — the first template consumer closed, and without the
+       lifetime work the survey assumed.** The catalog entry does not need to *hold* a tree: the
+       defining `Footnote` node in the enclosing content's tree carries the children, and
+       `Document::resolve_references` holds blocks and catalog in one closure, so only a `String`
+       travels. (Threading `'src` would have been the worse option anyway — the catalog is assembled
+       on the reuse-across-documents `Parser`, so `Footnote<'src>` forces `Parser<'src>`.) Folds ride
+       `ReferenceWarnings`, the accumulator already threaded through exactly the traversal that
+       reaches every content, so the two owned sub-parses a generic walk misses cannot be forgotten;
+       crossing them is explicit per site, because a table cell's footnote `1` must never overwrite
+       the document's. Contents that define a footnote now retain their render attributes too.
+       **Still on the template:** a footnote in a section heading, resolved by the title pass — 49 of
+       55 fold. Pinned by a stateful-renderer test, since no output comparison can see the
+       difference. Audit: one new row, this step's own fixture; no pre-existing source moved.
+       Coverage diff-neutral. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -598,6 +598,17 @@ impl<'src> QuoteBlock<'src> {
                     block.resolve_references(resolver, renderer, &mut owned_warnings, parser);
                 }
 
+                // A Markdown-style blockquote's blocks register their
+                // footnotes on the *document's* catalog, not on a list of their
+                // own, so their folded renderings belong to the enclosing pass
+                // and are carried out explicitly — `rehome_into` deliberately
+                // leaves them behind, since an AsciiDoc table cell in the same
+                // position must do the opposite. See
+                // `ReferenceWarnings::footnote_texts`.
+                warnings
+                    .footnote_texts
+                    .extend(owned_warnings.take_footnote_texts());
+
                 owned_warnings.rehome_into(warnings, source);
             });
         }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2548,16 +2548,29 @@ impl<'src> AsciiDocCell<'src> {
     ) {
         match self {
             Self::Borrowed(cell) => {
+                // This branch resolves into the *enclosing* accumulator, so the
+                // document's own folded footnote renderings are set aside first
+                // and restored afterwards. A cell keeps a footnote list of its
+                // own and footnote indices restart per list, so a cell's
+                // footnote `1` must never be installed onto the document's
+                // footnote `1` — see `ReferenceWarnings::footnote_texts`.
+                let enclosing = warnings.take_footnote_texts();
+
                 for block in &mut cell.blocks {
                     block.resolve_references(resolver, renderer, warnings, parser);
                 }
+
+                let mut folded = crate::document::folds_by_index(warnings.take_footnote_texts());
 
                 // A cell footnote records no document location (it is defined in
                 // an owned sub-source), so resolution falls back to `source`,
                 // the cell's span, for any unresolved-reference warning.
                 for footnote in &mut cell.footnotes {
-                    footnote.resolve_references(resolver, renderer, warnings, source);
+                    let mine = folded.remove(&footnote.index);
+                    footnote.resolve_references(resolver, renderer, warnings, source, mine);
                 }
+
+                warnings.footnote_texts = enclosing;
             }
 
             // The owned store is shared behind an `Arc`, but references are
@@ -2586,12 +2599,22 @@ impl<'src> AsciiDocCell<'src> {
                         // warning; those warnings are re-homed to the cell's span
                         // in the document below regardless.
                         let owned_root = Span::new(owned_source);
+
+                        // Consumed here and carried no further: this cell's
+                        // blocks registered their footnotes on the cell's own
+                        // list, not the document's, and `rehome_into` leaves
+                        // these behind for exactly that reason.
+                        let mut folded =
+                            crate::document::folds_by_index(owned_warnings.take_footnote_texts());
+
                         for footnote in &mut dependent.footnotes {
+                            let mine = folded.remove(&footnote.index);
                             footnote.resolve_references(
                                 resolver,
                                 renderer,
                                 &mut owned_warnings,
                                 owned_root,
+                                mine,
                             );
                         }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1148,6 +1148,17 @@ impl<'src> Content<'src> {
 
         let from_tree = self.resolve_tree_references();
 
+        // Independent of the arm chosen below. A content whose *only*
+        // cross-references sit inside its footnotes defers nothing itself — the
+        // replacer captures those onto the footnote's own state — so it reaches
+        // here with no deferred cross-references and takes the template arm,
+        // while its footnotes are exactly the ones needing a fresh rendering.
+        // Gating the fold on this content's own deferral would therefore miss
+        // the footnotes that most need it.
+        if let Some(attributes) = self.render_attributes.as_deref() {
+            self.collect_folded_footnotes(attributes, renderer, parser, warnings);
+        }
+
         // Exactly **one** of the two renderings runs, and which one is now a
         // question about the *tree* rather than about the cross-references in
         // it: a content with a tree folds it, and a content without one — the
@@ -1223,6 +1234,62 @@ impl<'src> Content<'src> {
     /// observable rather than merely wasteful, since a stateful host renderer
     /// would see every callback for this content twice in a single resolution
     /// pass.
+    /// Folds each footnote this content **defines** from its own subtree, and
+    /// hands the results to `warnings` for the resolution pass to install into
+    /// the catalog.
+    ///
+    /// This is [`refold`](Self::refold) for the footnote catalog. A footnote's
+    /// entry is re-rendered on every resolution pass, for the same reason a
+    /// deferred content is: its text may embed a cross-reference whose
+    /// destination is only known once resolution has run. The entry could not
+    /// hold a tree to fold — it outlives the parse borrow, and
+    /// [`InlineNode`] carries a [`Span`] — so it held a
+    /// placeholder template instead. It does not need to hold one: **the tree
+    /// is already here.** The defining [`Footnote`](crate::inlines::Footnote)
+    /// node in this content's own tree carries the footnote's children, and by
+    /// this point they carry the destinations just resolved —
+    /// [`resolve_tree_references`](Self::resolve_tree_references) installs a
+    /// footnote's embedded cross-references into its subtree alongside the
+    /// block-level ones.
+    ///
+    /// So the fold happens where the tree is, and only the resulting `String`
+    /// travels to the catalog. Nothing gains a lifetime.
+    ///
+    /// Only *defining* occurrences are folded. A bare reference to an existing
+    /// footnote carries no children and re-uses the defining entry, so folding
+    /// it would install an empty rendering over a real one.
+    ///
+    /// The trim-and-collapse mirrors `register_footnote_number`'s
+    /// normalization of the template it registers, so the two producers agree
+    /// byte for byte. The `\]` unescape that normalization also performs is
+    /// deliberately absent: the subtree's text left that form when it was
+    /// built (see `footnote_children`), and applying it again would unescape a
+    /// string that was never escaped.
+    fn collect_folded_footnotes(
+        &self,
+        attributes: &ResolvedAttributes,
+        renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
+        warnings: &mut ReferenceWarnings<'src>,
+    ) {
+        let mut found = vec![];
+        defining_footnotes(&self.inlines, &mut found);
+
+        if found.is_empty() {
+            return;
+        }
+
+        let context = parser.render_context_with(attributes.clone());
+
+        for (index, children) in found {
+            let rendered = crate::content::inline_builder::fold_html(children, renderer, &context);
+
+            warnings
+                .footnote_texts
+                .push((index.to_string(), rendered.trim().replace('\n', " ")));
+        }
+    }
+
     fn refold(
         &mut self,
         attributes: ResolvedAttributes,
@@ -2188,6 +2255,44 @@ impl std::fmt::Debug for Content<'_> {
         }
 
         s.finish()
+    }
+}
+
+/// Collects every **defining** footnote occurrence in `nodes`, in document
+/// order.
+///
+/// A defining occurrence carries the footnote's children; a bare reference to
+/// an existing footnote carries none and re-uses the defining entry. Both
+/// [`Content::collect_folded_footnotes`] — which folds these — and the
+/// retention of a content's render attributes at parse time ask the same
+/// question of the same tree, so they ask it through one function.
+pub(crate) fn defining_footnotes<'a, 'src>(
+    nodes: &'a [InlineNode<'src>],
+    out: &mut Vec<(&'a str, &'a [InlineNode<'src>])>,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Footnote(footnote) => {
+                // The number is part of what makes an occurrence *defining*:
+                // `Parser::define_footnote` assigns one to every footnote it
+                // registers, and only a reference that resolved to nothing is
+                // left without. Asking both questions in one condition is
+                // deliberate — asked separately, the second would have an arm
+                // no input can reach.
+                if !footnote.is_reference
+                    && let Some(number) = footnote.number.as_ref()
+                {
+                    out.push((number.as_ref(), &footnote.children));
+                }
+
+                defining_footnotes(&footnote.children, out);
+            }
+            InlineNode::Styled(styled) => defining_footnotes(&styled.children, out),
+            InlineNode::Ref(reference) => defining_footnotes(&reference.children, out),
+            InlineNode::IndexTerm(term) => defining_footnotes(&term.children, out),
+            InlineNode::Stem(stem) => defining_footnotes(&stem.children, out),
+            _ => {}
+        }
     }
 }
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -7,9 +7,10 @@ mod content;
 pub use content::Content;
 pub(crate) use content::{
     DeferredParts, FootnoteDeferred, OwnedTitle, PASSTHROUGH_PLACEHOLDER_END,
-    PASSTHROUGH_PLACEHOLDER_START, XrefSegment, document_text, escape_sentinels,
-    fold_resolved_title, rehome_xref_placeholders, render_xref_template, resolved_destinations,
-    sanitize_title, template_partition, unescape_sentinels, xref_segment_from_node,
+    PASSTHROUGH_PLACEHOLDER_START, XrefSegment, defining_footnotes, document_text,
+    escape_sentinels, fold_resolved_title, rehome_xref_placeholders, render_xref_template,
+    resolved_destinations, sanitize_title, template_partition, unescape_sentinels,
+    xref_segment_from_node,
 };
 // The two tree walks behind `Content::set_tree_xrefs`, which calls them
 // directly. Re-exported for the differential corpus that compares what they

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -453,7 +453,18 @@ impl SubstitutionGroup {
             // the parse has moved on from. Retain them here, where "now" is
             // still that point in the document. `Content::refold` reads them
             // back.
-            if content.deferred_parts().is_some() {
+            //
+            // A content that *defines a footnote* needs them for the same
+            // reason and is not covered by the test above: where the content's
+            // only cross-references sit inside a footnote, the replacer
+            // captures them onto the footnote's own deferred state and this
+            // content defers nothing at all — yet its footnote is re-rendered
+            // on every resolution pass, from this tree, under these attributes.
+            // See `Content::collect_folded_footnotes`.
+            let mut defines_footnote = vec![];
+            crate::content::defining_footnotes(content.inlines(), &mut defines_footnote);
+
+            if content.deferred_parts().is_some() || !defines_footnote.is_empty() {
                 content.set_render_attributes(parser.snapshot_attributes());
             }
         }

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -390,12 +390,32 @@ impl Footnote {
     /// `document_source` span.
     ///
     /// A footnote with no cross-references is left untouched.
+    ///
+    /// `folded` is the **tree's** rendering of this footnote, folded from the
+    /// defining occurrence's own subtree by the content that holds it (see
+    /// `Content::collect_folded_footnotes`) and handed here by the resolution
+    /// sweep. When it is present it *is* the rendering, and the placeholder
+    /// template is not rendered at all.
+    ///
+    /// Exactly one of the two runs, mirroring the same choice
+    /// `Content::resolve_references` makes between folding its tree and
+    /// rendering its template — and for the same reason, which is not
+    /// efficiency: a renderer is a host-supplied trait object, so a stateful
+    /// one would see every callback for this footnote twice if both ran and one
+    /// answer were discarded.
+    ///
+    /// `None` is the template path. One class of footnote still takes it: one
+    /// defined in a **section heading**, whose content is resolved by the
+    /// document-order title pass rather than by `Content::resolve_references`,
+    /// and so is not folded here yet. Measured across the suite, 49 of 55
+    /// resolved footnotes fold and the 6 that do not are that case.
     pub(crate) fn resolve_references<'src>(
         &mut self,
         resolver: &dyn crate::parser::ReferenceResolver,
         renderer: &dyn crate::parser::InlineSubstitutionRenderer,
         warnings: &mut crate::parser::ReferenceWarnings<'src>,
         document_source: crate::Span<'src>,
+        folded: Option<String>,
     ) {
         if let Some(deferred) = self.deferred.as_mut() {
             let source = match self.location {
@@ -403,9 +423,23 @@ impl Footnote {
                 None => document_source,
             };
             deferred.resolve(resolver, warnings, source);
-            self.text = deferred.render(renderer);
+
+            self.text = match folded {
+                Some(folded) => folded,
+                None => deferred.render(renderer),
+            };
         }
     }
+}
+
+/// Indexes folded footnote renderings by footnote index, for a resolution pass
+/// about to install them.
+///
+/// The pass collects `(index, text)` pairs from every content it walks (see
+/// `ReferenceWarnings::footnote_texts`) and then needs them keyed, because it
+/// installs while iterating footnotes rather than while iterating contents.
+pub(crate) fn folds_by_index(texts: Vec<(String, String)>) -> BTreeMap<String, String> {
+    texts.into_iter().collect()
 }
 
 impl std::fmt::Debug for Footnote {

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -626,8 +626,15 @@ impl<'src> Document<'src> {
             // cross-references are resolved here rather than by the block pass
             // above. The host resolver does not alias the catalog, so the
             // footnotes can be borrowed mutably in place.
+            // The tree's answer for each footnote, folded by the content that
+            // defines it during the block walk above. A footnote with an entry
+            // here renders from its subtree; one without falls back to its
+            // placeholder template. See `Footnote::resolve_references`.
+            let mut folded = crate::document::folds_by_index(warnings.take_footnote_texts());
+
             for footnote in dependent.catalog.footnotes.iter_mut() {
-                footnote.resolve_references(resolver, renderer, &mut warnings, source);
+                let mine = folded.remove(&footnote.index);
+                footnote.resolve_references(resolver, renderer, &mut warnings, source, mine);
             }
 
             replace_reference_warnings(&mut dependent.warnings, &mut warnings.doc);
@@ -675,8 +682,12 @@ impl<'src> Document<'src> {
             // Footnote text is extracted out of block content, so its
             // cross-references are resolved here rather than by the block pass
             // above.
+            // See the sibling pass in `resolve_references` for what these are.
+            let mut folded = crate::document::folds_by_index(warnings.take_footnote_texts());
+
             for footnote in footnotes.iter_mut() {
-                footnote.resolve_references(&resolver, renderer, &mut warnings, source);
+                let mine = folded.remove(&footnote.index);
+                footnote.resolve_references(&resolver, renderer, &mut warnings, source, mine);
             }
 
             dependent.catalog.restore_footnotes(footnotes);

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -12,8 +12,8 @@ mod author_line;
 pub use author_line::{AuthorLine, Authors};
 
 mod catalog;
-pub(crate) use catalog::DuplicateIdError;
 pub use catalog::{Catalog, Footnote, ImageReference, RefEntry, RefType};
+pub(crate) use catalog::{DuplicateIdError, folds_by_index};
 
 mod docinfo;
 pub(crate) use docinfo::Docinfo;

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -212,6 +212,35 @@ pub(crate) struct ReferenceWarnings<'src> {
 
     /// The same warnings, anchored to the source they were found in.
     pub(crate) doc: Vec<Warning<'src>>,
+
+    /// Each defining footnote's rendering, **folded from its own subtree**,
+    /// as `(footnote index, rendered text)` — the tree's answer to the
+    /// question the catalog entry's placeholder template used to answer.
+    ///
+    /// It rides on this accumulator rather than on a walker of its own for a
+    /// specific reason: this struct is already threaded through *exactly* the
+    /// traversal that reaches every [`Content`](crate::content::Content),
+    /// including the two privately-owned sub-parses a generic
+    /// `child_blocks_mut()` walk misses — a Markdown-style blockquote's blocks
+    /// and an AsciiDoc table cell's. A parallel walker would have to
+    /// rediscover both, and a walker that missed one would silently leave the
+    /// affected footnotes rendering from a template while every other footnote
+    /// folded. (Measured while scoping this step: a first-cut walker that
+    /// omitted the blockquote case reported exactly one unreachable footnote
+    /// across the whole suite — small enough to look like a boundary and
+    /// mistake for one.)
+    ///
+    /// **Crossing an owned sub-parse is not automatic**, and must not be:
+    /// [`rehome_into`](Self::rehome_into) deliberately leaves this field
+    /// behind, because whether these entries belong to the enclosing catalog
+    /// depends on the sub-parse. A Markdown-style blockquote's blocks register
+    /// their footnotes on the *document's* catalog, so its site carries them
+    /// out explicitly; an AsciiDoc table cell keeps a footnote list of its
+    /// own, so its site installs them there and carries nothing out. Carrying
+    /// a cell's entries outward would not merely waste them — footnote indices
+    /// restart per catalog, so a cell's footnote `1` would overwrite the
+    /// document's footnote `1`.
+    pub(crate) footnote_texts: Vec<(String, String)>,
 }
 
 impl<'src> ReferenceWarnings<'src> {
@@ -236,6 +265,12 @@ impl<'src> ReferenceWarnings<'src> {
     /// Those blocks borrow their own owned source, so their spans cannot be
     /// named in the enclosing document. Each document warning is re-anchored to
     /// `anchor`, the enclosing element's span in the document.
+    ///
+    /// [`footnote_texts`](Self::footnote_texts) is **not** carried across —
+    /// see that field for why the choice belongs to each sub-parse rather than
+    /// here. Take them with
+    /// [`take_footnote_texts`](Self::take_footnote_texts) first if this
+    /// sub-parse shares the enclosing catalog.
     pub(crate) fn rehome_into<'outer>(
         self,
         dest: &mut ReferenceWarnings<'outer>,
@@ -248,6 +283,17 @@ impl<'src> ReferenceWarnings<'src> {
                 .into_iter()
                 .map(|warning| Warning::with_origin(anchor, warning.warning, warning.origin)),
         );
+    }
+
+    /// Takes the folded footnote renderings gathered so far, leaving the
+    /// accumulator's own list empty.
+    ///
+    /// Used at the two ends of a footnote's journey: an owned sub-parse that
+    /// shares the enclosing catalog hands its entries outward with this before
+    /// [`rehome_into`](Self::rehome_into), and each resolution pass drains it
+    /// to install the entries into the catalog it owns.
+    pub(crate) fn take_footnote_texts(&mut self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.footnote_texts)
     }
 }
 

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -2613,6 +2613,75 @@ fn re_resolving_clears_a_now_unresolved_footnote_tree_destination() {
 }
 
 #[test]
+fn a_footnotes_rendering_is_refolded_from_its_subtree_at_resolution() {
+    // The property this increment adds, and the only one that can distinguish
+    // it: a footnote's catalog text is a **fold of its own subtree**, taken
+    // when resolution runs, rather than a splice into the placeholder template
+    // the string pipeline captured at parse time.
+    //
+    // No output comparison can see the difference — the two produce the same
+    // bytes, which is the whole point of the step and exactly why the
+    // differential corpora stayed green when the fold was wired in. What can
+    // see it is a renderer with *state*: `OrdinalRenderer` stamps an
+    // increasing ordinal into every special character it renders, so a `<`
+    // inside the footnote carries one ordinal if it was rendered once, at
+    // parse time, and spliced verbatim thereafter, and a **higher** one if the
+    // subtree was folded again at resolution.
+    //
+    // If the fold were removed and every footnote fell back to its template,
+    // the two readings below would be equal and this test would fail.
+    struct FixedResolver(Option<&'static str>);
+
+    impl crate::parser::ReferenceResolver for FixedResolver {
+        fn resolve(
+            &self,
+            _context: &crate::parser::ResolutionContext<'_>,
+        ) -> Option<crate::parser::ResolvedReference> {
+            self.0
+                .map(|href| crate::parser::ResolvedReference::new(href.to_string(), None))
+        }
+    }
+
+    let mut parser =
+        Parser::default().with_inline_substitution_renderer(OrdinalRenderer::default());
+
+    let mut doc = parser.parse_deferred("A claim.footnote:[x < y, see <<tgt>>]\n\n[[tgt]]Target.");
+
+    let at_parse = doc
+        .catalog()
+        .footnotes()
+        .first()
+        .expect("the footnote is registered while parsing")
+        .text
+        .clone();
+
+    doc.resolve_references(&FixedResolver(Some("#tgt")), &*parser.renderer, &parser);
+
+    let at_resolution = doc
+        .catalog()
+        .footnotes()
+        .first()
+        .expect("the footnote survives resolution")
+        .text
+        .clone();
+
+    // Both readings render the same `<`, so both contain an ordinal; the
+    // question is whether the second one is a *fresh* render.
+    assert!(
+        at_parse.contains('['),
+        "the parse-time rendering should carry an ordinal: {at_parse:?}"
+    );
+
+    println!("AT_PARSE={at_parse:?}\nAT_RESOLUTION={at_resolution:?}");
+
+    assert_ne!(
+        at_parse, at_resolution,
+        "a footnote's rendering must be refolded from its subtree at resolution, \
+         not spliced from the parse-time template"
+    );
+}
+
+#[test]
 fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
     // A footnote in a section heading is owned by the document-order title pass,
     // which resolves the heading's cross-references and now mirrors the


### PR DESCRIPTION
The first of the two template consumers the survey named, closed — and closed **without the lifetime work the survey assumed it needed.**

## The survey's premise was wrong

#1310 framed this as blocked on one fact: a footnote's catalog entry outlives the parse borrow, `InlineNode` carries a `Span<'src>`, so the entry cannot hold a tree and holds a placeholder template instead. Closing it looked like a choice between threading `'src` through `Footnote`/`Catalog`/`Document` or building an owned inline-node representation.

**Neither is needed.** The entry does not have to *hold* a tree — the tree is already alive somewhere else at exactly the moment the entry needs re-rendering:

- the defining `Footnote` node in the enclosing content's own tree carries the footnote's `children`;
- `Content::resolve_references` installs the footnote's embedded cross-references into that subtree, alongside the block-level ones;
- `Document::resolve_references` holds the blocks and the catalog together in one `with_dependent_mut` closure.

So the fold happens where the tree is, and only a `String` travels to the catalog. Nothing gains a lifetime.

Threading `'src` would have been the *worse* of the two options anyway, for a reason the survey missed: the catalog is assembled on the `Parser`, which is deliberately lifetime-free and reused across documents, so `Footnote<'src>` forces `Parser<'src>`. The public-API cost was the smaller half of that.

## Where the folds are collected, and why not in a walker of its own

Each content folds its own defining footnotes and pushes `(index, text)` onto `ReferenceWarnings` — an accumulator **already threaded through exactly the traversal that reaches every content.**

That is load-bearing, not convenience. A parallel walker has to rediscover the two sub-parses a generic `child_blocks_mut()` walk misses — a Markdown-style blockquote's blocks and an AsciiDoc table cell's. The scoping measurement for this step was itself written with a walker that missed the first, and it reported exactly **one** unreachable footnote across the suite: small enough to look like a boundary and be mistaken for one. Riding the existing traversal makes that class of miss unrepresentable.

**Crossing an owned sub-parse is deliberately explicit per site**, not automatic in `rehome_into`, because the right answer differs:

| sub-parse | footnotes registered on | folds |
|---|---|---|
| Markdown blockquote | the **document's** catalog | carried out |
| AsciiDoc table cell | its **own** list | installed locally, carried nowhere |

Backwards, this is not a lost fold but a **wrong** one: footnote indices restart per catalog, so a cell's footnote `1` would overwrite the document's footnote `1`.

## One retention change

A content whose only cross-references sit *inside* a footnote defers nothing itself — the replacer captures those onto the footnote's own state — so it did not retain the render attributes a later fold needs. `SubstitutionGroup::apply` now retains them for a content that **defines a footnote** as well as one that defers a cross-reference. Both are the same rule: a content whose rendering is rebuilt after the parse needs the attributes it was written under.

## What still uses the template, precisely

A footnote defined in a **section heading**. Its content is resolved by the document-order title pass rather than by `Content::resolve_references`, so no fold is collected and the entry falls back to its template.

Measured across the suite: **49 of 55** resolved footnotes fold; the 6 that do not are that case. So the fallback arm is not speculative — it has a real, named user, which is a better position than the survey's "no such footnote is known". The title pass is the follow-on increment; it has its own subtleties (memoized resolution, a cloned tree, `footnote_ordered` installed only in `write_back`) that deserve their own audit.

## What checks it

**Nothing in the differential corpora can.** The fold and the template produce the same bytes — that is the point of the step, and it is why all 5,529 existing tests stayed green the moment the fold was wired in.

`a_footnotes_rendering_is_refolded_from_its_subtree_at_resolution` is the test that can, using the same instrument as the reentrancy step before it: a renderer with **state**. `OrdinalRenderer` stamps an increasing ordinal into every special character, so a `<` inside a footnote carries one ordinal if it was rendered once at parse time and spliced ever after, and a higher one if the subtree was folded again at resolution.

It earned its place immediately: **the retention change above exists because this test failed without it, while every other test passed.**

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5530 passed
- `cargo +nightly doc --no-deps --document-private-items` — clean

**Fold-parity audit**: 62 distinct divergences on the base, 63 here. The one new row is this step's own new fixture — I verified its source does not exist in the base corpus — and **no pre-existing source changed**.

**Coverage** — diff-neutral: `content/content.rs` holds at **30** missed regions and **20** missed lines, both matching base, and the workspace total is unchanged at 605/348. The first cut regressed it by one region; that was a `continue` for a defining footnote with no number, which cannot arise, so it was removed rather than left untested (per the repo's own guidance) by asking both questions in one condition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_