### PR TITLE
chore: Retire three RenderParams structs for their nodes (Phase 5)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -609,8 +609,9 @@ below); the signature reshape has not.
 > - The one substitution-named method, `render_quoted_substitution`, is renamed to match its
 >   node kind: **`render_styled`**. ✅
 > - The `*RenderParams` structs fold into the node types (e.g. `XrefRenderParams` → the
->   `Ref` node), so most are removed rather than renamed. ⬜ *Not yet* — this is the
->   signature reshape, and it is the remaining Phase 5 slice.
+>   `Ref` node), so most are removed rather than renamed. 🔶 *In progress* — three of the
+>   eight are gone (see Phase 5's slice 2 note); the five that remain are the ones whose
+>   params carry a value no node holds.
 >
 > Considered and set aside: `InlineBackend` (introduces a "backend" noun not used elsewhere),
 > `InlineNodeRenderer` ("node" is redundant with "inline"), `InlineConverter` (the crate has
@@ -1514,7 +1515,10 @@ Each phase is a reviewable unit with a clear exit gate.
   which characters hide the callout in the raw source, decoupled from the render-seam's own
   `CalloutGuard` the same way every other node is decoupled from its `*RenderParams` counterpart (§4.6):
   the fold reconstructs `CalloutRenderParams` fresh from the node's `number` and `guard`, rather than the
-  node carrying a render-params type directly. The Phase 1/2 recorder
+  node carrying a render-params type directly. (That decoupling was right about the *direction* and
+  wrong about needing two types to express it: Phase 5's slice 2 has since retired both
+  `CalloutRenderParams` and the render-seam `CalloutGuard`, and `render_callout` takes the node. See
+  that note.) The Phase 1/2 recorder
   ([`inline_tree.rs`](../../parser/src/content/inline_tree.rs)), which had never captured a callout's
   guard (its differential corpus fixtures happened not to need it), now captures it too, so the two
   construction strategies agree on the node's shape.
@@ -11029,7 +11033,7 @@ Each phase is a reviewable unit with a clear exit gate.
   substitution pipeline. So an alternate renderer already walks the tree; what Phase 5 still
   owes it is a seam whose *shape* says so.
 
-  *What still defers:* the signature reshape — folding the eight `*RenderParams` structs into
+  *What slice 1 left:* the signature reshape — folding the eight `*RenderParams` structs into
   the node types they each shadow, so a method receives the node itself. Note that §4.6's
   framing of that reshape ("instead of being called mid-regex") no longer describes what is
   left of it: the string replacers went in step 6, so the trait is *already* called only by
@@ -11037,8 +11041,58 @@ Each phase is a reviewable unit with a clear exit gate.
   than the framing suggests — eight structs with **nine** construction sites between them,
   eight in [`fold.rs`](../../parser/src/content/inline_builder/fold.rs) and one in
   [`content.rs`](../../parser/src/content/content.rs)'s deferred-cross-reference re-render,
-  because the fold is now their sole constructor. Then Landing. (Step 7's
-  `Document::to_asg()` also remains, blocked on reading the Eclipse ASG schema.)
+  because the fold is now their sole constructor.
+
+  *Slice 2 landed as (the three params structs that were pure node projections):*
+  `CalloutRenderParams`, `FootnoteRenderParams` and `MenuRenderParams` are gone, and with the
+  first of them the render-seam's own `CalloutGuard` — a second enum that said exactly what
+  [`inlines::CalloutGuard`](../../parser/src/inlines/callout.rs) says, differing only in
+  holding a `&str` where the node holds a `CowStr`, and existing only to be converted into.
+  [`render_callout`](../../parser/src/parser/inline_renderer.rs) now takes
+  `(&Callout, &RenderContext)`, `render_footnote` takes `&Footnote`, and `render_menu` takes
+  [`UiKind::Menu`](../../parser/src/inlines/ui.rs)'s own fields.
+
+  *Why these three and not all eight.* The survey that sized the reshape also split it. Five
+  of the eight params carry a value **no node holds**: `LinkRenderParams::link_text`,
+  `XrefRenderParams::provided_text` and `IndexTermRenderParams::visible_term` are each the
+  *fold of the node's children*, and `Image`/`IconRenderParams` derive `alt` and `size` from
+  the node's attribute list. A parent's rendered children cannot live on the node — it is a
+  fold result, computed per render — so retiring those five is not a substitution but a
+  decision about how a method receives children it did not fold itself. That decision is the
+  next slice's, and it deserves a diff with nothing else in it. These three needed no such
+  decision: the fold's own doc comments already described two of them as "reconstructed
+  entirely from the node… no build-time state is needed", which is the definition of a struct
+  that should not exist.
+
+  *`render_keyboard` came along, and should have.* It is not a `*RenderParams` struct, but it
+  is the third method of the `Ui` family and took `&[String]` where the node holds
+  `&[CowStr]`, so the fold materialized a `Vec<String>` per keyboard macro purely to satisfy
+  the seam. Leaving it would have made `render_menu` and `render_keyboard` disagree about
+  their own node's field types one line apart. Both now take `&[CowStr]`; the two
+  per-node allocations are gone, and the one `join` that needed `Borrow<str>` is a
+  four-line helper in the renderer.
+
+  *The footnote derivation moved rather than vanished.* `fold_footnote`'s three-way
+  `(index, id, text)` match now lives in `HtmlInlineRenderer::render_footnote`, verbatim, and
+  the three cases it distinguishes are documented on the trait method where an alternate
+  backend will read them. Moving it kept the same match arms in the same shape deliberately:
+  splitting it into a four-arm match on `(is_reference, number)` would have exposed a
+  `(false, None)` arm that `build_footnote_node` never produces, trading a real conversion for
+  an untested branch.
+
+  *Verification.* No expected-output string changed and all 5,474 tests pass, so §5.3's oracle
+  pins the same bytes across the reshape. Coverage **improved**: 582 → 561 missed regions.
+  The cause is worth recording, because it started as a regression — moving code into
+  `TestRenderer`'s overrides pushed `parser.rs` from 87 to 95, since those overrides are
+  *longer* now and nothing exercised them. The `with_inline_renderer` test parses one
+  paragraph of specials and a footnote; every UI, callout, image, link and xref override on
+  that renderer was dead. A second test parsing `kbd:`/`btn:`/`menu:` and a callout list
+  closed that pre-existing hole along with the new one, taking `parser.rs` to 66.
+
+  *What still defers:* the five remaining params structs — `Link`, `Xref`, `IndexTerm`,
+  `Image` and `Icon`, the ones whose values are folds of children or derivations from an
+  attribute list — then Landing. (Step 7's `Document::to_asg()` also remains, blocked on
+  reading the Eclipse ASG schema.)
 
 - **Landing — preflight + merge to `main`.** Preflight the whole branch against the
   `asciidoctor` port (§5.1) to confirm the public API and reshaped seam serve a real

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -5,14 +5,12 @@ use crate::{
     attributes::Attrlist,
     content::{Content, XrefSegment, xref_segment_from_node},
     inlines::{
-        Anchor, Callout, CalloutGuard, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm,
-        Ref, RefVariant, SpanForm, Stem, StemNotation, Ui, UiKind,
+        Anchor, Callout, CharRef, Footnote, Image, IndexTerm, InlineNode, RawForm, Ref, RefVariant,
+        SpanForm, Stem, StemNotation, Ui, UiKind,
     },
     parser::{
-        CalloutGuard as ParserCalloutGuard, CalloutRenderParams, FootnoteRenderParams,
         IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineRenderer,
-        LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, RenderContext, SpecialCharacter,
-        XrefRenderParams,
+        LinkRenderParams, QuoteScope, QuoteType, RenderContext, SpecialCharacter, XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -476,8 +474,7 @@ fn fold_image(
 fn fold_ui(ui: &Ui<'_>, renderer: &dyn InlineRenderer, context: &RenderContext, out: &mut String) {
     match &ui.kind {
         UiKind::Keyboard(keys) => {
-            let keys: Vec<String> = keys.iter().map(|k| k.to_string()).collect();
-            renderer.render_keyboard(&keys, out);
+            renderer.render_keyboard(keys, out);
         }
 
         UiKind::Button(text) => {
@@ -489,16 +486,7 @@ fn fold_ui(ui: &Ui<'_>, renderer: &dyn InlineRenderer, context: &RenderContext, 
             submenus,
             item,
         } => {
-            let submenus: Vec<String> = submenus.iter().map(|s| s.to_string()).collect();
-
-            let params = MenuRenderParams {
-                menu: menu.as_ref(),
-                submenus: &submenus,
-                menuitem: item.as_deref(),
-                context,
-            };
-
-            renderer.render_menu(&params, out);
+            renderer.render_menu(menu.as_ref(), submenus, item.as_deref(), context, out);
         }
     }
 }
@@ -759,9 +747,9 @@ fn fold_index_term(
 }
 
 /// Folds a [`Footnote`](InlineNode::Footnote) through the same
-/// `render_footnote` the string step calls, reconstructing
-/// [`FootnoteRenderParams`] entirely from the node's `is_reference`, `number`,
-/// and `id` fields — no build-time state is needed (design §3.3.1).
+/// `render_footnote` the string step calls — handing over the node itself,
+/// since everything the marker needs is on it (`is_reference`, `number`, `id`)
+/// and no build-time state is required (design §3.3.1).
 ///
 /// Only the in-flow **marker** is folded here (`[1]`, or `[id]` for an
 /// unresolved reference): `render_footnote` never emits the footnote's own
@@ -770,60 +758,29 @@ fn fold_index_term(
 /// `footnote.children` is not folded into `out` at all, the same relationship
 /// [`fold_anchor`]'s `reftext` has to its own marker.
 ///
-/// A defining occurrence (`is_reference == false`) always carries its number
-/// (see `build_footnote_node`) and folds its own `id`, when it has one, into
-/// the marker's `id` attribute. A reference either reuses an existing
-/// footnote's number (`number: Some`, `id` never folded — matching the string
-/// replacer, which renders a reference's `id` attribute only for the
-/// *defining* occurrence) or, unresolved (`number: None`), falls back to
-/// displaying its own `id` as the render params' `text`.
+/// Which of the three markers a node produces is now the *renderer's* reading
+/// of it rather than this fold's — see
+/// [`render_footnote`](crate::parser::InlineRenderer::render_footnote)'s own
+/// documentation for the three cases, and `HtmlInlineRenderer` for the reading
+/// the built-in backend makes.
 fn fold_footnote(footnote: &Footnote<'_>, renderer: &dyn InlineRenderer, out: &mut String) {
-    let (index, id, text): (Option<&str>, Option<&str>, &str) = if footnote.is_reference {
-        match footnote.number.as_deref() {
-            Some(number) => (Some(number), None, ""),
-            None => (None, None, footnote.id.as_deref().unwrap_or("")),
-        }
-    } else {
-        (footnote.number.as_deref(), footnote.id.as_deref(), "")
-    };
-
-    renderer.render_footnote(
-        &FootnoteRenderParams {
-            index,
-            id,
-            is_reference: footnote.is_reference,
-            text,
-        },
-        out,
-    );
+    renderer.render_footnote(footnote, out);
 }
 
 /// Folds a [`Callout`](InlineNode::Callout) through the same `render_callout`
-/// the string step's `Callouts` group calls, reconstructing
-/// [`CalloutRenderParams`] from the node's `number` and `guard` — no
-/// build-time state is needed, mirroring [`fold_footnote`]. This is the
-/// decoupling design §4.6 previews for Phase 5: the node is the canonical,
-/// structured record; the `*RenderParams` struct is rebuilt from it fresh at
-/// fold time, not carried alongside it.
+/// the string step's `Callouts` group calls, handing over the node itself —
+/// no build-time state is needed, mirroring [`fold_footnote`]. This is design
+/// §4.6's Phase 5 reshape arrived at: the node was already the canonical
+/// structured record, and the render-params struct this fold used to rebuild
+/// from it (along with a second `CalloutGuard` differing only in whether the
+/// prefix was a `CowStr` or a `&str`) is gone.
 fn fold_callout(
     callout: &Callout<'_>,
     renderer: &dyn InlineRenderer,
     context: &RenderContext,
     out: &mut String,
 ) {
-    let guard = match &callout.guard {
-        CalloutGuard::LineComment(prefix) => ParserCalloutGuard::LineComment(prefix.as_ref()),
-        CalloutGuard::Xml => ParserCalloutGuard::Xml,
-    };
-
-    renderer.render_callout(
-        &CalloutRenderParams {
-            number: callout.number.as_ref(),
-            guard,
-            context,
-        },
-        out,
-    );
+    renderer.render_callout(callout, context, out);
 }
 
 /// Folds a [`Stem`](InlineNode::Stem) through the same

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -394,9 +394,9 @@ fn build_candidate_node<'src>(
 /// Builds one [`Footnote`](InlineNode::Footnote) node from a `footnote:` match,
 /// resolving it into the same three (id, content) cases the string
 /// replacer's `InlineFootnoteMacroReplacer` distinguishes, so the fold —
-/// which reconstructs
-/// [`FootnoteRenderParams`](crate::parser::FootnoteRenderParams) from the node
-/// alone (see `fold_footnote`) — reproduces the same bytes. Returns `None` for
+/// which hands the node straight to
+/// [`render_footnote`](crate::parser::InlineRenderer::render_footnote) (see
+/// `fold_footnote`) — reproduces the same bytes. Returns `None` for
 /// a form this increment defers, or for `footnote:[]` (neither an id nor
 /// content), which is not a footnote at all.
 ///

--- a/parser/src/inlines/callout.rs
+++ b/parser/src/inlines/callout.rs
@@ -24,11 +24,16 @@ impl<'src> HasSpan<'src> for Callout<'src> {
 }
 
 /// Describes the characters that guard (hide) a callout number in verbatim
-/// source. Mirrors [`crate::parser::CalloutGuard`], the render-time
-/// counterpart the fold reconstructs this into, but is decoupled from it (as
-/// every node in this module is decoupled from its `*RenderParams`
-/// counterpart) so the node stays canonical, structured data rather than a
-/// render-seam type.
+/// source, so a fold can preserve them when icons are not enabled.
+///
+/// This used to be mirrored by a render-time `parser::CalloutGuard` that the
+/// fold converted into, on the reasoning that a node should stay canonical
+/// structured data rather than a render-seam type. Phase 5 retired that
+/// duplicate: with
+/// [`render_callout`](crate::parser::InlineRenderer::render_callout) taking
+/// the [`Callout`] node itself, the node *is* what the seam carries, and a
+/// second enum saying the same thing in `&str` where this one says
+/// [`CowStr`] bought nothing but a conversion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CalloutGuard<'src> {
     /// A line-comment (or absent) guard. Holds the line-comment prefix that

--- a/parser/src/parser/inline_renderer.rs
+++ b/parser/src/parser/inline_renderer.rs
@@ -4,9 +4,11 @@ use regex::Regex;
 
 use crate::{
     attributes::Attrlist,
+    inlines::{Callout, CalloutGuard, Footnote},
     parser::{
         DerivedReference, RenderContext, ResolvedReference, SafeMode, XrefSignifier, XrefStyle,
     },
+    strings::CowStr,
 };
 
 /// An implementation of `InlineRenderer` converts the inline content of a
@@ -212,13 +214,17 @@ pub trait InlineRenderer: Debug {
 
     /// Renders a [callout] number that annotates a line in a verbatim block.
     ///
-    /// The renderer should write an appropriate rendering of the callout number
-    /// to `dest`. The rendering typically depends on whether font-based or
-    /// image-based icons are enabled (via the `icons` document attribute).
+    /// The renderer should write an appropriate rendering of the callout's
+    /// [`number`](crate::inlines::Callout::number) to `dest`. The rendering
+    /// typically depends on whether font-based or image-based icons are
+    /// enabled (via the `icons` document attribute, read off `context`); when
+    /// they are not, the node's [`guard`](crate::inlines::Callout::guard) says
+    /// which comment characters hid the callout in the raw source and should
+    /// be preserved around it.
     ///
     /// [callout]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
-    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String) {
-        DEFAULT_HTML_RENDERER.render_callout(params, dest);
+    fn render_callout(&self, callout: &Callout<'_>, context: &RenderContext, dest: &mut String) {
+        DEFAULT_HTML_RENDERER.render_callout(callout, context, dest);
     }
 
     /// Renders an [index term].
@@ -251,24 +257,39 @@ pub trait InlineRenderer: Debug {
 
     /// Renders a [keyboard] UI macro (`kbd:[keys]`).
     ///
-    /// `keys` holds one entry per key in the shortcut. A single-element slice
-    /// is a lone key; multiple entries form a key sequence. The renderer
-    /// should write an appropriate rendering (e.g. a lone `<kbd>` element,
-    /// or a `<span class="keyseq">` wrapping several `<kbd>` elements) to
-    /// `dest`.
+    /// `keys` holds one entry per key in the shortcut, exactly as
+    /// [`UiKind::Keyboard`](crate::inlines::UiKind) carries them. A
+    /// single-element slice is a lone key; multiple entries form a key
+    /// sequence. The renderer should write an appropriate rendering (e.g. a
+    /// lone `<kbd>` element, or a `<span class="keyseq">` wrapping several
+    /// `<kbd>` elements) to `dest`.
     ///
     /// [keyboard]: https://docs.asciidoctor.org/asciidoc/latest/macros/keyboard-macro/
-    fn render_keyboard(&self, keys: &[String], dest: &mut String) {
+    fn render_keyboard(&self, keys: &[CowStr<'_>], dest: &mut String) {
         DEFAULT_HTML_RENDERER.render_keyboard(keys, dest);
     }
 
     /// Renders a [menu] UI macro (`menu:menu[submenu > … > item]`).
     ///
+    /// The arguments are [`UiKind::Menu`](crate::inlines::UiKind)'s own
+    /// fields: `menu` is the top-level name, `submenus` holds zero or more
+    /// intermediate names outermost-first, and `menuitem` is the final item
+    /// (`None` renders a bare menu reference such as `menu:File[]`).
+    /// `context` is where the renderer reads the `icons` document attribute
+    /// to choose the caret between menu levels.
+    ///
     /// The renderer should write an appropriate rendering to `dest`.
     ///
     /// [menu]: https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
-    fn render_menu(&self, params: &MenuRenderParams, dest: &mut String) {
-        DEFAULT_HTML_RENDERER.render_menu(params, dest);
+    fn render_menu(
+        &self,
+        menu: &str,
+        submenus: &[CowStr<'_>],
+        menuitem: Option<&str>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        DEFAULT_HTML_RENDERER.render_menu(menu, submenus, menuitem, context, dest);
     }
 
     /// Renders the inline reference produced by a [`footnote`] macro.
@@ -277,13 +298,26 @@ pub trait InlineRenderer: Debug {
     /// document's footnote list); this method renders only the superscript
     /// marker that appears in the flow of text and links to the footnote.
     ///
-    /// See [`FootnoteRenderParams`] for the three cases the renderer must
-    /// handle (a defining occurrence, a reference to an earlier footnote, and
-    /// an unresolved reference).
+    /// There are three cases the renderer must distinguish, all readable off
+    /// the node:
+    ///
+    /// * A *defining* occurrence ([`is_reference`] is `false`): the footnote
+    ///   introduces new text. It always carries its
+    ///   [`number`](crate::inlines::Footnote::number), and when it was given an
+    ///   [`id`](crate::inlines::Footnote::id) the marker takes an anchor of its
+    ///   own.
+    /// * A *reference* to an earlier footnote ([`is_reference`] is `true`,
+    ///   `number` is `Some`): a later occurrence (`footnote:id[]`) reusing an
+    ///   existing footnote's number, with no anchor of its own.
+    /// * An *unresolved* reference ([`is_reference`] is `true`, `number` is
+    ///   `None`): the ID was never defined, and the renderer should emit a
+    ///   visible error marker built from the node's own `id`.
+    ///
+    /// [`is_reference`]: crate::inlines::Footnote::is_reference
     ///
     /// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
-    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String) {
-        DEFAULT_HTML_RENDERER.render_footnote(params, dest);
+    fn render_footnote(&self, footnote: &Footnote<'_>, dest: &mut String) {
+        DEFAULT_HTML_RENDERER.render_footnote(footnote, dest);
     }
 }
 
@@ -481,43 +515,6 @@ pub struct LinkRenderParams<'a> {
     pub context: &'a RenderContext,
 }
 
-/// Provides parameters for rendering a [callout] number.
-///
-/// [callout]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
-#[derive(Clone, Debug)]
-pub struct CalloutRenderParams<'a> {
-    /// The callout number to display. For automatically-numbered callouts
-    /// (`<.>`), this is the resolved sequential number.
-    pub number: &'a str,
-
-    /// The guard surrounding the callout in the source. This controls whether
-    /// (and how) the line-comment or XML-comment characters that hide the
-    /// callout in the raw source are preserved in the output when icons are not
-    /// enabled.
-    pub guard: CalloutGuard<'a>,
-
-    /// The document state as of the point in the document this callout came
-    /// from. The renderer reads the `icons`, `iconsdir`, and `icontype`
-    /// document attributes from it to decide how to render the callout. See
-    /// [`RenderContext`].
-    pub context: &'a RenderContext,
-}
-
-/// Describes the characters that guard (hide) a callout number in verbatim
-/// source.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CalloutGuard<'a> {
-    /// A line-comment (or absent) guard. Holds the line-comment prefix that
-    /// precedes the callout in the source (e.g. `# `), or an empty string when
-    /// the callout is not tucked behind a line comment. When icons are not
-    /// enabled, the prefix is preserved ahead of the rendered callout number.
-    LineComment(&'a str),
-
-    /// An XML comment guard (`<!--N-->`). When icons are not enabled, the XML
-    /// comment delimiters are preserved around the rendered callout number.
-    Xml,
-}
-
 /// Provides parameters for rendering a cross-reference.
 #[derive(Clone, Debug)]
 pub struct XrefRenderParams<'a> {
@@ -567,61 +564,20 @@ pub struct IndexTermRenderParams<'a> {
     pub visible_term: Option<&'a str>,
 }
 
-/// Provides parameters for rendering a [menu] UI macro.
+/// Joins a slice of [`CowStr`]s with `sep`.
 ///
-/// [menu]: https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
-#[derive(Clone, Debug)]
-pub struct MenuRenderParams<'a> {
-    /// The top-level menu name.
-    pub menu: &'a str,
-
-    /// Zero or more intermediate submenu names, in order from outermost to
-    /// innermost.
-    pub submenus: &'a [String],
-
-    /// The final menu item, if any. `None` renders a bare menu reference (a
-    /// `menu:File[]` with no items).
-    pub menuitem: Option<&'a str>,
-
-    /// The document state as of the point in the document this menu reference
-    /// came from, used to read the `icons` document attribute when choosing
-    /// how to render the caret between menu levels. See [`RenderContext`].
-    pub context: &'a RenderContext,
-}
-
-/// Provides parameters for rendering the inline marker of a [`footnote`] macro.
-///
-/// There are three cases the renderer must distinguish:
-///
-/// * A *defining* occurrence (`index` is `Some`, `is_reference` is `false`):
-///   the footnote introduces new text. The marker carries the footnote number
-///   and, when the footnote was given an ID, an `id` of its own.
-/// * A *reference* to an earlier footnote (`index` is `Some`, `is_reference` is
-///   `true`): a later occurrence (`footnote:id[]`) that reuses an existing
-///   footnote's number.
-/// * An *unresolved* reference (`index` is `None`, `is_reference` is `true`): a
-///   reference whose ID was never defined; the renderer emits a visible error
-///   marker built from [`text`](Self::text).
-///
-/// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
-#[derive(Clone, Debug)]
-pub struct FootnoteRenderParams<'a> {
-    /// The footnote's number, or `None` for an unresolved reference. Normally a
-    /// consecutive integer, but the `footnote-number` counter honors any seed
-    /// the document sets, so it is passed through as text.
-    pub index: Option<&'a str>,
-
-    /// The footnote's own ID, used only on a defining occurrence to produce the
-    /// `id="_footnote_<id>"` attribute on the marker.
-    pub id: Option<&'a str>,
-
-    /// `true` when this occurrence references an existing footnote (or fails to
-    /// resolve one); `false` for the defining occurrence.
-    pub is_reference: bool,
-
-    /// For an unresolved reference, the text to show inside the error marker
-    /// (the unresolved ID). Ignored in the other cases.
-    pub text: &'a str,
+/// The node fields this renderer receives (a keyboard macro's keys, a menu's
+/// submenu path) are `CowStr` slices rather than `String` ones, so that the
+/// fold hands them over exactly as the node holds them instead of
+/// materializing a `Vec<String>` for every such node. `[T]::join` needs
+/// `Borrow<str>`, which `CowStr` does not implement, so the borrow is taken
+/// explicitly here.
+fn join_cow_strs(parts: &[CowStr<'_>], sep: &str) -> String {
+    parts
+        .iter()
+        .map(CowStr::as_ref)
+        .collect::<Vec<&str>>()
+        .join(sep)
 }
 
 /// Implementation of [`InlineRenderer`] that renders substitutions
@@ -1383,9 +1339,8 @@ impl InlineRenderer for HtmlInlineRenderer {
         }
     }
 
-    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String) {
-        let n = params.number;
-        let context = params.context;
+    fn render_callout(&self, callout: &Callout<'_>, context: &RenderContext, dest: &mut String) {
+        let n = callout.number.as_ref();
 
         if context.attribute_value("icons").as_maybe_str() == Some("font") {
             dest.push_str(&format!(
@@ -1403,13 +1358,13 @@ impl InlineRenderer for HtmlInlineRenderer {
 
             dest.push_str(&format!(r#"<img src="{src}" alt="{n}">"#));
         } else {
-            match params.guard {
+            match &callout.guard {
                 CalloutGuard::Xml => {
                     dest.push_str(&format!(r#"&lt;!--<b class="conum">({n})</b>--&gt;"#));
                 }
 
                 CalloutGuard::LineComment(prefix) => {
-                    dest.push_str(prefix);
+                    dest.push_str(prefix.as_ref());
                     dest.push_str(&format!(r#"<b class="conum">({n})</b>"#));
                 }
             }
@@ -1429,7 +1384,7 @@ impl InlineRenderer for HtmlInlineRenderer {
         dest.push_str(&format!(r#"<b class="button">{text}</b>"#));
     }
 
-    fn render_keyboard(&self, keys: &[String], dest: &mut String) {
+    fn render_keyboard(&self, keys: &[CowStr<'_>], dest: &mut String) {
         if let [key] = keys {
             dest.push_str(&format!("<kbd>{key}</kbd>"));
         } else {
@@ -1439,22 +1394,27 @@ impl InlineRenderer for HtmlInlineRenderer {
             // not how the sequence is displayed.
             dest.push_str(&format!(
                 r#"<span class="keyseq"><kbd>{keys}</kbd></span>"#,
-                keys = keys.join("</kbd>+<kbd>")
+                keys = join_cow_strs(keys, "</kbd>+<kbd>")
             ));
         }
     }
 
-    fn render_menu(&self, params: &MenuRenderParams, dest: &mut String) {
-        let caret = if params.context.attribute_value("icons").as_maybe_str() == Some("font") {
+    fn render_menu(
+        &self,
+        menu: &str,
+        submenus: &[CowStr<'_>],
+        menuitem: Option<&str>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        let caret = if context.attribute_value("icons").as_maybe_str() == Some("font") {
             r#"&#160;<i class="fa fa-angle-right caret"></i> "#
         } else {
             r#"&#160;<b class="caret">&#8250;</b> "#
         };
 
-        let menu = params.menu;
-
-        if params.submenus.is_empty() {
-            if let Some(menuitem) = params.menuitem {
+        if submenus.is_empty() {
+            if let Some(menuitem) = menuitem {
                 dest.push_str(&format!(
                     r#"<span class="menuseq"><b class="menu">{menu}</b>{caret}<b class="menuitem">{menuitem}</b></span>"#
                 ));
@@ -1465,15 +1425,31 @@ impl InlineRenderer for HtmlInlineRenderer {
             let submenu_joiner = format!(r#"</b>{caret}<b class="submenu">"#);
             dest.push_str(&format!(
                 r#"<span class="menuseq"><b class="menu">{menu}</b>{caret}<b class="submenu">{submenus}</b>{caret}<b class="menuitem">{menuitem}</b></span>"#,
-                submenus = params.submenus.join(&submenu_joiner),
-                menuitem = params.menuitem.unwrap_or_default(),
+                submenus = join_cow_strs(submenus, &submenu_joiner),
+                menuitem = menuitem.unwrap_or_default(),
             ));
         }
     }
 
-    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String) {
-        match params.index {
-            Some(index) if params.is_reference => {
+    fn render_footnote(&self, footnote: &Footnote<'_>, dest: &mut String) {
+        // The three cases `render_footnote`'s own documentation names, read
+        // off the node. A defining occurrence always carries its number (see
+        // `build_footnote_node`) and folds its own id into the marker's
+        // anchor; a reference either reuses an existing footnote's number —
+        // never folding an id, matching the string replacer, which rendered a
+        // reference's id attribute only for the *defining* occurrence — or,
+        // unresolved, displays its own id in an error marker.
+        let (index, id, text): (Option<&str>, Option<&str>, &str) = if footnote.is_reference {
+            match footnote.number.as_deref() {
+                Some(number) => (Some(number), None, ""),
+                None => (None, None, footnote.id.as_deref().unwrap_or("")),
+            }
+        } else {
+            (footnote.number.as_deref(), footnote.id.as_deref(), "")
+        };
+
+        match index {
+            Some(index) if footnote.is_reference => {
                 // A reference to an already-defined footnote reuses its number
                 // but gets no anchor of its own.
                 dest.push_str(&format!(
@@ -1484,8 +1460,7 @@ impl InlineRenderer for HtmlInlineRenderer {
             Some(index) => {
                 // A defining occurrence. When the footnote carries an ID, the
                 // marker is given a matching anchor so it can be linked to.
-                let id_attr = params
-                    .id
+                let id_attr = id
                     .map(|id| format!(r#" id="_footnote_{id}""#))
                     .unwrap_or_default();
 
@@ -1497,8 +1472,7 @@ impl InlineRenderer for HtmlInlineRenderer {
             None => {
                 // An unresolved reference: the ID was never defined.
                 dest.push_str(&format!(
-                    r#"<sup class="footnoteref red" title="Unresolved footnote reference.">[{text}]</sup>"#,
-                    text = params.text
+                    r#"<sup class="footnoteref red" title="Unresolved footnote reference.">[{text}]</sup>"#
                 ));
             }
         }

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -19,9 +19,9 @@ pub use include_file_handler::{IncludeContent, IncludeFileHandler, IncludeResolu
 
 mod inline_renderer;
 pub use inline_renderer::{
-    CalloutGuard, CalloutRenderParams, CharacterReplacementType, FootnoteRenderParams,
-    HtmlInlineRenderer, IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineRenderer,
-    LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
+    CharacterReplacementType, HtmlInlineRenderer, IconRenderParams, ImageRenderParams,
+    IndexTermRenderParams, InlineRenderer, LinkRenderParams, QuoteScope, QuoteType,
+    SpecialCharacter, XrefRenderParams,
 };
 pub(crate) use inline_renderer::{has_dangerous_scheme, has_dangerous_self_href, is_uri_ish};
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -4566,8 +4566,13 @@ mod tests {
             dest.push_str(&format!("[XREF:{}]", params.target));
         }
 
-        fn render_callout(&self, params: &crate::parser::CalloutRenderParams, dest: &mut String) {
-            dest.push_str(&format!("[CALLOUT:{}]", params.number));
+        fn render_callout(
+            &self,
+            callout: &crate::inlines::Callout<'_>,
+            _context: &crate::parser::RenderContext,
+            dest: &mut String,
+        ) {
+            dest.push_str(&format!("[CALLOUT:{}]", callout.number));
         }
 
         fn render_index_term(
@@ -4585,18 +4590,29 @@ mod tests {
             dest.push_str(&format!("[BUTTON:{text}]"));
         }
 
-        fn render_keyboard(&self, keys: &[String], dest: &mut String) {
+        fn render_keyboard(&self, keys: &[crate::strings::CowStr<'_>], dest: &mut String) {
+            let keys: Vec<&str> = keys.iter().map(|k| k.as_ref()).collect();
             dest.push_str(&format!("[KBD:{}]", keys.join("+")));
         }
 
-        fn render_menu(&self, params: &crate::parser::MenuRenderParams, dest: &mut String) {
-            dest.push_str(&format!("[MENU:{}]", params.menu));
+        fn render_menu(
+            &self,
+            menu: &str,
+            _submenus: &[crate::strings::CowStr<'_>],
+            _menuitem: Option<&str>,
+            _context: &crate::parser::RenderContext,
+            dest: &mut String,
+        ) {
+            dest.push_str(&format!("[MENU:{menu}]"));
         }
 
-        fn render_footnote(&self, params: &crate::parser::FootnoteRenderParams, dest: &mut String) {
-            match params.index {
+        fn render_footnote(&self, footnote: &crate::inlines::Footnote<'_>, dest: &mut String) {
+            match footnote.number.as_deref() {
                 Some(index) => dest.push_str(&format!("[FOOTNOTE:{index}]")),
-                None => dest.push_str(&format!("[FOOTNOTE:{}]", params.text)),
+                None => dest.push_str(&format!(
+                    "[FOOTNOTE:{}]",
+                    footnote.id.as_deref().unwrap_or("")
+                )),
             }
         }
     }
@@ -4643,6 +4659,36 @@ mod tests {
         assert_eq!(
             simple_block.content().rendered_html(),
             "test.[FOOTNOTE:missing]"
+        );
+    }
+
+    #[test]
+    fn custom_renderer_renders_ui_macros_and_callouts() {
+        // The UI-macro and callout overrides take the node (or its fields)
+        // rather than a `*RenderParams` struct, so this pins that they are
+        // reached and read the values the node carries.
+        let mut parser = Parser::default().with_inline_renderer(TestRenderer);
+
+        let doc = parser.parse(
+            ":experimental:\n\nPress kbd:[Ctrl,T] then btn:[OK] from menu:File[Save As].\n\n\
+             [source]\n----\nlet x = 1; # <1>\n----",
+        );
+
+        let rendered: Vec<String> = doc
+            .child_blocks()
+            .filter_map(|b| match b {
+                Block::Simple(s) => Some(s.content().rendered_html().to_string()),
+                Block::RawDelimited(r) => Some(r.content().rendered_html().to_string()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "Press [KBD:Ctrl+T] then [BUTTON:OK] from [MENU:File].".to_string(),
+                "let x = 1; [CALLOUT:1]".to_string(),
+            ]
         );
     }
 


### PR DESCRIPTION
## What

§4.6's **signature reshape**, for the three of eight `*RenderParams` structs that were pure node projections.

| before | after |
| --- | --- |
| `render_callout(&CalloutRenderParams, …)` | `render_callout(&Callout<'_>, &RenderContext, …)` |
| `render_footnote(&FootnoteRenderParams, …)` | `render_footnote(&Footnote<'_>, …)` |
| `render_menu(&MenuRenderParams, …)` | `render_menu(&str, &[CowStr<'_>], Option<&str>, &RenderContext, …)` |
| `render_keyboard(&[String], …)` | `render_keyboard(&[CowStr<'_>], …)` |

`CalloutRenderParams` takes the render-seam's own **`CalloutGuard`** with it — a second enum saying exactly what `inlines::CalloutGuard` says, differing only in holding a `&str` where the node holds a `CowStr`, and existing only to be converted into.

**Breaking**, to a public seam, and an accepted pre-1.0 break (§4.6).

## Why three of eight, and not all of them

The survey that sized this reshape also split it. Five of the eight params carry a value **no node holds**:

- `LinkRenderParams::link_text`, `XrefRenderParams::provided_text` and `IndexTermRenderParams::visible_term` are each the **fold of the node's children**.
- `Image`/`IconRenderParams` derive `alt` and `size` from the node's attribute list.

A parent's rendered children cannot live on the node — it's a fold result, computed per render. So retiring those five isn't a substitution; it's a *decision* about how a method receives children it did not fold itself, and that decision deserves a diff with nothing else in it.

These three needed no such decision. The fold's own doc comments already described two of them as "reconstructed entirely from the node… no build-time state is needed" — which is the definition of a struct that should not exist.

## `render_keyboard` came along, and should have

It isn't a `*RenderParams` struct, but it's the third method of the `Ui` family and took `&[String]` where the node holds `&[CowStr]`, so the fold materialized a `Vec<String>` per keyboard macro purely to satisfy the seam. Leaving it would have made `render_menu` and `render_keyboard` disagree about their own node's field types one line apart. Both now take `&[CowStr]`, and two per-node allocations are gone. The one `join` that needed `Borrow<str>` is a four-line helper in the renderer.

## The footnote derivation moved rather than vanished

`fold_footnote`'s three-way `(index, id, text)` match now lives in `HtmlInlineRenderer::render_footnote`, verbatim, and the three cases it distinguishes are documented on the trait method where an alternate backend will read them.

Keeping the same arms in the same shape was deliberate. Splitting it into a four-arm match on `(is_reference, number)` reads more naturally, but exposes a `(false, None)` arm that `build_footnote_node` never produces — trading a real conversion for an untested branch, which is the opposite of the trade this repo makes.

## Verification

No expected-output string changed and all **5,474 tests pass**, so §5.3's golden-HTML oracle pins the same bytes across the reshape.

### Coverage — it started as a regression

Worth recording, because the first measurement said the change made things worse: **582 → 590** missed regions, all of it in `parser.rs`.

The cause wasn't the reshape. `TestRenderer`'s overrides are *longer* now (a 5-argument `render_menu`, a `render_keyboard` that borrows before joining), and nothing exercised them: the `with_inline_renderer` test parses one paragraph of specials and a footnote, so every UI, callout, image, link and xref override on that renderer was dead code. My change simply made a pre-existing hole bigger.

A second test parsing `kbd:`/`btn:`/`menu:` and a callout closed it — and it passed on its first run, which is the evidence the overrides really are reached and really do read the node's values.

| | base (`9cd09a9`) | this PR |
| --- | --- | --- |
| `parser/parser.rs` | 87 | **66** |
| `content/inline_builder/fold.rs` | 3 | 3 |
| `content/inline_builder/footnotes.rs` | 5 | 5 |
| `parser/inline_renderer.rs` | 18 | 18 |
| **TOTAL missed regions** | 582 | **561** |
| **TOTAL missed functions** | 45 | **41** |

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5,474 passed, 0 failed)
- `cargo +nightly doc --no-deps --document-private-items` ✅ — this one mattered: deleting `parser::CalloutGuard` dangled three intra-doc links, and `#[deny(warnings)]` makes those build failures rather than warnings.

## What still defers

The five remaining params structs — `Link`, `Xref`, `IndexTerm`, `Image`, `Icon` — then Landing. Step 7's `Document::to_asg()` also remains, still blocked on reading the Eclipse ASG schema (`gitlab.eclipse.org` is egress-blocked from my environment and I found no mirror); see #1326 for the detail on what can and cannot be grounded without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK)_