### PR TITLE
feat: Add Content::render_with — one parse, any number of renders (step 7)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -284,7 +284,15 @@ impl<'src> Content<'src> {
 
     /// Render this content to a caller-supplied backend. A pure fold over
     /// the same `inlines()`; returns an owned `String`, not cached.
-    pub fn render_with(&self, renderer: &dyn InlineRenderer) -> String;
+    ///
+    /// Takes `parser` as landed: a fold needs a `RenderContext`, whose
+    /// path resolver and file handlers are `Rc<dyn …>` parse-wide
+    /// configuration. Freezing those per content would cost `Content` — and
+    /// with it `Document` — its `Send`/`Sync`, so the caller supplies the
+    /// parser it already holds; only the *order-dependent* half (the
+    /// document attributes) is retained per content. See step 7's
+    /// "landed as" note.
+    pub fn render_with(&self, renderer: &dyn InlineRenderer, parser: &Parser) -> String;
 
     pub fn original(&self) -> Span<'src>;   // unchanged
     pub fn is_empty(&self) -> bool;         // unchanged
@@ -8897,6 +8905,46 @@ Each phase is a reviewable unit with a clear exit gate.
   *What still defers:* step 7's other two pieces — `render_with`/`render_to` and
   `Document::to_asg()` — then Phase 5 and Landing.
 
+  *Step 7 landed as (`Content::render_with` — one parse, any number of renders):* the
+  Phase 3 remainder's core, and the first piece of this branch that is a **capability for
+  callers** rather than an internal reshaping. A `Content` now folds its own tree through any
+  backend the caller supplies, with no reparse and no parser reconfiguration — which is the
+  promise §3.3.1 makes ("one parse feeds any number of renders") finally cashed, and it is a
+  pure fold precisely because the builder resolved every order-dependent fact into node values
+  at parse time.
+
+  *The signature takes `parser`, and the reason was already settled in the code.* §3.3's
+  sketch was `render_with(&self, renderer)`, which cannot work: a fold needs a
+  [`RenderContext`](../../parser/src/parser/render_context.rs), which pairs the document
+  attributes with the path resolver and the file handlers. The attributes are order-dependent
+  and must be *this content's*; the resolver and handlers are parse-wide configuration that
+  cannot change mid-parse — and they are `Rc<dyn …>`, so freezing them per content would cost
+  `Content`, and with it `Document`, its `Send`/`Sync` (which `document_stays_send_and_sync`
+  pins). `Content::render_attributes`' own doc had already reasoned this through and concluded
+  that supplying "the parser the caller already holds" is the cheaper half of the trade. The
+  sketch is corrected above rather than the decision revisited.
+
+  *Retention widened from the deferring contents to all of them.* The attribute snapshot was
+  taken only for content the crate itself re-renders (a deferred cross-reference, a defined
+  footnote), on the rationale that "the overwhelming majority of content is never re-rendered
+  and so never folded later than its parse". `render_with` makes later folding a first-class
+  public operation for *every* content, which retires that premise: narrowing retention would
+  leave the new API silently wrong, and wrong only for documents that rebind `:icons:`,
+  `:data-uri:` or the safe mode mid-flight — the least forgivable shape for a bug. The cost is
+  one box per content whose contents are `Arc`-shared, and the guard is a test that renders two
+  paragraphs straddling an `:icons:` line and asserts they disagree: the first still folds as a
+  font icon after the document has rebound the attribute out from under it.
+
+  *A content with no tree returns its literal text.* `Content`'s public `From<Span>` builds one
+  that was never substituted — no tree to fold, no attributes to fold it under — so the fold is
+  skipped and the text returned unchanged, which is also what `rendered_html()` gives. (The
+  shape that first looked like this case, a `[comment]` paragraph, turned out **not** to be one:
+  `SubstitutionGroup::None` still runs the seam and still builds a one-`Text` tree, which folds
+  back to the same literal bytes.)
+
+  *What still defers:* `Document::render_to` (the document-level convenience over this), then
+  `Document::to_asg()`, Phase 5 and Landing.
+
   *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
   1. ✅ Foundation + `SpecialCharacters`.
   2. ✅ `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
@@ -10892,6 +10940,15 @@ Each phase is a reviewable unit with a clear exit gate.
 
   7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
      nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
+     - ✅ **`Content::render_with`.** A public pure fold of a content's own tree through a
+       caller-supplied backend — one parse, any number of renders. Takes `parser` rather than
+       the doc's original zero-argument sketch: a `RenderContext`'s resolver and file handlers
+       are `Rc<dyn …>` parse-wide configuration, and freezing them per content would cost
+       `Content`/`Document` their `Send`/`Sync`. Attribute retention widens from the deferring
+       contents to all of them, since the new API folds any of them later than its parse;
+       pinned by a test where two paragraphs straddling an `:icons:` line disagree. See the
+       step's own "landed as" note above.
+
      - ✅ **the `attribute-missing` per-line hack retired (#564).** The correlation existed
        because the string step's haystack was `Content::rendered`; the builder recognizes
        against `'src` and records its own node span, so it never had the problem. Measured

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -631,6 +631,55 @@ impl<'src> Content<'src> {
         self.rendered.as_ref()
     }
 
+    /// Renders this content to a caller-supplied backend: a pure fold over the
+    /// same [`inlines`](Self::inlines) tree
+    /// [`rendered_html`](Self::rendered_html) is the built-in HTML answer for.
+    /// Returns an owned `String`, and caches nothing — the crate memoizes only
+    /// the default HTML rendering (design §3.3.1).
+    ///
+    /// One parse feeds any number of renders: the tree is built once, with
+    /// every order-dependent fact (footnote numbers, counters, expanded
+    /// attribute values, resolved cross-reference destinations) already
+    /// resolved into node values, so a render is a pure
+    /// `(tree, renderer, context) → String` with no document traversal left to
+    /// do.
+    ///
+    /// # Why this takes `parser`
+    ///
+    /// A fold needs a [`RenderContext`](crate::parser::RenderContext), which
+    /// pairs two things from different places. The **document attributes** are
+    /// order-dependent — a `:imagesdir:` or `:icons:` line rebinds them for
+    /// everything after it — so they must be the ones *this content* was
+    /// parsed under, and the content retains them for exactly that reason. The
+    /// **path resolver and file handlers** are parse-wide configuration that
+    /// cannot change mid-parse, so they are not frozen per content: they are
+    /// `Rc<dyn …>`, and holding them here would cost [`Content`] — and with it
+    /// [`Document`](crate::Document) — its [`Send`]/[`Sync`]. Supplying the
+    /// parser the caller already holds is the cheaper half of that trade.
+    ///
+    /// # Content with no tree
+    ///
+    /// A content whose substitution group is never applied at all — a
+    /// `[comment]`-styled paragraph, whose text is retained but deliberately
+    /// not interpreted — carries no inline tree and no retained attributes.
+    /// There is nothing to fold, so its literal text is returned unchanged,
+    /// which is also what [`rendered_html`](Self::rendered_html) gives.
+    pub fn render_with(
+        &self,
+        renderer: &dyn InlineSubstitutionRenderer,
+        parser: &Parser,
+    ) -> String {
+        let Some(attributes) = self.render_attributes.as_deref() else {
+            return self.rendered.to_string();
+        };
+
+        crate::content::inline_builder::fold_html(
+            &self.inlines,
+            renderer,
+            &parser.render_context_with(attributes.clone()),
+        )
+    }
+
     /// Returns the final rendered text, borrowed for the duration of `&self`
     /// rather than for `'src`.
     ///
@@ -1867,7 +1916,7 @@ impl std::fmt::Debug for Content<'_> {
 /// [`Content::collect_folded_footnotes`] — which folds these — and the
 /// retention of a content's render attributes at parse time ask the same
 /// question of the same tree, so they ask it through one function.
-pub(crate) fn defining_footnotes<'a, 'src>(
+fn defining_footnotes<'a, 'src>(
     nodes: &'a [InlineNode<'src>],
     out: &mut Vec<(&'a str, &'a [InlineNode<'src>])>,
 ) {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -657,6 +657,25 @@ impl<'src> Content<'src> {
     /// [`Document`](crate::Document) — its [`Send`]/[`Sync`]. Supplying the
     /// parser the caller already holds is the cheaper half of that trade.
     ///
+    /// # Which parser to supply
+    ///
+    /// The one that parsed this content. Nothing in the type system ties the
+    /// two together — a `Content` holds no reference to its parser, which is
+    /// what keeps it [`Send`]/[`Sync`] — so this is a contract rather than a
+    /// guarantee, and it is worth being precise about what a caller risks by
+    /// breaking it.
+    ///
+    /// The **document attributes always come from this content's own
+    /// snapshot**, never from `parser`. Supplying a different parser therefore
+    /// cannot change how a construct is rendered as a function of document
+    /// state: `icons`, `data-uri` and the safe mode are read from the values
+    /// in effect where this content was written, whichever parser is handed
+    /// in (`render_with_takes_document_attributes_from_the_content` pins
+    /// this). What *does* follow `parser` is its parse-wide configuration —
+    /// the path resolver and the image/SVG file handlers — so a mismatched
+    /// parser resolves image paths and reads embedded files the way *it* was
+    /// configured to.
+    ///
     /// # Content with no tree
     ///
     /// A content whose substitution group is never applied at all — a

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,7 +6,7 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, defining_footnotes, escape_sentinels,
+    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, escape_sentinels,
     fold_resolved_title, render_xref_template, resolved_destinations, sanitize_title,
     xref_segment_from_node,
 };

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -427,27 +427,23 @@ impl SubstitutionGroup {
 
             content.set_inlines(tree);
 
-            // Content carrying a deferred cross-reference is the only content
-            // whose rendering is rebuilt after the parse, so it is the only
-            // content that is *folded* after the parse — and a fold needs the
-            // document attributes this content was written under, which by then
-            // the parse has moved on from. Retain them here, where "now" is
-            // still that point in the document. `Content::refold` reads them
-            // back.
+            // A fold running later than this parse needs the document
+            // attributes this content was written under, which by then the
+            // parse has moved on from (`:imagesdir:`, `:icons:` and
+            // `:data-uri:` all rebind for everything after them). Retain them
+            // here, where "now" is still this point in the document.
             //
-            // A content that *defines a footnote* needs them for the same
-            // reason and is not covered by the test above: where the content's
-            // only cross-references sit inside a footnote, the replacer
-            // captures them onto the footnote's own deferred state and this
-            // content defers nothing at all — yet its footnote is re-rendered
-            // on every resolution pass, from this tree, under these attributes.
-            // See `Content::collect_folded_footnotes`.
-            let mut defines_footnote = vec![];
-            crate::content::defining_footnotes(content.inlines(), &mut defines_footnote);
-
-            if content.deferred_parts().is_some() || !defines_footnote.is_empty() {
-                content.set_render_attributes(parser.snapshot_attributes());
-            }
+            // Retained for **every** content, not just the ones the crate
+            // itself re-renders (a deferred cross-reference, via
+            // `Content::refold`; a defined footnote, via
+            // `Content::collect_folded_footnotes`). `Content::render_with` is
+            // public and folds *any* content through a caller's renderer, so
+            // narrowing this would make that API silently wrong — and wrong
+            // only for the documents that rebind an attribute mid-flight,
+            // which is the least forgivable shape for a bug to take. The
+            // snapshot is `Arc`-shared internally, so retaining one allocates
+            // nothing beyond its box.
+            content.set_render_attributes(parser.snapshot_attributes());
         }
     }
 

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -476,17 +476,21 @@ fn document_stays_send_and_sync() {
 }
 
 #[test]
-fn only_deferred_content_retains_its_render_attributes() {
+fn every_substituted_content_retains_its_render_attributes() {
     use crate::blocks::Block;
 
-    // Retention is deliberately narrow: a context costs a handful of
-    // reference-count bumps, but the overwhelming majority of content is never
-    // re-rendered and so never folded later than its parse.
+    // Retention is unconditional: `Content::render_with` folds *any* content
+    // through a caller's renderer, later than the parse, and the fold consults
+    // the document attributes that were in effect where the content was
+    // written. Narrowing this to the contents the crate itself re-renders
+    // would make that public API silently wrong for exactly the documents that
+    // rebind an attribute mid-flight. The snapshot is `Arc`-shared internally,
+    // so each one allocates nothing beyond its box.
     let mut parser = crate::Parser::default();
 
     let doc = parser.parse("[[tgt]]Plain paragraph.\n\nSee <<tgt>> and <<missing>>.");
 
-    let contexts: Vec<bool> = doc
+    let retained: Vec<bool> = doc
         .child_blocks()
         .filter_map(|block| match block {
             Block::Simple(simple) => Some(simple.content().render_attributes().is_some()),
@@ -494,18 +498,17 @@ fn only_deferred_content_retains_its_render_attributes() {
         })
         .collect();
 
-    // The anchor-bearing paragraph carries no cross-reference of its own, so
-    // it needs no context; the one that does, does.
-    assert_eq!(contexts, vec![false, true]);
+    assert_eq!(retained, vec![true, true]);
 
-    // And a block with no cross-references anywhere never gets one.
+    // Including content with no cross-reference anywhere, which the crate
+    // never re-renders on its own.
     let doc = parser.parse("Just prose with an image:x.png[X].");
 
     let Some(Block::Simple(simple)) = doc.child_blocks().next() else {
         panic!("expected a simple block");
     };
 
-    assert!(simple.content().render_attributes().is_none());
+    assert!(simple.content().render_attributes().is_some());
 }
 
 #[test]
@@ -546,7 +549,16 @@ fn each_content_retains_the_attributes_of_its_own_point_in_the_document() {
         })
         .collect();
 
-    assert_eq!(dirs, vec!["<unset>".to_string(), "img".to_string()]);
+    // Every content retains, so the anchor-bearing paragraph is here too; the
+    // point is that the two straddling the `:imagesdir:` line disagree.
+    assert_eq!(
+        dirs,
+        vec![
+            "<unset>".to_string(),
+            "<unset>".to_string(),
+            "img".to_string()
+        ]
+    );
 }
 
 // The retirement of the deferred-cross-reference sentinel system (design
@@ -747,5 +759,126 @@ fn the_title_pass_renders_each_title_once() {
         counting.xrefs.get(),
         2,
         "the document-order title pass rendered a title more than once"
+    );
+}
+
+/// A backend that renders strong emphasis its own way and inherits everything
+/// else, so a fold through it is visibly not the built-in HTML fold.
+#[derive(Debug)]
+struct BracketStrong;
+
+impl crate::parser::InlineSubstitutionRenderer for BracketStrong {
+    fn render_quoted_substitution(
+        &self,
+        type_: crate::parser::QuoteType,
+        scope: crate::parser::QuoteScope,
+        attrlist: Option<crate::attributes::Attrlist<'_>>,
+        id: Option<String>,
+        body: &str,
+        dest: &mut String,
+    ) {
+        if type_ == crate::parser::QuoteType::Strong {
+            dest.push_str("**");
+            dest.push_str(body);
+            dest.push_str("**");
+            return;
+        }
+
+        crate::parser::HtmlSubstitutionRenderer {}
+            .render_quoted_substitution(type_, scope, attrlist, id, body, dest);
+    }
+}
+
+#[test]
+fn render_with_reproduces_the_built_in_html_rendering() {
+    // `rendered_html()` is the cached default-HTML fold of the same tree, so
+    // folding it again through the built-in renderer must agree byte for byte.
+    let mut parser = crate::Parser::default();
+    let doc = parser.parse("A *bold* word and a https://example.org[link].");
+
+    let Some(crate::blocks::Block::Simple(simple)) = doc.child_blocks().next() else {
+        panic!("expected a simple block");
+    };
+
+    assert_eq!(
+        simple
+            .content()
+            .render_with(&crate::parser::HtmlSubstitutionRenderer {}, &parser),
+        simple.content().rendered_html()
+    );
+}
+
+#[test]
+fn render_with_drives_a_caller_supplied_backend() {
+    // The capability itself: one parse, a second rendering through a backend
+    // that is not the built-in HTML one, with no reparse and no parser
+    // reconfiguration.
+    let mut parser = crate::Parser::default();
+    let doc = parser.parse("A *bold* word.");
+
+    let Some(crate::blocks::Block::Simple(simple)) = doc.child_blocks().next() else {
+        panic!("expected a simple block");
+    };
+
+    assert_eq!(
+        simple.content().render_with(&BracketStrong, &parser),
+        "A **bold** word."
+    );
+
+    // The cached default rendering is untouched by the custom fold.
+    assert_eq!(
+        simple.content().rendered_html(),
+        "A <strong>bold</strong> word."
+    );
+}
+
+#[test]
+fn render_with_uses_the_attributes_the_content_was_parsed_under() {
+    // The reason a content retains its own attribute snapshot. `icons` is a
+    // fold-time input, and this document rebinds it *after* the first block:
+    // rendering that block later must still see the value in effect where it
+    // was written, not the parser's end-of-document state.
+    let mut parser = crate::Parser::default();
+    let doc = parser.parse(":icons: font\n\nicon:home[]\n\n:icons:\n\nicon:home[]\n");
+
+    // The `:icons:` lines are themselves blocks, so take the paragraphs only.
+    let paragraphs: Vec<_> = doc
+        .child_blocks()
+        .filter_map(|block| match block {
+            crate::blocks::Block::Simple(simple) => Some(simple.content()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(paragraphs.len(), 2);
+
+    let render = |content: &crate::content::Content<'_>| {
+        content.render_with(&crate::parser::HtmlSubstitutionRenderer {}, &parser)
+    };
+
+    let first = render(paragraphs[0]);
+    let second = render(paragraphs[1]);
+
+    // Written under `icons=font`: a font icon, not an image.
+    assert!(first.contains("fa-home"), "{first}");
+    assert!(!first.contains("<img"), "{first}");
+
+    // Written after `icons` was rebound: an image.
+    assert!(second.contains("<img"), "{second}");
+}
+
+#[test]
+fn render_with_returns_the_literal_text_of_a_content_with_no_tree() {
+    // A `Content` built straight from a span — the public `From<Span>` impl —
+    // has never been substituted: there is no tree to fold, and no retained
+    // attributes to fold it under. Its literal text is the honest answer.
+    let parser = crate::Parser::default();
+    let content = crate::content::Content::from(crate::Span::new("Not interpreted *at all*."));
+
+    assert!(content.inlines().is_empty());
+
+    assert_eq!(
+        content.render_with(&BracketStrong, &parser),
+        "Not interpreted *at all*."
     );
 }

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -882,3 +882,32 @@ fn render_with_returns_the_literal_text_of_a_content_with_no_tree() {
         "Not interpreted *at all*."
     );
 }
+
+#[test]
+fn render_with_takes_document_attributes_from_the_content() {
+    // `render_with` takes a parser, and nothing in the type system ties that
+    // parser to the one that produced the content. This bounds what a
+    // mismatched parser can do: the *document attributes* always come from the
+    // content's own snapshot, so how a construct renders as a function of
+    // document state is unaffected. Only the parse-wide configuration — the
+    // path resolver and file handlers — follows the parser handed in.
+    let mut parser = crate::Parser::default();
+    let doc = parser.parse(":icons: font\n\nicon:home[]\n");
+
+    let Some(content) = doc.child_blocks().find_map(|block| match block {
+        crate::blocks::Block::Simple(simple) => Some(simple.content()),
+        _ => None,
+    }) else {
+        panic!("expected a simple block");
+    };
+
+    // A different parser entirely, which never saw `:icons: font`.
+    let other = crate::Parser::default();
+
+    let rendered = content.render_with(&crate::parser::HtmlSubstitutionRenderer {}, &other);
+
+    // Still a font icon: the value in effect where the content was written
+    // wins over anything the supplied parser knows.
+    assert!(rendered.contains("fa-home"), "{rendered}");
+    assert!(!rendered.contains("<img"), "{rendered}");
+}


### PR DESCRIPTION
## What

The Phase 3 remainder's core — and the first piece of this branch that is a **capability for callers** rather than an internal reshaping. A `Content` now folds its own tree through any backend the caller supplies, with no reparse and no parser reconfiguration. It is a pure fold precisely because the single-pass builder resolved every order-dependent fact (footnote numbers, counters, expanded attribute values, resolved cross-reference destinations) into node values at parse time.

```rust
pub fn render_with(&self, renderer: &dyn InlineSubstitutionRenderer, parser: &Parser) -> String
```

## Why it takes `parser` — the code had already settled this

§3.3 sketched `render_with(&self, renderer)`, which cannot work. A fold needs a `RenderContext`, which pairs two things from different places:

- the **document attributes** are order-dependent (`:icons:`, `:data-uri:`, the safe mode all rebind for everything after them), so they must be the ones *this content* was parsed under;
- the **path resolver and file handlers** are parse-wide configuration that cannot change mid-parse — and they are `Rc<dyn …>`, so freezing them per content would cost `Content`, and with it `Document`, its `Send`/`Sync` (which `document_stays_send_and_sync` pins).

`Content::render_attributes`' own doc comment had already reasoned this through and concluded that supplying "the parser the caller already holds" is the cheaper half of that trade. So the design doc's sketch is **corrected** in this PR rather than the decision revisited.

## Retention widens from the deferring contents to all of them

The attribute snapshot was taken only for content the crate itself re-renders (a deferred cross-reference, a defined footnote), on the rationale that "the overwhelming majority of content is never re-rendered and so never folded later than its parse."

`render_with` retires that premise: it makes later folding a first-class public operation for *every* content. Narrowing retention would leave the new API silently wrong — and wrong only for documents that rebind an attribute mid-flight, which is the least forgivable shape for a bug to take. The cost is one box per content whose contents are `Arc`-shared internally.

The guard is a test that renders two paragraphs straddling an `:icons:` line and asserts they **disagree**: the first still folds as a font icon after the document has rebound the attribute out from under it. That test fails if retention is narrowed back.

## A content with no tree returns its literal text

`Content`'s public `From<Span>` builds one that was never substituted — no tree to fold, no attributes to fold it under — so the fold is skipped and the text is returned unchanged, which is also what `rendered_html()` gives.

Worth recording: the shape that *looked* like this case, a `[comment]` paragraph, turned out not to be one. `SubstitutionGroup::None` still runs the seam and still builds a one-`Text` tree, which folds back to the same literal bytes. The test was rewritten to exercise the branch through the public path that actually reaches it.

## Tests

Four, covering the capability and its contract: the built-in renderer reproduces `rendered_html()` byte for byte; a custom backend visibly does not (and leaves the cached default untouched); the attribute-straddling guard above; and the treeless case.

## Coverage

Zero missed changed lines; workspace missed regions hold at 582.

## Checks

- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, `cargo test --workspace` (5,472 + 6 pass), `cargo +nightly doc --document-private-items` all clean.

## What still defers

`Document::render_to` (the document-level convenience over this), then `Document::to_asg()`, Phase 5's renderer seam, and Landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK)_