### PR TITLE
feat: Synthesize a carried title's template from its own tree (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8527,6 +8527,76 @@ Each phase is a reviewable unit with a clear exit gate.
   closed. Coverage diff-neutral (`document/catalog.rs` 2 missed regions and 0 missed lines, both
   unchanged; workspace total unchanged at 605 / 348).
 
+  *Step 6 landed as (the carried title's template is the tree's own — and the suppression window
+  measured dead):* the template item's last production consumer switched producers, which is the
+  increment that genuinely unblocks the oracle call's deletion: nothing on the production path
+  reads the string pipeline's placeholder template any more.
+
+  [`Content::to_owned_title`](../../parser/src/content/content.rs) now takes the parser and — for
+  a title that defers a cross-reference and still holds its tree — synthesizes the placeholder
+  template and the segment list its indices point into from that tree, at the stash site
+  (`SectionBlock::parse`), while the nodes are still alive. The `'src`-erasing hop across
+  `Parser::pending_block_title` is unchanged, and so is the render path: the snapshot arrives at
+  the claiming block node-less and renders by splicing, exactly as before, but the splice's inputs
+  are the tree's.
+
+  *Why the synthesis is a gap walk and not one `fold_deferring_xrefs` call.* The footnote template
+  is one such call, and inheriting it here was the obvious move — and the wrong one, for a reason
+  worth keeping: in that fold's output a document-typed `U+E000 0 U+E001` (the issue #1235 class
+  the `sentinels` suite pins) is **byte-identical** to a real placeholder, and nothing downstream
+  can tell them apart. The footnote template carries that ambiguity today and gets away with it
+  because resolution renders a footnote from its subtree and the template is a parse-time fallback;
+  a carried title's template is *rendered*, so it cannot. The string pipeline never had the problem
+  because it escaped the whole haystack before any step ran — so the synthesis reproduces exactly
+  that form: [`carried_title_template`](../../parser/src/content/content.rs) walks the tree's
+  top-level nodes, a cross-reference node contributing a raw placeholder plus its segment (through
+  `xref_segment_from_node`, the derivation every other segment shares) and every other node
+  contributing its own fold passed through `escape_sentinels`. Escaped bytes are the document's,
+  raw sentinels are the fold's own, and the template stays in the escaped form the render path
+  (`EscapedForm { template: true, … }`) already handles — no new case anywhere downstream.
+  Verified against the base byte-for-byte on the typed-sentinel and two-reference probes, and
+  pinned by `a_typed_placeholder_in_a_carried_title_cannot_forge_a_cross_reference`.
+
+  *The boundary the top-level walk draws*, pinned by
+  `a_reference_nested_in_a_span_of_a_carried_title_stays_its_fallback`: a cross-reference nested
+  inside another top-level construct (a styled span, a visible index term) folds with its
+  enclosing node as template text — baked as its unresolved fallback, neither resolved nor
+  reported — where the pipeline's template spliced it, its placeholder sitting inside the rendered
+  markup. Measured at zero: no golden source carries a nested cross-reference in a carried block
+  title (the suite's one carried deferring title is `.See <<goal>>`, whose reference is
+  top-level). Nothing survives the hop to do better; if the synthesis ever learns nested
+  placeholders, the test's own comment says where it moves.
+
+  *The condition's other exits are real, and one grew its own test.* A title re-stashed past an
+  empty section body reaches `to_owned_title` a second time, node-less, and must keep the template
+  the first hop synthesized rather than synthesize from the empty tree
+  (`a_title_restashed_past_an_empty_section_keeps_its_template`). The cost is one extra fold per
+  carried *deferring* title — population across the suite: one — on the transitional
+  double-render this branch already pays everywhere until the oracle goes.
+
+  *And the measurement the deletion survey asked for:* `Parser::suppress_recognition_side_effects`
+  documents itself as "set by `SubstitutionGroup::apply` around its authoritative string pass" and
+  slated to die with the oracle. By measurement it is dead **now**: the field is initialized
+  `false`, read at ten sites, and set nowhere — the inversion removed its only setter when the
+  string pass moved onto the discarded clone, and every remaining `.get()` guard is a branch that
+  cannot take. Its retirement is a pure deletion, independent of the call's, and stays with the
+  vestigial-mechanisms item where the survey filed it.
+
+  *What still defers*, more precisely than the survey could say: the oracle call itself — now a
+  deletion with no template question inside it — carrying the `set_tree_xrefs` rewrite (derive
+  the deferred state from the tree, which deletes the carve-out branch and `template_splices`
+  with it), the template-emptiness debug asserts, and the retirement of
+  `inline_builder_xref_segment_parity` and the document-parity harness's template comparison,
+  each of which already documents that it goes when `run_pipeline` does; then the
+  `apply_string_pipeline` call sites and `run_pipeline` itself; the vestigial mechanisms
+  (the suppression window above, the `from_tree: false` machinery, the sentinel escape/unescape
+  pair); and the Strategy-A recorder with `inline_recorder`.
+
+  Fold-parity audit: 63 distinct divergences on the base and on this branch alike — zero new,
+  zero closed (the seam this increment touches is behind the audit's comparison, not in it).
+  Coverage diff-neutral: `content/content.rs` 30 missed regions and 20 missed lines,
+  `blocks/section.rs` 40 and 39, workspace totals 605 and 348, all matching the base.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10406,6 +10476,26 @@ Each phase is a reviewable unit with a clear exit gate.
        caller, the parse-time unresolved fallback, which goes with the oracle. The template arm of
        `Footnote::resolve_references` stays — unreachable by measurement, not by construction — and is
        pinned by a direct unit test rather than deleted. Audit zero-new/zero-closed; coverage
+       diff-neutral. See the step's own "landed as" note above.
+
+     - ✅ **the carried title's template is the tree's own — the template item closed, and the
+       suppression window measured dead.** `Content::to_owned_title` takes the parser and, for a
+       title deferring a cross-reference, synthesizes the placeholder template and its segment
+       list from the title's own tree at the stash site, while the nodes are alive; the
+       `'src`-erasing hop and the splice-rendering restored side are unchanged, so the one content
+       that renders from a template in production no longer reads anything the string pipeline
+       produced. The synthesis is a **top-level gap walk**, not one `fold_deferring_xrefs` call:
+       each gap's fold passes through `escape_sentinels` and each placeholder is emitted raw, so
+       the template keeps the escaped form the render path already handles and a document-typed
+       placeholder (issue #1235) stays distinguishable from a real one — the ambiguity the
+       footnote template carries but never renders, and a carried title would have. The price is a
+       cross-reference *nested* inside a top-level construct, which bakes as its unresolved
+       fallback (measured zero in the suite; pinned with its own test, as is the empty-section
+       re-stash that must keep the first hop's template). Byte-identical against the base on the
+       typed-sentinel and two-reference probes. Also measured here, as the deletion survey asked:
+       `suppress_recognition_side_effects` is initialized `false`, read at ten sites, and **set
+       nowhere** — dead since the inversion, its retirement a pure deletion filed with the
+       vestigial mechanisms. Audit 63 rows either side, 0 new and 0 closed; coverage
        diff-neutral. See the step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -313,8 +313,13 @@ impl<'src> SectionBlock<'src> {
         if !discrete && let Some(title) = metadata.title.as_ref() {
             // The carried title travels as an owned snapshot, keeping any
             // deferred cross-references so an embedded `<<id>>` still resolves
-            // for the claiming block once the catalog is complete.
-            parser.pending_block_title = Some(title.to_owned_title());
+            // for the claiming block once the catalog is complete. The snapshot
+            // is taken here, while the title's inline tree is still alive: its
+            // placeholder template is synthesized from that tree (see
+            // `Content::to_owned_title`), which the restored content — whose
+            // nodes cannot cross this hop — renders from.
+            let owned_title = title.to_owned_title(parser);
+            parser.pending_block_title = Some(owned_title);
         }
 
         let mut maw_blocks = parse_blocks_until(

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -166,17 +166,23 @@ struct DeferredContent {
     /// subtrees instead.
     footnote: Vec<XrefSegment>,
 
-    /// The string pipeline's own placeholder template, still captured by
-    /// [`Content::finalize_deferred`] as it always was.
+    /// The placeholder template, in escaped sentinel form: every
+    /// document-derived byte escaped, every raw `U+E000 <index> U+E001` a real
+    /// placeholder.
     ///
-    /// Nothing on the production path renders from it any more except the one
-    /// content that has no tree to fold: a block title carried across a section
-    /// heading, which travels through `Parser::pending_block_title` as an
-    /// [`OwnedTitle`] because the parser it rides on has no `'src` lifetime,
-    /// and so arrives at the claiming block with its inline nodes dropped. Its
-    /// rendering cannot be a fold, so it stays a splice — see
-    /// [`Content::rebuild_rendered`]. It goes when that title keeps its tree,
-    /// which is what deletes design §4.2's second sentinel system outright.
+    /// Two producers write one, and only one of them reaches a production
+    /// reader. The string pipeline still captures its own through
+    /// [`Content::finalize_deferred`], as it always did — that copy is what the
+    /// test-only oracle path renders from, and it goes with `run_pipeline`.
+    /// The one content that *renders* from a template in production — a block
+    /// title carried across a section heading, which travels through
+    /// `Parser::pending_block_title` as an [`OwnedTitle`] because the parser it
+    /// rides on has no `'src` lifetime, and so arrives at the claiming block
+    /// with its inline nodes dropped — carries a template synthesized **from
+    /// its own tree** at the hop instead (see [`Content::to_owned_title`] and
+    /// [`carried_title_template`]). Its rendering cannot be a fold, so it stays
+    /// a splice — see [`Content::rebuild_rendered`] — but the splice's inputs
+    /// no longer come from the string pipeline.
     ///
     /// Empty between [`Content::set_deferred_xrefs`] recording the list and
     /// `finalize_deferred` capturing the template, which is within one
@@ -634,10 +640,52 @@ impl<'src> Content<'src> {
     /// Returns a fully-owned snapshot of this content's rendered text and
     /// deferred cross-references, for a title that must outlive its source
     /// borrow (see [`OwnedTitle`]).
-    pub(crate) fn to_owned_title(&self) -> OwnedTitle {
+    ///
+    /// A title that defers a cross-reference and still holds its tree swaps its
+    /// placeholder template — and the segment list the template's indices point
+    /// into — for the **tree's own**, synthesized here by
+    /// [`carried_title_template`]. The snapshot travels across the
+    /// `'src`-erasing hop (`Parser::pending_block_title`) with its inline nodes
+    /// dropped, so the claiming block's title is the one content that renders
+    /// from a template rather than folding a tree; this is where that template
+    /// stops being the string pipeline's and becomes a product of the tree,
+    /// which is what lets the oracle pipeline be deleted without losing the
+    /// carried title's resolution.
+    ///
+    /// `parser` supplies the renderer; the fold runs under the title's own
+    /// retained render attributes, the same pairing [`refold`](Self::refold)
+    /// uses. A deferring content always retains them
+    /// (`set_render_attributes` is called for exactly that content), so the
+    /// binding below always takes for a title with a tree; it is written as a
+    /// binding rather than an unwrap because the invariant lives in that
+    /// pairing, not in the field's type. The condition's other exits are real:
+    /// a title **re-stashed** past an empty section body arrives here with its
+    /// nodes already dropped and keeps the template the first hop synthesized,
+    /// and a `from_tree` `false` snapshot keeps the string pipeline's own — the
+    /// only honest one where the tree is known not to describe the content.
+    pub(crate) fn to_owned_title(&self, parser: &Parser) -> OwnedTitle {
+        let deferred = self.deferred.as_ref().map(|d| {
+            let mut d = (**d).clone();
+
+            if d.from_tree
+                && !self.inlines.is_empty()
+                && let Some(attributes) = self.render_attributes.as_deref()
+            {
+                let context = parser.render_context_with(attributes.clone());
+
+                let (template, block) =
+                    carried_title_template(&self.inlines, &*parser.renderer, &context);
+
+                d.template = template;
+                d.block = block;
+            }
+
+            d
+        });
+
         OwnedTitle {
             rendered: self.rendered.as_ref().to_string(),
-            deferred: self.deferred.as_ref().map(|d| (**d).clone()),
+            deferred,
             render_attributes: self.render_attributes.clone(),
         }
     }
@@ -1841,6 +1889,69 @@ pub(crate) fn xref_segment_from_node(
         derived: reference.derived.clone(),
         resolved: None,
     }
+}
+
+/// Synthesizes the placeholder template — and the segment list its indices
+/// point into — that a **carried block title** takes across the `'src`-erasing
+/// hop (see [`Content::to_owned_title`]), from the title's own inline tree.
+///
+/// The construction is a walk over the tree's **top-level** nodes: a
+/// cross-reference node contributes a raw `U+E000 <index> U+E001` placeholder
+/// and its [`XrefSegment`] (via [`xref_segment_from_node`], the same reading
+/// every other segment derivation uses), and every other node contributes its
+/// own fold, passed through [`escape_sentinels`]. That escape is what makes the
+/// template's two byte populations distinguishable — the property the whole
+/// splice rests on, and the reason the template is *not* one
+/// [`fold_deferring_xrefs`](crate::content::inline_builder::fold_deferring_xrefs)
+/// call: in that fold's output a document-typed `U+E000 0 U+E001` (see the
+/// `sentinels` test module, issue #1235) is byte-identical to a real
+/// placeholder, and nothing downstream can tell them apart. Here every
+/// document-derived byte is escaped and every raw sentinel is the fold's own —
+/// exactly the escaped form the string pipeline's templates have always been
+/// in, so the render path ([`render_template`], `EscapedForm { template: true,
+/// … }`) needs no new case.
+///
+/// The price of reading only the top level is a cross-reference **nested**
+/// inside another top-level construct (a styled span's children, a visible
+/// index term's shown text): its enclosing node folds as a gap, so the
+/// reference is baked into the template as its unresolved fallback rendering
+/// rather than spliced — and, having no segment, it is neither resolved nor
+/// reported by the title pass. The string pipeline's template did splice those
+/// (its placeholders sat inside the rendered markup). That narrowing is
+/// accepted for the same reason the carried title renders from a template at
+/// all — no tree survives the hop to do better — and it is measured at zero:
+/// no golden source carries a nested cross-reference in a carried block title.
+/// `a_reference_nested_in_a_span_of_a_carried_title_stays_its_fallback` pins
+/// the boundary.
+fn carried_title_template(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    context: &crate::parser::RenderContext,
+) -> (String, Vec<XrefSegment>) {
+    let mut template = String::new();
+    let mut segments = Vec::new();
+
+    for node in nodes {
+        match node {
+            InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => {
+                let index = segments.len();
+                segments.push(xref_segment_from_node(reference, renderer, context));
+                template.push_str(&Content::xref_placeholder(index));
+            }
+
+            other => {
+                let folded = crate::content::inline_builder::fold_html(
+                    std::slice::from_ref(other),
+                    renderer,
+                    context,
+                );
+
+                template.push_str(&escape_sentinels(&folded));
+            }
+        }
+    }
+
+    (template, segments)
 }
 
 /// Walks an inline node slice in document order and installs each

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -140,6 +140,45 @@ fn a_typed_placeholder_inside_a_passthrough_cannot_forge_a_cross_reference() {
 }
 
 #[test]
+fn a_typed_placeholder_in_a_carried_title_cannot_forge_a_cross_reference() {
+    // A block title carried across a section heading is the one content that
+    // renders from a placeholder template in production, and that template is
+    // synthesized from the title's inline tree (`carried_title_template`)
+    // rather than captured from the escaped string pipeline. The synthesis must
+    // therefore do its own escaping: each gap between placeholders passes
+    // through `escape_sentinels`, or the typed sequence here would be
+    // byte-identical to the real placeholder beside it and the splice could not
+    // tell them apart.
+    let doc = Parser::default().parse(concat!(
+        "[[a]]anchor\n",
+        "\n",
+        ".x\u{e000}0\u{e001}y <<a>>\n",
+        "== Section\n",
+        "\n",
+        "para\n",
+    ));
+
+    let Some(Block::Section(section)) = doc.child_blocks().nth(1) else {
+        panic!("expected a section block");
+    };
+
+    let title = section
+        .child_blocks()
+        .next()
+        .expect("expected the section's first child block")
+        .title()
+        .expect("expected the carried title");
+
+    assert_eq!(
+        title.matches("<a href=").count(),
+        1,
+        "the title wrote one cross-reference; got {title:?}"
+    );
+
+    assert_eq!(title, "x\u{e000}0\u{e001}y <a href=\"#a\">[a]</a>");
+}
+
+#[test]
 fn a_typed_marker_sentinel_does_not_truncate_a_section_reftext() {
     // The footnote-marker sentinels bracket a marker so it can be excised from
     // a section's reference text and auto-generated ID. A typed start sentinel

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1354,6 +1354,95 @@ mod xrefs_in_titles {
     }
 
     #[test]
+    fn two_references_in_a_carried_title_resolve_in_order() {
+        // The carried title's placeholder template is synthesized from its own
+        // inline tree at the hop (see `Content::to_owned_title`), so the
+        // placeholder indices and the segment list are built in one walk and
+        // must line up: the first reference takes the first segment's
+        // destination, the second the second's.
+        let doc = Parser::default()
+            .parse(".See <<goal>> then <<par>>\n== Section\n\n[[par]]para\n\n[#goal]\n== Goal");
+
+        let section = crate::tests::prelude::first_section(&doc);
+        let para = section
+            .child_blocks()
+            .next()
+            .expect("expected the section's first child block");
+
+        assert_eq!(
+            para.title(),
+            Some(r##"See <a href="#goal">Goal</a> then <a href="#par">[par]</a>"##)
+        );
+    }
+
+    #[test]
+    fn a_title_restashed_past_an_empty_section_keeps_its_template() {
+        // A carried title that finds its section empty is re-stashed by the
+        // sibling section that follows, for that section's own first block. The
+        // re-stash runs `to_owned_title` on the *restored* content — inline
+        // nodes already dropped — so it must keep the template the first hop
+        // synthesized rather than synthesize from the empty tree, or the
+        // reference would be lost.
+        let doc = Parser::default().parse(".See <<goal>>\n== Empty\n\n[#goal]\n== Goal\n\npara");
+
+        let sections: Vec<_> = doc
+            .child_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let para = sections[1]
+            .child_blocks()
+            .next()
+            .expect("expected the second section's first child block");
+
+        assert_eq!(para.title(), Some(r##"See <a href="#goal">Goal</a>"##));
+    }
+
+    #[test]
+    fn a_reference_nested_in_a_span_of_a_carried_title_stays_its_fallback() {
+        // A documented boundary of the tree-synthesized carried-title template
+        // (see `carried_title_template`): the synthesis reads the tree's
+        // top-level nodes, so a cross-reference *nested* inside another
+        // construct — here a styled span — folds with its enclosing node as
+        // template text rather than contributing a placeholder. It is baked as
+        // its unresolved fallback (the derived `#goal` destination with the
+        // bracketed text) instead of splicing the target's reference text, and
+        // — having no segment — an unresolvable one is not reported either.
+        //
+        // The string pipeline's template did splice these (its placeholders sat
+        // inside the rendered markup), so this narrows behavior for a shape no
+        // golden source exercises: nothing survives the `'src`-erasing hop to
+        // do better. If the synthesis ever learns nested placeholders, this
+        // fixture moves up to the resolved reading `See <strong>x
+        // <a href="#goal">Goal</a></strong> done`.
+        let doc = Parser::default()
+            .parse(".See *x <<goal>>* done\n== Section\n\npara\n\n[#goal]\n== Goal");
+
+        let section = crate::tests::prelude::first_section(&doc);
+        let para = section
+            .child_blocks()
+            .next()
+            .expect("expected the section's first child block");
+
+        assert_eq!(
+            para.title(),
+            Some(r##"See <strong>x <a href="#goal">[goal]</a></strong> done"##)
+        );
+
+        // The complement: an unresolvable nested target raises no warning,
+        // because the synthesis captured no segment for it.
+        let doc = Parser::default().parse(".See *x <<nowhere>>* done\n== Section\n\npara");
+
+        assert_eq!(doc.warnings().count(), 0);
+    }
+
+    #[test]
     fn resolver_chosen_text_wins_over_the_local_title() {
         // A caller-supplied resolver may resolve a target to its local `#id`
         // destination while choosing its own display text (e.g. a curated


### PR DESCRIPTION
## What

The oracle-deletion increment's last true blocker, closed: the one content that renders from a placeholder template in production — a block title carried across a section heading, whose inline nodes cannot cross the `'src`-erasing hop through `Parser::pending_block_title` — now carries a template synthesized **from its own tree** at the stash site (`Content::to_owned_title`, which now takes the parser), in place of the template the string pipeline captured. Nothing on the production path reads the pipeline's template any more, which is what makes the oracle `run_pipeline` call's deletion a deletion.

## How, and why not `fold_deferring_xrefs`

The synthesis (`carried_title_template`) is a **top-level gap walk**, not one deferring-fold call: a cross-reference node contributes a raw `U+E000 <index> U+E001` placeholder plus its segment (through the shared `xref_segment_from_node`), and every other node contributes its own fold passed through `escape_sentinels`. In a deferring fold's output, a document-typed placeholder sequence (the issue #1235 class the `sentinels` suite pins) is byte-identical to a real placeholder — the footnote template carries that ambiguity but never renders it (resolution folds the subtree); a carried title's template *is* rendered, so it cannot. The gap walk reproduces exactly the escaped form the string pipeline's templates were always in, so the render path (`EscapedForm { template: true, … }`) needs no new case. Verified byte-for-byte against the base on typed-sentinel and two-reference probes.

## The boundary it draws

A cross-reference **nested** inside a top-level construct (a styled span's children) bakes into the template as its unresolved fallback rendering — neither resolved nor reported — where the pipeline's template spliced it. Measured at zero across the suite (its one carried deferring title is `.See <<goal>>`, top-level), and pinned by `a_reference_nested_in_a_span_of_a_carried_title_stays_its_fallback`, whose comment says where the fixture moves if the synthesis ever learns nested placeholders. Two more tests pin the typed-sentinel crossing and the empty-section **re-stash** (which must keep the first hop's template rather than synthesize from the node-less restored content).

## Also measured, as the deletion survey asked

`Parser::suppress_recognition_side_effects` documents itself as set around the authoritative string pass and dying with the oracle. By measurement it is dead **now**: initialized `false`, read at ten sites, set nowhere — the inversion removed its only setter. Its retirement is a pure deletion, filed with the vestigial mechanisms.

## Checks

- Fold-parity audit: **63 rows either side, 0 new, 0 closed** (this seam sits behind the audit's comparison, not in it).
- Coverage diff-neutral: `content/content.rs` 30 missed regions / 20 missed lines, `blocks/section.rs` 40 / 39, workspace totals 605 / 348 — all matching base.
- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, `cargo test --workspace` (5535 + 6 pass), `cargo +nightly doc --document-private-items` all clean.

## What still defers

The oracle call itself — now a deletion with no template question inside it — carrying the `set_tree_xrefs` rewrite (deferred state derived from the tree; carve-out branch and `template_splices` deleted), the template-emptiness debug asserts, and the retirement of `inline_builder_xref_segment_parity` and the document-parity template comparison (each already documents it goes with `run_pipeline`); then the `apply_string_pipeline` call sites and `run_pipeline` itself; the vestigial mechanisms; and the Strategy-A recorder with `inline_recorder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK)_