### PR TITLE
fix: Resolve a discrete heading's title; fold step 6's last constants

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8844,6 +8844,18 @@ Each phase is a reviewable unit with a clear exit gate.
   *Coverage:* 639 → **582** missed regions — below the 606 the whole freeze-and-delete arc
   started from. Every changed line covered.
 
+  *One pre-existing bug rode along, because the review of this increment found it.* A
+  **discrete** heading is the one section kind that keeps its own `.Title` decoration (every
+  other section's is carried into its first block), and no pass resolved it: the title pass's
+  `Section` arm reads only the heading, and `Block::block_title_content_mut` mapped `Section`
+  to `None`, so its else-branch never saw one either. A cross-reference in such a title stayed
+  at its unresolved fallback. This predates the whole deletion arc — the two probes render
+  byte-identically on the base — and `rebuild_rendered` was never its write-back, so the fold
+  above neither caused it nor could have fixed it by staying. `SectionBlock` now exposes the
+  same `title_content_mut` seam every other titled block does, and both title-pass walks run
+  their block-title branch for every block: heading first, decoration second, in the same order
+  on each side.
+
   *What still defers:* step 7 (`render_with`/`render_to`, `Document::to_asg()`, the
   `attribute-missing` per-line hack #564), Phase 5's renderer seam, and Landing. Item (6) — and
   with it step 6's decomposition — is closed.

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -8820,6 +8820,34 @@ Each phase is a reviewable unit with a clear exit gate.
   thread through the live resolve/refold path; then step 7 (`render_with`/`render_to`,
   `Document::to_asg()`, the `attribute-missing` per-line hack), Phase 5, and Landing.
 
+  *Step 6 landed as (the constant fold — item (6) closed):* the collapse the two slices set up,
+  now that every flag has exactly one producer left. `DeferredContent::from_tree` (always
+  `true`), `DeferredParts::from_tree` and `TitleNode::from_tree` (its copies),
+  `FootnoteDeferred::sentinels_escaped` (always `false`: the string replacer's `true` call died
+  with the replacer, and `define_footnote` loses the parameter with it) are gone, and every
+  branch they gated folds: the resolve loops read a segment's `target` directly — a tree read
+  *is* the document's own text — `template_partition` and its callers' else-arms are deleted,
+  and the `EscapedForm` pair reduces to `render_template`'s one honest bool
+  (`template_escaped`: `true` for a `DeferredContent`'s synthesized carried-title template,
+  `false` for a `FootnoteDeferred`'s fold). The side-effect parity harness drops its
+  `set_sentinels_escaped` normalization — there is no encoding difference left to normalize.
+
+  *The dead arm the fold exposed.* Collapsing `resolve_references`' template arm showed its body
+  was already unreachable: a deferring body content always has its tree installed and its
+  attributes retained (the fold arm always binds), and the one template-rendering content — the
+  carried block title — never enters the per-content resolution walk at all, because titles are
+  resolved by the document-order title pass (`title_refs`), which splices through
+  `render_xref_template`. Coverage agreed (the splice line had zero hits on the base too), so
+  `Content::rebuild_rendered` is deleted rather than kept as an untested arm, per the same
+  dead-defensive-branch doctrine every prior increment has applied.
+
+  *Coverage:* 639 → **582** missed regions — below the 606 the whole freeze-and-delete arc
+  started from. Every changed line covered.
+
+  *What still defers:* step 7 (`render_with`/`render_to`, `Document::to_asg()`, the
+  `attribute-missing` per-line hack #564), Phase 5's renderer seam, and Landing. Item (6) — and
+  with it step 6's decomposition — is closed.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10791,6 +10819,16 @@ Each phase is a reviewable unit with a clear exit gate.
        Coverage: 1,296 → 639 missed regions (`macros.rs` 617 → 3) — the freeze's debt paid.
        What remains of item (6) is the `from_tree`/`EscapedForm` constant-folding collapse, its
        own increment. See the step's own "landed as" note above.
+
+     - ✅ **the constant fold — item (6) closed.** Every flag with one producer left folds:
+       `from_tree` (always true) and `sentinels_escaped` (always false) deleted with every
+       branch they gated; `template_partition` gone; `EscapedForm` reduced to
+       `render_template`'s one honest `template_escaped` bool. The fold exposed
+       `Content::rebuild_rendered` as already unreachable — titles resolve through the
+       document-order title pass, never the per-content walk — and it is deleted per the
+       dead-defensive-branch doctrine, with coverage as the witness (zero hits on the base
+       too). Coverage: 639 → 582 missed regions, below the arc's 606 starting point. See the
+       step's own "landed as" note above.
 
      - ℹ️ **the *link* family's dangerous-scheme warning is part of this step, not a prep for it.**
        The last survey item that is not hard-blocked, and the one the survey said would need "a

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -985,6 +985,11 @@ impl<'src> Block<'src> {
     pub(crate) fn block_title_content_mut(&mut self) -> Option<&mut Content<'src>> {
         match self {
             Self::Simple(b) => b.title_content_mut(),
+            // A section's `.Title` decoration, which only a *discrete* heading
+            // keeps (a non-discrete section's is carried into its first block);
+            // distinct from the section heading, which the title pass reaches
+            // through its own `section_title_*` accessors.
+            Self::Section(b) => b.title_content_mut(),
             Self::Media(b) => b.title_content_mut(),
             Self::List(b) => b.title_content_mut(),
             Self::RawDelimited(b) => b.title_content_mut(),
@@ -1010,6 +1015,7 @@ impl<'src> Block<'src> {
     pub(crate) fn block_title_content(&self) -> Option<&Content<'src>> {
         match self {
             Self::Simple(b) => b.title_content(),
+            Self::Section(b) => b.title_content(),
             Self::Media(b) => b.title_content(),
             Self::List(b) => b.title_content(),
             Self::RawDelimited(b) => b.title_content(),

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -551,6 +551,30 @@ impl<'src> SectionBlock<'src> {
         &self.section_title
     }
 
+    /// Returns the section's `.Title` decoration as a mutable [`Content`], if
+    /// it has one — a **discrete heading** keeps its own (see
+    /// [`parse`](Self::parse)'s carried-title hop, which every non-discrete
+    /// section takes instead).
+    ///
+    /// The same narrow seam every other titled block exposes, and for the same
+    /// caller: the document-order title resolution pass
+    /// (`document::title_refs`), which installs the re-rendered title after
+    /// resolving any cross-references embedded in it. Distinct from the
+    /// section *heading*, which that pass reaches through
+    /// [`section_title_content`](Self::section_title_content).
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
+    /// Returns the section's `.Title` decoration as a read-only [`Content`],
+    /// if it has one — the counterpart of
+    /// [`title_content_mut`](Self::title_content_mut), for the inline-tree
+    /// tests that inspect a block title's mirrored cross-reference resolution.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     /// The document attributes in force where this heading was written, when
     /// they were retained — the order-dependent half of the render context a
     /// fold of the tree above needs. See

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -3408,7 +3408,6 @@ mod tests {
                     deferred: Some(Box::new(FootnoteDeferred::new(
                         "RESOLVED".to_string(),
                         vec![],
-                        false,
                     ))),
                     location: None,
                 }],

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -179,39 +179,13 @@ struct DeferredContent {
     /// rides on has no `'src` lifetime, and so arrives at the claiming block
     /// with its inline nodes dropped — carries a template synthesized **from
     /// its own tree** at the hop instead (see [`Content::to_owned_title`] and
-    /// [`carried_title_template`]). Its rendering cannot be a fold, so it stays
-    /// a splice — see [`Content::rebuild_rendered`] — but the splice's inputs
-    /// no longer come from the string pipeline.
+    /// [`carried_title_template`]). Its rendering cannot be a fold, so it
+    /// stays a splice — the document-order title pass renders it through
+    /// [`render_xref_template`] — but the splice's inputs no longer come from
+    /// the string pipeline.
     ///
     /// Empty for every production content but the carried title above.
     template: String,
-
-    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
-    /// read off this content's **inline tree**, rather than being the string
-    /// pipeline's own flat list.
-    ///
-    /// Always `true` now: [`Content::set_tree_xrefs`] is the only producer
-    /// left — the string macros step's `set_deferred_xrefs` went with the
-    /// pipeline. The field and the `!from_tree` branches it still gates — the
-    /// escaped-form reads, the template partition — are a constant-folding
-    /// collapse deferred to its own increment (design §5.2 step 6's tail),
-    /// since they thread through the live resolve/refold path.
-    from_tree: bool,
-}
-
-impl DeferredContent {
-    /// Which halves of this content's template inputs are in escaped sentinel
-    /// form.
-    ///
-    /// The template is always the string pipeline's — it is the only pass that
-    /// writes one — while the segments are the tree's wherever the carve-out
-    /// did not fire, and the tree's are the document's own text already.
-    fn escaped_form(&self) -> EscapedForm {
-        EscapedForm {
-            template: true,
-            segments: !self.from_tree,
-        }
-    }
 }
 
 /// A read-only view of a [`Content`]'s deferred cross-references — the shape
@@ -227,11 +201,6 @@ pub(crate) struct DeferredParts<'a> {
     /// The placeholder template, for a content that renders from one — see
     /// [`DeferredContent::template`].
     pub(crate) template: &'a str,
-
-    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
-    /// read off the content's inline tree — see
-    /// [`DeferredContent::from_tree`].
-    pub(crate) from_tree: bool,
 }
 
 /// A single deferred cross-reference.
@@ -402,13 +371,13 @@ pub(crate) fn unescape_sentinels(text: &str) -> Cow<'_, str> {
 /// legitimately contains the escape introducer, which is precisely the
 /// confusion the escaping exists to end. So every caller says.
 ///
-/// The three answers in this module: a segment the **string pipeline** deferred
-/// is escaped and one read off the **tree** is not
-/// ([`DeferredContent::from_tree`]); a placeholder template's own literal text
-/// is escaped for a `DeferredContent` and follows its producer for a
-/// [`FootnoteDeferred`]; and a **resolved** or **derived** destination is never
-/// escaped, the resolver having been handed the document's own text and
-/// answering in kind. That last one is why the decoding happens here, piece by
+/// The two answers in this module: a placeholder template's own literal text
+/// is escaped for a `DeferredContent` (see [`carried_title_template`]) and not
+/// for a [`FootnoteDeferred`], whose fold never enters escaped form; and a
+/// segment's fields, a **resolved** and a **derived** destination are never
+/// escaped — the tree reads carry the document's own text, and the resolver
+/// was handed that text and answered in kind. The latter is why the decoding
+/// happens here, piece by
 /// piece, rather than over a completed rendering: a rendering splices the
 /// resolver's answer into the template, and a pass over the result would decode
 /// bytes the resolver supplied.
@@ -418,29 +387,6 @@ pub(crate) fn document_text(text: &str, escaped: bool) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(text)
     }
-}
-
-/// Which halves of a placeholder template's inputs are held in the string
-/// pipeline's escaped sentinel form (see [`escape_sentinels`]).
-///
-/// The two are independent: a `DeferredContent` always carries the string
-/// pipeline's own template — it is the only pass that writes one — while its
-/// *segments* are the tree's wherever the carve-out did not fire. A
-/// [`FootnoteDeferred`] has one producer for both halves.
-#[derive(Clone, Copy, Debug)]
-struct EscapedForm {
-    /// The template's own literal text — everything between the placeholders.
-    template: bool,
-
-    /// The segments' [`target`](XrefSegment::target),
-    /// [`provided_text`](XrefSegment::provided_text),
-    /// [`window`](XrefSegment::window) and [`roles`](XrefSegment::roles): the
-    /// fields read back out of the substituted text.
-    ///
-    /// Never [`resolved`](XrefSegment::resolved) or
-    /// [`derived`](XrefSegment::derived), which are the resolver's own answer
-    /// and are spliced verbatim.
-    segments: bool,
 }
 
 /// Returns `true` if `c` is one of the codepoints the substitution pipeline
@@ -616,17 +562,14 @@ impl<'src> Content<'src> {
     /// (`set_render_attributes` is called for exactly that content), so the
     /// binding below always takes for a title with a tree; it is written as a
     /// binding rather than an unwrap because the invariant lives in that
-    /// pairing, not in the field's type. The condition's other exits are real:
+    /// pairing, not in the field's type. The condition's other exit is real:
     /// a title **re-stashed** past an empty section body arrives here with its
-    /// nodes already dropped and keeps the template the first hop synthesized,
-    /// and a `from_tree` `false` snapshot keeps the string pipeline's own — the
-    /// only honest one where the tree is known not to describe the content.
+    /// nodes already dropped and keeps the template the first hop synthesized.
     pub(crate) fn to_owned_title(&self, parser: &Parser) -> OwnedTitle {
         let deferred = self.deferred.as_ref().map(|d| {
             let mut d = (**d).clone();
 
-            if d.from_tree
-                && !self.inlines.is_empty()
+            if !self.inlines.is_empty()
                 && let Some(attributes) = self.render_attributes.as_deref()
             {
                 let context = parser.render_context_with(attributes.clone());
@@ -851,7 +794,6 @@ impl<'src> Content<'src> {
             block: &d.block,
             footnote: &d.footnote,
             template: &d.template,
-            from_tree: d.from_tree,
         })
     }
 
@@ -926,7 +868,6 @@ impl<'src> Content<'src> {
             block,
             footnote,
             template: String::new(),
-            from_tree: true,
         }));
     }
 
@@ -953,66 +894,38 @@ impl<'src> Content<'src> {
         let source = self.original;
 
         if let Some(deferred) = self.deferred.as_mut() {
-            // Where the two lists were read off the tree they arrive already
-            // partitioned, and only the block-level ones are reported here: a
-            // footnote's own copy of an embedded reference resolves and reports
-            // it. Where they are still the string pipeline's flat list, that
-            // same split is read out of the template — a placeholder that has
-            // left it was re-homed onto a footnote — which is what
-            // `reports_unresolved` answers for either shape.
-            // A tree content carries no template and never consults one —
-            // `reports_unresolved` below short-circuits on `from_tree` — while
-            // a string-pipeline content (a shape only `set_deferred_xrefs`'s
-            // remaining callers, the string macros step and its unit tests,
-            // can still build) reaches here with the template its producer
-            // captured. The assert that used to pin that pairing went with the
-            // last test that could reach this on the string path; the
-            // invariant is the vestigial machinery's own now, held by its own
-            // unit tests until it is deleted whole.
-            let from_tree = deferred.from_tree;
-            let template = deferred.template.clone();
-
-            for (index, xref) in deferred.block.iter_mut().enumerate() {
+            // The two lists arrive off the tree already partitioned, and only
+            // the block-level ones are reported here: a footnote's own copy of
+            // an embedded reference resolves and reports it.
+            for xref in deferred.block.iter_mut() {
                 // The catalog holds the document's own text (an ID as it was
-                // written, a section's reference text), so the key handed to
-                // the resolver leaves the string pipeline's escaped sentinel
-                // form here. See `document_text`.
-                let target = document_text(&xref.target, !from_tree);
-
+                // written, a section's reference text), which is exactly what
+                // a tree-read segment carries.
                 let resolved = resolver.resolve(&ResolutionContext {
-                    target: &target,
+                    target: &xref.target,
                     provided_text: xref.provided_text.as_deref(),
                     derived: xref.derived.as_ref(),
                 });
 
-                let reports_unresolved =
-                    from_tree || template.contains(&Content::xref_placeholder(index));
-
                 // A target that names a document is never reported: it carries
                 // its own destination, so there was nothing here to resolve.
-                if resolved.is_none() && xref.derived.is_none() && reports_unresolved {
-                    warnings.unresolved(&target, source);
+                if resolved.is_none() && xref.derived.is_none() {
+                    warnings.unresolved(&xref.target, source);
                 }
 
                 xref.resolved = resolved;
             }
 
             for xref in deferred.footnote.iter_mut() {
-                // The string pipeline produces one flat list, all of it
-                // block-level (`set_deferred_xrefs`), so this list is only ever
-                // the tree's — but it is read through `document_text` all the
-                // same, so the two loops say the same thing about their keys.
-                let target = document_text(&xref.target, !from_tree);
-
                 xref.resolved = resolver.resolve(&ResolutionContext {
-                    target: &target,
+                    target: &xref.target,
                     provided_text: xref.provided_text.as_deref(),
                     derived: xref.derived.as_ref(),
                 });
             }
         }
 
-        let from_tree = self.resolve_tree_references();
+        let resolved_tree = self.resolve_tree_references();
 
         // Independent of the arm chosen below. A content whose *only*
         // cross-references sit inside its footnotes defers nothing itself — the
@@ -1023,39 +936,27 @@ impl<'src> Content<'src> {
         // the footnotes that most need it.
         self.collect_own_folded_footnotes(renderer, parser, warnings);
 
-        // Exactly **one** of the two renderings runs, and which one is now a
-        // question about the *tree* rather than about the cross-references in
-        // it: a content with a tree folds it, and a content without one — the
-        // carried block title, the only content in that position — renders its
-        // template. Running both and keeping the second would be observable,
-        // not merely wasteful: a renderer is a host-supplied trait object, so a
-        // stateful one (a recorder, a numbering backend, anything counting its
-        // own callbacks) would see every callback for this content twice in one
-        // pass.
+        // A deferring content is re-rendered by folding its tree; a content
+        // with nothing deferred keeps the rendering it has. The one content
+        // that renders from a *template* — a block title carried across a
+        // section heading, whose inline nodes cannot cross the `'src`-erasing
+        // hop — never reaches this per-content pass at all: titles are
+        // resolved by the document-order title pass
+        // (`title_refs::resolve_title_references`), which splices its
+        // template through `render_xref_template`.
         //
-        // The carve-out this replaces was narrower on paper and wider in fact:
-        // it kept the template wherever the tree did not hold *every*
-        // cross-reference the string pipeline deferred. Reading the
-        // cross-references off the tree makes that condition unstatable — the
-        // tree holds all of its own — so what is left is only the content that
-        // has no tree at all.
-        //
-        // A content with deferred cross-references retains its own attributes
-        // (`set_render_attributes` is called for exactly that content — see
-        // `only_deferred_content_retains_its_render_attributes`), so the fold
-        // arm always binds. It is written as a binding rather than an unwrap
-        // because the invariant lives in that pairing, not in the field's type.
-        if from_tree
+        // A content with deferred cross-references always has its tree
+        // installed and retains its own attributes (`set_render_attributes`
+        // is called for exactly that content — see
+        // `only_deferred_content_retains_its_render_attributes`), so the
+        // bindings below always take with `resolved_tree`; they are written
+        // as bindings rather than unwraps because the invariant lives in that
+        // pairing, not in the fields' types.
+        if resolved_tree
             && !self.inlines.is_empty()
             && let Some(attributes) = self.render_attributes.as_deref().cloned()
         {
             self.refold(attributes, renderer, parser);
-        } else {
-            // `rebuild_rendered` emits the document's own text directly — the
-            // template's literal runs leave escaped form as they are spliced,
-            // so the resolver's own answer is never decoded along with them.
-            // See `render_template`.
-            self.rebuild_rendered(renderer);
         }
     }
 
@@ -1078,16 +979,10 @@ impl<'src> Content<'src> {
     ///
     /// The caller gates this on the content **holding a tree**, which every
     /// production content with deferred state does — the deferred lists are
-    /// read off that tree, the only producer left at the seam. What takes the
-    /// other arm is a content with no tree at all: the carried block title,
-    /// which renders from its synthesized template instead (see
-    /// [`carried_title_template`]).
-    ///
-    /// This runs **instead of**
-    /// [`rebuild_rendered`](Self::rebuild_rendered), not after it: rendering
-    /// both and discarding one would be observable rather than merely
-    /// wasteful, since a stateful host renderer would see every callback for
-    /// this content twice in a single resolution pass.
+    /// read off that tree, the only producer left at the seam. The one
+    /// content that renders from a *template* instead — the carried block
+    /// title (see [`carried_title_template`]) — is resolved by the
+    /// document-order title pass, never here.
     /// Folds each footnote this content **defines** from its own subtree, and
     /// hands the results to `warnings` for the resolution pass to install into
     /// the catalog.
@@ -1208,38 +1103,19 @@ impl<'src> Content<'src> {
     /// the block correlation above and correlated instead with the tree's
     /// footnote subtrees (see [`resolved_destinations`]).
     ///
-    /// Returns what
-    /// [`mirror_tree_xref_resolution`](Self::mirror_tree_xref_resolution)
-    /// returns — whether the tree holds exactly the block-level
-    /// cross-references the string pipeline deferred — and `false` for a
-    /// content with no tree or nothing deferred, neither of which is re-folded.
+    /// Returns whether there was deferred state to install — `false` for a
+    /// content with nothing deferred, which is not re-folded.
     fn resolve_tree_references(&mut self) -> bool {
         let Some(deferred) = self.deferred.as_ref() else {
             return false;
         };
 
-        let (block_ordered, footnote_ordered) = if deferred.from_tree {
-            (
-                resolved_destinations(&deferred.block),
-                resolved_destinations(&deferred.footnote),
-            )
-        } else {
-            // The string pipeline's flat list, split the way it has always been
-            // split: a placeholder still in the template is block-level, one
-            // that has left it was re-homed onto a footnote. The block half
-            // will not correlate (that count mismatch is why this content is on
-            // this path at all), but the footnote half still can, and does.
-            (
-                template_partition(&deferred.template, &deferred.block, true),
-                template_partition(&deferred.template, &deferred.block, false),
-            )
-        };
-
-        let from_tree = deferred.from_tree;
+        let block_ordered = resolved_destinations(&deferred.block);
+        let footnote_ordered = resolved_destinations(&deferred.footnote);
 
         self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered);
 
-        from_tree
+        true
     }
 
     /// Installs a pre-computed list of resolved cross-reference destinations —
@@ -1307,29 +1183,6 @@ impl<'src> Content<'src> {
             let mut next = 0;
             assign_footnote_tree_xrefs(&mut self.inlines, footnote_ordered, &mut next);
         }
-    }
-
-    /// Rebuilds [`Content::rendered`] from the deferred template and the
-    /// current (resolved or unresolved) state of its cross-references.
-    fn rebuild_rendered(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
-        let Some(deferred) = self.deferred.as_ref() else {
-            return;
-        };
-
-        // A `deferred` content always reaches here with its template captured
-        // — in production, the carried block title's, synthesized from its own
-        // tree at the hop (see `carried_title_template`). An
-        // empty one here would blank the content, so catch that invariant break
-        // in debug builds rather than let it render.
-        debug_assert!(!deferred.template.is_empty());
-
-        self.rendered = render_template(
-            &deferred.template,
-            &deferred.block,
-            renderer,
-            deferred.escaped_form(),
-        )
-        .into();
     }
 }
 
@@ -1425,27 +1278,6 @@ pub(crate) fn resolved_destinations(xrefs: &[XrefSegment]) -> Vec<Option<Resolve
     xrefs.iter().map(|xref| xref.resolved.clone()).collect()
 }
 
-/// The resolved destinations of the string pipeline's own flat list, filtered
-/// to the half `template` still splices (`spliced`) or to the half it no longer
-/// does — the block-level and footnote-embedded partitions respectively.
-///
-/// This is the split the tree performs structurally, done the only way a flat
-/// placeholder-indexed list allows. It is reached only for a content the
-/// carve-out keeps on the string pipeline's answer — see
-/// [`DeferredContent::from_tree`] — and goes with it.
-pub(crate) fn template_partition(
-    template: &str,
-    xrefs: &[XrefSegment],
-    spliced: bool,
-) -> Vec<Option<ResolvedReference>> {
-    xrefs
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)) == spliced)
-        .map(|(_, xref)| xref.resolved.clone())
-        .collect()
-}
-
 /// Counts the [`Xref`](RefVariant::Xref) nodes an [`assign_tree_xrefs`] walk
 /// over `nodes` would visit — i.e. the block-level cross-reference slots of the
 /// tree, excluding footnote subtrees (which [`count_footnote_tree_xrefs`]
@@ -1527,9 +1359,7 @@ fn tree_defers_xrefs(nodes: &[InlineNode<'_>]) -> bool {
 /// still solely owning — the first of them the survey called *blocked* rather
 /// than merely unbuilt. It is **wired**: [`Content::set_tree_xrefs`] installs
 /// what this returns, so what a content carries for its deferred
-/// cross-references is what its tree said — everywhere the tree describes the
-/// same cross-references the string pipeline deferred, which is the carve-out
-/// [`DeferredContent::from_tree`] names.
+/// cross-references is what its tree said.
 ///
 /// A [`Ref`](InlineNode::Ref)`{`[`Xref`](RefVariant::Xref)`}` node already
 /// carries every field an [`XrefSegment`] holds but one — `target`, `window`,
@@ -1713,8 +1543,8 @@ pub(crate) fn xref_segment_from_node(
 /// placeholder, and nothing downstream can tell them apart. Here every
 /// document-derived byte is escaped and every raw sentinel is the fold's own —
 /// exactly the escaped form the string pipeline's templates have always been
-/// in, so the render path ([`render_template`], `EscapedForm { template: true,
-/// … }`) needs no new case.
+/// in, so the render path ([`render_template`] with `template_escaped`) needs
+/// no new case.
 ///
 /// The price of reading only the top level is a cross-reference **nested**
 /// inside another top-level construct (a styled span's children, a visible
@@ -1855,23 +1685,14 @@ fn assign_footnote_tree_xrefs(
 /// [`resolved`](XrefSegment::resolved) fields it has filled in with cross-title
 /// (including circular) coordination, and receives the final rendered title.
 ///
-/// `segments_escaped` says whether those segments are the string pipeline's own
-/// (see [`EscapedForm`]); the template always is.
+/// A [`DeferredContent`] template's literal text is in escaped sentinel form
+/// (see [`carried_title_template`]), so it is rendered `template_escaped`.
 pub(crate) fn render_xref_template(
     template: &str,
     xrefs: &[XrefSegment],
     renderer: &dyn InlineSubstitutionRenderer,
-    segments_escaped: bool,
 ) -> String {
-    render_template(
-        template,
-        xrefs,
-        renderer,
-        EscapedForm {
-            template: true,
-            segments: segments_escaped,
-        },
-    )
+    render_template(template, xrefs, renderer, true)
 }
 
 /// Splices resolved (or fallback) cross-reference renderings into a placeholder
@@ -1880,7 +1701,7 @@ fn render_template(
     template: &str,
     xrefs: &[XrefSegment],
     renderer: &dyn InlineSubstitutionRenderer,
-    form: EscapedForm,
+    template_escaped: bool,
 ) -> String {
     let mut out = String::with_capacity(template.len());
     let mut rest = template;
@@ -1894,7 +1715,7 @@ fn render_template(
     // catalog id that happens to hold the escape introducer into some other
     // sentinel entirely. See [`document_text`].
     let push_literal = |out: &mut String, text: &str| {
-        out.push_str(&document_text(text, form.template));
+        out.push_str(&document_text(text, template_escaped));
     };
 
     while let Some(start) = rest.find(XREF_PLACEHOLDER_START) {
@@ -1917,33 +1738,15 @@ fn render_template(
             .and_then(|index| xrefs.get(index))
         {
             Some(xref) => {
-                // The four fields the *substitution* read back out of its own
-                // text leave escaped form here; `derived` and `resolved` never
-                // entered it. Roles are rebuilt only when one actually carries
-                // an escape, which for the overwhelming majority is never.
-                let unescaped_roles: Option<Vec<String>> = (form.segments
-                    && xref.roles.iter().any(|role| role.contains(SENTINEL_ESCAPE)))
-                .then(|| {
-                    xref.roles
-                        .iter()
-                        .map(|role| unescape_sentinels(role).into_owned())
-                        .collect()
-                });
-
+                // A segment's fields are the tree's reads — the document's
+                // own text, never in escaped form; `derived` and `resolved`
+                // never entered it either.
                 renderer.render_xref(
                     &XrefRenderParams {
-                        target: &document_text(&xref.target, form.segments),
-                        provided_text: xref
-                            .provided_text
-                            .as_deref()
-                            .map(|text| document_text(text, form.segments))
-                            .as_deref(),
-                        window: xref
-                            .window
-                            .as_deref()
-                            .map(|window| document_text(window, form.segments))
-                            .as_deref(),
-                        roles: unescaped_roles.as_deref().unwrap_or(&xref.roles),
+                        target: &xref.target,
+                        provided_text: xref.provided_text.as_deref(),
+                        window: xref.window.as_deref(),
+                        roles: &xref.roles,
                         xrefstyle: xref.xrefstyle,
                         derived: xref.derived.as_ref(),
                         resolved: xref.resolved.as_ref(),
@@ -1990,58 +1793,23 @@ pub(crate) struct FootnoteDeferred {
 
     /// The cross-references, in placeholder order.
     xrefs: Vec<XrefSegment>,
-
-    /// Whether [`template`](Self::template) and the segments' targets are held
-    /// in the string pipeline's escaped sentinel form (see
-    /// [`escape_sentinels`]).
-    ///
-    /// A footnote registered by the string replacer is; one registered from its
-    /// own subtree by the single-pass builder is not, the builder having no
-    /// in-band sentinels to hide a document's own codepoints from. The
-    /// distinction cannot be recovered from the text, so it is carried — see
-    /// [`document_text`], which is the same question for a block's segments.
-    sentinels_escaped: bool,
 }
 
 impl FootnoteDeferred {
     /// Constructs a footnote's deferred cross-reference state from the
     /// placeholder-bearing `template` and its `xrefs` (in placeholder order).
-    ///
-    /// `sentinels_escaped` says which pipeline produced them — see the field.
-    pub(crate) fn new(template: String, xrefs: Vec<XrefSegment>, sentinels_escaped: bool) -> Self {
-        Self {
-            template,
-            xrefs,
-            sentinels_escaped,
-        }
-    }
-
-    /// Overrides [`sentinels_escaped`](Self::sentinels_escaped).
-    ///
-    /// For the side-effect differential harness alone, which compares the
-    /// footnote catalog entry the string pipeline registers against the one the
-    /// builder registers. The two encode their templates differently *by
-    /// construction* — that is what the flag records — so the encoding is
-    /// normalized away before the entries are compared, leaving the footnote
-    /// itself (index, id, rendered text, segments) as the subject.
-    #[cfg(test)]
-    pub(crate) fn set_sentinels_escaped(&mut self, sentinels_escaped: bool) {
-        self.sentinels_escaped = sentinels_escaped;
+    pub(crate) fn new(template: String, xrefs: Vec<XrefSegment>) -> Self {
+        Self { template, xrefs }
     }
 
     /// Renders the footnote text from the template and the current (resolved or
     /// unresolved) state of its cross-references.
+    ///
+    /// The template is the builder's fold of the footnote's subtree, which
+    /// never enters escaped sentinel form — unlike a [`DeferredContent`]'s
+    /// synthesized carried-title template.
     pub(crate) fn render(&self, renderer: &dyn InlineSubstitutionRenderer) -> String {
-        // One producer wrote both halves, so they are in the same form.
-        render_template(
-            &self.template,
-            &self.xrefs,
-            renderer,
-            EscapedForm {
-                template: self.sentinels_escaped,
-                segments: self.sentinels_escaped,
-            },
-        )
+        render_template(&self.template, &self.xrefs, renderer, false)
     }
 
     /// Resolves the footnote's cross-references using `resolver`, reporting any
@@ -2054,18 +1822,16 @@ impl FootnoteDeferred {
         source: Span<'src>,
     ) {
         for xref in self.xrefs.iter_mut() {
-            // The catalog holds the document's own text, so the lookup key
-            // leaves escaped form here (see `document_text`).
-            let target = document_text(&xref.target, self.sentinels_escaped);
-
+            // The catalog holds the document's own text, which is exactly
+            // what a tree-read segment's target carries.
             let resolved = resolver.resolve(&ResolutionContext {
-                target: &target,
+                target: &xref.target,
                 provided_text: xref.provided_text.as_deref(),
                 derived: xref.derived.as_ref(),
             });
 
             if resolved.is_none() && xref.derived.is_none() {
-                warnings.unresolved(&target, source);
+                warnings.unresolved(&xref.target, source);
             }
 
             xref.resolved = resolved;
@@ -2399,7 +2165,7 @@ mod tests {
 
     mod render_template {
         use super::super::{
-            EscapedForm, XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, XrefSegment, render_template,
+            XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, XrefSegment, render_template,
         };
         use crate::parser::HtmlSubstitutionRenderer;
 
@@ -2416,15 +2182,7 @@ mod tests {
         }
 
         fn render(template: &str, xrefs: &[XrefSegment]) -> String {
-            render_template(
-                template,
-                xrefs,
-                &HtmlSubstitutionRenderer {},
-                EscapedForm {
-                    template: true,
-                    segments: true,
-                },
-            )
+            render_template(template, xrefs, &HtmlSubstitutionRenderer {}, true)
         }
 
         #[test]
@@ -2478,7 +2236,7 @@ mod tests {
 
         #[test]
         fn debug_includes_template_and_xrefs() {
-            let deferred = FootnoteDeferred::new("t".to_string(), vec![segment("a")], true);
+            let deferred = FootnoteDeferred::new("t".to_string(), vec![segment("a")]);
             let rendered = format!("{deferred:?}");
             assert!(rendered.contains("FootnoteDeferred"));
             assert!(rendered.contains("template"));

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -784,7 +784,7 @@ fn register_footnote_number(
 
     // The builder folds this entry from the footnote's own subtree, which
     // never enters the string pipeline's escaped sentinel form.
-    parser.define_footnote(id, template, xrefs, root, false)
+    parser.define_footnote(id, template, xrefs, root)
 }
 
 #[cfg(test)]

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,9 +6,9 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, defining_footnotes, document_text,
-    escape_sentinels, fold_resolved_title, render_xref_template, resolved_destinations,
-    sanitize_title, template_partition, unescape_sentinels, xref_segment_from_node,
+    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, defining_footnotes, escape_sentinels,
+    fold_resolved_title, render_xref_template, resolved_destinations, sanitize_title,
+    xref_segment_from_node,
 };
 pub(crate) mod inline_builder;
 

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -592,7 +592,6 @@ mod tests {
                 deferred: Some(Box::new(FootnoteDeferred::new(
                     "the template".to_string(),
                     vec![],
-                    false,
                 ))),
                 location: None,
             }

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -25,10 +25,7 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{
-        XrefSegment, document_text, fold_resolved_title, render_xref_template,
-        resolved_destinations, template_partition,
-    },
+    content::{XrefSegment, fold_resolved_title, render_xref_template, resolved_destinations},
     document::Catalog,
     inlines::InlineNode,
     parser::{
@@ -70,15 +67,10 @@ struct TitleNode<'src> {
     /// The cross-references the title's footnotes carry.
     footnote: Vec<XrefSegment>,
 
-    /// The string pipeline's placeholder template, which a title renders from
-    /// when it cannot fold: one whose nodes did not survive the `'src`-erasing
-    /// hop a carried block title travels on, and one the carve-out keeps on the
-    /// string pipeline's own answer (`from_tree` false).
+    /// The placeholder template, which a title renders from when it cannot
+    /// fold: one whose nodes did not survive the `'src`-erasing hop a carried
+    /// block title travels on (see `carried_title_template`).
     template: String,
-
-    /// Whether [`block`](Self::block) and [`footnote`](Self::footnote) were
-    /// read off this title's inline tree.
-    from_tree: bool,
 
     /// The ID under which other cross-references reach this title's reference
     /// text — present only when the title *is* the target's reference text (no
@@ -175,13 +167,11 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
                 let block = deferred.block.to_vec();
                 let footnote = deferred.footnote.to_vec();
                 let template = deferred.template.to_string();
-                let from_tree = deferred.from_tree;
 
                 nodes.push(TitleNode {
                     block,
                     footnote,
                     template,
-                    from_tree,
                     map_id,
                     source: section.section_title_source(),
                     inlines: section.section_title_inlines().to_vec(),
@@ -204,13 +194,11 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
                 let block = deferred.block.to_vec();
                 let footnote = deferred.footnote.to_vec();
                 let template = deferred.template.to_string();
-                let from_tree = deferred.from_tree;
 
                 nodes.push(TitleNode {
                     block,
                     footnote,
                     template,
-                    from_tree,
                     map_id: None,
                     source,
                     inlines: title.inlines().to_vec(),
@@ -324,16 +312,11 @@ fn compute<'src>(
     // difference is pre-existing: a title reports every unresolved target it
     // carries, wherever in the title it sits.
     for xref in block.iter_mut().chain(footnote.iter_mut()) {
-        // The catalog holds the document's own text, so a target the *string
-        // pipeline* deferred leaves that pipeline's escaped sentinel form to be
-        // matched against it. A target read off the tree is already the
-        // document's own and is left alone — unescaping it would corrupt one
-        // that legitimately contains the escape introducer. Same question, and
-        // same discriminator, as `Content::resolve_references`.
-        let target = document_text(&xref.target, !node.from_tree);
-
+        // The catalog holds the document's own text, which is exactly what a
+        // tree-read segment's target carries — same as
+        // `Content::resolve_references`.
         let mut resolved = resolver.resolve(&ResolutionContext {
-            target: &target,
+            target: &xref.target,
             provided_text: xref.provided_text.as_deref(),
             derived: xref.derived.as_ref(),
         });
@@ -357,7 +340,7 @@ fn compute<'src>(
         // correct.
         if !has_explicit_text
             && let Some(reference) = resolved.as_mut()
-            && let Some(target_id) = lookup_id(catalog, &target)
+            && let Some(target_id) = lookup_id(catalog, &xref.target)
             && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
             && reference.href.strip_prefix('#') == Some(target_id.as_str())
         {
@@ -397,7 +380,7 @@ fn compute<'src>(
         // A target that resolved to nothing — and did not carry its own derived
         // destination — is an unresolved reference, reported against the title.
         if resolved.is_none() && xref.derived.is_none() {
-            warnings.unresolved(&target, node.source);
+            warnings.unresolved(&xref.target, node.source);
         }
 
         xref.resolved = resolved;
@@ -408,20 +391,8 @@ fn compute<'src>(
     // were read off that tree in, so they line up one-to-one when mirrored
     // (see `write_back`). These are the very segments the rendering below is
     // computed from, so the tree cannot disagree with the string.
-    let (block_ordered, footnote_ordered) = if node.from_tree {
-        (
-            resolved_destinations(&block),
-            resolved_destinations(&footnote),
-        )
-    } else {
-        // A title the carve-out keeps on the string pipeline's answer: `block`
-        // is that flat list, split by which placeholders the template still
-        // splices, exactly as it always was.
-        (
-            template_partition(&node.template, &block, true),
-            template_partition(&node.template, &block, false),
-        )
-    };
+    let block_ordered = resolved_destinations(&block);
+    let footnote_ordered = resolved_destinations(&footnote);
 
     // The title's rendering is a **fold of its tree**, with the destinations
     // just resolved installed into it — the same answer `Content::refold` gives
@@ -436,11 +407,10 @@ fn compute<'src>(
     let rendered = node
         .render_attributes
         .as_ref()
-        .filter(|_| node.from_tree)
         .and_then(|attributes| {
             fold_resolved_title(&node.inlines, &block_ordered, attributes, renderer, parser)
         })
-        .unwrap_or_else(|| render_xref_template(&node.template, &block, renderer, !node.from_tree));
+        .unwrap_or_else(|| render_xref_template(&node.template, &block, renderer));
 
     if let Some(flag) = in_progress.get_mut(index) {
         *flag = false;

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -178,14 +178,19 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
                     render_attributes: section.section_title_render_attributes().cloned(),
                 });
             }
-        } else {
-            // A non-section block's `.Title` decoration. A block title is not
-            // treated as a recomputable reference target (`map_id` is `None`):
-            // its own cross-references are resolved, but a reference *to* the
-            // block still uses the block's parse-time reference text.
-            //
-            // The span is taken before the title borrow: `block` stays
-            // mutably borrowed while the template is in scope.
+        }
+
+        // A block's `.Title` decoration — a *discrete* heading's included,
+        // which is the one section kind that keeps its own (a non-discrete
+        // section's is carried into its first block; its heading was collected
+        // above). A block title is not treated as a recomputable reference
+        // target (`map_id` is `None`): its own cross-references are resolved,
+        // but a reference *to* the block still uses the block's parse-time
+        // reference text.
+        //
+        // The span is taken before the title borrow: `block` stays mutably
+        // borrowed while the template is in scope.
+        {
             let source = block.span();
 
             if let Some(title) = block.block_title_content_mut()
@@ -225,29 +230,34 @@ fn write_back<'src>(
     parser: &crate::Parser,
 ) {
     for block in blocks.iter_mut() {
-        if let Block::Section(section) = block {
-            if section.section_title_deferred_parts().is_some() {
-                if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
-                    section.set_section_title_rendered(resolution.rendered.clone());
-                    section.mirror_section_title_tree_xrefs(
-                        &resolution.block_ordered,
-                        &resolution.footnote_ordered,
-                    );
+        if let Block::Section(section) = block
+            && section.section_title_deferred_parts().is_some()
+        {
+            if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
+                section.set_section_title_rendered(resolution.rendered.clone());
+                section.mirror_section_title_tree_xrefs(
+                    &resolution.block_ordered,
+                    &resolution.footnote_ordered,
+                );
 
-                    // **After** the mirror, not before: a footnote defined in
-                    // this heading is folded from the heading's own subtree, and
-                    // that subtree only carries the destinations just resolved
-                    // once `mirror_section_title_tree_xrefs` has installed them.
-                    // The fold `compute` took above cannot serve — it ran on a
-                    // *clone* holding only the block-level list, because the real
-                    // tree is not reachable while the pass is still computing.
-                    section
-                        .section_title_content()
-                        .collect_own_folded_footnotes(renderer, parser, warnings);
-                }
-                *index += 1;
+                // **After** the mirror, not before: a footnote defined in
+                // this heading is folded from the heading's own subtree, and
+                // that subtree only carries the destinations just resolved
+                // once `mirror_section_title_tree_xrefs` has installed them.
+                // The fold `compute` took above cannot serve — it ran on a
+                // *clone* holding only the block-level list, because the real
+                // tree is not reachable while the pass is still computing.
+                section
+                    .section_title_content()
+                    .collect_own_folded_footnotes(renderer, parser, warnings);
             }
-        } else if let Some(title) = block.block_title_content_mut()
+            *index += 1;
+        }
+
+        // The block-title decoration's write-back — the same order [`collect`]
+        // pushed them in: a section's heading first, then any block's own
+        // `.Title`, a discrete heading's included.
+        if let Some(title) = block.block_title_content_mut()
             && title.deferred_parts().is_some()
         {
             if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1862,20 +1862,16 @@ impl Parser {
     /// does not map to the document, so no location is recorded and
     /// resolution falls back to the whole-document span.
     ///
-    /// Takes `&self` so it can be called from the macros substitution step.
-    /// `sentinels_escaped` says whether `text` is held in the string
-    /// pipeline's escaped sentinel form (see
-    /// [`escape_sentinels`](crate::content::escape_sentinels)) — true for the
-    /// string replacer's own call, false for the single-pass builder's, which
-    /// folds the entry from the footnote's subtree and so never enters that
-    /// form.
+    /// Takes `&self` so it can be called during substitution. `text` is the
+    /// single-pass builder's fold of the footnote's subtree, which never
+    /// enters the escaped sentinel form the string pipeline's entries were
+    /// held in.
     pub(crate) fn define_footnote(
         &self,
         id: Option<&str>,
         text: String,
         xrefs: Vec<crate::content::XrefSegment>,
         source: crate::Span<'_>,
-        sentinels_escaped: bool,
     ) -> String {
         // A footnote's text is extracted out of the block during macro
         // substitution, so any cross-reference inside it never reaches the
@@ -1885,20 +1881,9 @@ impl Parser {
         // references. The stored `text` is the unresolved fallback rendering
         // until then, so it is always clean.
         let (text, deferred) = if xrefs.is_empty() {
-            // A string-pipeline text was extracted from content held in escaped
-            // sentinel form (see `escape_sentinels`); it is user-facing from
-            // here, so it leaves escaped form now. The deferred branch below
-            // does the same from `FootnoteDeferred::render`, keeping its
-            // template escaped for later re-rendering.
-            let text = if sentinels_escaped {
-                crate::content::unescape_sentinels(&text).into_owned()
-            } else {
-                text
-            };
-
             (text, None)
         } else {
-            let deferred = crate::content::FootnoteDeferred::new(text, xrefs, sentinels_escaped);
+            let deferred = crate::content::FootnoteDeferred::new(text, xrefs);
 
             let rendered = deferred.render(&*self.renderer);
 

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -601,10 +601,10 @@ fn resolution_renders_a_deferred_content_once() {
     // recorder, a numbering backend, anything counting its own callbacks) sees
     // whatever this pass does.
     //
-    // Both renderings exist: the template's (`rebuild_rendered`) and the
-    // tree's (`refold`). Exactly one of them runs for any given content —
-    // whichever is authoritative for it — rather than one running and then
-    // being overwritten by the other.
+    // Both renderings exist: the template's (`render_xref_template`, in the
+    // title pass) and the tree's (`refold`). Exactly one of them runs for any
+    // given content — whichever is authoritative for it — rather than one
+    // running and then being overwritten by the other.
     #[derive(Debug, Default)]
     struct CountingRenderer {
         xrefs: std::cell::Cell<usize>,

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -114,11 +114,7 @@ struct FootnoteRecord {
     /// `Debug` spelling — the template and the segments, in placeholder order.
     ///
     /// A spelling here for the same reason as `warnings`: an `XrefSegment`
-    /// carries seven fields, three of them resolver types of their own. That
-    /// `Debug` omits `sentinels_escaped` costs this corpus nothing, because
-    /// [`snapshot`] already normalizes that field away before comparing — it
-    /// records which *pipeline* built the entry, which is exactly what a
-    /// differential must not treat as a difference.
+    /// carries seven fields, three of them resolver types of their own.
     deferred: Option<String>,
 
     location: Option<(usize, usize)>,
@@ -155,33 +151,12 @@ fn snapshot(parser: &Parser) -> SideEffects {
                 .footnotes()
                 .iter()
                 .cloned()
-                .map(|mut footnote| {
-                    // The one field of an entry that is *not* written by the
-                    // recognizing pass in the same form on both sides: it
-                    // records whether the entry's template is held in the
-                    // string pipeline's escaped sentinel form, which is true of
-                    // that pipeline's own entry and false of the builder's fold
-                    // of the footnote's subtree. Both render the same text —
-                    // which is compared — so the encoding is normalized away
-                    // here rather than counted as a divergence.
-                    //
-                    // Kept even though `FootnoteDeferred`'s `Debug` — the
-                    // spelling `FootnoteRecord::deferred` records — does not
-                    // print the flag: the normalization is the statement that
-                    // the two sides' encodings are not a difference, and it
-                    // should not rest on which fields a `Debug` impl happens
-                    // to include.
-                    if let Some(deferred) = footnote.deferred.as_mut() {
-                        deferred.set_sentinels_escaped(false);
-                    }
-
-                    FootnoteRecord {
-                        index: footnote.index,
-                        id: footnote.id,
-                        text: footnote.text,
-                        deferred: footnote.deferred.map(|d| format!("{d:?}")),
-                        location: footnote.location,
-                    }
+                .map(|footnote| FootnoteRecord {
+                    index: footnote.index,
+                    id: footnote.id,
+                    text: footnote.text,
+                    deferred: footnote.deferred.map(|d| format!("{d:?}")),
+                    location: footnote.location,
                 })
                 .collect(),
         )

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1596,4 +1596,24 @@ mod xrefs_in_titles {
             r##"See <a href="other.html#b">B [c]</a>"##
         );
     }
+
+    #[test]
+    fn a_discrete_headings_own_title_resolves_its_xref() {
+        // A discrete heading is the one section kind that *keeps* its `.Title`
+        // decoration (a non-discrete section's is carried into its first
+        // block), and its title's cross-references resolve like any other
+        // block title's: the reference text below is the target section's
+        // title, not the unresolved `[real]` fallback.
+        let doc = Parser::default().parse(
+            ".See <<real>> here\n[discrete]\n== Discrete heading\n\nbody\n\n[[real]]\n== Real Section\n",
+        );
+
+        let block = doc.child_blocks().next().unwrap();
+        assert_eq!(block.raw_context().as_ref(), "floating_title");
+
+        assert_eq!(
+            block.title().unwrap(),
+            r##"See <a href="#real">Real Section</a> here"##
+        );
+    }
 }


### PR DESCRIPTION
## What

The constant fold the two deletion slices set up — item (6)'s close, and with it step 6's whole decomposition — **plus one pre-existing bug fix the review of it turned up** (see the last section).

Every flag left with exactly one producer folds:

- **`DeferredContent::from_tree` is always `true`** (`set_tree_xrefs` is the only producer since the string macros step's `set_deferred_xrefs` went in the first slice). The field, its `DeferredParts`/`TitleNode` copies, every `!from_tree` branch, and `template_partition` are deleted. The resolve loops read a segment's `target` directly — a tree read *is* the document's own text, so the `document_text` unescape question no longer arises for segments.
- **`FootnoteDeferred::sentinels_escaped` is always `false`** (the string replacer's `true` call died with the replacer in the second slice). The field goes, `define_footnote` loses the parameter and its unescape branch, and the side-effect parity harness drops its now-moot `set_sentinels_escaped` normalization.
- **`EscapedForm` reduces to one honest bool**: `render_template(…, template_escaped)` — `true` for a `DeferredContent`'s synthesized carried-title template (escaped by construction, see `carried_title_template`), `false` for a `FootnoteDeferred`'s fold, which never enters escaped form. The `segments` half was `false` at every surviving call site.

## The dead arm the fold exposed

Collapsing `resolve_references`' template arm showed its body was already unreachable: a deferring body content always has its tree installed and its attributes retained (the fold arm always binds), and the one template-rendering content — the carried block title — never enters the per-content resolution walk at all, because titles are resolved by the document-order title pass (`title_refs`), which splices through `render_xref_template`. Coverage was the witness (the splice line had **zero hits on the base too**), so `Content::rebuild_rendered` is deleted rather than kept as an untestable arm, per the dead-defensive-branch doctrine every prior increment has applied.

## The fold itself is behavior-identical by construction

Every hunk of the first commit replaces a read of a constant with the constant, or deletes a branch only the deleted machinery could take. The golden-HTML corpora are untouched.

## The bug the review found (second commit, `fix:`)

Greptile's P1 claimed the fold left a discrete section's decorative title stale. Its **causality was wrong** — the two probes render byte-identically on `origin/inline-ast` and this head, and `rebuild_rendered` was never that title's write-back — but the staleness it described is **real and pre-existing**:

A discrete heading is a `SectionBlock` with the `floating_title` context, and it is the one section kind that *keeps* its own `.Title` (every other section's is carried into its first block). No pass resolved it: the title pass's `Section` arm reads only the heading, and `Block::block_title_content_mut` mapped `Section` to `None`, so its else-branch never saw one either. A cross-reference in such a title stayed at its unresolved `[target]` fallback.

`SectionBlock` now exposes the same `title_content_mut` seam every other titled block does, `Block::block_title_content_mut` includes it, and both title-pass walks run their block-title branch for every block — heading first, decoration second, in the same order on each side. Pinned by a regression test asserting the discrete heading's title resolves to the target section's reference text.

## Coverage

639 → **582** workspace missed regions — below the 606 the whole freeze-and-delete arc started from. All changed lines verified covered under CI's exact coverage command.

## Checks

- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, `cargo test --workspace` (5,467 + 6 pass), `cargo +nightly doc --document-private-items` all clean.

## What still defers

Step 7 (`render_with`/`render_to`, `Document::to_asg()`, retiring the `attribute-missing` per-line hack #564), Phase 5's renderer seam, and Landing. Item (6) is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK