### PR TITLE
chore: Delete run_pipeline — every corpus reads its frozen recording (step 6)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8690,6 +8690,50 @@ Each phase is a reviewable unit with a clear exit gate.
   transition plan), `run_pipeline`, and the vestigial machinery it keeps compiled — then item (6)'s
   window, `from_tree: false` paths, and `EscapedForm` collapse.
 
+  *Step 6 landed as (`run_pipeline` deleted, and every corpus goldenless):* the survey's item
+  (5), landed the increment after the recorder retirement unblocked it. `apply_string_pipeline`
+  and `run_pipeline` are gone; every golden helper's body is the lookup the freeze design promised
+  ("a helper's body becomes a lookup, its callers do not move"), reading `snapshots/<corpus>.txt`
+  through a [`snapshot`](../../parser/src/content/inline_builder/snapshot.rs) API that no longer
+  takes a golden at all. The drift guard and `ASCIIDOC_UPDATE_SNAPSHOTS` update mode went with the
+  pipeline that fed them: a recording is now edited by hand and reviewed as the behavior change it
+  records — the missing-fixture panic prints the ready-to-paste line where the caller holds the
+  fold — and a divergence corpus's rows are frozen pipeline bytes that must never be refreshed
+  from current behavior.
+
+  *The seventeen structural-golden tests the survey's "mechanical" count missed.* Not every golden
+  was a string: the per-family registration-parity tests read what the pipeline **registered** —
+  catalogs and warning lists off a golden parser the helpers ran the steps against as a side
+  effect. Each is now **frozen at the last differentially-verified parity**: the builder side is
+  untouched by this increment and the suite was green against the live pipeline one commit
+  earlier, so the literals baked into those tests are the pipeline's own answers, recorded the
+  same way every corpus's bytes were. The three link-order tests already asserted literals and
+  merely lost their trailing cross-checks; the two divergence tests among them
+  (`a_family_matching_across_an_earlier_familys_markup…`, the quotes attribute-list one) keep the
+  pipeline's rendering in the fixture as the recorded half and pin the divergence with
+  `assert_ne!`.
+
+  *Production is untouched by construction.* The seam's `apply_inner` did not change a line;
+  outside comments, the whole diff is deletions of `#[cfg(test)]` and dead items (the callable
+  pair, the sentinel-escaping tests that pinned `run_pipeline`'s own escape gating,
+  `Passthroughs::observable`) plus the test-side rework. The golden-HTML suite and every frozen
+  corpus pass unchanged, which is this increment's whole gate; the fold-parity audit's comparison
+  is no longer constructible — there is no pipeline left to reconstruct — and by the same fact
+  has nothing left to check here.
+
+  *Coverage moves, and honestly.* The vestigial string-pipeline machinery — `macros.rs`'s
+  replacers, `passthroughs.rs`'s extraction pass, the pipeline-only substitution steps — was
+  exercised almost entirely by the oracle runs the golden helpers performed; with those gone its
+  uncovered mass surfaces (workspace missed regions 606 → 1,775, all of it in the four files the
+  tail deletion removes). Changed lines are covered; the uncovered lines are the dead machinery
+  itself, and they leave with it.
+
+  *What still defers:* the tail — item (6): the vestigial machinery whole (the replacers, the
+  extraction pass, the sentinel escape window and `suppress_recognition_side_effects`, the
+  `from_tree: false` paths and the `EscapedForm` split, `set_deferred_xrefs`,
+  `finalize_deferred`), with the shared regexes and the two substitution steps the header/author
+  machinery still runs in production (`SpecialCharacters`, `AttributeReferences`) staying behind.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10621,6 +10665,18 @@ Each phase is a reviewable unit with a clear exit gate.
        `attach_footnote_subtrees` units. Audit zero-new, 56 → 12 with all departures the deleted
        harnesses' own marker-bearing rows; coverage unchanged on every surviving file. See the
        step's own "landed as" note above.
+
+     - ✅ **`run_pipeline` deleted — every corpus goldenless.** `apply_string_pipeline` and
+       `run_pipeline` are gone; golden helpers read the frozen recordings through a `snapshot`
+       API with no golden parameter, and the drift guard and update mode went with the pipeline
+       that fed them (a recording is hand-edited and reviewed as the behavior change it records).
+       Seventeen structural-golden tests — registration catalogs and warning orders read off a
+       pipeline-run parser, which no string recording could freeze — are frozen as literals at
+       the last differentially-verified parity. Production untouched by construction (the seam's
+       `apply_inner` did not change a line); the golden-HTML suite and every frozen corpus pass
+       unchanged. Coverage surfaces the vestigial machinery's uncovered mass (606 → 1,775 missed
+       regions, all in the four files item (6) deletes). See the step's own "landed as" note
+       above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -107,8 +107,9 @@ impl<'src> ElementAttribute<'src> {
     /// influence how the list divides (`image:x.png[++a,b++]` is one
     /// positional whose value is `a,b`, not two). Restoring per *parsed value*
     /// reproduces that, exactly as
-    /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices each
-    /// body over whatever sentinel reached the rendered string.
+    /// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+    /// splices each body over whatever sentinel reached the rendered
+    /// string.
     ///
     /// [`shorthand_item_indices`](Self::shorthand_item_indices) are byte
     /// offsets into `value`, so each is **shifted** past every substitution
@@ -791,10 +792,11 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// before it.
 ///
 /// The token spelling is the string pipeline's own passthrough sentinel (see
-/// [`Passthroughs`](crate::content::Passthroughs)), which is what makes this
-/// the faithful restore: a caller hands over the very text
+/// [`Passthroughs`](crate::content::passthroughs::Passthroughs)), which is what
+/// makes this the faithful restore: a caller hands over the very text
 /// `Attrlist::parse` would have seen there, and each body lands where
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices it.
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+/// splices it.
 ///
 /// A run that is not a well-formed token, or whose index `bodies` does not
 /// supply, is copied through verbatim — the same index-keyed leniency

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -170,10 +170,9 @@ struct DeferredContent {
     /// document-derived byte escaped, every raw `U+E000 <index> U+E001` a real
     /// placeholder.
     ///
-    /// Two producers write one, and only one of them reaches a production
-    /// reader. The string pipeline still captures its own through
-    /// [`Content::finalize_deferred`], as it always did — that copy is what the
-    /// test-only oracle path renders from, and it goes with `run_pipeline`.
+    /// Two producers wrote one, and only one still runs. The string pipeline
+    /// captured its own through [`Content::finalize_deferred`], which now runs
+    /// nowhere but the unit tests that pin that vestigial machinery directly.
     /// The one content that *renders* from a template in production — a block
     /// title carried across a section heading, which travels through
     /// `Parser::pending_block_title` as an [`OwnedTitle`] because the parser it
@@ -184,9 +183,7 @@ struct DeferredContent {
     /// a splice — see [`Content::rebuild_rendered`] — but the splice's inputs
     /// no longer come from the string pipeline.
     ///
-    /// Empty between [`Content::set_deferred_xrefs`] recording the list and
-    /// `finalize_deferred` capturing the template, which is within one
-    /// `run_pipeline` call and reaches no reader.
+    /// Empty for every production content but the carried title above.
     template: String,
 
     /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
@@ -196,10 +193,10 @@ struct DeferredContent {
     /// Always `true` for a production content: [`Content::set_tree_xrefs`] is
     /// the only producer of deferred state at the seam now that the string
     /// pipeline no longer runs there. `false` arises only through
-    /// [`Content::set_deferred_xrefs`], on the test-only oracle path
-    /// (`apply_string_pipeline`), and the `!from_tree` branches this field
-    /// still gates — the escaped-form reads, the template partition — are that
-    /// path's and go with `run_pipeline`.
+    /// [`Content::set_deferred_xrefs`], which nothing but the vestigial
+    /// machinery's own unit tests can reach, and the `!from_tree` branches
+    /// this field still gates — the escaped-form reads, the template
+    /// partition — are that machinery's and go with it.
     from_tree: bool,
 }
 
@@ -844,8 +841,9 @@ impl<'src> Content<'src> {
     ///
     /// Called once, before substitution begins; the matching
     /// [`unescape_sentinels`](Self::unescape_sentinels) call restores them.
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn escape_sentinels(&mut self) {
         if let Cow::Owned(escaped) = escape_sentinels(self.rendered.as_ref()) {
@@ -860,8 +858,9 @@ impl<'src> Content<'src> {
     /// The deferred template is deliberately left escaped: it is an internal
     /// representation that is re-rendered (through [`render_template`], whose
     /// callers unescape the result) each time references are resolved.
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn unescape_sentinels(&mut self) {
         if let Cow::Owned(unescaped) = unescape_sentinels(self.rendered.as_ref()) {
@@ -918,11 +917,9 @@ impl<'src> Content<'src> {
     /// discovered, in placeholder order. The placeholder tokens must already
     /// have been written into [`Content::rendered`], in the same order.
     ///
-    /// Reached only through `run_pipeline`, which no longer runs in production:
-    /// what this records is the string pipeline's own answer — the golden every
-    /// differential corpus on this branch takes through
-    /// [`apply_string_pipeline`](crate::content::SubstitutionGroup) — and it
-    /// goes with `run_pipeline` itself. The production list is installed by
+    /// Reached only through the string pipeline's macros step, which runs
+    /// nowhere but that vestigial machinery's own unit tests now; it goes
+    /// with the machinery. The production list is installed by
     /// [`set_tree_xrefs`](Self::set_tree_xrefs), from the tree, on a content
     /// this was never called on.
     ///
@@ -1012,8 +1009,9 @@ impl<'src> Content<'src> {
     /// it is captured as the template and `rendered` is rebuilt as the
     /// unresolved fallback so it is immediately clean for callers that read it
     /// before resolution.
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn finalize_deferred(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
         let template = self.rendered.as_ref().to_string();
@@ -1035,8 +1033,9 @@ impl<'src> Content<'src> {
     /// A deferred reference's text is captured out of the main rendered string
     /// during macro substitution, so passthrough placeholders inside it are not
     /// reached by the ordinary restore pass. This lets that pass reach them.
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn restore_deferred_xref_passthroughs(
         &mut self,

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1232,11 +1232,7 @@ mod tests {
         SubstitutionStep::Macros.apply(&mut content, parser, None);
         SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            corpus,
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded(corpus, source)
     }
 
     #[test]
@@ -1480,16 +1476,10 @@ mod tests {
         assert_special_char(&nodes[2], '>');
 
         // And the fold escapes the tag, byte-for-byte as the real pipeline
-        // does — the documented `subs=attributes+` trick for inspecting a
-        // stored attribute value.
-        let mut content = Content::from(Span::new(source));
-        group.apply_string_pipeline(&mut content, &parser_with_attribute("tag", "<b>"), None);
-
-        assert_eq!(content.rendered_str(), "&lt;b&gt;");
-        assert_eq!(
-            fold_html(&nodes, &HtmlSubstitutionRenderer {}),
-            content.rendered_str()
-        );
+        // did (`&lt;b&gt;`, its recorded rendering for this order) — the
+        // documented `subs=attributes+` trick for inspecting a stored
+        // attribute value.
+        assert_eq!(fold_html(&nodes, &HtmlSubstitutionRenderer {}), "&lt;b&gt;");
     }
 
     #[test]

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -438,11 +438,7 @@ mod tests {
         SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
         SubstitutionStep::Callouts.apply(&mut content, parser, attrlist);
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            corpus,
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded(corpus, source)
     }
 
     /// [`golden_callouts_with`] with a default parser and no attribute list.

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -366,11 +366,7 @@ mod tests {
         SubstitutionStep::CharacterReplacements.apply(&mut content, &parser, None);
         SubstitutionStep::PostReplacement.apply(&mut content, &parser, None);
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "char_replacements",
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded("char_replacements", source)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -855,11 +855,7 @@ mod tests {
         // (9 source bytes) expanding to `"Widget"` (6 bytes) corrupted the gap
         // *before* a sibling footnote into a truncated slice of the raw
         // source (`"{produ"`) instead of the resolved value.
-        use crate::{
-            Parser,
-            content::{Content, SubstitutionGroup, inline_builder::build},
-            parser::ModificationContext,
-        };
+        use crate::{Parser, content::inline_builder::build, parser::ModificationContext};
 
         // Two *independent* parsers (design §5.3's discipline, established by
         // this module's own differential corpus below): `build` and the real
@@ -877,15 +873,11 @@ mod tests {
         let nodes = build(Span::new(source), &configure(), None);
         let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
 
-        let mut golden = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &configure(), None);
-
         assert_eq!(
             folded,
-            crate::content::inline_builder::snapshot::recorded_golden(
+            crate::content::inline_builder::snapshot::recorded(
                 "footnotes_expanded_attribute",
-                source,
-                golden.rendered_str(),
+                source
             ),
             "{nodes:#?}"
         );
@@ -1547,17 +1539,8 @@ mod tests {
     /// The real, public pipeline's output for `source` — the golden for the
     /// expanded-value fixtures, which need the `AttributeReferences` step the
     /// module's own [`golden_macros`] helper deliberately omits.
-    fn golden_normal(source: &str, parser: &crate::Parser) -> String {
-        use crate::content::{Content, SubstitutionGroup};
-
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "footnotes_normal",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_normal(source: &str, _parser: &crate::Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("footnotes_normal", source)
     }
 
     #[test]
@@ -1651,11 +1634,7 @@ mod tests {
         // `…_are_recognized_when_the_whole_seed_is_synthesized` tests. Before
         // this increment an id-carrying footnote reached this way took the
         // *whole seed* as its id.
-        use crate::{
-            Parser,
-            content::{Content, SubstitutionGroup, inline_builder::build_from_value},
-            strings::CowStr,
-        };
+        use crate::{Parser, content::inline_builder::build_from_value, strings::CowStr};
 
         for (filtered, source) in [
             (
@@ -1680,15 +1659,11 @@ and another.footnote:[note two]",
 
             let folded = fold_html(&nodes, &HtmlSubstitutionRenderer {});
 
-            let mut golden = Content::from(Span::new(filtered));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &Parser::default(), None);
-
             assert_eq!(
                 folded,
-                crate::content::inline_builder::snapshot::recorded_golden(
+                crate::content::inline_builder::snapshot::recorded(
                     "footnotes_build_from_value",
-                    filtered,
-                    golden.rendered_str(),
+                    filtered
                 ),
                 "for {filtered:?}: {nodes:#?}"
             );

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1123,22 +1123,8 @@ mod tests {
     /// this exercises `AttributeReferences` too, so an attribute whose
     /// expanded value contains `[[id]]` is spliced in before `Macros` runs —
     /// the scenario the divergence test below needs.
-    fn golden_attributes_with(source: &str, parser: &Parser) -> String {
-        use crate::content::{Content, SubstitutionStep};
-
-        let mut content = Content::from(Span::new(source));
-        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-        SubstitutionStep::Quotes.apply(&mut content, parser, None);
-        SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
-        SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
-        SubstitutionStep::Macros.apply(&mut content, parser, None);
-        SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "anchors_attributes",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_attributes_with(source: &str, _parser: &Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("anchors_attributes", source)
     }
 
     #[test]
@@ -1508,40 +1494,36 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
-        // Each fixture uses its own pair of *independent* parsers (design
-        // §5.3's two-independent-parsers discipline, already established by
-        // the image increment's own differential corpus): one that the
-        // additive builder builds against and this function then walks, one
-        // that the real string pipeline (`golden_macros_with`, which also
-        // runs the `Quotes` step and so exercises the attributed-span
-        // registration too) runs against directly.
+    fn registers_the_recorded_ids_for_a_broad_fixture_set() {
+        // Each expected set is **frozen at the last differentially-verified
+        // parity**: while the string pipeline existed this test registered
+        // each fixture through it on an independent parser and compared the
+        // two catalogs, and the suite was green at the commit that deleted
+        // it — so the literals below are the pipeline's own answer, recorded
+        // the same way every frozen corpus's bytes were.
         let fixtures = [
-            "[[install]]",
-            "[[install,Installation]]",
-            "anchor:install[Installation]",
-            "[#free_the_world]#free the world#",
-            // An id carrying a special character: both pipelines register the
-            // *escaped* id, since both parse the attribute list out of text
-            // the escaping step already ran over (see
+            ("[[install]]", r#"["install"]"#),
+            ("[[install,Installation]]", r#"["install"]"#),
+            ("anchor:install[Installation]", r#"["install"]"#),
+            ("[#free_the_world]#free the world#", r#"["free_the_world"]"#),
+            // An id carrying a special character: the *escaped* id is
+            // registered, since the attribute list is parsed out of text the
+            // escaping step already ran over (see
             // [`quote_attributes`](crate::content::inline_builder::quotes)).
-            "[#a&b]#x#",
-            "[[a]] [[a]]",
-            "[[[id]]]",
-            "*see [[x]]* and footnote:[see [[y]]]",
+            ("[#a&b]#x#", r#"["a&amp;b"]"#),
+            ("[[a]] [[a]]", r#"["a"]"#),
+            ("[[[id]]]", "[]"),
+            ("*see [[x]]* and footnote:[see [[y]]]", r#"["x", "y"]"#),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = Parser::default();
             let nodes = build_with(Span::new(fixture), &builder_parser);
             apply_ref_side_effects(&nodes, &builder_parser, Span::new(fixture), false);
 
-            let golden_parser = Parser::default();
-            golden_macros_with(fixture, &golden_parser);
-
             assert_eq!(
-                builder_parser.catalog().ids().collect::<Vec<_>>(),
-                golden_parser.catalog().ids().collect::<Vec<_>>(),
+                format!("{:?}", builder_parser.catalog().ids().collect::<Vec<_>>()),
+                expected,
                 "registered ids diverged for {fixture:?}"
             );
         }
@@ -1850,36 +1832,52 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_bibliography_registrations() {
-        // Each side registers against its own *independent* parser (design
-        // §5.3's two-independent-parsers discipline), so the staged side effect
-        // is compared with the real pipeline's own registrations — id, reference
-        // text, and `RefType` alike.
+    fn registers_the_recorded_bibliography_entries() {
+        // Frozen at the last differentially-verified parity — see
+        // `registers_the_recorded_ids_for_a_broad_fixture_set` for the
+        // provenance of these literals (id, reference text, and `RefType`
+        // alike were compared against the string pipeline's own registrations
+        // until the commit that deleted it).
         let fixtures = [
-            "[[[gof]]] Gamma.",
-            "[[[gof,GoF]]] Gamma.",
-            "[[[gof, GoF ]]] Gamma.",
-            "[[[gof,A & B]]] Gamma.",
-            "[[[1984]]] Orwell.",
-            "See [[[mid]]] inline.",
-            "[[[gof]]] and an inline [[extra]] anchor",
+            (
+                "[[[gof]]] Gamma.",
+                r#"[("gof", Some("[gof]"), RefType::Bibliography)]"#,
+            ),
+            (
+                "[[[gof,GoF]]] Gamma.",
+                r#"[("gof", Some("[GoF]"), RefType::Bibliography)]"#,
+            ),
+            (
+                "[[[gof, GoF ]]] Gamma.",
+                r#"[("gof", Some("[GoF ]"), RefType::Bibliography)]"#,
+            ),
+            (
+                "[[[gof,A & B]]] Gamma.",
+                r#"[("gof", Some("[A &amp; B]"), RefType::Bibliography)]"#,
+            ),
+            ("[[[1984]]] Orwell.", "[]"),
+            ("See [[[mid]]] inline.", "[]"),
+            (
+                "[[[gof]]] and an inline [[extra]] anchor",
+                r#"[("extra", None, RefType::Anchor), ("gof", Some("[gof]"), RefType::Bibliography)]"#,
+            ),
             // An ordinary anchor at the very start of the content: the
             // bibliography pass leaves it to `apply_ref_side_effects`, which
             // catalogs it under `RefType::Anchor`.
-            "[[plain]] leads an entry that has no bibliography anchor",
+            (
+                "[[plain]] leads an entry that has no bibliography anchor",
+                r#"[("plain", None, RefType::Anchor)]"#,
+            ),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = biblio_parser();
             let nodes = build_with(Span::new(fixture), &builder_parser);
             apply_biblio_side_effects(&nodes, &builder_parser, Span::new(fixture));
             apply_ref_side_effects(&nodes, &builder_parser, Span::new(fixture), false);
 
-            let golden_parser = biblio_parser();
-            golden_macros_with(fixture, &golden_parser);
-
-            let entries = |parser: &Parser| {
-                let catalog = parser.catalog();
+            let entries = {
+                let catalog = builder_parser.catalog();
 
                 catalog
                     .ids()
@@ -1895,8 +1893,8 @@ mod tests {
             };
 
             assert_eq!(
-                entries(&builder_parser),
-                entries(&golden_parser),
+                format!("{entries:?}"),
+                expected,
                 "registered references diverged for {fixture:?}"
             );
         }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -358,7 +358,7 @@ pub(in crate::content::inline_builder) fn range_is_substitution_restorable(
 /// rather than reads: the placeholder's bytes are not the string pipeline's
 /// (its haystack holds the `\u{96}`*n*`\u{97}` sentinel there), but the
 /// masked construct's own rendered body **is** known at build time — it is
-/// what [`Passthroughs::restore_to`](crate::content::Passthroughs) splices
+/// what [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs) splices
 /// over the sentinel after the steps run — so a computed value that
 /// substitutes it for the placeholder (see
 /// [`restore_masked_passthroughs`](super::links))
@@ -427,14 +427,14 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
 /// ([`Stem`](InlineNode::Stem)).
 ///
 /// These are exactly the two node kinds the *same* extraction pass
-/// ([`Passthroughs::extract_from`](crate::content::Passthroughs)) masks before
-/// any substitution step runs — STEM being an implicit passthrough, as
-/// [`Stem::value`](crate::inlines::Stem) documents — so each stands in the
-/// string pipeline's haystack as one `\u{96}`*n*`\u{97}` sentinel and in this
-/// module's match string as one [`SPAN_PLACEHOLDER`](super::super::quotes)
-/// character, and each has a body known at build time that
-/// `Passthroughs::restore_to` splices over that sentinel once the steps have
-/// run.
+/// ([`Passthroughs::extract_from`](crate::content::passthroughs::Passthroughs))
+/// masks before any substitution step runs — STEM being an implicit
+/// passthrough, as [`Stem::value`](crate::inlines::Stem) documents — so each
+/// stands in the string pipeline's haystack as one `\u{96}`*n*`\u{97}` sentinel
+/// and in this module's match string as one
+/// [`SPAN_PLACEHOLDER`](super::super::quotes) character, and each has a body
+/// known at build time that `Passthroughs::restore_to` splices over that
+/// sentinel once the steps have run.
 ///
 /// Every restoring family admits both kinds. The `image:`/`icon:` family's
 /// values are the only restored ones the **fold** re-processes —
@@ -459,8 +459,9 @@ pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'
 }
 
 /// The bytes a [`node_is_restorable`] node restores to — the very text
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices over
-/// the string pipeline's own sentinel — or `None` for any other node.
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+/// splices over the string pipeline's own sentinel — or `None` for any other
+/// node.
 ///
 /// The invariant both callers rest on is that this returns **exactly what the
 /// fold of that node emits**, so a value finished with these bytes reads the
@@ -772,11 +773,11 @@ fn widen_masked_pieces(
 /// [`node_is_restorable`] piece's placeholder becomes the same
 /// sentinel-shaped token, the arithmetic runs, and each *surviving* token is
 /// restored with its own node's body ([`restorable_body`]) — index-keyed, as
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) is, so a token
-/// the basename cut dropped (a masked construct wholly inside a directory
-/// prefix or an extension) does not shift the ones that survive. A token
-/// survives whole or is dropped whole: both of the cut points [`basename`]
-/// reads (the last `/`, the last `.`) are bytes no token contains.
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs) is,
+/// so a token the basename cut dropped (a masked construct wholly inside a
+/// directory prefix or an extension) does not shift the ones that survive. A
+/// token survives whole or is dropped whole: both of the cut points
+/// [`basename`] reads (the last `/`, the last `.`) are bytes no token contains.
 ///
 /// A range holding no masked construct takes the plain derivation over the
 /// match-string bytes — exactly what this family computed before the restore
@@ -983,8 +984,8 @@ pub(in crate::content::inline_builder) enum Tokened {
 /// on the way back out ([`Attrlist::into_owned_restoring`]) — the parse can
 /// drop a token (a blank slot, a value the split discards) without shifting
 /// the ones that survive, exactly as
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) is unshifted by
-/// a sentinel that never reached the rendered string.
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs) is
+/// unshifted by a sentinel that never reached the rendered string.
 ///
 /// Shared by the two families whose bracket comes back from a parse — the
 /// `image:`/`icon:` bracket here, and the link families' display-text list
@@ -1214,7 +1215,7 @@ mod tests {
         super::{
             super::test_support::{
                 assert_styled, assert_text, build_src, build_through_quotes, fold_html,
-                golden_macros, golden_macros_in, golden_macros_with,
+                golden_macros, golden_macros_in,
             },
             ComputedSpecials,
         },
@@ -2605,26 +2606,26 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_a_target_crossing_an_escaped_special() {
+    fn registers_the_recorded_target_for_a_target_crossing_an_escaped_special() {
         // The staged `register_image` reads the node's own stored `target`,
-        // which is now the escaped one — so it must be byte-identical to the
-        // `caps[1]` the string replacer registers. Two independent parsers, as
-        // elsewhere in this module.
+        // which is the escaped one — byte-identical to the `caps[1]` the
+        // string replacer registered. Frozen at the last differentially-
+        // verified parity, like the broad set above.
         let fixtures = [
-            "image:a&b.png[]",
-            "image:a<b.png[Alt]",
-            "image:a&b.png[] image:c&d.png[]",
-            "icon:a&b[]",
-            "\\image:a&b.png[A]",
+            ("image:a&b.png[]", r#"["a&amp;b.png"]"#),
+            ("image:a<b.png[Alt]", r#"["a&lt;b.png"]"#),
+            (
+                "image:a&b.png[] image:c&d.png[]",
+                r#"["a&amp;b.png", "c&amp;d.png"]"#,
+            ),
+            ("icon:a&b[]", "[]"),
+            ("\\image:a&b.png[A]", "[]"),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = Parser::default().with_catalog_assets(true);
             let nodes = build_with(Span::new(fixture), &builder_parser);
             apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
-
-            let golden_parser = Parser::default().with_catalog_assets(true);
-            golden_macros_with(fixture, &golden_parser);
 
             let got: Vec<_> = builder_parser
                 .catalog()
@@ -2633,14 +2634,11 @@ mod tests {
                 .map(|i| i.target.clone())
                 .collect();
 
-            let want: Vec<_> = golden_parser
-                .catalog()
-                .images()
-                .iter()
-                .map(|i| i.target.clone())
-                .collect();
-
-            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+            assert_eq!(
+                format!("{got:?}"),
+                expected,
+                "registered images diverged for {fixture:?}"
+            );
         }
     }
 
@@ -2760,34 +2758,32 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
-        // Each fixture uses its own pair of *independent* parsers (design
-        // §5.3's two-independent-parsers discipline, already established by
-        // the footnote increment's own differential corpus): one that the
-        // additive builder builds against and this function then walks, one
-        // that the real string pipeline (`golden_macros_with`) runs against
-        // directly. Because neither path is wired into the other, comparing
-        // their two catalogs after the fact is the whole test.
+    fn registers_the_recorded_targets_for_a_broad_fixture_set() {
+        // Each expected set is **frozen at the last differentially-verified
+        // parity**: until the string pipeline's deletion this test registered
+        // each fixture through it on an independent parser and compared the
+        // two catalogs, green at the commit that deleted it — the literals are
+        // that pipeline's own answer.
         let fixtures = [
-            "image:sunset.jpg[Sunset]",
-            "icon:home[]",
-            "image:sunset.jpg[Sunset]{sp}image:other.png[]",
-            "image without a bracket image:foo.png stays literal",
-            "\\image:sunset.jpg[Sunset]",
+            ("image:sunset.jpg[Sunset]", r#"["sunset.jpg"]"#),
+            ("icon:home[]", "[]"),
+            (
+                "image:sunset.jpg[Sunset]{sp}image:other.png[]",
+                r#"["sunset.jpg", "other.png"]"#,
+            ),
+            ("image without a bracket image:foo.png stays literal", "[]"),
+            ("\\image:sunset.jpg[Sunset]", "[]"),
             // A bracket with no `'src` slice of its own: the attribute list
             // is parsed from the match string, but `register_image` reads the
-            // node's `target`, so the catalogs must still agree.
-            "image:sunset.jpg[a < b]",
-            "image:a&b.png[Tom &amp; Jerry,200]",
+            // node's `target`, so the recorded target is still the match's.
+            ("image:sunset.jpg[a < b]", r#"["sunset.jpg"]"#),
+            ("image:a&b.png[Tom &amp; Jerry,200]", r#"["a&amp;b.png"]"#),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = Parser::default().with_catalog_assets(true);
             let nodes = build_with(Span::new(fixture), &builder_parser);
             apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
-
-            let golden_parser = Parser::default().with_catalog_assets(true);
-            golden_macros_with(fixture, &golden_parser);
 
             let got: Vec<_> = builder_parser
                 .catalog()
@@ -2795,14 +2791,12 @@ mod tests {
                 .iter()
                 .map(|i| i.target.clone())
                 .collect();
-            let want: Vec<_> = golden_parser
-                .catalog()
-                .images()
-                .iter()
-                .map(|i| i.target.clone())
-                .collect();
 
-            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+            assert_eq!(
+                format!("{got:?}"),
+                expected,
+                "registered images diverged for {fixture:?}"
+            );
         }
     }
 
@@ -2974,17 +2968,8 @@ mod tests {
     /// The real, public pipeline's output for `source` — the golden for the
     /// expanded-value fixtures, which need the `AttributeReferences` step
     /// [`golden_macros_with`] deliberately omits.
-    fn golden_normal(source: &str, parser: &Parser) -> String {
-        use crate::content::{Content, SubstitutionGroup};
-
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "image_normal",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_normal(source: &str, _parser: &Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("image_normal", source)
     }
 
     #[test]
@@ -3174,26 +3159,26 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_images_inside_expanded_values() {
+    fn registers_the_recorded_target_for_images_inside_expanded_values() {
         // The staged `register_image` side effect reads the node's own stored
-        // `target`, which is now the *expanded* one — so the catalog must match
-        // the golden pipeline's, which registers what its own expanded haystack
-        // matched. Two independent parsers, as elsewhere in this module.
+        // `target`, which is the *expanded* one — what the string pipeline's
+        // own expanded haystack matched and registered. Frozen at the last
+        // differentially-verified parity, like the broad set above.
         let fixtures = [
-            "image:{logo}[Logo]",
-            "image:{logo}[]",
-            "image:{dir}/{logo}[]",
-            "see {img-src} here",
-            "image:{logo}[A] then image:other.png[B]",
+            ("image:{logo}[Logo]", r#"["sunset.jpg"]"#),
+            ("image:{logo}[]", r#"["sunset.jpg"]"#),
+            ("image:{dir}/{logo}[]", r#"["assets/sunset.jpg"]"#),
+            ("see {img-src} here", r#"["sunset.jpg"]"#),
+            (
+                "image:{logo}[A] then image:other.png[B]",
+                r#"["sunset.jpg", "other.png"]"#,
+            ),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = expanding_parser().with_catalog_assets(true);
             let nodes = build(Span::new(fixture), &builder_parser, None);
             apply_image_side_effects(&nodes, &builder_parser, Span::new(fixture));
-
-            let golden_parser = expanding_parser().with_catalog_assets(true);
-            golden_normal(fixture, &golden_parser);
 
             let got: Vec<_> = builder_parser
                 .catalog()
@@ -3202,14 +3187,11 @@ mod tests {
                 .map(|i| i.target.clone())
                 .collect();
 
-            let want: Vec<_> = golden_parser
-                .catalog()
-                .images()
-                .iter()
-                .map(|i| i.target.clone())
-                .collect();
-
-            assert_eq!(got, want, "registered images diverged for {fixture:?}");
+            assert_eq!(
+                format!("{got:?}"),
+                expected,
+                "registered images diverged for {fixture:?}"
+            );
         }
     }
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1646,7 +1646,7 @@ mod tests {
         // and its `indexterm2:` twin used to pin.
         use crate::{
             Parser,
-            content::{Content, SubstitutionGroup, inline_builder::build},
+            content::inline_builder::build,
             parser::{HtmlSubstitutionRenderer, ModificationContext},
         };
 
@@ -1689,20 +1689,13 @@ mod tests {
         for source in fixtures {
             let nodes = build(Span::new(source), &parser, None);
 
-            let mut golden = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut golden, &parser, None);
-
             assert_eq!(
                 crate::content::inline_builder::fold_html(
                     &nodes,
                     &HtmlSubstitutionRenderer {},
                     &parser.render_context()
                 ),
-                crate::content::inline_builder::snapshot::recorded_golden(
-                    "indexterm_expanded",
-                    source,
-                    golden.rendered_str(),
-                ),
+                crate::content::inline_builder::snapshot::recorded("indexterm_expanded", source),
                 "fold diverged from the string pipeline for {source:?}"
             );
         }

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -154,11 +154,11 @@ use crate::{
 /// the bare branch's trailing-character class admits the last byte of either
 /// spelling, so the two recognize the same extent — this family needs no
 /// widening of its own, unlike the `image:`/`icon:` one), and
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) then splices
-/// the extracted body's substituted text over every sentinel in the rendered
-/// string. A `Raw` node's `value` **is** that text, known at build time, so
-/// [`restore_masked_passthroughs`] substitutes it for the placeholder and the
-/// computed target finishes into exactly the restored string's bytes —
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+/// then splices the extracted body's substituted text over every sentinel in
+/// the rendered string. A `Raw` node's `value` **is** that text, known at build
+/// time, so [`restore_masked_passthroughs`] substitutes it for the placeholder
+/// and the computed target finishes into exactly the restored string's bytes —
 /// `https://++example.org/now_this__link_works.html++` and
 /// `https://example.orgpass:[/a b]`, the two documented idioms, and every
 /// partial mask around them.
@@ -1088,7 +1088,7 @@ fn find_link_macro_matches<'src>(
 /// range holds no masked construct (so a caller keeps the bytes it
 /// already has).
 ///
-/// This is [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own
+/// This is [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)'s own
 /// rewrite, applied to a *computed value* instead of the rendered string: the
 /// string pipeline's replacer reads the `\u{96}`*n*`\u{97}` sentinel into the
 /// value (a `link:` macro's target, and with it the emitted `href` and a bare
@@ -1626,10 +1626,10 @@ struct TextAttrlist<'src> {
 /// second and third positionals become the `?subject=`/`&amp;body=` query
 /// through [`encode_uri_component`]. The string pipeline percent-encodes its
 /// own sentinel there (`%C2%960%C2%97`), which
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) then cannot find
-/// in the finished `href` — so its golden *leaks* the encoded sentinel, and no
-/// restore here can reproduce that. This is the same boundary the
-/// cross-reference family's own pre-restore target keeps, drawn per slot
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+/// then cannot find in the finished `href` — so its golden *leaks* the encoded
+/// sentinel, and no restore here can reproduce that. This is the same boundary
+/// the cross-reference family's own pre-restore target keeps, drawn per slot
 /// rather than per family so that a masked piece in the display text beside a
 /// plain subject still restores.
 ///
@@ -2095,7 +2095,7 @@ mod tests {
 
     use super::super::super::test_support::{
         assert_entity, assert_link, assert_raw, assert_special_char, assert_styled, assert_text,
-        build_src, fold_html, golden_macros, golden_macros_in, golden_macros_with, link_text_of,
+        build_src, fold_html, golden_macros, golden_macros_in, link_text_of,
     };
     use crate::{
         HasSpan, Parser, Span,
@@ -6347,11 +6347,6 @@ mod tests {
             parser.catalog().links(),
             ["https://a.example", "https://c.example", "b.html"]
         );
-
-        // The golden string pipeline agrees.
-        let golden_parser = Parser::default().with_catalog_assets(true);
-        golden_macros_with(source, &golden_parser);
-        assert_eq!(golden_parser.catalog().links(), parser.catalog().links());
     }
 
     #[test]
@@ -6372,11 +6367,6 @@ mod tests {
             parser.catalog().links(),
             ["https://a.example", "b.html", "c.html"]
         );
-
-        // The golden string pipeline agrees.
-        let golden_parser = Parser::default().with_catalog_assets(true);
-        golden_macros_with(source, &golden_parser);
-        assert_eq!(golden_parser.catalog().links(), parser.catalog().links());
     }
 
     #[test]
@@ -6407,11 +6397,6 @@ mod tests {
             parser.catalog().links(),
             ["https://a.example", "b.html", "mailto:first@example.org"]
         );
-
-        // The golden string pipeline agrees.
-        let golden_parser = Parser::default().with_catalog_assets(true);
-        golden_macros_with(source, &golden_parser);
-        assert_eq!(golden_parser.catalog().links(), parser.catalog().links());
     }
 
     #[test]
@@ -6450,7 +6435,7 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_a_broad_fixture_set() {
+    fn registers_the_recorded_links_for_a_broad_fixture_set() {
         // Each fixture uses its own pair of *independent* parsers (design
         // §5.3's two-independent-parsers discipline, already established by
         // the image increment's own differential corpus): one that the
@@ -6468,54 +6453,87 @@ mod tests {
         // character, which `INLINE_LINK` rejects, while the builder sees the
         // expanded space and links it).
         let fixtures = [
-            "link:index.html[Docs]",
-            "link:[]",
-            "mailto:hello@example.org[Email us]",
-            "mailto:[]",
-            "https://example.org",
-            "https://example.org[Example]",
-            "link:https://example.org[Example]",
-            "\\link:index.html[Docs]",
-            "link:a.html[A] link:b.html[B]",
+            ("link:index.html[Docs]", r#"["index.html"]"#),
+            ("link:[]", r#"[""]"#),
+            (
+                "mailto:hello@example.org[Email us]",
+                r#"["mailto:hello@example.org"]"#,
+            ),
+            ("mailto:[]", r#"["mailto:"]"#),
+            ("https://example.org", r#"["https://example.org"]"#),
+            ("https://example.org[Example]", r#"["https://example.org"]"#),
+            (
+                "link:https://example.org[Example]",
+                r#"["https://example.org"]"#,
+            ),
+            ("\\link:index.html[Docs]", r#"[]"#),
+            ("link:a.html[A] link:b.html[B]", r#"["a.html", "b.html"]"#),
             // Interleaved forms, out of source order relative to the family
             // passes that register them (see `apply_link_side_effects`'s own
             // "Registration order" doc note).
-            "link:b.html[B] then https://a.example",
+            (
+                "link:b.html[B] then https://a.example",
+                r#"["https://a.example", "b.html"]"#,
+            ),
             // The bare e-mail form, alone and interleaved with both URL-link
             // forms — it registers last of the three, wherever it appears.
-            "doc@example.com",
-            "\\doc@example.com",
-            "doc@example.com then link:b.html[B]",
-            "a@example.org link:b.html[B] https://c.example d@example.org",
+            ("doc@example.com", r#"["mailto:doc@example.com"]"#),
+            ("\\doc@example.com", r#"[]"#),
+            (
+                "doc@example.com then link:b.html[B]",
+                r#"["b.html", "mailto:doc@example.com"]"#,
+            ),
+            (
+                "a@example.org link:b.html[B] https://c.example d@example.org",
+                r#"["https://c.example", "b.html", "mailto:a@example.org", "mailto:d@example.org"]"#,
+            ),
             // A macro whose target crosses an escaped special registers the
             // *escaped* target, exactly as the string replacer does.
-            "link:a&b.html[x]",
-            "mailto:a&b@example.org[]",
-            "link:a&b.html[x] then link:c.html[C]",
+            ("link:a&b.html[x]", r#"["a&amp;b.html"]"#),
+            (
+                "mailto:a&b@example.org[]",
+                r#"["mailto:a&amp;b@example.org"]"#,
+            ),
+            (
+                "link:a&b.html[x] then link:c.html[C]",
+                r#"["a&amp;b.html", "c.html"]"#,
+            ),
             // The same, for the auto-link / formal-URL family (whose own
             // registration pass runs first) and the ANGLE branch.
-            "https://example.org/?a=1&b=2",
-            "https://example.org/a&b[Example]",
-            "<https://example.org/a&b>",
-            "https://a.example/?x=1&y=2 then link:b&c.html[B]",
+            (
+                "https://example.org/?a=1&b=2",
+                r#"["https://example.org/?a=1&amp;b=2"]"#,
+            ),
+            (
+                "https://example.org/a&b[Example]",
+                r#"["https://example.org/a&amp;b"]"#,
+            ),
+            (
+                "<https://example.org/a&b>",
+                r#"["https://example.org/a&amp;b"]"#,
+            ),
+            (
+                "https://a.example/?x=1&y=2 then link:b&c.html[B]",
+                r#"["https://a.example/?x=1&amp;y=2", "b&amp;c.html"]"#,
+            ),
             // And for the bare-e-mail family, whose registration pass runs
             // last: the `mailto:` target it records carries the address's own
             // `&amp;`.
-            "a&b@example.com",
-            "a&b@example.com then link:c.html[C] then https://d.example",
+            ("a&b@example.com", r#"["mailto:a&amp;b@example.com"]"#),
+            (
+                "a&b@example.com then link:c.html[C] then https://d.example",
+                r#"["https://d.example", "c.html", "mailto:a&amp;b@example.com"]"#,
+            ),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = Parser::default().with_catalog_assets(true);
             let nodes = build_with(Span::new(fixture), &builder_parser);
             apply_link_side_effects(&nodes, &builder_parser);
 
-            let golden_parser = Parser::default().with_catalog_assets(true);
-            golden_macros_with(fixture, &golden_parser);
-
             assert_eq!(
-                builder_parser.catalog().links(),
-                golden_parser.catalog().links(),
+                format!("{:?}", builder_parser.catalog().links()),
+                expected,
                 "registered links diverged for {fixture:?}"
             );
         }
@@ -6548,17 +6566,8 @@ mod tests {
     /// The real, public pipeline's output for `source` — the golden for the
     /// expanded-value fixtures, which need the `AttributeReferences` step
     /// [`golden_macros_with`] deliberately omits.
-    fn golden_normal(source: &str, parser: &Parser) -> String {
-        use crate::content::{Content, SubstitutionGroup};
-
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "links_normal",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_normal(source: &str, _parser: &Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("links_normal", source)
     }
 
     #[test]
@@ -6716,30 +6725,39 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_expanded_link_macros() {
+    fn registers_the_recorded_links_for_expanded_link_macros() {
         // The registration order that used to depend on the node's location:
         // an expanded macro registers in the *macro* pass, between the two URL
         // link forms' pass and the bare-e-mail one's, wherever it stands in
         // the source. Driven through the real pipeline on both sides, since
         // these fixtures need the `AttributeReferences` step.
-        for fixture in [
-            "{link-src}",
-            "see {link-src} now",
-            "see {link-src} and https://example.org now",
-            "https://a.example then {link-src} then doc@example.org",
-            "doc@example.org then {link-src}",
-            "{link-src} then link:b.html[B]",
+        for (fixture, expected) in [
+            ("{link-src}", r#"["index.html"]"#),
+            ("see {link-src} now", r#"["index.html"]"#),
+            (
+                "see {link-src} and https://example.org now",
+                r#"["https://example.org", "index.html"]"#,
+            ),
+            (
+                "https://a.example then {link-src} then doc@example.org",
+                r#"["https://a.example", "index.html", "mailto:doc@example.org"]"#,
+            ),
+            (
+                "doc@example.org then {link-src}",
+                r#"["index.html", "mailto:doc@example.org"]"#,
+            ),
+            (
+                "{link-src} then link:b.html[B]",
+                r#"["index.html", "b.html"]"#,
+            ),
         ] {
             let builder_parser = expanding_parser().with_catalog_assets(true);
             let nodes = build(Span::new(fixture), &builder_parser, None);
             apply_link_side_effects(&nodes, &builder_parser);
 
-            let golden_parser = expanding_parser().with_catalog_assets(true);
-            golden_normal(fixture, &golden_parser);
-
             assert_eq!(
-                builder_parser.catalog().links(),
-                golden_parser.catalog().links(),
+                format!("{:?}", builder_parser.catalog().links()),
+                expected,
                 "registered links diverged for {fixture:?}"
             );
         }
@@ -6775,7 +6793,7 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registration_for_links_inside_expanded_values() {
+    fn registers_the_recorded_links_inside_expanded_values() {
         // The staged `register_link` side effect classifies each node by the
         // pass that built it, from the node's own `location` — which is exactly
         // why `link_macro_level` still requires its `link:`/`mailto:` marker to
@@ -6783,25 +6801,31 @@ mod tests {
         // over expanded values, in both relative orders, so a misclassification
         // would show up as the wrong catalog order.
         let fixtures = [
-            "link:{url}[Docs]",
-            "https://{host}",
-            "link:{url}[Docs] and https://{host}",
-            "https://{host} then link:{url}[Docs]",
-            "see {site} now",
-            "mailto:{addr}[Team] and https://{host}",
+            ("link:{url}[Docs]", r#"["index.html"]"#),
+            ("https://{host}", r#"["https://example.org"]"#),
+            (
+                "link:{url}[Docs] and https://{host}",
+                r#"["https://example.org", "index.html"]"#,
+            ),
+            (
+                "https://{host} then link:{url}[Docs]",
+                r#"["https://example.org", "index.html"]"#,
+            ),
+            ("see {site} now", r#"["https://example.org"]"#),
+            (
+                "mailto:{addr}[Team] and https://{host}",
+                r#"["https://example.org", "mailto:hello@example.org"]"#,
+            ),
         ];
 
-        for fixture in fixtures {
+        for (fixture, expected) in fixtures {
             let builder_parser = expanding_parser().with_catalog_assets(true);
             let nodes = build(Span::new(fixture), &builder_parser, None);
             apply_link_side_effects(&nodes, &builder_parser);
 
-            let golden_parser = expanding_parser().with_catalog_assets(true);
-            golden_normal(fixture, &golden_parser);
-
             assert_eq!(
-                builder_parser.catalog().links(),
-                golden_parser.catalog().links(),
+                format!("{:?}", builder_parser.catalog().links()),
+                expected,
                 "registered links diverged for {fixture:?}"
             );
         }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -875,10 +875,10 @@ pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> Stri
 /// honest reading.
 ///
 /// The walk is index-keyed and left to right, like
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs)'s own: each
-/// token is sought only in the bytes after the previous one, and a token the
-/// parse dropped (a value the split discarded) is simply not found, leaving
-/// the ones after it to splice by their own index.
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)'s
+/// own: each token is sought only in the bytes after the previous one, and a
+/// token the parse dropped (a value the split discarded) is simply not found,
+/// leaving the ones after it to splice by their own index.
 pub(super) fn restored_value_children<'src>(
     text: &str,
     restores: &[InlineNode<'src>],
@@ -1067,8 +1067,8 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::{
-        super::{special_chars::Masked, test_support::golden_macros_with},
-        ComputedSpecials, apply_macro_side_effects, apply_macros, escaped_value_children,
+        super::special_chars::Masked, ComputedSpecials, apply_macro_side_effects, apply_macros,
+        escaped_value_children,
     };
     use crate::{
         Parser, Span,
@@ -1102,9 +1102,6 @@ mod tests {
             r"xref:target[\{name}]",
             r"<<target,a \{name} b>>",
         ] {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-
             let nodes = build_for_group(
                 &SubstitutionGroup::Normal,
                 CowStr::from(source),
@@ -1126,10 +1123,9 @@ mod tests {
 
             assert_eq!(
                 folded,
-                crate::content::inline_builder::snapshot::recorded_golden(
+                crate::content::inline_builder::snapshot::recorded(
                     "build_for_group_escaped_reference",
-                    source,
-                    content.rendered_html(),
+                    source
                 )
             );
             assert!(!folded.contains('\\'));
@@ -1222,9 +1218,6 @@ mod tests {
                         },
                     ),
                 ] {
-                    let mut content = Content::from(Span::new(&source));
-                    group.apply_string_pipeline(&mut content, &parser, None);
-
                     let nodes = build_for_group(
                         group,
                         CowStr::from(source.clone()),
@@ -1241,11 +1234,7 @@ mod tests {
 
                     assert_eq!(
                         folded,
-                        crate::content::inline_builder::snapshot::recorded_golden(
-                            corpus,
-                            &source,
-                            content.rendered_html()
-                        ),
+                        crate::content::inline_builder::snapshot::recorded(corpus, &source),
                         "{source:?}"
                     );
                     assert!(folded.contains(expected), "{source:?}: {folded:?}");
@@ -1372,9 +1361,6 @@ mod tests {
             // Inline STEM, whose expression is a passthrough.
             "stem:[a &copy; b]",
         ] {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-
             let nodes = build_for_group(
                 &SubstitutionGroup::Normal,
                 CowStr::from(source),
@@ -1389,10 +1375,9 @@ mod tests {
                     &HtmlSubstitutionRenderer {},
                     &parser.render_context()
                 ),
-                crate::content::inline_builder::snapshot::recorded_golden(
+                crate::content::inline_builder::snapshot::recorded(
                     "build_for_group_restored_entity",
-                    source,
-                    content.rendered_html(),
+                    source
                 ),
                 "fold diverged from the string pipeline for {source:?}"
             );
@@ -1430,9 +1415,6 @@ mod tests {
         };
 
         let parity = |source: &str| {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &configure(), None);
-
             let built_parser = configure();
 
             let nodes = build_for_group(
@@ -1449,10 +1431,9 @@ mod tests {
                     &HtmlSubstitutionRenderer {},
                     &built_parser.render_context()
                 ),
-                crate::content::inline_builder::snapshot::recorded_golden(
+                crate::content::inline_builder::snapshot::recorded(
                     "build_for_group_recoverable_piece",
-                    source,
-                    content.rendered_html(),
+                    source
                 ),
                 "fold diverged from the string pipeline for {source:?}"
             );
@@ -1550,8 +1531,11 @@ mod tests {
         //
         // This is a **keep**: the tree's answer is the well-formed one, and
         // the string pipeline's is markup no backend would choose to emit.
-        let parser = Parser::default();
 
+        // `golden_html` is what the string pipeline rendered — kept in the
+        // fixture as the recorded half of the divergence now that the
+        // pipeline itself is gone, exactly as the divergence corpora keep
+        // theirs in `snapshots/`.
         for (source, golden_html, folded_html) in [
             (
                 "x link:t.html[pre xref:tgt[T] post] y",
@@ -1568,19 +1552,16 @@ mod tests {
                 r##"x <a href="t.html">pre footnote:[n</a> post] y"##,
             ),
         ] {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-
-            assert_eq!(content.rendered_str(), golden_html);
-
-            assert_eq!(
-                fold_html(
-                    &build(Span::new(source), &Parser::default(), None),
-                    &HtmlSubstitutionRenderer {},
-                    &Parser::default().render_context(),
-                ),
-                folded_html,
+            let folded = fold_html(
+                &build(Span::new(source), &Parser::default(), None),
+                &HtmlSubstitutionRenderer {},
+                &Parser::default().render_context(),
             );
+
+            assert_eq!(folded, folded_html);
+
+            // The divergence itself, pinned as bytes.
+            assert_ne!(folded, golden_html);
         }
     }
 
@@ -1607,7 +1588,7 @@ mod tests {
     }
 
     #[test]
-    fn matches_the_golden_pipelines_registrations_and_warning_order_for_mixed_families() {
+    fn registers_the_recorded_order_and_warnings_for_mixed_families() {
         // A content that exercises every family this function composes in one
         // go: an image whose `link=` targets a dangerous scheme (a warning
         // from the image family) *before* a duplicate anchor id (a warning
@@ -1623,9 +1604,8 @@ mod tests {
         let nodes = build(Span::new(source), &builder_parser, None);
         apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
 
-        let golden_parser = Parser::default().with_catalog_assets(true);
-        golden_macros_with(source, &golden_parser);
-
+        // Frozen at the last differentially-verified parity, like every other
+        // registration expectation in this module.
         assert_eq!(
             builder_parser
                 .catalog()
@@ -1633,12 +1613,7 @@ mod tests {
                 .iter()
                 .map(|i| i.target.clone())
                 .collect::<Vec<_>>(),
-            golden_parser
-                .catalog()
-                .images()
-                .iter()
-                .map(|i| i.target.clone())
-                .collect::<Vec<_>>(),
+            ["x.png"],
         );
 
         let builder_warnings: Vec<_> = builder_parser
@@ -1646,13 +1621,7 @@ mod tests {
             .into_iter()
             .map(|w| w.warning)
             .collect();
-        let golden_warnings: Vec<_> = golden_parser
-            .drain_substitution_warnings_since(0)
-            .into_iter()
-            .map(|w| w.warning)
-            .collect();
 
-        assert_eq!(builder_warnings, golden_warnings);
         assert_eq!(
             builder_warnings,
             [
@@ -1681,25 +1650,15 @@ mod tests {
         let nodes = build(Span::new(source), &builder_parser, None);
         apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
 
-        let golden_parser = Parser::default().with_catalog_assets(true);
-        golden_parser.in_bibliography_list_item.set(true);
-        golden_parser
-            .register_ref("dup", None, crate::document::RefType::Bibliography)
-            .unwrap();
+        let builder_warnings = builder_parser
+            .drain_substitution_warnings_since(0)
+            .into_iter()
+            .map(|w| w.warning)
+            .collect::<Vec<_>>();
 
-        golden_macros_with(source, &golden_parser);
-
-        let warnings = |parser: &Parser| {
-            parser
-                .drain_substitution_warnings_since(0)
-                .into_iter()
-                .map(|w| w.warning)
-                .collect::<Vec<_>>()
-        };
-
-        let builder_warnings = warnings(&builder_parser);
-
-        assert_eq!(builder_warnings, warnings(&golden_parser));
+        // Frozen at the last differentially-verified parity: the string
+        // pipeline's own pass order landed the same two warnings in the same
+        // order until the commit that deleted it.
         assert_eq!(
             builder_warnings,
             [

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -913,17 +913,8 @@ mod tests {
     /// The real, public pipeline's output for `source` — the golden for the
     /// expanded-value fixtures, which need the `AttributeReferences` step the
     /// module's own [`golden_macros`] helper deliberately omits.
-    fn golden_normal(source: &str, parser: &Parser) -> String {
-        use crate::content::{Content, SubstitutionGroup};
-
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "ui_normal",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_normal(source: &str, _parser: &Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("ui_normal", source)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -868,7 +868,7 @@ mod tests {
     };
     use crate::{
         HasSpan, Parser, Span,
-        content::{Content, SubstitutionGroup, SubstitutionStep},
+        content::Content,
         inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant},
         parser::{HtmlSubstitutionRenderer, XrefStyle},
     };
@@ -883,17 +883,11 @@ mod tests {
     /// side while the builder expands it, and report the difference as a
     /// divergence the fixture does not have.
     fn golden_whole_pipeline(source: &str) -> String {
-        let parser = Parser::default();
         let mut content = Content::from(Span::new(source));
 
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
         content.finalize_deferred(&HtmlSubstitutionRenderer {});
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "xref_whole_pipeline",
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded("xref_whole_pipeline", source)
     }
 
     /// The string pipeline's output through the **macros** step for `source`,
@@ -903,23 +897,8 @@ mod tests {
     /// placeholder must be finalized — no catalog resolution runs, so the
     /// result is the unresolved-fallback rendering the additive builder's
     /// fold (always unresolved) must reproduce.
-    fn golden_xref_with(source: &str, parser: &Parser) -> String {
-        let mut content = Content::from(Span::new(source));
-        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-        SubstitutionStep::Quotes.apply(&mut content, parser, None);
-        SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
-        SubstitutionStep::Macros.apply(&mut content, parser, None);
-        SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
-
-        // Finalize as the real pipeline does after the last step, capturing the
-        // placeholder template and rebuilding the unresolved fallback.
-        content.finalize_deferred(&HtmlSubstitutionRenderer {});
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "xref_macros",
-            source,
-            content.rendered_str(),
-        )
+    fn golden_xref_with(source: &str, _parser: &Parser) -> String {
+        crate::content::inline_builder::snapshot::recorded("xref_macros", source)
     }
 
     /// [`golden_xref_with`] with a default parser.
@@ -2222,29 +2201,13 @@ mod tests {
         // the golden output's own `href` and fallback text. The tree defers
         // instead and folds the restored literal — the well-formed reading
         // against the string pipeline's leaked one.
-        use crate::content::Passthroughs;
-
         let source = "xref:++someid++[]";
 
-        let parser = Parser::default();
-        let mut content = Content::from(Span::new(source));
-        let passthroughs = Passthroughs::extract_from(&mut content, &parser);
-
-        SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
-        SubstitutionStep::Quotes.apply(&mut content, &parser, None);
-        SubstitutionStep::CharacterReplacements.apply(&mut content, &parser, None);
-        SubstitutionStep::Macros.apply(&mut content, &parser, None);
-        SubstitutionStep::PostReplacement.apply(&mut content, &parser, None);
-
-        passthroughs.restore_to(&mut content, &parser);
-        content.finalize_deferred(&HtmlSubstitutionRenderer {});
-
         // Recorded, so the leaked bytes this divergence is *about* outlive the
-        // string pipeline that leaks them (see [`snapshot`]).
-        let golden = crate::content::inline_builder::snapshot::recorded_golden(
+        // string pipeline that leaked them (see [`snapshot`]).
+        let golden = crate::content::inline_builder::snapshot::recorded(
             "xref_passthrough_divergence",
             source,
-            content.rendered_str(),
         );
 
         assert!(
@@ -2555,18 +2518,11 @@ mod tests {
     /// expanded-value fixtures, which need the `AttributeReferences` step
     /// [`golden_xref_with`] deliberately omits (it also finalizes the deferred
     /// cross-references, which this does through the group's own pipeline).
-    fn golden_normal(source: &str, parser: &Parser) -> String {
-        use crate::content::SubstitutionGroup;
-
+    fn golden_normal(source: &str, _parser: &Parser) -> String {
         let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
         content.finalize_deferred(&HtmlSubstitutionRenderer {});
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "xref_normal",
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded("xref_normal", source)
     }
 
     #[test]

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -741,7 +741,7 @@ mod tests {
     use super::{build, build_from_value};
     use crate::{
         Parser, Span,
-        content::{Content, inline_builder::fold_html},
+        content::inline_builder::fold_html,
         inlines::{InlineNode, RawOrigin},
         parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
@@ -840,14 +840,6 @@ mod tests {
         );
     }
 
-    /// Runs `source` through the real, public `SubstitutionGroup::Normal`
-    /// pipeline, exactly as a real block's content is substituted in
-    /// production.
-    fn golden(source: &str, _parser: &Parser) -> String {
-        let content = Content::from(Span::new(source));
-        content.rendered_str().to_string()
-    }
-
     /// Builds and folds the single-pass tree for `source` — the same [`build`]
     /// a real cutover would call — through the built-in HTML renderer.
     fn built(source: &str, parser: &Parser) -> String {
@@ -859,31 +851,29 @@ mod tests {
         )
     }
 
-    /// Asserts that `source` folds identically whether taken through the real
-    /// production pipeline or through the single-pass builder, under a
+    /// Asserts that the single-pass builder's fold of `source` matches the
+    /// frozen recording of what the string pipeline rendered it as, under a
     /// document configured by `configure`.
     ///
-    /// `configure` is called once per side rather than sharing one `Parser`
-    /// between them: `golden`'s `SubstitutionGroup::apply` and `built`'s
-    /// `build` each advance document counters (footnote numbers,
-    /// `{counter:...}` values) for real, so sharing a parser would double
-    /// them. Two independently-built parsers, identically configured, see
-    /// the same fixture in the same left-to-right order and so stay in
-    /// lockstep — the same two-independent-parsers discipline this module's
-    /// other differential corpora already use (see e.g. `footnotes.rs`).
+    /// `configure` builds the parser here rather than the caller passing one
+    /// in — a signature kept from when this assertion also ran the string
+    /// pipeline and each side needed its own identically-configured document
+    /// (both sides advanced footnote numbers and `{counter:...}` values for
+    /// real, so sharing one parser would have doubled them). Only [`built`]'s
+    /// side runs today, but every call site passes a constructor, so the
+    /// shape stays.
     fn assert_parity_with(source: &str, configure: impl Fn() -> Parser) {
         assert_parity_in("whole_pipeline", source, configure);
     }
 
-    /// [`assert_parity_with`], recording into a named corpus.
+    /// [`assert_parity_with`], reading a named corpus.
     ///
-    /// The comparison is not `golden` against `built` directly: both are handed
-    /// to [`snapshot::assert_recorded`], which checks the **fold** against a
-    /// checked-in recording of the known-good bytes and the **golden** against
-    /// that same recording. The fold is never what a recording is written from,
-    /// which is what keeps this corpus honest once `rendered_html()` becomes a
-    /// fold of the tree and `golden` stops being an independent construction
-    /// (design §5.2 Phase 4, step 6 — see [`snapshot`](super::snapshot)).
+    /// The fold is handed to [`snapshot::assert_recorded`], which checks it
+    /// against a checked-in recording of the known-good bytes the string
+    /// pipeline produced while it existed. The fold is never what a recording
+    /// is written from, which is what keeps this corpus honest once
+    /// `rendered_html()` becomes a fold of the tree (design §5.2 Phase 4,
+    /// step 6 — see [`snapshot`](super::snapshot)).
     fn assert_parity_in(corpus: &str, source: &str, configure: impl Fn() -> Parser) {
         super::snapshot::assert_recorded(corpus, source, &built(source, &configure()));
     }

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -741,7 +741,7 @@ mod tests {
     use super::{build, build_from_value};
     use crate::{
         Parser, Span,
-        content::{Content, SubstitutionGroup, inline_builder::fold_html},
+        content::{Content, inline_builder::fold_html},
         inlines::{InlineNode, RawOrigin},
         parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
@@ -843,9 +843,8 @@ mod tests {
     /// Runs `source` through the real, public `SubstitutionGroup::Normal`
     /// pipeline, exactly as a real block's content is substituted in
     /// production.
-    fn golden(source: &str, parser: &Parser) -> String {
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, None);
+    fn golden(source: &str, _parser: &Parser) -> String {
+        let content = Content::from(Span::new(source));
         content.rendered_str().to_string()
     }
 
@@ -886,12 +885,7 @@ mod tests {
     /// fold of the tree and `golden` stops being an independent construction
     /// (design §5.2 Phase 4, step 6 — see [`snapshot`](super::snapshot)).
     fn assert_parity_in(corpus: &str, source: &str, configure: impl Fn() -> Parser) {
-        super::snapshot::assert_recorded(
-            corpus,
-            source,
-            &golden(source, &configure()),
-            &built(source, &configure()),
-        );
+        super::snapshot::assert_recorded(corpus, source, &built(source, &configure()));
     }
 
     fn assert_parity(source: &str) {
@@ -1011,7 +1005,6 @@ mod tests {
                 if !super::snapshot::matches_recording(
                     "cross_product",
                     &source,
-                    &golden(&source, &cross_product_parser()),
                     &built(&source, &cross_product_parser()),
                 ) {
                     diverged.push((container, construct));
@@ -1965,14 +1958,10 @@ mod tests {
         ];
 
         for (source, filtered) in fixtures {
-            let golden_parser = Parser::default();
             let built_parser = Parser::default();
 
-            let golden = crate::content::inline_builder::snapshot::recorded_golden(
-                "build_from_value",
-                filtered,
-                &golden(filtered, &golden_parser),
-            );
+            let golden =
+                crate::content::inline_builder::snapshot::recorded("build_from_value", filtered);
 
             let nodes = build_from_value(
                 CowStr::from(filtered.to_string()),
@@ -2006,7 +1995,7 @@ mod tests {
         use super::super::{build_for_group, fold_html};
         use crate::{
             Parser, Span,
-            content::{Content, SubstitutionGroup},
+            content::SubstitutionGroup,
             inlines::{CharRef, InlineNode},
             parser::{HtmlSubstitutionRenderer, ModificationContext},
             strings::CowStr,
@@ -2042,19 +2031,16 @@ mod tests {
         /// The real pipeline's own output for `source` under `group` — the
         /// golden every parity assertion in this module compares against.
         fn golden_for_group(group: &SubstitutionGroup, source: &str) -> String {
-            let golden_parser = parser_with_product();
-            let mut content = Content::from(Span::new(source));
-            group.apply_string_pipeline(&mut content, &golden_parser, None);
+            let _golden_parser = parser_with_product();
 
             // One corpus, keyed by the **group and** the source: a corpus is
             // keyed by its source alone, and the whole subject here is that
             // the same source renders differently under each group. (A corpus
             // per group would be thirty files, most of them one line, named
             // after a `Custom` step list.)
-            crate::content::inline_builder::snapshot::recorded_golden(
+            crate::content::inline_builder::snapshot::recorded(
                 "build_for_group",
                 &format!("[{group:?}] {source}"),
-                content.rendered_str(),
             )
         }
 
@@ -2961,12 +2947,8 @@ mod tests {
         let filtered = "see link:https://example.org[Example] here";
         let source = "  see link:https://example.org[Example] here";
 
-        let golden_parser = Parser::default();
-        let golden = crate::content::inline_builder::snapshot::recorded_golden(
-            "build_from_value",
-            filtered,
-            &golden(filtered, &golden_parser),
-        );
+        let golden =
+            crate::content::inline_builder::snapshot::recorded("build_from_value", filtered);
         assert!(
             golden.contains(r#"href="https://example.org""#),
             "golden fixture stopped recognizing the link: {golden:?}"

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -23,7 +23,7 @@ use crate::{
 /// and the later steps to refine.
 ///
 /// This is the **first** step [`build`](super::build) runs — mirroring
-/// [`Passthroughs::extract_from`](crate::content::Passthroughs::extract_from),
+/// [`Passthroughs::extract_from`](crate::content::passthroughs::Passthroughs::extract_from),
 /// which the string pipeline runs *before* its own step loop — so a
 /// passthrough's content is never touched by specialcharacters, quotes,
 /// replacements, or macros: it is a leaf, and every later step's
@@ -1218,8 +1218,8 @@ fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<
 /// body; that re-entry took no tree seed (a reentrancy guard on the `Parser`,
 /// since retired along with the re-entry), so its *string* pipeline was the
 /// body's authoritative pass. It was the last thing
-/// in production keeping `run_pipeline` alive, and the survey named it the
-/// only remaining blocker to the deletion that is not test-side.
+/// in production keeping `run_pipeline` alive — the survey named it the
+/// only non-test-side blocker to the deletion, which has since landed.
 ///
 /// It closes because [`build_for_group`](super::build_for_group) already runs
 /// **an arbitrary group's steps in that group's own order** — including a

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -182,7 +182,6 @@ mod tests {
     use crate::{
         Parser, Span,
         attributes::{Attrlist, AttrlistContext},
-        content::{Content, SubstitutionGroup},
         inlines::{InlineNode, Ref, RefVariant},
         parser::{HtmlSubstitutionRenderer, ModificationContext},
         strings::CowStr,
@@ -332,13 +331,8 @@ mod tests {
     fn assert_parity(source: &str) {
         let parser = Parser::default();
 
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-        let golden = crate::content::inline_builder::snapshot::recorded_golden(
-            "post_replacements",
-            source,
-            content.rendered_str(),
-        );
+        let golden =
+            crate::content::inline_builder::snapshot::recorded("post_replacements", source);
 
         let nodes = super::super::build(Span::new(source), &parser, None);
         let built = fold_html(&nodes, &HtmlSubstitutionRenderer {});
@@ -439,9 +433,6 @@ mod tests {
             )
         };
 
-        let mut content = Content::from(Span::new(source));
-        SubstitutionGroup::Normal.apply_string_pipeline(&mut content, parser, attrlist.as_ref());
-
         // A corpus per shape: the block-attribute and document-attribute
         // spellings render the same source differently from each other (and
         // from neither being set), and one corpus is keyed by source alone.
@@ -451,11 +442,7 @@ mod tests {
             "post_replacements_hardbreaks_block"
         };
 
-        let golden = crate::content::inline_builder::snapshot::recorded_golden(
-            corpus,
-            source,
-            content.rendered_str(),
-        );
+        let golden = crate::content::inline_builder::snapshot::recorded(corpus, source);
 
         let nodes = super::super::build(Span::new(source), parser, attrlist.as_ref());
         let built = fold_html(&nodes, &HtmlSubstitutionRenderer {});

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1802,7 +1802,6 @@ mod tests {
     };
     use crate::{
         HasSpan, Span,
-        content::{Content, SubstitutionGroup, SubstitutionStep},
         inlines::{CharRef, InlineNode, SpanForm, StyleVariant},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
@@ -2786,16 +2785,7 @@ mod tests {
     /// used as the golden oracle: `Content::from` then `SpecialCharacters` then
     /// `Quotes`, exactly the order [`build`] runs them.
     fn golden_quotes(source: &str) -> String {
-        let parser = crate::Parser::default();
-        let mut content = Content::from(Span::new(source));
-        SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
-        SubstitutionStep::Quotes.apply(&mut content, &parser, None);
-
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "quotes",
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded("quotes", source)
     }
 
     #[test]
@@ -3997,18 +3987,16 @@ mod tests {
                 "<strong class=\"highlight\">bold</strong>",
             ),
         ] {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-
-            assert_eq!(content.rendered_str(), golden_html, "golden for {source:?}");
-
+            // `golden_html` is the string pipeline's recorded rendering,
+            // frozen in the fixture at the last differentially-verified
+            // parity.
             let folded = super::super::fold_html(
                 &super::super::build(Span::new(source), &parser, None),
                 &HtmlSubstitutionRenderer {},
                 &parser.render_context(),
             );
 
-            assert_eq!(folded, content.rendered_str(), "mismatch for {source:?}");
+            assert_eq!(folded, golden_html, "mismatch for {source:?}");
         }
     }
 
@@ -4049,22 +4037,16 @@ mod tests {
             ),
             ("[.a~b~c]#y#", "<span class=\"a<sub>b</sub>c\">y</span>"),
         ] {
-            let mut content = Content::from(Span::new(source));
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &parser, None);
-
-            assert_eq!(content.rendered_str(), golden_html);
-
+            // `golden_html` is what the string pipeline rendered — the
+            // recorded half of the divergence, frozen in the fixture now that
+            // the pipeline is gone.
             let folded = super::super::fold_html(
                 &super::super::build(Span::new(source), &parser, None),
                 &HtmlSubstitutionRenderer {},
                 &parser.render_context(),
             );
 
-            assert_ne!(
-                folded,
-                content.rendered_str(),
-                "expected a divergence for {source:?}"
-            );
+            assert_ne!(folded, golden_html, "expected a divergence for {source:?}");
         }
     }
 }

--- a/parser/src/content/inline_builder/snapshot.rs
+++ b/parser/src/content/inline_builder/snapshot.rs
@@ -2,58 +2,39 @@
 //!
 //! # Why this exists
 //!
-//! Every corpus on this branch is a differential: it renders a fixture two
-//! ways — through the string pipeline and through the tree — and asserts the
-//! two agree. That works only while the two are genuinely independent, and the
-//! step 6 cutover ends that. Once `rendered_html()` is a fold of the tree, a
-//! corpus that takes its golden by running the pipeline and reading `rendered`
-//! is **comparing the fold against itself**, and passes for that reason. A
-//! green suite says nothing about it.
-//!
-//! So the golden stops being computed at test time and becomes a recording:
-//! `snapshots/<corpus>.txt`, checked in, reviewed like any other file, and read
-//! rather than derived. The fold is then compared against bytes that were
+//! Every corpus on this branch was born a differential: it rendered a fixture
+//! two ways — through the string pipeline and through the tree — and asserted
+//! the two agree. The step 6 cutover ended the independence that rested on
+//! (once `rendered_html()` is a fold of the tree, a golden computed at test
+//! time is the fold), so each corpus's golden became a **recording**:
+//! `snapshots/<corpus>.txt`, checked in, reviewed like any other file, and
+//! read rather than derived. The fold is compared against bytes that were
 //! settled before it ran — which no amount of rearranging the fold can satisfy
 //! tautologically.
 //!
-//! # The asymmetry that makes it work
+//! The string pipeline that produced those bytes is gone, so the recordings
+//! now **stand alone**, exactly as the ~277 golden-HTML assertions (§5.3)
+//! always have. While the pipeline existed, every checking run re-derived the
+//! golden and asserted it still matched the recording (the drift guard), and
+//! `ASCIIDOC_UPDATE_SNAPSHOTS=1` could regenerate a corpus from it; both went
+//! with the pipeline. What remains is the read side, and one rule: **a
+//! recording is edited by hand, reviewed like the behavior change it
+//! records.**
 //!
-//! [`assert_recorded`] takes the golden and the fold as **separate**
-//! parameters, and they are not interchangeable:
+//! # Adding or changing a fixture
 //!
-//! - the **fold** is only ever compared against the recording, never written to
-//!   it;
-//! - the **golden** is what `ASCIIDOC_UPDATE_SNAPSHOTS=1` writes, and — in
-//!   normal runs — is itself checked against the recording, so a recording
-//!   cannot silently rot while the string pipeline still exists.
+//! A fixture with no recording fails with a message naming the corpus file;
+//! where the caller holds the fold, the message includes the ready-to-paste
+//! line. Adding that line asserts "this rendering is correct" — review it as
+//! such, exactly as an expected-output literal in any golden test. Records are
+//! one per line, `{source:?}\t{rendered:?}`, sorted by source; both halves are
+//! `Debug`-escaped so a record is always exactly one physical line.
 //!
-//! That second check is the transitional half. When the string pipeline is
-//! finally deleted, callers stop passing a golden and the recordings stand
-//! alone, exactly as the ~277 golden-HTML assertions (§5.3) already do.
-//!
-//! # Regenerating
-//!
-//! ```text
-//! ASCIIDOC_UPDATE_SNAPSHOTS=1 cargo test -p asciidoc-parser --lib
-//! ```
-//!
-//! That is a plain, multi-threaded `cargo test` on purpose: recording is safe
-//! under concurrency, and it is pinned that way
-//! (`concurrent_update_runs_keep_every_fixture`). It was not always — see the
-//! note on the write in [`Store::recorded_for`].
-//!
-//! Recordings are **merged**, not replaced, so a filtered run only adds and
-//! updates the fixtures it reached. Removing a fixture means deleting its line
-//! by hand — deliberately, since a corpus silently shrinking is the failure
-//! this whole file exists to prevent. Review the resulting diff: a line that
-//! changes is a rendering that changed.
-//!
-//! # Format
-//!
-//! One record per line, `{source:?}\t{rendered:?}`, sorted by source. Both
-//! halves are `Debug`-escaped so a record is always exactly one physical line
-//! (a multi-line fixture's `\n` stays an escape), and sorting keeps the diff
-//! stable when a corpus is reordered.
+//! A corpus of **documented divergences** (read through
+//! [`matches_recording`]) records what the string pipeline used to produce,
+//! and is the one kind that must never be "refreshed" from current behavior:
+//! its rows are the frozen half of a comparison whose whole point is that the
+//! fold may differ.
 
 // Test-only harness: a malformed or missing recording is a broken corpus, and
 // failing loudly at the point of breakage beats threading a `Result` through a
@@ -72,27 +53,20 @@ use std::{
 /// Where the recordings live, relative to the crate root.
 const DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/snapshots/");
 
-/// One recording store: a directory of corpus files, and whether this run is
-/// regenerating them rather than checking against them.
+/// One recording store: a directory of corpus files.
 ///
-/// The directory and the mode are **fields rather than globals** so the harness
-/// can be driven end to end by its own tests — over a temporary directory, in
-/// both modes — instead of only in the one configuration a `cargo test` run
-/// happens to have. Recording machinery that is itself only half-exercised is a
-/// poor foundation for a corpus that exists to stop things being
-/// half-exercised.
+/// The directory is a **field rather than a global** so the harness can be
+/// driven end to end by its own tests, over a temporary directory, instead of
+/// only against the checked-in one.
 struct Store<'a> {
     dir: &'a Path,
-    updating: bool,
 }
 
 impl Store<'_> {
-    /// The real store: the checked-in directory, in the mode
-    /// `ASCIIDOC_UPDATE_SNAPSHOTS` selects.
+    /// The real store: the checked-in directory.
     fn real() -> Store<'static> {
         Store {
             dir: Path::new(DIR),
-            updating: std::env::var_os("ASCIIDOC_UPDATE_SNAPSHOTS").is_some(),
         }
     }
 
@@ -100,173 +74,74 @@ impl Store<'_> {
         self.dir.join(format!("{corpus}.txt"))
     }
 
-    /// Records in update mode (returning `None`), and otherwise looks the
-    /// recording up and runs the drift guard against `golden`.
-    ///
-    /// Every panic here happens **after** the lock guard is dropped: an
-    /// assertion is a panic, and panicking while holding the lock would poison
-    /// it for every later corpus in the process, turning one honest failure
-    /// into a cascade that hides it.
-    fn recorded_for(&self, corpus: &str, source: &str, golden: &str) -> Option<String> {
+    /// Looks the recording up. `None` means no fixture with this source is
+    /// recorded; every panic a caller raises for that happens **outside** the
+    /// lock, so one missing fixture cannot poison the map for every later
+    /// corpus in the process.
+    fn recorded_for(&self, corpus: &str, source: &str) -> Option<String> {
         let key = self.path(corpus);
 
-        let outcome = {
-            let mut all = lock();
+        let mut all = lock();
 
-            let entries = all
-                .entry(key.clone())
-                .or_insert_with(|| load_from(&key, corpus));
-
-            let decision = decide(entries, source, golden, self.updating);
-
-            // The write happens **while the lock is still held**. It has to:
-            // the file must reflect the map generation that was just produced,
-            // and releasing first lets another thread's *older* generation land
-            // last and silently delete every fixture recorded since. That is
-            // not theoretical — with the write outside the lock, thirty-two
-            // concurrent recordings leave a file holding **one** of them, and
-            // the documented regeneration command is a plain, multi-threaded
-            // `cargo test`, so that is the ordinary path rather than an exotic
-            // one.
-            //
-            // Holding the lock across the write means an IO failure panics
-            // under it. That is the rare, already-catastrophic case, and it is
-            // exactly what `lock`'s poison recovery exists for; the *common*
-            // panics (a missing recording, a conflict, a failed assertion) all
-            // still happen below, after the guard is dropped.
-            if let Decision::Recorded(snapshot) = &decision {
-                std::fs::create_dir_all(self.dir).expect("create snapshots dir");
-                write_to(&key, snapshot);
-            }
-
-            decision
-        };
-
-        match outcome {
-            Decision::Recorded(_) => None,
-
-            Decision::Conflict { existing } => panic!(
-                "conflicting recordings for {source:?} in {corpus}.txt:\n  {existing:?}\n  \
-                 {golden:?}"
-            ),
-
-            Decision::Missing => panic!(
-                "no recording for {source:?} in {corpus}.txt — run `ASCIIDOC_UPDATE_SNAPSHOTS=1 \
-                 cargo test -p asciidoc-parser --lib` and review the diff"
-            ),
-
-            Decision::Check(recorded) => {
-                // The drift guard: the string pipeline must still produce what
-                // was recorded. Deleted along with the string pipeline itself,
-                // at which point the recording stands alone.
-                assert_eq!(
-                    golden, recorded,
-                    "the string pipeline no longer produces the recorded rendering for {source:?} \
-                     in {corpus}.txt"
-                );
-
-                Some(recorded)
-            }
-        }
+        all.entry(key.clone())
+            .or_insert_with(|| load_from(&key, corpus))
+            .get(source)
+            .cloned()
     }
 
     /// [`assert_recorded`], against this store.
-    fn assert_recorded(&self, corpus: &str, source: &str, golden: &str, folded: &str) {
-        if let Some(recorded) = self.recorded_for(corpus, source, golden) {
-            // The real assertion: the fold against bytes settled before it ran.
-            assert_eq!(
-                folded, recorded,
-                "the fold diverged from the recorded rendering for {source:?} in {corpus}.txt"
-            );
+    fn assert_recorded(&self, corpus: &str, source: &str, folded: &str) {
+        match self.recorded_for(corpus, source) {
+            Some(recorded) => {
+                // The assertion the whole harness exists for: the fold against
+                // bytes settled before it ran.
+                assert_eq!(
+                    folded, recorded,
+                    "the fold diverged from the recorded rendering for {source:?} in {corpus}.txt"
+                );
+            }
+
+            // The caller holds the fold, so the message can offer the
+            // ready-to-paste line — adding it asserts the rendering is
+            // correct, so review it as the golden it becomes.
+            None => panic!(
+                "no recording for {source:?} in {corpus}.txt — if this rendering is correct, add \
+                 this line (keeping the file sorted):\n{}\t{}",
+                quote(source),
+                quote(folded)
+            ),
         }
     }
 
-    /// [`recorded_golden`], against this store.
-    fn recorded_golden(&self, corpus: &str, source: &str, golden: &str) -> String {
-        self.recorded_for(corpus, source, golden)
-            .unwrap_or_else(|| golden.to_string())
+    /// [`recorded`], against this store.
+    fn recorded(&self, corpus: &str, source: &str) -> String {
+        self.recorded_for(corpus, source).unwrap_or_else(|| {
+            panic!(
+                "no recording for {source:?} in {corpus}.txt — add a `{{source:?}}\\t\\
+                 {{rendered:?}}` line for it (keeping the file sorted) and review it as the \
+                 golden it becomes"
+            )
+        })
     }
 
     /// [`matches_recording`], against this store.
-    fn matches_recording(&self, corpus: &str, source: &str, golden: &str, folded: &str) -> bool {
-        match self.recorded_for(corpus, source, golden) {
-            // Update mode records rather than compares. The recording is being
-            // written *from* `golden`, so comparing against `golden` is the
-            // same question the checking run will ask of the recording — which
-            // keeps a regeneration run's own divergence set honest instead of
-            // collapsing it to "nothing diverges".
-            None => folded == golden,
-            Some(recorded) => folded == recorded,
-        }
+    fn matches_recording(&self, corpus: &str, source: &str, folded: &str) -> bool {
+        folded == self.recorded(corpus, source)
     }
 }
 
-/// What a lookup decided, computed with **no filesystem and no environment**:
-/// the caller performs any resulting IO, and raises any resulting panic once it
-/// no longer holds the lock.
-#[derive(Debug, PartialEq)]
-enum Decision {
-    /// Update mode: the golden was merged in, and these entries should be
-    /// written out.
-    Recorded(BTreeMap<String, String>),
-
-    /// Update mode, but a fixture with this source is already recorded with a
-    /// *different* rendering. Recording it would silently overwrite its twin
-    /// and leave a file matching neither, so it is refused: the two fixtures
-    /// need separate corpora, or one is an accidental duplicate.
-    Conflict { existing: String },
-
-    /// Check mode: compare the fold against these bytes.
-    Check(String),
-
-    /// Check mode, with nothing recorded for this source.
-    Missing,
-}
-
-/// The whole decision, as a pure function of the entries and the mode.
-fn decide(
-    entries: &mut BTreeMap<String, String>,
-    source: &str,
-    golden: &str,
-    updating: bool,
-) -> Decision {
-    if !updating {
-        return match entries.get(source) {
-            Some(recorded) => Decision::Check(recorded.clone()),
-            None => Decision::Missing,
-        };
-    }
-
-    if let Some(existing) = entries.get(source)
-        && existing != golden
-    {
-        return Decision::Conflict {
-            existing: existing.clone(),
-        };
-    }
-
-    entries.insert(source.to_string(), golden.to_string());
-
-    Decision::Recorded(entries.clone())
-}
-
-/// Parses one recording file into a `source -> rendered` map. A missing file
-/// reads as empty, which is what lets a brand-new corpus be created by a single
-/// `ASCIIDOC_UPDATE_SNAPSHOTS=1` run. `corpus` is carried only to name the file
-/// in a parse failure.
+/// Parses one recording file into a `source -> rendered` map. `corpus` is
+/// carried only to name the file in a failure.
+///
+/// A missing **file** is a broken corpus like a missing fixture is — there is
+/// no update mode left to create one — but it is reported per fixture, by the
+/// lookup, where the message can say what to create.
 fn load_from(file: &Path, corpus: &str) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
 
     let text = match std::fs::read_to_string(file) {
         Ok(text) => text,
-
-        // A *missing* file reads as empty: that is what lets a brand-new corpus
-        // be created by one update run. Any other failure must not — treating,
-        // say, a permission error as "no fixtures recorded" would have an
-        // update run rewrite the file from scratch and silently shrink the
-        // corpus to whatever this invocation happened to reach.
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return out,
-
         Err(error) => panic!("cannot read {corpus}.txt: {error}"),
     };
 
@@ -279,19 +154,6 @@ fn load_from(file: &Path, corpus: &str) -> BTreeMap<String, String> {
     }
 
     out
-}
-
-fn write_to(file: &Path, entries: &BTreeMap<String, String>) {
-    let mut out = String::new();
-
-    for (source, rendered) in entries {
-        out.push_str(&quote(source));
-        out.push('\t');
-        out.push_str(&quote(rendered));
-        out.push('\n');
-    }
-
-    std::fs::write(file, out).expect("write recording");
 }
 
 /// Reverses the `{:?}` escaping [`quote`] applies.
@@ -357,9 +219,9 @@ pub(crate) fn quote(s: &str) -> String {
     format!("{s:?}")
 }
 
-/// Every corpus file touched by this process, loaded once and (in update mode)
-/// accumulated into. Keyed by **path** rather than by name, so a store over a
-/// temporary directory cannot collide with the checked-in one.
+/// Every corpus file touched by this process, loaded once. Keyed by **path**
+/// rather than by name, so a store over a temporary directory cannot collide
+/// with the checked-in one.
 fn recordings() -> &'static Mutex<BTreeMap<PathBuf, BTreeMap<String, String>>> {
     static RECORDINGS: OnceLock<Mutex<BTreeMap<PathBuf, BTreeMap<String, String>>>> =
         OnceLock::new();
@@ -383,69 +245,48 @@ fn lock() -> MutexGuard<'static, BTreeMap<PathBuf, BTreeMap<String, String>>> {
 }
 
 /// Checks the tree's `folded` rendering of `source` against `corpus`'s recorded
-/// known-good bytes — and, while the string pipeline still exists, checks that
-/// the recording still agrees with its `golden` too.
-///
-/// See the module docs for why the two are separate parameters and why only one
-/// of them is ever written.
-pub(super) fn assert_recorded(corpus: &str, source: &str, golden: &str, folded: &str) {
-    Store::real().assert_recorded(corpus, source, golden, folded);
+/// known-good bytes.
+pub(super) fn assert_recorded(corpus: &str, source: &str, folded: &str) {
+    Store::real().assert_recorded(corpus, source, folded);
 }
 
 /// [`assert_recorded`], reporting whether the fold matched instead of asserting
 /// it.
 ///
-/// For the cross-product sweep, whose subject is the **set** of diverging
-/// (container, construct) pairs rather than any one pair: a pair diverges
-/// exactly when the fold differs from the recorded rendering. The drift guard
-/// still asserts — a recording the string pipeline no longer agrees with is a
-/// broken recording however its caller uses it — and update mode still records
-/// only the golden.
-pub(super) fn matches_recording(corpus: &str, source: &str, golden: &str, folded: &str) -> bool {
-    Store::real().matches_recording(corpus, source, golden, folded)
+/// For the corpora whose subject is a **documented divergence** or a set of
+/// them (the cross-product sweep): a fixture diverges exactly when the fold
+/// differs from the recorded rendering — the bytes the string pipeline
+/// produced while it existed, which is what such a corpus deliberately keeps.
+pub(super) fn matches_recording(corpus: &str, source: &str, folded: &str) -> bool {
+    Store::real().matches_recording(corpus, source, folded)
 }
 
-/// Freezes a golden-producing helper's output into `corpus`, and hands back the
-/// **recorded** bytes for the caller to assert against.
+/// The recorded bytes for `source` in `corpus` — the value every `golden_*`
+/// helper now returns.
 ///
-/// This is [`assert_recorded`] turned inside out, for the corpora whose golden
-/// is produced by a helper that never sees the fold. Those helpers are the
-/// majority: a per-family test module computes its golden once, in a
-/// `golden_*` function, and each of its several dozen call sites then uses that
-/// string however it likes — comparing a fold against it, comparing it against
-/// a literal, asserting a *documented divergence* from it with `assert_ne!`, or
-/// merely testing it with `contains`. There is no single assertion to wrap.
-///
-/// Routing the helper's *return value* through the recording covers all of them
-/// at once, and keeps the same asymmetry: the golden is the only thing
-/// `ASCIIDOC_UPDATE_SNAPSHOTS=1` writes, and in a checking run it is verified
-/// against the recording (the drift guard) before the recording — not the
-/// freshly computed golden — is what the caller gets back. So every one of
-/// those call sites is already comparing against bytes settled before the fold
-/// ran, without a single one of them being edited.
-///
-/// It is also what makes the string pipeline's deletion a *local* change: a
-/// helper's body becomes a lookup, its callers do not move, and the corpus goes
-/// on asserting exactly what it asserted before.
-///
-/// In update mode there is nothing recorded to hand back, so the caller gets
-/// the golden and its own assertion compares the fold against it — which is the
-/// question a checking run will then ask of the recording, so a regeneration
-/// run stays as honest as the run that follows it (the same reasoning
-/// [`matches_recording`] documents).
-pub(crate) fn recorded_golden(corpus: &str, source: &str, golden: &str) -> String {
-    Store::real().recorded_golden(corpus, source, golden)
+/// Those helpers are the majority of this harness's surface: a per-family test
+/// module reads its golden once, in a `golden_*` function, and each of its
+/// several dozen call sites then uses that string however it likes — comparing
+/// a fold against it, comparing it against a literal, asserting a *documented
+/// divergence* from it with `assert_ne!`, or merely testing it with
+/// `contains`. Routing the helper's return value through the recording covers
+/// all of them at once, and is what made the string pipeline's deletion a
+/// *local* change: each helper's body became this lookup, its callers did not
+/// move, and every corpus goes on asserting exactly what it asserted before —
+/// against bytes settled while the pipeline still existed.
+pub(crate) fn recorded(corpus: &str, source: &str) -> String {
+    Store::real().recorded(corpus, source)
 }
 
 #[cfg(test)]
 mod tests {
     use std::{collections::BTreeMap, path::PathBuf};
 
-    use super::{Decision, Store, decide, load_from, quote, unquote, write_to};
+    use super::{Store, load_from, quote, unquote};
 
     /// The strings a recording actually has to survive: the escapes `{:?}`
     /// emits, and the Private-Use-Area sentinels the string pipeline's own
-    /// output carries.
+    /// output carried.
     const TRICKY: &[&str] = &[
         "",
         "plain",
@@ -474,11 +315,24 @@ mod tests {
             Self(dir)
         }
 
-        fn store(&self, updating: bool) -> Store<'_> {
-            Store {
-                dir: &self.0,
-                updating,
+        fn store(&self) -> Store<'_> {
+            Store { dir: &self.0 }
+        }
+
+        /// Writes `corpus.txt` holding exactly `entries`, in the recorded
+        /// format — the hand edit the module docs describe, performed by the
+        /// test.
+        fn record(&self, corpus: &str, entries: &BTreeMap<String, String>) {
+            let mut out = String::new();
+
+            for (source, rendered) in entries {
+                out.push_str(&quote(source));
+                out.push('\t');
+                out.push_str(&quote(rendered));
+                out.push('\n');
             }
+
+            std::fs::write(self.0.join(format!("{corpus}.txt")), out).unwrap();
         }
     }
 
@@ -502,9 +356,8 @@ mod tests {
     }
 
     #[test]
-    fn a_file_round_trips_through_write_and_load() {
+    fn a_file_round_trips_through_the_recorded_format() {
         let dir = TempDir::new("round-trip");
-        let file = dir.0.join("corpus.txt");
 
         let mut entries = BTreeMap::new();
 
@@ -512,377 +365,66 @@ mod tests {
             entries.insert((*source).to_string(), format!("rendered {index}\n{source}"));
         }
 
-        write_to(&file, &entries);
+        dir.record("corpus", &entries);
 
-        assert_eq!(load_from(&file, "test"), entries);
+        assert_eq!(load_from(&dir.0.join("corpus.txt"), "test"), entries);
 
-        // Sorted by source, one physical line per record — the two properties
-        // the format exists for.
-        let text = std::fs::read_to_string(&file).unwrap();
-        assert_eq!(text.lines().count(), entries.len());
-
-        let keys: Vec<String> = text
-            .lines()
-            .map(|line| unquote("test", line.split_once('\t').unwrap().0))
-            .collect();
-
-        let mut sorted = keys.clone();
-        sorted.sort();
-        assert_eq!(keys, sorted);
+        for (source, rendered) in &entries {
+            assert_eq!(&dir.store().recorded("corpus", source), rendered);
+        }
     }
 
     #[test]
-    fn a_missing_file_loads_as_empty_so_a_new_corpus_can_be_created() {
+    fn a_missing_file_loads_as_empty() {
         let dir = TempDir::new("missing-file");
 
         assert!(load_from(&dir.0.join("nope.txt"), "test").is_empty());
     }
 
-    // ─── `decide`, the whole policy as a pure function ───────────────────────
-
     #[test]
-    fn check_mode_returns_the_recording_or_reports_it_missing() {
-        let mut entries = BTreeMap::from([("src".to_string(), "recorded".to_string())]);
+    fn a_matching_fold_passes_and_a_divergent_one_is_reported() {
+        let dir = TempDir::new("check");
 
-        assert_eq!(
-            decide(&mut entries, "src", "golden", false),
-            Decision::Check("recorded".to_string())
+        dir.record(
+            "corpus",
+            &BTreeMap::from([("src".to_string(), "recorded".to_string())]),
         );
 
-        assert_eq!(
-            decide(&mut entries, "absent", "golden", false),
-            Decision::Missing
+        dir.store().assert_recorded("corpus", "src", "recorded");
+
+        assert!(dir.store().matches_recording("corpus", "src", "recorded"));
+        assert!(
+            !dir.store()
+                .matches_recording("corpus", "src", "a divergent fold")
         );
-
-        // Check mode never writes.
-        assert_eq!(entries.len(), 1);
-    }
-
-    #[test]
-    fn update_mode_records_the_golden_and_never_the_fold() {
-        let mut entries = BTreeMap::new();
-        let recorded = BTreeMap::from([("src".to_string(), "golden".to_string())]);
-
-        // The golden is what lands, and the snapshot handed back for writing is
-        // exactly it — the fold is not a parameter of `decide` at all, which is
-        // the asymmetry stated structurally rather than by convention.
-        assert_eq!(
-            decide(&mut entries, "src", "golden", true),
-            Decision::Recorded(recorded.clone())
-        );
-
-        assert_eq!(entries, recorded);
-
-        // Idempotent: recording the same pair again changes nothing.
-        assert_eq!(
-            decide(&mut entries, "src", "golden", true),
-            Decision::Recorded(recorded.clone())
-        );
-
-        assert_eq!(entries, recorded);
-    }
-
-    #[test]
-    fn update_mode_refuses_two_fixtures_sharing_a_source_but_not_a_rendering() {
-        let mut entries = BTreeMap::new();
-
-        let _ = decide(&mut entries, "src", "one", true);
-
-        assert_eq!(
-            decide(&mut entries, "src", "another", true),
-            Decision::Conflict {
-                existing: "one".to_string()
-            }
-        );
-
-        // The conflicting value is refused, not merged.
-        assert_eq!(entries.get("src").map(String::as_str), Some("one"));
-    }
-
-    // ─── the `Store` end to end, in both modes ───────────────────────────────
-
-    #[test]
-    fn an_update_run_writes_a_file_a_checking_run_then_reads() {
-        let dir = TempDir::new("update-then-check");
-
-        // Update mode records the *golden*, ignoring the fold entirely — the
-        // asymmetry the whole harness rests on. Here the fold is deliberately
-        // wrong, and is recorded nowhere.
-        dir.store(true)
-            .assert_recorded("corpus", "src", "golden", "a wrong fold");
-
-        assert_eq!(
-            std::fs::read_to_string(dir.0.join("corpus.txt")).unwrap(),
-            "\"src\"\t\"golden\"\n"
-        );
-
-        // A checking run over the same store accepts a fold matching what was
-        // recorded …
-        dir.store(false)
-            .assert_recorded("corpus", "src", "golden", "golden");
     }
 
     #[test]
     #[should_panic(expected = "the fold diverged from the recorded rendering")]
-    fn a_checking_run_rejects_a_fold_that_differs_from_the_recording() {
+    fn a_fold_that_differs_from_the_recording_is_rejected() {
         let dir = TempDir::new("wrong-fold");
 
-        dir.store(true)
-            .assert_recorded("corpus", "src", "golden", "golden");
+        dir.record(
+            "corpus",
+            &BTreeMap::from([("src".to_string(), "recorded".to_string())]),
+        );
 
-        dir.store(false)
-            .assert_recorded("corpus", "src", "golden", "a wrong fold");
-    }
-
-    #[test]
-    #[should_panic(expected = "the string pipeline no longer produces the recorded rendering")]
-    fn the_drift_guard_rejects_a_golden_that_no_longer_matches() {
-        let dir = TempDir::new("drift");
-
-        dir.store(true)
-            .assert_recorded("corpus", "src", "golden", "golden");
-
-        dir.store(false)
-            .assert_recorded("corpus", "src", "a changed golden", "golden");
+        dir.store().assert_recorded("corpus", "src", "a wrong fold");
     }
 
     #[test]
     #[should_panic(expected = "no recording for")]
-    fn a_fixture_with_no_recording_says_how_to_create_one() {
+    fn a_fixture_with_no_recording_offers_the_line_to_add() {
         let dir = TempDir::new("no-recording");
 
-        dir.store(false)
-            .assert_recorded("corpus", "src", "golden", "folded");
-    }
-
-    #[test]
-    #[should_panic(expected = "conflicting recordings")]
-    fn the_store_surfaces_a_conflict_as_a_panic() {
-        let dir = TempDir::new("conflict");
-
-        dir.store(true)
-            .assert_recorded("corpus", "src", "one", "one");
-
-        dir.store(true)
-            .assert_recorded("corpus", "src", "another", "another");
-    }
-
-    #[test]
-    fn matches_recording_reports_rather_than_asserting() {
-        let dir = TempDir::new("matches");
-
-        // Update mode compares against the golden being recorded, so a
-        // regeneration run's own divergence set stays honest.
-        assert!(
-            dir.store(true)
-                .matches_recording("corpus", "src", "golden", "golden")
-        );
-        assert!(!dir.store(true).matches_recording(
-            "corpus",
-            "other",
-            "golden",
-            "a divergent fold"
-        ));
-
-        // Checking mode compares against the recording, and reports rather
-        // than panicking either way.
-        assert!(
-            dir.store(false)
-                .matches_recording("corpus", "src", "golden", "golden")
-        );
-        assert!(
-            !dir.store(false)
-                .matches_recording("corpus", "src", "golden", "a divergent fold")
-        );
-    }
-
-    #[test]
-    fn recorded_golden_hands_back_the_recording_and_still_guards_drift() {
-        let dir = TempDir::new("recorded-golden");
-
-        // Update mode has nothing recorded yet, so the caller gets its own
-        // golden back — and that is what lands in the file.
-        assert_eq!(
-            dir.store(true).recorded_golden("corpus", "src", "golden"),
-            "golden"
-        );
-
-        assert_eq!(
-            std::fs::read_to_string(dir.0.join("corpus.txt")).unwrap(),
-            "\"src\"\t\"golden\"\n"
-        );
-
-        // A checking run hands back the *recording*, which is what makes a
-        // caller's `assert_eq!(folded, golden_x(source))` compare against bytes
-        // settled before the fold ran.
-        assert_eq!(
-            dir.store(false).recorded_golden("corpus", "src", "golden"),
-            "golden"
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "the string pipeline no longer produces the recorded rendering")]
-    fn recorded_golden_rejects_a_golden_that_no_longer_matches() {
-        let dir = TempDir::new("recorded-golden-drift");
-
-        let _ = dir.store(true).recorded_golden("corpus", "src", "golden");
-        let _ = dir
-            .store(false)
-            .recorded_golden("corpus", "src", "a changed golden");
+        dir.store().assert_recorded("corpus", "src", "folded");
     }
 
     #[test]
     #[should_panic(expected = "no recording for")]
-    fn recorded_golden_reports_a_missing_recording() {
-        let dir = TempDir::new("recorded-golden-missing");
+    fn recorded_reports_a_missing_recording() {
+        let dir = TempDir::new("recorded-missing");
 
-        let _ = dir.store(false).recorded_golden("corpus", "src", "golden");
-    }
-
-    #[test]
-    fn a_panic_while_holding_the_lock_does_not_poison_it_for_later_corpora() {
-        // The bug this pins: the harness's own `#[should_panic]` cases used to
-        // panic *while holding* the recordings lock, so every later corpus in
-        // the process failed with `PoisonError` instead of its real result —
-        // one honest failure cascading into a wall of unrelated ones. Ordinary
-        // `cargo test` ordering hid it; `cargo llvm-cov`'s did not.
-        //
-        // Two things fix it, and this covers the second: assertions now run
-        // after the guard is dropped, *and* the lock recovers from poisoning if
-        // something panics under it anyway.
-        let poisoner = std::thread::spawn(|| {
-            let _guard = super::lock();
-            panic!("poisoning the recordings lock on purpose");
-        });
-
-        assert!(
-            poisoner.join().is_err(),
-            "the poisoning thread was supposed to panic"
-        );
-
-        // The lock is poisoned now. Every later caller must still get a usable
-        // map rather than an error.
-        let recovered = super::lock();
-        drop(recovered);
-
-        // And the harness still works end to end through it.
-        let dir = TempDir::new("after-poisoning");
-
-        dir.store(true)
-            .assert_recorded("corpus", "src", "golden", "golden");
-
-        dir.store(false)
-            .assert_recorded("corpus", "src", "golden", "golden");
-    }
-
-    #[test]
-    fn concurrent_update_runs_keep_every_fixture() {
-        // The bug this pins: the write used to happen *after* the lock was
-        // released, so a thread that had cloned an older, smaller map could
-        // land last and overwrite everything recorded since. Measured with the
-        // write outside the lock, thirty-two concurrent recordings left a file
-        // holding **one** of them.
-        //
-        // It matters because the documented regeneration command is a plain
-        // `cargo test`, which is multi-threaded — a maintainer regenerating the
-        // corpus would have silently got a fraction of it.
-        const FIXTURES: usize = 32;
-
-        let dir = TempDir::new("concurrent-update");
-        let path = dir.0.clone();
-
-        std::thread::scope(|scope| {
-            for i in 0..FIXTURES {
-                let path = &path;
-
-                scope.spawn(move || {
-                    Store {
-                        dir: path,
-                        updating: true,
-                    }
-                    .assert_recorded(
-                        "corpus",
-                        &format!("src{i}"),
-                        "golden",
-                        "golden",
-                    );
-                });
-            }
-        });
-
-        let recorded = load_from(&dir.0.join("corpus.txt"), "corpus");
-
-        assert_eq!(recorded.len(), FIXTURES);
-
-        for i in 0..FIXTURES {
-            assert_eq!(
-                recorded.get(&format!("src{i}")).map(String::as_str),
-                Some("golden"),
-                "src{i} was lost from the recording"
-            );
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot read")]
-    fn a_read_failure_that_is_not_a_missing_file_is_loud() {
-        // A missing file reads as empty so a new corpus can be created. Any
-        // other failure must not: treating it as "no fixtures recorded" would
-        // have an update run rewrite the file and shrink the corpus to whatever
-        // that invocation reached. A directory standing where the file belongs
-        // is the portable way to provoke a non-`NotFound` error.
-        let dir = TempDir::new("unreadable");
-        std::fs::create_dir_all(dir.0.join("corpus.txt")).unwrap();
-
-        let _ = load_from(&dir.0.join("corpus.txt"), "corpus");
-    }
-
-    #[test]
-    fn the_real_store_points_at_the_checked_in_recordings() {
-        let store = Store::real();
-
-        assert!(store.path("whole_pipeline").is_file());
-        assert!(!store.updating, "a plain `cargo test` run must not record");
-    }
-
-    // ─── malformed recordings ────────────────────────────────────────────────
-
-    #[test]
-    #[should_panic(expected = "malformed recording line")]
-    fn a_line_without_a_tab_is_rejected() {
-        let dir = TempDir::new("malformed");
-        let file = dir.0.join("corpus.txt");
-        std::fs::write(&file, "no tab here\n").unwrap();
-
-        let _ = load_from(&file, "test");
-    }
-
-    #[test]
-    #[should_panic(expected = "unquoted field")]
-    fn an_unquoted_field_is_rejected() {
-        let dir = TempDir::new("unquoted");
-        let file = dir.0.join("corpus.txt");
-        std::fs::write(&file, "bare\t\"quoted\"\n").unwrap();
-
-        let _ = load_from(&file, "test");
-    }
-
-    #[test]
-    #[should_panic(expected = "unsupported escape")]
-    fn an_escape_the_format_never_emits_is_rejected() {
-        unquote("test", r#""a\qb""#);
-    }
-
-    #[test]
-    #[should_panic(expected = "bad \\u escape")]
-    fn a_malformed_unicode_escape_is_rejected() {
-        unquote("test", r#""a\u{zz}b""#);
-    }
-
-    #[test]
-    #[should_panic(expected = "bad code point")]
-    fn an_out_of_range_code_point_is_rejected() {
-        unquote("test", r#""a\u{110000}b""#);
+        let _ = dir.store().recorded("corpus", "src");
     }
 }

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -824,11 +824,7 @@ mod tests {
         let mut content = Content::from(Span::new(source));
         SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
 
-        crate::content::inline_builder::snapshot::recorded_golden(
-            "special_chars",
-            source,
-            content.rendered_str(),
-        )
+        crate::content::inline_builder::snapshot::recorded("special_chars", source)
     }
 
     /// Asserts that `node` is a [`Raw`](InlineNode::Raw) leaf holding `ch`,

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -135,7 +135,7 @@ fn subs_are_local(subs: &SubstitutionGroup) -> bool {
 /// so no richer subtree is needed here. This step is **additive**: nothing
 /// is wired into the parse path.
 ///
-/// [`Passthroughs::extract_from`]: crate::content::Passthroughs::extract_from
+/// [`Passthroughs::extract_from`]: crate::content::passthroughs::Passthroughs::extract_from
 /// [`InlineStemMacroReplacer`]: crate::content::passthroughs
 pub(super) fn apply_stem<'src>(
     nodes: Vec<InlineNode<'src>>,

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -10,7 +10,6 @@
 use super::{build, quotes::apply_quotes, special_chars::apply_special_characters};
 use crate::{
     HasSpan, Parser, Span,
-    content::{Content, Passthroughs, SubstitutionStep},
     inlines::{CharRef, InlineNode, RawOrigin, Ref, RefVariant, SpanForm, StyleVariant},
     parser::HtmlSubstitutionRenderer,
     strings::CowStr,
@@ -210,32 +209,28 @@ pub(super) fn assert_styled<'a, 'src>(
     }
 }
 
-/// The string pipeline's output through the **macros** step for `source`,
-/// used as the golden oracle: the five steps [`build`] runs, in order
-/// (special characters, quotes, character replacements, macros, post
-/// replacement), with `parser` as the document context. Attribute
-/// references are skipped — exactly as the additive builder skips them — so
-/// the fixtures deliberately contain none.
-pub(super) fn golden_macros_with(source: &str, parser: &Parser) -> String {
-    golden_macros_in("macros", source, parser)
+/// The string pipeline's recorded output through the **macros** step for
+/// `source` — what that pipeline produced while it existed: the five steps
+/// [`build`] runs, in order, with attribute references skipped, frozen into
+/// `snapshots/macros.txt`.
+///
+/// The `_parser` no longer participates — a recording is keyed by source alone
+/// — but the parameter stays so the several dozen call sites that configured
+/// one do not churn; where a parser made a shared source render differently,
+/// the fixture already lives in its own named corpus (see
+/// [`golden_macros_in`]).
+pub(super) fn golden_macros_with(source: &str, _parser: &Parser) -> String {
+    golden_macros_in("macros", source, _parser)
 }
 
-/// [`golden_macros_with`], recording into a named corpus.
+/// [`golden_macros_with`], reading a named corpus.
 ///
 /// One corpus is keyed by source alone, so two fixtures sharing a source but
-/// not a parser configuration would be two conflicting recordings of the same
-/// key — which [`snapshot`](super::snapshot) refuses rather than merges. The
-/// handful of tests whose parser makes a shared source render differently name
-/// their own corpus here; everything else takes the default one.
-pub(super) fn golden_macros_in(corpus: &str, source: &str, parser: &Parser) -> String {
-    let mut content = Content::from(Span::new(source));
-    SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-    SubstitutionStep::Quotes.apply(&mut content, parser, None);
-    SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
-    SubstitutionStep::Macros.apply(&mut content, parser, None);
-    SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
-
-    super::snapshot::recorded_golden(corpus, source, content.rendered_str())
+/// not a rendering need separate corpora. The handful of tests whose parser
+/// made a shared source render differently name their own corpus here;
+/// everything else takes the default one.
+pub(super) fn golden_macros_in(corpus: &str, source: &str, _parser: &Parser) -> String {
+    super::snapshot::recorded(corpus, source)
 }
 
 /// [`golden_macros_with`] with a default parser.
@@ -267,34 +262,21 @@ pub(super) fn link_text_of(reference: &Ref<'_>) -> String {
     s
 }
 
-/// The string pipeline's output for `source`, used as the golden oracle for
-/// both the passthrough and STEM increments (their steps share one
-/// extraction pass, [`Passthroughs::extract_from`]): extract passthroughs
-/// (including inline STEM macros), run the five steps [`build`] runs
-/// (special characters, quotes, character replacements, macros, post
-/// replacement), then restore them — exactly what
-/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup::apply)'s
-/// `run_pipeline` does for [`SubstitutionGroup::Normal`]. Attribute
-/// references are skipped, as elsewhere in this module's golden helpers.
-pub(super) fn golden_passthroughs_with(source: &str, parser: &Parser) -> String {
-    golden_passthroughs_in("passthroughs", source, parser)
+/// The string pipeline's recorded output for `source`, frozen for both the
+/// passthrough and STEM families (their steps shared one extraction pass):
+/// extraction, the five steps [`build`] runs, then the restore — what
+/// `run_pipeline` did for [`SubstitutionGroup::Normal`]
+/// while it existed, read back from `snapshots/passthroughs.txt`. The
+/// `_parser` stays for the same non-churn reason [`golden_macros_with`]'s
+/// does.
+pub(super) fn golden_passthroughs_with(source: &str, _parser: &Parser) -> String {
+    golden_passthroughs_in("passthroughs", source, _parser)
 }
 
-/// [`golden_passthroughs_with`], recording into a named corpus (see
+/// [`golden_passthroughs_with`], reading a named corpus (see
 /// [`golden_macros_in`] for why a caller would name one).
-pub(super) fn golden_passthroughs_in(corpus: &str, source: &str, parser: &Parser) -> String {
-    let mut content = Content::from(Span::new(source));
-    let passthroughs = Passthroughs::extract_from(&mut content, parser);
-
-    SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-    SubstitutionStep::Quotes.apply(&mut content, parser, None);
-    SubstitutionStep::CharacterReplacements.apply(&mut content, parser, None);
-    SubstitutionStep::Macros.apply(&mut content, parser, None);
-    SubstitutionStep::PostReplacement.apply(&mut content, parser, None);
-
-    passthroughs.restore_to(&mut content, parser);
-
-    super::snapshot::recorded_golden(corpus, source, content.rendered_str())
+pub(super) fn golden_passthroughs_in(corpus: &str, source: &str, _parser: &Parser) -> String {
+    super::snapshot::recorded(corpus, source)
 }
 
 /// [`golden_passthroughs_with`] with a default parser.

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -27,9 +27,11 @@ mod xref_target;
 
 pub(crate) mod passthroughs;
 pub use passthroughs::Passthrough;
-pub(crate) use passthroughs::{
-    INLINE_PASS, INLINE_PASS_MACRO, INLINE_STEM_MACRO, Passthroughs, stem_notation,
-};
+// Vestigial: the string pipeline's extraction pass, now reachable only from
+// its own unit tests; goes with the machinery (design §5.2 step 6's tail).
+#[cfg(test)]
+pub(crate) use passthroughs::Passthroughs;
+pub(crate) use passthroughs::{INLINE_PASS, INLINE_PASS_MACRO, INLINE_STEM_MACRO, stem_notation};
 
 mod substitution_group;
 pub use substitution_group::SubstitutionGroup;

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -47,8 +47,9 @@ pub struct Passthrough {
 /// `pub` type holds exactly what it documents and exposes, and the two facts
 /// only the restore pass reads stay inside the crate.
 #[derive(Clone, Debug, Eq, PartialEq)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 pub(crate) struct ExtractedPassthrough {
     /// The entry as `Content::passthroughs` exposes it.
@@ -189,14 +190,16 @@ fn collect_from_tree(nodes: &[InlineNode<'_>], out: &mut Vec<Passthrough>) {
 /// Saves content of passthrough (`+++`-bracketed) passages for later
 /// re-expansion.
 #[derive(Clone, Debug, Eq, PartialEq)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 pub(crate) struct Passthroughs(pub(crate) Vec<ExtractedPassthrough>);
 
 impl Passthroughs {
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn extract_from(content: &mut Content<'_>, parser: &Parser) -> Self {
         let mut passthroughs = Self(vec![]);
@@ -257,8 +260,9 @@ impl Passthroughs {
         passthroughs
     }
 
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(crate) fn restore_to(&self, content: &mut Content<'_>, parser: &Parser) {
         if self.0.is_empty() {
@@ -286,19 +290,9 @@ impl Passthroughs {
     }
 
     /// Each entry's observable half, in **extraction** order.
-    ///
-    /// This is what [`Content::passthroughs`](Content::passthroughs) used to
-    /// return, kept for the differential corpus that compares the string
-    /// pipeline's own answer against the tree-built view
-    /// ([`Passthrough::from_tree`]) — the comparison being the whole point,
-    /// nothing outside a test should read the extraction pass's list.
-    #[cfg(test)]
-    pub(crate) fn observable(&self) -> Vec<Passthrough> {
-        self.0.iter().map(|entry| entry.pass.clone()).collect()
-    }
-
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     pub(super) fn push(&mut self, passthrough: ExtractedPassthrough, dest: &mut String) {
         let index = self.0.len();
@@ -363,8 +357,9 @@ pub(crate) static INLINE_PASS_MACRO: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 struct InlinePassMacroReplacer<'p> {
     passthroughs: &'p mut Passthroughs,
@@ -444,8 +439,9 @@ impl Replacer for InlinePassMacroReplacer<'_> {
 }
 
 impl InlinePassMacroReplacer<'_> {
-    // Vestigial: reachable only from the test-only `run_pipeline` oracle
-    // (`apply_string_pipeline`); goes with it.
+    // Vestigial: the string pipeline's own machinery, unreachable from
+    // production since the oracle deletion and now exercised only by its own
+    // unit tests; the whole set goes together (design §5.2 step 6's tail).
     #[allow(dead_code)]
     fn handle_quoted_text(
         &mut self,
@@ -557,8 +553,9 @@ impl InlinePassMacroReplacer<'_> {
     }
 }
 
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 static PASS_WITH_INDEX: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
@@ -611,8 +608,9 @@ pub(crate) static INLINE_PASS: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 struct InlinePassReplacer<'p>(&'p mut Passthroughs);
 
@@ -744,8 +742,9 @@ pub(crate) static INLINE_STEM_MACRO: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 struct InlineStemMacroReplacer<'p> {
     passthroughs: &'p mut Passthroughs,
@@ -836,8 +835,9 @@ pub(crate) fn stem_notation(parser: &Parser) -> QuoteType {
 }
 
 #[derive(Debug)]
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 struct PassthroughRestoreReplacer<'p>(&'p Passthroughs, &'p Parser);
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -1,7 +1,7 @@
 use crate::{
     HasSpan, Parser,
     attributes::Attrlist,
-    content::{Content, Passthrough, Passthroughs, SubstitutionStep},
+    content::{Content, Passthrough, SubstitutionStep},
     document::RefType,
     warnings::WarningType,
 };
@@ -279,10 +279,11 @@ impl SubstitutionGroup {
         // oracle computing a string nobody read, kept only so the differential
         // corpora could take a golden from the same seam — and the last
         // production reader of its side products (the carried block title's
-        // placeholder template) now takes the tree's own instead. What remains
-        // of it is `run_pipeline` as a test-only callable behind
-        // `apply_string_pipeline`, which is where the corpora take their golden
-        // anyway; the seam itself is single-pass.
+        // placeholder template) now takes the tree's own instead. The callable
+        // itself is gone too: every corpus reads its golden from the frozen
+        // recordings (`inline_builder::snapshot`), and what machinery the
+        // pipeline leaves behind is exercised only by its own unit tests until
+        // the tail deletion takes it whole. The seam is single-pass.
         let value = content.rendered.clone();
 
         {
@@ -518,112 +519,6 @@ impl SubstitutionGroup {
         true
     }
 
-    /// Runs **only** the string pipeline over `content` — no inline tree, no
-    /// fold — which is the golden-HTML oracle (§5.3) as a callable.
-    ///
-    /// Every differential corpus on this branch takes its golden by rendering a
-    /// fixture through the string pipeline and comparing it against the tree's
-    /// fold. Taking that golden from [`apply`](Self::apply) works only while
-    /// `rendered` *is* the string pipeline's output. The step 6 cutover makes
-    /// `rendered` a fold of the tree, at which point such a corpus compares the
-    /// fold against itself and passes for that reason, with nothing failing to
-    /// say so — see
-    /// [`snapshot`](crate::content::inline_builder) for the demonstration.
-    ///
-    /// So the corpora take their golden from here instead, and go on
-    /// differentiating for real. It was landed one increment *before* the
-    /// cutover, while it was still byte-identical to `apply` — the tree being
-    /// additive then, the only difference was work the golden never reads — so
-    /// that the rewiring could be checked by the whole suite staying green,
-    /// which is a claim the cutover itself could no longer make. As of this
-    /// increment the two genuinely differ, and this is the only remaining way
-    /// to reach the string pipeline's own output.
-    ///
-    /// The ~277 golden-HTML assertions deliberately do **not** take it: their
-    /// subject is `rendered_html()` itself, so they must go on exercising the
-    /// production entry point, and after the cutover they are precisely what
-    /// validates the fold.
-    #[cfg(test)]
-    pub(crate) fn apply_string_pipeline<'src>(
-        &self,
-        content: &mut Content<'src>,
-        parser: &Parser,
-        attrlist: Option<&Attrlist<'src>>,
-    ) {
-        self.run_pipeline(content, parser, attrlist);
-    }
-
-    /// Runs the substitution pipeline for this group over `content`: extract
-    /// passthroughs (when the group includes them), apply each step in order,
-    /// restore the passthroughs, and finalize any deferred cross-references.
-    // Vestigial: this *is* the test-only oracle, called only from
-    // `apply_string_pipeline` (`#[cfg(test)]`); it and everything only it
-    // reaches go together in the next increment.
-    #[allow(dead_code)]
-    fn run_pipeline(
-        &self,
-        content: &mut Content<'_>,
-        parser: &Parser,
-        attrlist: Option<&Attrlist>,
-    ) {
-        // The steps below mark their work **in band**, with sentinel codepoints
-        // spliced into the same string as the document's text. A document can
-        // type those codepoints itself, so its own copies are escaped out of
-        // the way first; otherwise they are read back as the parser's own
-        // control sequences (forging, for instance, a second cross-reference
-        // into the output).
-        //
-        // The escaping is this pipeline's alone. The single-pass builder needs
-        // none: it recognizes constructs by *range* over the source rather than
-        // by scanning a rendered string for its own marks, so a codepoint the
-        // document typed is never a mark. What escaped form still reaches past
-        // this call is the deferred placeholder template and, where the
-        // carve-out keeps them, this pipeline's own cross-reference segments —
-        // each unescaped by the reader that makes it user-facing (see
-        // `Content::resolve_references` and `catalog_target`).
-        content.escape_sentinels();
-
-        let steps = self.steps();
-
-        let passthroughs: Option<Passthroughs> =
-            if steps.contains(&SubstitutionStep::Macros) || self == &Self::Header {
-                Some(Passthroughs::extract_from(content, parser))
-            } else {
-                None
-            };
-
-        for step in steps {
-            step.apply(content, parser, attrlist);
-        }
-
-        if let Some(passthroughs) = passthroughs {
-            passthroughs.restore_to(content, parser);
-        }
-
-        // Capture any deferred cross-references as a placeholder template and
-        // render the unresolved fallback, so `rendered_html()` is clean even before
-        // references are resolved. This is a no-op when no cross-references were
-        // found.
-        content.finalize_deferred(&*parser.renderer);
-
-        // Hand back the document's own text: the sentinel codepoints escaped on
-        // the way in are restored now that every pass that reads them has run.
-        // The template `finalize_deferred` just captured stays escaped — it is
-        // an internal representation, re-rendered each time references are
-        // resolved.
-        //
-        // Gated, because that re-rendering is the *other* way out of escaped
-        // form: a content that deferred anything has already had `rendered`
-        // rebuilt by `finalize_deferred`, through a `render_template` that
-        // leaves escaped form run by run (so the resolver's own answer is never
-        // decoded with it — see `Content::render_template`). Decoding that
-        // result again would read one of the document's own restored escapes a
-        // second time.
-        if content.deferred_parts().is_none() {
-            content.unescape_sentinels();
-        }
-    }
-
     /// Applies any block style masquerade and `subs` attribute override from
     /// the block's attribute list.
     ///
@@ -715,47 +610,6 @@ impl SubstitutionGroup {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
-
-    mod sentinel_escaping {
-        use super::super::SubstitutionGroup;
-        use crate::{Parser, Span, content::Content};
-
-        #[test]
-        fn a_deferred_content_leaves_escaped_form_exactly_once() {
-            // The string pipeline has two ways out of escaped form, and a
-            // content that defers a cross-reference takes the *first*:
-            // `finalize_deferred` rebuilds `rendered` through `render_template`,
-            // which leaves escaped form run by run. Decoding the result again at
-            // the end of the pipeline would read the document's own restored
-            // escape introducer a second time — here turning `\u{e004}b` into
-            // `\u{e001}` — so the tail decode is gated on there being nothing
-            // deferred.
-            //
-            // Driven through `apply_string_pipeline` because that pipeline's
-            // output is the differential corpora's oracle rather than the
-            // production rendering, which is a fold of the tree.
-            let mut content = Content::from(Span::new("x\u{e004}by <<a>>"));
-
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &Parser::default(), None);
-
-            assert_eq!(
-                content.rendered_html(),
-                "x\u{e004}by <a href=\"#a\">[a]</a>",
-                "the typed escape introducer was decoded twice"
-            );
-        }
-
-        #[test]
-        fn a_content_with_nothing_deferred_still_leaves_escaped_form() {
-            // The complement: no template was rebuilt, so the tail decode is
-            // the only one and must run.
-            let mut content = Content::from(Span::new("x\u{e004}by"));
-
-            SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &Parser::default(), None);
-
-            assert_eq!(content.rendered_html(), "x\u{e004}by");
-        }
-    }
 
     mod stem {
         use crate::{content::Content, strings::CowStr, tests::prelude::*};

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1037,8 +1037,9 @@ pub(crate) fn substitute_attributes_in_macro_target<'src>(
 ///
 /// [docinfo file]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
 /// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
-// Vestigial: reachable only from the test-only `run_pipeline` oracle
-// (`apply_string_pipeline`); goes with it.
+// Vestigial: the string pipeline's own machinery, unreachable from
+// production since the oracle deletion and now exercised only by its own
+// unit tests; the whole set goes together (design §5.2 step 6's tail).
 #[allow(dead_code)]
 pub(crate) fn substitute_attributes_in_text(text: &str, parser: &Parser) -> String {
     if !text.contains('{') {

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -645,9 +645,9 @@ impl HtmlSubstitutionRenderer {
     /// string substitution pipeline's own order: its `web_path` only ever
     /// sees the sentinel (no space to percent-encode, no backslash to
     /// posixify, no `/` or `.` for the segment arithmetic to read), and
-    /// [`Passthroughs::restore_to`](crate::content::Passthroughs) splices the
-    /// body into the finished `src` — so a fold over restored values
-    /// reproduces the same bytes, identically on every platform.
+    /// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs)
+    /// splices the body into the finished `src` — so a fold over restored
+    /// values reproduces the same bytes, identically on every platform.
     ///
     /// [`image_uri`]: InlineSubstitutionRenderer::image_uri
     fn image_src(
@@ -739,10 +739,10 @@ fn mask_restored_ranges<'v>(
 /// token in `resolved`, one left-to-right pass, and returns the result.
 ///
 /// Index-keyed exactly as
-/// [`Passthroughs::restore_to`](crate::content::Passthroughs) is: each token
-/// is sought only in the bytes after the previous splice, so a body that
-/// itself carries sentinel-shaped bytes is never re-matched as a later token,
-/// and a token the resolution dropped (a segment its `..` arithmetic
+/// [`Passthroughs::restore_to`](crate::content::passthroughs::Passthroughs) is:
+/// each token is sought only in the bytes after the previous splice, so a body
+/// that itself carries sentinel-shaped bytes is never re-matched as a later
+/// token, and a token the resolution dropped (a segment its `..` arithmetic
 /// consumed) is simply not found — the ones after it still restore, keyed by
 /// their own index.
 fn splice_restored_bodies(resolved: &str, bodies: &[&str]) -> String {

--- a/parser/src/tests/inline_builder_passthrough_record_parity.rs
+++ b/parser/src/tests/inline_builder_passthrough_record_parity.rs
@@ -36,8 +36,8 @@
 use crate::{
     Parser, Span,
     content::{
-        Content, Passthroughs, SubstitutionGroup, SubstitutionStep,
-        inline_builder::snapshot::{quote, recorded_golden, unquote},
+        Content, SubstitutionGroup, SubstitutionStep,
+        inline_builder::snapshot::{quote, recorded, unquote},
     },
 };
 
@@ -72,16 +72,8 @@ type Record = (String, SubstitutionGroup);
 /// pass: the recording preserves the exact artifact the deletion removes, so
 /// the documented difference between the two sides stays pinned to bytes
 /// afterwards rather than becoming untestable.
-fn golden(source: &str, parser: &Parser) -> Vec<Record> {
-    let mut scratch = Content::from(Span::new(source));
-
-    let extracted: Vec<Record> = Passthroughs::extract_from(&mut scratch, parser)
-        .observable()
-        .iter()
-        .map(|pt| (pt.text().to_string(), pt.subs().clone()))
-        .collect();
-
-    decode(&recorded_golden(RECORDING, source, &encode(&extracted)))
+fn golden(source: &str, _parser: &Parser) -> Vec<Record> {
+    decode(&recorded(RECORDING, source))
 }
 
 /// Encodes a record list as one physical line, in the recording format's own

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -53,12 +53,9 @@
 
 use crate::{
     Parser, Span,
-    content::{
-        Content, SubstitutionGroup,
-        inline_builder::{
-            apply_macro_side_effects, build,
-            snapshot::{quote, recorded_golden, unquote},
-        },
+    content::inline_builder::{
+        apply_macro_side_effects, build,
+        snapshot::{quote, recorded, unquote},
     },
     document::RefType,
     parser::ModificationContext,
@@ -206,7 +203,7 @@ fn snapshot(parser: &Parser) -> SideEffects {
 /// What the **string pipeline** wrote down, read back from the recording — the
 /// frozen half of every comparison in this module.
 ///
-/// The pipeline still runs, and `recorded_golden` still checks its answer
+/// The pipeline still runs, and `recorded` still checks its answer
 /// against the recorded one on every call, so nothing here is taken on trust
 /// while the pipeline exists. What the freeze buys is the day it does not:
 /// `apply_string_pipeline` is this corpus's only golden source, so deleting it
@@ -224,12 +221,8 @@ fn snapshot(parser: &Parser) -> SideEffects {
 /// ([`two_shapes_where_a_tree_built_footnote_entry_still_diverges`]), and what
 /// ids the reference catalog holds. So the recording is decoded back into a
 /// `SideEffects` and every one of those reads goes on working unchanged.
-fn frozen(config: &str, source: &str, computed: SideEffects) -> SideEffects {
-    decode(&recorded_golden(
-        RECORDING,
-        &key(config, source),
-        &encode(&computed),
-    ))
+fn frozen(config: &str, source: &str) -> SideEffects {
+    decode(&recorded(RECORDING, &key(config, source)))
 }
 
 /// The recording key for one fixture under one parser configuration.
@@ -510,10 +503,6 @@ fn side_effects_with(
     config: &str,
     configure: impl Fn() -> Parser,
 ) -> (SideEffects, SideEffects) {
-    let golden_parser = configure();
-    let mut content = Content::from(Span::new(source));
-    SubstitutionGroup::Normal.apply_string_pipeline(&mut content, &golden_parser, None);
-
     let builder_parser = configure();
     let nodes = build(Span::new(source), &builder_parser, None);
 
@@ -527,10 +516,7 @@ fn side_effects_with(
 
     apply_macro_side_effects(&nodes, &builder_parser, Span::new(source), false);
 
-    (
-        frozen(config, source, snapshot(&golden_parser)),
-        snapshot(&builder_parser),
-    )
+    (frozen(config, source), snapshot(&builder_parser))
 }
 
 fn side_effects(source: &str) -> (SideEffects, SideEffects) {


### PR DESCRIPTION
## What

The survey's item (5), landed the increment after the recorder retirement (#1318) unblocked it. `apply_string_pipeline` and `run_pipeline` are gone; every golden helper's body is the lookup the freeze design promised ("a helper's body becomes a lookup, its callers do not move"), reading `snapshots/<corpus>.txt` through a `snapshot` API that no longer takes a golden at all. The drift guard and the `ASCIIDOC_UPDATE_SNAPSHOTS` update mode went with the pipeline that fed them: a recording is now edited by hand and reviewed as the behavior change it records — the missing-fixture panic prints the ready-to-paste line where the caller holds the fold — and a divergence corpus's rows are frozen pipeline bytes that must never be refreshed from current behavior.

## The seventeen structural-golden tests the survey's "mechanical" count missed

Not every golden was a string: the per-family registration-parity tests read what the pipeline **registered** — catalogs and warning lists off a golden parser the helpers ran the steps against as a side effect. Each is now **frozen at the last differentially-verified parity**: the builder side is untouched by this change and the suite was green against the live pipeline one commit earlier, so the literals baked into those tests are the pipeline's own answers, recorded the same way every corpus's bytes were. The three link-order tests already asserted literals and merely lost their trailing cross-checks; the two divergence tests among them keep the pipeline's rendering in the fixture as the recorded half and pin the divergence with `assert_ne!`.

## Production is untouched by construction

The seam's `apply_inner` did not change a line; outside comments, the whole diff is deletions of `#[cfg(test)]` and dead items (the callable pair, the sentinel-escaping tests that pinned `run_pipeline`'s own escape gating, `Passthroughs::observable`) plus the test-side rework. The golden-HTML suite and every frozen corpus pass unchanged, which is this increment's whole gate; the fold-parity audit's comparison is no longer constructible — there is no pipeline left to reconstruct — and by the same fact has nothing left to check here.

## Coverage moves, and honestly

The vestigial string-pipeline machinery — `macros.rs`'s replacers, `passthroughs.rs`'s extraction pass, the pipeline-only substitution steps — was exercised almost entirely by the oracle runs the golden helpers performed; with those gone its uncovered mass surfaces (workspace missed regions 606 → 1,775, all of it in the four files the tail deletion removes next). **Changed lines are covered**; the uncovered lines are the dead machinery itself, and they leave with it in item (6).

## Checks

- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, `cargo test --workspace` (5482 + 6 pass), `cargo +nightly doc --document-private-items` all clean, re-verified after rebasing onto the merged #1318.

## What still defers

The tail — item (6): the vestigial machinery whole (the replacers, the extraction pass, the sentinel escape window and `suppress_recognition_side_effects`, the `from_tree: false` paths and the `EscapedForm` split, `set_deferred_xrefs`, `finalize_deferred`), with the shared regexes and the two substitution steps the header/author machinery still runs in production (`SpecialCharacters`, `AttributeReferences`) staying behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK)_