### PR TITLE
feat: Fold a section heading's footnotes too (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8484,6 +8484,49 @@ Each phase is a reviewable unit with a clear exit gate.
   changed. Coverage diff-neutral (`content/content.rs` 30 missed regions and 20 missed lines, both
   unchanged).
 
+  *Step 6 landed as (the title pass folds its footnotes too — the footnote template is now unused):*
+  the small remainder of the increment before it, and the one that takes the count to all of them.
+
+  The footnote fold left 6 of 55 resolved footnotes on the placeholder template: those defined in a
+  **section heading**. A heading is not resolved by `Content::resolve_references` at all — the
+  document-order title pass (`document::title_refs`) owns it, because a cross-reference *between* two
+  titles needs coordination the per-content pass cannot do — so nothing collected a fold for it.
+
+  *Where the fold goes, and why not where the title's own fold happens.* The obvious site is
+  `compute`, beside `fold_resolved_title`. It is the wrong one. That fold runs on a **clone** of the
+  tree carrying only `block_ordered`, because the pass holds no `&mut` to the blocks while it is still
+  computing — and a footnote's rendering needs `footnote_ordered`, which reaches the real tree only in
+  `write_back`. So the collection happens in `write_back`, immediately after each
+  `mirror_*_tree_xrefs` call has installed the destinations.
+
+  That also answers the walker question the same way the increment before it did: `write_back`
+  already visits exactly the headings and block titles that matter, in document order, with the
+  access needed. Extending it beats a third walk beside `collect` and `write_back` that could drift
+  from both. It costs three parameters on a private function with one caller.
+
+  Both passes now ask for folds through one method,
+  [`Content::collect_own_folded_footnotes`](../../parser/src/content/content.rs), which folds under
+  the content's own retained attributes or does nothing if it has none. Neither pass re-derives
+  "which attributes, and is there anything to fold". `SectionBlock::section_title_content` loses its
+  `#[cfg(test)]` gate to serve it — the accessor's doc comment already described this caller
+  hypothetically.
+
+  *Measured: 55 of 55 folds, 0 templates.* Every footnote the crate resolves now renders from its own
+  subtree. `FootnoteDeferred::render` keeps exactly one caller, `Parser::define_footnote`'s
+  parse-time unresolved fallback, which belongs to the string pipeline and goes with the oracle.
+
+  *The fallback arm stays, and is now unit-tested rather than deleted.* It is unreachable by
+  **measurement**, not by construction: a footnote whose defining content retained no render
+  attributes would still land there, and rendering its template is the honest answer — better than
+  leaving the parse-time text standing as though resolution had never run. This branch keeps
+  confusing the two, so the arm is pinned directly by
+  `a_footnote_folds_when_given_one_and_renders_its_template_otherwise`, which drives both arms with an
+  empty cross-reference list so the choice itself is the only subject.
+
+  Fold-parity audit: 63 distinct divergences on the base and on this branch alike — zero new, zero
+  closed. Coverage diff-neutral (`document/catalog.rs` 2 missed regions and 0 missed lines, both
+  unchanged; workspace total unchanged at 605 / 348).
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10351,6 +10394,19 @@ Each phase is a reviewable unit with a clear exit gate.
        55 fold. Pinned by a stateful-renderer test, since no output comparison can see the
        difference. Audit: one new row, this step's own fixture; no pre-existing source moved.
        Coverage diff-neutral. See the step's own "landed as" note above.
+
+     - ✅ **the title pass folds its footnotes too — 55 of 55, and the footnote template is unused.**
+       The 6 footnotes still on the template were those defined in a section heading, which
+       `document::title_refs` owns rather than `Content::resolve_references`. The fold belongs in
+       `write_back`, not beside `fold_resolved_title`: that fold runs on a *clone* carrying only
+       `block_ordered`, while a footnote's rendering needs `footnote_ordered`, which reaches the real
+       tree only when `write_back` mirrors it. Extending `write_back` also avoids a third walk beside
+       `collect` and `write_back` that could drift from both. Both passes now collect through one
+       `Content::collect_own_folded_footnotes`. `FootnoteDeferred::render` is left with a single
+       caller, the parse-time unresolved fallback, which goes with the oracle. The template arm of
+       `Footnote::resolve_references` stays — unreachable by measurement, not by construction — and is
+       pinned by a direct unit test rather than deleted. Audit zero-new/zero-closed; coverage
+       diff-neutral. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -537,7 +537,11 @@ impl<'src> SectionBlock<'src> {
     /// and [`section_title_render_attributes`](Self::section_title_render_attributes)
     /// expose — the deferred cross-reference segments a heading carries, which
     /// the document-order title pass resolves.
-    #[cfg(test)]
+    ///
+    /// No longer test-only: that pass folds a heading's own defining footnotes
+    /// through [`Content::collect_own_folded_footnotes`], which wants the
+    /// content rather than the two halves, so that both passes which collect
+    /// folds ask for them the same way.
     pub(crate) fn section_title_content(&self) -> &Content<'src> {
         &self.section_title
     }

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1155,9 +1155,7 @@ impl<'src> Content<'src> {
         // while its footnotes are exactly the ones needing a fresh rendering.
         // Gating the fold on this content's own deferral would therefore miss
         // the footnotes that most need it.
-        if let Some(attributes) = self.render_attributes.as_deref() {
-            self.collect_folded_footnotes(attributes, renderer, parser, warnings);
-        }
+        self.collect_own_folded_footnotes(renderer, parser, warnings);
 
         // Exactly **one** of the two renderings runs, and which one is now a
         // question about the *tree* rather than about the cross-references in
@@ -1265,6 +1263,32 @@ impl<'src> Content<'src> {
     /// deliberately absent: the subtree's text left that form when it was
     /// built (see `footnote_children`), and applying it again would unescape a
     /// string that was never escaped.
+    /// Folds this content's defining footnotes under **its own** retained
+    /// render attributes, when it has any.
+    ///
+    /// Two passes resolve content and so two passes have to collect: the
+    /// per-content one below, and the document-order title pass
+    /// (`document::title_refs`), which owns section headings and block titles
+    /// and does not route them through
+    /// [`resolve_references`](Self::resolve_references) at all. Both want the
+    /// same thing of the same content, so they ask for it the same way rather
+    /// than each re-deriving "which attributes, and is there anything to fold".
+    ///
+    /// A content with no retained attributes folds nothing: it is one whose
+    /// rendering is never rebuilt after the parse, so no footnote of its can
+    /// need a fresh one either (see `SubstitutionGroup::apply`, which retains
+    /// them for exactly the contents that are rebuilt).
+    pub(crate) fn collect_own_folded_footnotes(
+        &self,
+        renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
+        warnings: &mut ReferenceWarnings<'src>,
+    ) {
+        if let Some(attributes) = self.render_attributes.as_deref() {
+            self.collect_folded_footnotes(attributes, renderer, parser, warnings);
+        }
+    }
+
     fn collect_folded_footnotes(
         &self,
         attributes: &ResolvedAttributes,

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -560,6 +560,79 @@ mod tests {
 
     use super::*;
 
+    /// Both arms of the fold-or-template choice in
+    /// [`Footnote::resolve_references`], pinned directly.
+    ///
+    /// The fold arm is what every footnote in the crate takes — measured, 55 of
+    /// 55 across the suite once the document-order title pass began collecting
+    /// folds too. That leaves the template arm with no *parse* that reaches it,
+    /// which is exactly why it is worth a unit test rather than a deletion: it
+    /// is unreachable by measurement, not by construction. A footnote whose
+    /// defining content retained no render attributes would still land here,
+    /// and rendering its template is the honest answer to that — better than
+    /// leaving the parse-time fallback standing as though resolution had never
+    /// run.
+    ///
+    /// An empty cross-reference list keeps the subject to the choice itself:
+    /// `resolve` has nothing to do, so what `text` ends up holding is decided
+    /// by the arm and nothing else.
+    #[test]
+    fn a_footnote_folds_when_given_one_and_renders_its_template_otherwise() {
+        use crate::{
+            Span,
+            content::FootnoteDeferred,
+            parser::{CatalogResolver, HtmlSubstitutionRenderer, ReferenceWarnings},
+        };
+
+        fn footnote() -> Footnote {
+            Footnote {
+                index: "1".to_string(),
+                id: None,
+                text: "the parse-time fallback".to_string(),
+                deferred: Some(Box::new(FootnoteDeferred::new(
+                    "the template".to_string(),
+                    vec![],
+                    false,
+                ))),
+                location: None,
+            }
+        }
+
+        let renderer = HtmlSubstitutionRenderer {};
+        let source = Span::new("irrelevant");
+
+        // The crate's own resolver over an empty catalog, rather than a stub:
+        // the empty cross-reference list below means it is never consulted, and
+        // a stub written for that would be dead code of this test's own making.
+        let catalog = Catalog::new();
+        let resolver = CatalogResolver::new(&catalog);
+
+        let mut folded = footnote();
+        let mut warnings = ReferenceWarnings::default();
+        folded.resolve_references(
+            &resolver,
+            &renderer,
+            &mut warnings,
+            source,
+            Some("the tree's fold".to_string()),
+        );
+
+        assert_eq!(
+            folded.text, "the tree's fold",
+            "a footnote handed the tree's answer must render that, not its template"
+        );
+
+        let mut templated = footnote();
+        let mut warnings = ReferenceWarnings::default();
+        templated.resolve_references(&resolver, &renderer, &mut warnings, source, None);
+
+        assert_eq!(
+            templated.text, "the template",
+            "a footnote no pass folded must fall back to its placeholder template, \
+             not keep the parse-time text"
+        );
+    }
+
     #[test]
     fn new_catalog_is_empty() {
         let catalog = Catalog::new();

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -156,7 +156,7 @@ pub(crate) fn resolve_title_references<'src>(
     }
 
     let mut index = 0;
-    write_back(blocks, &memo, &mut index);
+    write_back(blocks, &memo, &mut index, renderer, warnings, parser);
 }
 
 /// Walks `blocks` in document order, collecting each section heading and block
@@ -228,7 +228,14 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
 /// this installs both views the resolution carries: the coordinated rendered
 /// string, and — mirrored into the title's inline tree — the resolved
 /// destinations of its cross-references.
-fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], index: &mut usize) {
+fn write_back<'src>(
+    blocks: &mut [Block<'src>],
+    memo: &[Option<Resolution>],
+    index: &mut usize,
+    renderer: &dyn InlineSubstitutionRenderer,
+    warnings: &mut ReferenceWarnings<'src>,
+    parser: &crate::Parser,
+) {
     for block in blocks.iter_mut() {
         if let Block::Section(section) = block {
             if section.section_title_deferred_parts().is_some() {
@@ -238,6 +245,17 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], ind
                         &resolution.block_ordered,
                         &resolution.footnote_ordered,
                     );
+
+                    // **After** the mirror, not before: a footnote defined in
+                    // this heading is folded from the heading's own subtree, and
+                    // that subtree only carries the destinations just resolved
+                    // once `mirror_section_title_tree_xrefs` has installed them.
+                    // The fold `compute` took above cannot serve — it ran on a
+                    // *clone* holding only the block-level list, because the real
+                    // tree is not reachable while the pass is still computing.
+                    section
+                        .section_title_content()
+                        .collect_own_folded_footnotes(renderer, parser, warnings);
                 }
                 *index += 1;
             }
@@ -250,11 +268,21 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], ind
                     &resolution.block_ordered,
                     &resolution.footnote_ordered,
                 );
+
+                // After the mirror, for the reason given in the section arm.
+                title.collect_own_folded_footnotes(renderer, parser, warnings);
             }
             *index += 1;
         }
 
-        write_back(block.child_blocks_mut(), memo, index);
+        write_back(
+            block.child_blocks_mut(),
+            memo,
+            index,
+            renderer,
+            warnings,
+            parser,
+        );
     }
 }
 


### PR DESCRIPTION
The small remainder of #1313, and the one that takes the count to all of them.

## What was left

#1313 left **6 of 55** resolved footnotes on the placeholder template: those defined in a **section heading**. A heading is not resolved by `Content::resolve_references` at all — the document-order title pass owns it, because a cross-reference *between* two titles needs coordination the per-content pass cannot do — so nothing collected a fold for it.

## Where the fold goes, and why not the obvious place

The obvious site is `compute`, beside `fold_resolved_title`. **It is the wrong one.** That fold runs on a *clone* of the tree carrying only `block_ordered`, because the pass holds no `&mut` to the blocks while it is still computing — and a footnote's rendering needs `footnote_ordered`, which reaches the real tree only in `write_back`.

So the collection happens in `write_back`, immediately after each `mirror_*_tree_xrefs` call installs the destinations.

That also answers the walker question the way #1313 did: `write_back` already visits exactly the headings and block titles that matter, in document order, with the access needed. Extending it beats a third walk beside `collect` and `write_back` that could drift from both. Cost: three parameters on a private function with one caller.

Both passes now ask for folds through one method, `Content::collect_own_folded_footnotes`, which folds under the content's own retained attributes or does nothing if it has none — so neither re-derives *"which attributes, and is there anything to fold"*. `SectionBlock::section_title_content` loses its `#[cfg(test)]` gate to serve it; its doc comment already described this caller hypothetically.

## Result

**Measured: 55 of 55 folds, 0 templates.** Every footnote the crate resolves now renders from its own subtree.

`FootnoteDeferred::render` keeps exactly one caller — `Parser::define_footnote`'s parse-time unresolved fallback, which belongs to the string pipeline and goes with the oracle.

## The fallback arm stays, and is unit-tested rather than deleted

It is unreachable by **measurement**, not by construction. A footnote whose defining content retained no render attributes would still land there, and rendering its template is the honest answer — better than leaving the parse-time text standing as though resolution had never run.

This branch keeps confusing those two, so the arm is pinned directly by `a_footnote_folds_when_given_one_and_renders_its_template_otherwise`, driving both arms with an empty cross-reference list so the choice itself is the only subject.

That test uses the crate's own `CatalogResolver` over an empty catalog rather than a stub resolver. A stub's body would have been dead code of the test's own making — and was, on the first attempt, which the coverage check caught before this was pushed.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5531 passed
- `cargo +nightly doc --no-deps --document-private-items` — clean

**Fold-parity audit**: 63 distinct divergences on the base and here alike — **zero new, zero closed**.

**Coverage** — diff-neutral: `document/catalog.rs` holds at **2** missed regions and **0** missed lines, both matching base, and the workspace total is unchanged at **605 / 348**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVT1gvcX9JpMgA59yHybfz)_