### PR TITLE
chore: Retire Image and IconRenderParams for their node (Phase 5)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -609,9 +609,9 @@ below); the signature reshape has not.
 > - The one substitution-named method, `render_quoted_substitution`, is renamed to match its
 >   node kind: **`render_styled`**. ✅
 > - The `*RenderParams` structs fold into the node types (e.g. `XrefRenderParams` → the
->   `Ref` node), so most are removed rather than renamed. 🔶 *In progress* — three of the
->   eight are gone (see Phase 5's slice 2 note); the five that remain are the ones whose
->   params carry a value no node holds.
+>   `Ref` node), so most are removed rather than renamed. 🔶 *In progress* — five of the
+>   eight are gone (see Phase 5's slice 2 and slice 3 notes); the three that remain are the
+>   ones whose params carry the fold of the node's children.
 >
 > Considered and set aside: `InlineBackend` (introduces a "backend" noun not used elsewhere),
 > `InlineNodeRenderer` ("node" is redundant with "inline"), `InlineConverter` (the crate has
@@ -624,6 +624,11 @@ below); the signature reshape has not.
 > not more faithful. So a `render_styled` or an `HtmlInlineRenderer` in a note dated before
 > this rename is the *current* name of what that note described, not the name it was written
 > with. (Names in `CHANGELOG.md` are **not** swept: those describe APIs as released.)
+>
+> A **retired** type is the other case, and it is left alone rather than swept: where an older
+> note names a `*RenderParams` struct that this phase has since deleted, it is describing the
+> mechanism that existed when the note was written, and there is no current name to point it
+> at. The Phase 5 slice notes below are the authoritative record of which are gone.
 
 ---
 
@@ -11089,10 +11094,44 @@ Each phase is a reviewable unit with a clear exit gate.
   that renderer was dead. A second test parsing `kbd:`/`btn:`/`menu:` and a callout list
   closed that pre-existing hole along with the new one, taking `parser.rs` to 66.
 
-  *What still defers:* the five remaining params structs — `Link`, `Xref`, `IndexTerm`,
+  *What slice 2 left:* the five remaining params structs — `Link`, `Xref`, `IndexTerm`,
   `Image` and `Icon`, the ones whose values are folds of children or derivations from an
-  attribute list — then Landing. (Step 7's `Document::to_asg()` also remains, blocked on
-  reading the Eclipse ASG schema.)
+  attribute list.
+
+  *Slice 3 landed as (`Image`/`IconRenderParams`, and a dead field with them):* the two whose
+  values are *derivations* rather than folds.
+  [`render_image`](../../parser/src/parser/inline_renderer.rs) and `render_icon` now take
+  `(&Image, &Attrlist, &RenderContext)`; `alt`'s empty default and an icon's `size` lookup move
+  into the renderer, where the built-in one was **already** doing the `size` lookup itself.
+
+  *`IconRenderParams::size` was dead.* The fold computed it —
+  `attrlist.named_or_positional_attribute("size", 1)` — and stored it in a public field that
+  nothing read, because `HtmlInlineRenderer::render_icon` performs the same lookup off the
+  attrlist a few lines later. Retiring the struct retires the field, the redundant lookup, and
+  the small trap that a downstream renderer reading `params.size` and one reading the attrlist
+  could disagree.
+
+  *Why the attribute list is a separate argument and not just `image.attrs`.* Because
+  [`Image::attrs`](../../parser/src/inlines/image.rs) is an `Option`: a macro-built image always
+  carries its list, but a hand-built node need not, and the fold has always resolved that with
+  an empty list sliced from the node's own location so the lifetime matches. Pushing that
+  `let empty; let attrlist = match … ` dance into every backend that wants to read `title`,
+  `link`, `format` or a role is the wrong trade for a seam whose whole point is to be easy to
+  implement — so the fold keeps resolving it once and hands it over. The tidier fix is at the
+  *node* (make `attrs` non-optional, as `Styled` and `Ref` would also want), which is a change
+  to a public node's field type and belongs in its own increment, not smuggled into a seam
+  reshape.
+
+  *Verification.* No expected-output string changed, all 5,474 tests pass, and coverage is
+  flat at 561 missed regions with every touched file unchanged — `fold.rs` 3, `inline_renderer.rs`
+  18, `parser.rs` 66, exactly as slice 2 left them.
+
+  *What still defers:* the last three — `Link`, `Xref` and `IndexTerm`, whose params carry the
+  **fold of the node's children**. That one is not a substitution and should not be taken
+  without deciding first whether a method receives the folded children as a `&str` beside its
+  node (which §4.6's "or node fields" sanctions) or a handle it can fold them with itself (the
+  more genuinely AST-walking seam, and the larger commitment). Then Landing. (Step 7's
+  `Document::to_asg()` also remains, blocked on reading the Eclipse ASG schema.)
 
 - **Landing — preflight + merge to `main`.** Preflight the whole branch against the
   `asciidoctor` port (§5.1) to confirm the public API and reshaped seam serve a real

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -9,8 +9,8 @@ use crate::{
         SpanForm, Stem, StemNotation, Ui, UiKind,
     },
     parser::{
-        IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineRenderer,
-        LinkRenderParams, QuoteScope, QuoteType, RenderContext, SpecialCharacter, XrefRenderParams,
+        IndexTermRenderParams, InlineRenderer, LinkRenderParams, QuoteScope, QuoteType,
+        RenderContext, SpecialCharacter, XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -403,14 +403,17 @@ pub(super) fn render_char(ch: char, renderer: &dyn InlineRenderer, out: &mut Str
     renderer.render_special_character(type_, out);
 }
 
-/// Folds an [`Image`](InlineNode::Image) node, reconstructing the
-/// [`ImageRenderParams`]/[`IconRenderParams`] the string pipeline built and
-/// calling the same `render_image`/`render_icon`, so the output is
-/// byte-for-byte identical. The pre-extracted `alt` (and, for an image,
-/// `width`/`height`) come straight off the node; an icon's `size` and every
-/// other rendered attribute (`title`, `link`, `format`, roles, …) are read back
-/// from the node's own [`Attrlist`] — which is why the macro step
-/// captured it.
+/// Folds an [`Image`](InlineNode::Image) node through the same
+/// `render_image`/`render_icon` the string pipeline's macros step calls, so the
+/// output is byte-for-byte identical — handing over the node itself, since
+/// `target`, `alt`, `width`/`height` and the restored-range list are all on it.
+///
+/// The one thing that is *not* on the node is a resolved attribute list: a
+/// macro-built image always carries one, but a hand-built node need not, and a
+/// renderer reading `title`, `link`, `format`, roles or an icon's `size` should
+/// not have to write that fallback itself. So this fold resolves it once — the
+/// node's own [`Attrlist`] when it has one, an empty list sliced from the
+/// node's location when it does not — and passes it alongside.
 fn fold_image(
     image: &Image<'_>,
     renderer: &dyn InlineRenderer,
@@ -431,37 +434,10 @@ fn fold_image(
         }
     };
 
-    let alt = image
-        .alt
-        .as_ref()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-
     if image.is_icon {
-        let params = IconRenderParams {
-            target: image.target.as_ref(),
-            restored_target_ranges: &image.restored_target_ranges,
-            alt,
-            size: attrlist
-                .named_or_positional_attribute("size", 1)
-                .map(|a| a.value()),
-            attrlist,
-            context,
-        };
-
-        renderer.render_icon(&params, out);
+        renderer.render_icon(image, attrlist, context, out);
     } else {
-        let params = ImageRenderParams {
-            target: image.target.as_ref(),
-            restored_target_ranges: &image.restored_target_ranges,
-            alt,
-            width: image.width.as_deref(),
-            height: image.height.as_deref(),
-            attrlist,
-            context,
-        };
-
-        renderer.render_image(&params, out);
+        renderer.render_image(image, attrlist, context, out);
     }
 }
 

--- a/parser/src/inlines/image.rs
+++ b/parser/src/inlines/image.rs
@@ -29,11 +29,9 @@ pub struct Image<'src> {
     /// `web_path` would percent-encode, a backslash it would posixify, a `/`
     /// or `.` its segment arithmetic would read — ever reaches the resolver.
     /// The built-in renderer reproduces that order by masking these ranges
-    /// around its own `web_path` call (see
-    /// [`ImageRenderParams::restored_target_ranges`]).
-    ///
-    /// [`ImageRenderParams::restored_target_ranges`]:
-    ///     crate::parser::ImageRenderParams::restored_target_ranges
+    /// around its own `web_path` call — see
+    /// [`image_uri`](crate::parser::InlineRenderer::image_uri), which receives
+    /// them off this node.
     pub restored_target_ranges: Vec<std::ops::Range<usize>>,
 
     /// The alt text, explicit or defaulted.

--- a/parser/src/parser/inline_renderer.rs
+++ b/parser/src/parser/inline_renderer.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 
 use crate::{
     attributes::Attrlist,
-    inlines::{Callout, CalloutGuard, Footnote},
+    inlines::{Callout, CalloutGuard, Footnote, Image},
     parser::{
         DerivedReference, RenderContext, ResolvedReference, SafeMode, XrefSignifier, XrefStyle,
     },
@@ -106,8 +106,14 @@ pub trait InlineRenderer: Debug {
     ///
     /// The renderer should write an appropriate rendering of the specified
     /// image to `dest`.
-    fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
-        DEFAULT_HTML_RENDERER.render_image(params, dest);
+    fn render_image(
+        &self,
+        image: &Image<'_>,
+        attrlist: &Attrlist<'_>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        DEFAULT_HTML_RENDERER.render_image(image, attrlist, context, dest);
     }
 
     /// Construct a URI reference or data URI to the target image.
@@ -150,8 +156,14 @@ pub trait InlineRenderer: Debug {
     ///
     /// The renderer should write an appropriate rendering of the specified
     /// icon to `dest`.
-    fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
-        DEFAULT_HTML_RENDERER.render_icon(params, dest);
+    fn render_icon(
+        &self,
+        icon: &Image<'_>,
+        attrlist: &Attrlist<'_>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        DEFAULT_HTML_RENDERER.render_icon(icon, attrlist, context, dest);
     }
 
     /// Construct a reference or data URI to an icon image for the specified
@@ -427,71 +439,7 @@ pub enum CharacterReplacementType {
     CharacterReference(String),
 }
 
-/// Provides parsed parameters for an image to be rendered.
-#[derive(Clone, Debug)]
-pub struct ImageRenderParams<'a> {
-    /// Target (the reference to the image).
-    pub target: &'a str,
-
-    /// Byte ranges of [`target`](Self::target) restored from a masked
-    /// passthrough or STEM expression, in ascending order; empty otherwise
-    /// (the string substitution pipeline always passes an empty list — its
-    /// target still carries the sentinel here, and its restore pass runs over
-    /// the rendered string afterwards). The built-in renderer resolves the
-    /// image's `src` with these ranges masked and splices them back in
-    /// afterwards, so path resolution treats each as one opaque run — the
-    /// same order the string pipeline itself applies (`web_path` over the
-    /// sentinel, the restore after). See
-    /// [`Image::restored_target_ranges`](crate::inlines::Image).
-    pub restored_target_ranges: &'a [std::ops::Range<usize>],
-
-    /// Alt text (either explicitly set or defaulted).
-    pub alt: String,
-
-    /// Width. The data type is not checked; this may be any string.
-    pub width: Option<&'a str>,
-
-    /// Height. The data type is not checked; this may be any string.
-    pub height: Option<&'a str>,
-
-    /// Attribute list.
-    pub attrlist: &'a Attrlist<'a>,
-
-    /// The document state as of the point in the document this element came
-    /// from — where a renderer finds document settings such as an image
-    /// directory. See [`RenderContext`].
-    pub context: &'a RenderContext,
-}
-
-/// Provides parsed parameters for an icon to be rendered.
-#[derive(Clone, Debug)]
-pub struct IconRenderParams<'a> {
-    /// Target (the reference to the image).
-    pub target: &'a str,
-
-    /// Byte ranges of [`target`](Self::target) restored from a masked
-    /// passthrough or STEM expression, in ascending order; empty otherwise.
-    /// See [`ImageRenderParams::restored_target_ranges`] — the built-in
-    /// renderer resolves the icon URI with these ranges masked and splices
-    /// them back in afterwards.
-    pub restored_target_ranges: &'a [std::ops::Range<usize>],
-
-    /// Alt text (either explicitly set or defaulted).
-    pub alt: String,
-
-    /// Size. The data type is not checked; this may be any string.
-    pub size: Option<&'a str>,
-
-    /// Attribute list.
-    pub attrlist: &'a Attrlist<'a>,
-
-    /// The document state as of the point in the document this element came
-    /// from — where a renderer finds document settings such as an image
-    /// directory. See [`RenderContext`].
-    pub context: &'a RenderContext,
-}
-
-/// Provides parsed parameters for an icon to be rendered.
+/// Provides parsed parameters for a link to be rendered.
 #[derive(Clone, Debug)]
 pub struct LinkRenderParams<'a> {
     /// Target (the target of this link).
@@ -602,7 +550,8 @@ impl HtmlInlineRenderer {
     ///
     /// `restored_target_ranges` names the byte ranges of `target` restored
     /// from a masked passthrough or STEM expression (see
-    /// [`ImageRenderParams::restored_target_ranges`]). Resolution runs with
+    /// [`Image::restored_target_ranges`](crate::inlines::Image)). Resolution
+    /// runs with
     /// each of them — and each restored range of the macro-level `imagesdir`
     /// value — replaced by an index-keyed `\u{96}`*n*`\u{97}` token, the
     /// bodies spliced back into the resolved path afterwards. This is the
@@ -903,14 +852,18 @@ impl InlineRenderer for HtmlInlineRenderer {
         dest.push_str("<br>");
     }
 
-    fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
-        let src = self.image_src(
-            params.target,
-            params.restored_target_ranges,
-            params.attrlist,
-            params.context,
-        );
-        let alt_encoded = encode_attribute_value(params.alt.clone());
+    fn render_image(
+        &self,
+        image: &Image<'_>,
+        attrlist: &Attrlist<'_>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        let target = image.target.as_ref();
+        let alt = image.alt.as_deref().unwrap_or_default();
+
+        let src = self.image_src(target, &image.restored_target_ranges, attrlist, context);
+        let alt_encoded = encode_attribute_value(alt.to_owned());
 
         // The dimension attributes (width, height, and title) are shared by the
         // plain `<img>`, the interactive `<object>`, and the `<object>`'s image
@@ -918,29 +871,28 @@ impl InlineRenderer for HtmlInlineRenderer {
         // concatenate cleanly after `src`/`alt` (or the `data` attribute).
         let mut dimension_attrs = String::new();
 
-        if let Some(width) = params.width {
+        if let Some(width) = image.width.as_deref() {
             dimension_attrs.push_str(&format!(
                 r#" width="{width}""#,
                 width = encode_attribute_value(width.to_owned())
             ));
         }
 
-        if let Some(height) = params.height {
+        if let Some(height) = image.height.as_deref() {
             dimension_attrs.push_str(&format!(
                 r#" height="{height}""#,
                 height = encode_attribute_value(height.to_owned())
             ));
         }
 
-        if let Some(title) = params.attrlist.named_attribute("title") {
+        if let Some(title) = attrlist.named_attribute("title") {
             dimension_attrs.push_str(&format!(
                 r#" title="{title}""#,
                 title = encode_attribute_value(title.value().to_owned())
             ));
         }
 
-        let format = params
-            .attrlist
+        let format = attrlist
             .named_attribute("format")
             .map(|format| format.value());
 
@@ -948,27 +900,32 @@ impl InlineRenderer for HtmlInlineRenderer {
         // (they embed file contents or a live `<object>`), so they only take
         // effect below the `Secure` safe mode. In `Secure` mode an SVG image
         // renders as an ordinary `<img>`, matching Ruby Asciidoctor.
-        let svg_active = (format == Some("svg") || params.target.contains(".svg"))
-            && params.context.safe_mode() < SafeMode::Secure;
+        let svg_active = (format == Some("svg") || target.contains(".svg"))
+            && context.safe_mode() < SafeMode::Secure;
 
         // An inline SVG is embedded verbatim and has no meaningful `src`, so a
         // `link=self` on it is left as the literal `self` rather than resolved
         // to a URI (see `render_icon_or_image`). Every other image form does
         // have a `src` (a data URI or web path) that `link=self` resolves to.
-        let inline_svg = svg_active && params.attrlist.has_option("inline");
+        let inline_svg = svg_active && attrlist.has_option("inline");
 
         let img = if inline_svg {
             // Embed the SVG contents directly. When the contents cannot be read
             // (no handler is registered, or it cannot find the file), fall back
             // to the alt text, mirroring Ruby Asciidoctor.
-            read_svg_contents(&src, params.width, params.height, params.context)
-                .unwrap_or_else(|| format!(r#"<span class="alt">{alt}</span>"#, alt = params.alt))
-        } else if svg_active && params.attrlist.has_option("interactive") {
+            read_svg_contents(
+                &src,
+                image.width.as_deref(),
+                image.height.as_deref(),
+                context,
+            )
+            .unwrap_or_else(|| format!(r#"<span class="alt">{alt}</span>"#, alt = alt))
+        } else if svg_active && attrlist.has_option("interactive") {
             // Render an interactive SVG as an `<object>` element so its embedded
             // scripting and links remain live. A `fallback` image (or, failing
             // that, the alt text) is nested inside for user agents that can't
             // display the object.
-            let fallback = if let Some(fallback) = params.attrlist.named_attribute("fallback") {
+            let fallback = if let Some(fallback) = attrlist.named_attribute("fallback") {
                 // A `fallback=` value restored from a masked construct
                 // resolves over its restored ranges masked, exactly as the
                 // target does — the one other value this renderer runs
@@ -976,15 +933,15 @@ impl InlineRenderer for HtmlInlineRenderer {
                 let fallback_src = self.image_src(
                     fallback.value(),
                     fallback.restored_value_ranges(),
-                    params.attrlist,
-                    params.context,
+                    attrlist,
+                    context,
                 );
                 format!(
                     r#"<img src="{fallback_src}" alt="{alt_encoded}"{dimension_attrs}>"#,
                     fallback_src = encode_attribute_value(fallback_src)
                 )
             } else {
-                format!(r#"<span class="alt">{alt}</span>"#, alt = params.alt)
+                format!(r#"<span class="alt">{alt}</span>"#, alt = alt)
             };
 
             format!(
@@ -1004,10 +961,10 @@ impl InlineRenderer for HtmlInlineRenderer {
         // embedded), so a `link=self` resolving to it is author-supplied and
         // subject to the stricter SVG-data-URI check; a plain path target is
         // resolved to a web path or a trusted embedded `data-uri`.
-        let self_href_from_uri_target = is_uri_ish(params.target);
+        let self_href_from_uri_target = is_uri_ish(target);
 
         render_icon_or_image(
-            params.attrlist,
+            attrlist,
             &img,
             "image",
             link_self_href,
@@ -1058,26 +1015,32 @@ impl InlineRenderer for HtmlInlineRenderer {
         normalized
     }
 
-    fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
+    fn render_icon(
+        &self,
+        icon: &Image<'_>,
+        attrlist: &Attrlist<'_>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
+        let target = icon.target.as_ref();
+        let alt = icon.alt.as_deref().unwrap_or_default();
+
         // As in `render_image`, a target restored from a masked construct
         // resolves with its restored ranges masked — the whole `icon_uri`
         // computation included, since its extension probe (`has_extname`)
         // must read the sentinel-shaped bytes the string pipeline's own
         // probe reads — and the bodies splice back in afterwards.
-        let src = if params.restored_target_ranges.is_empty() {
-            self.icon_uri(params.target, params.attrlist, params.context)
+        let src = if icon.restored_target_ranges.is_empty() {
+            self.icon_uri(target, attrlist, context)
         } else {
             let (masked_target, bodies) =
-                mask_restored_ranges(params.target, params.restored_target_ranges, 0);
+                mask_restored_ranges(target, &icon.restored_target_ranges, 0);
 
-            splice_restored_bodies(
-                &self.icon_uri(&masked_target, params.attrlist, params.context),
-                &bodies,
-            )
+            splice_restored_bodies(&self.icon_uri(&masked_target, attrlist, context), &bodies)
         };
 
-        let img = if params.context.is_attribute_set("icons") {
-            let icons = params.context.attribute_value("icons");
+        let img = if context.is_attribute_set("icons") {
+            let icons = context.attribute_value("icons");
             if let Some(icons) = icons.as_maybe_str()
                 && icons == "font"
             {
@@ -1092,23 +1055,23 @@ impl InlineRenderer for HtmlInlineRenderer {
                     "fa".to_owned(),
                     format!(
                         "fa-{target}",
-                        target = encode_attribute_value(params.target.to_owned())
+                        target = encode_attribute_value(target.to_owned())
                     ),
                 ];
 
-                if let Some(size) = params.attrlist.named_or_positional_attribute("size", 1) {
+                if let Some(size) = attrlist.named_or_positional_attribute("size", 1) {
                     i_class_attrs.push(format!(
                         "fa-{size}",
                         size = encode_attribute_value(size.value().to_owned())
                     ));
                 }
 
-                if let Some(flip) = params.attrlist.named_attribute("flip") {
+                if let Some(flip) = attrlist.named_attribute("flip") {
                     i_class_attrs.push(format!(
                         "fa-flip-{flip}",
                         flip = encode_attribute_value(flip.value().to_owned())
                     ));
-                } else if let Some(rotate) = params.attrlist.named_attribute("rotate") {
+                } else if let Some(rotate) = attrlist.named_attribute("rotate") {
                     i_class_attrs.push(format!(
                         "fa-rotate-{rotate}",
                         rotate = encode_attribute_value(rotate.value().to_owned())
@@ -1118,7 +1081,7 @@ impl InlineRenderer for HtmlInlineRenderer {
                 format!(
                     r##"<i class="{i_class_attr_val}"{title_attr}></i>"##,
                     i_class_attr_val = i_class_attrs.join(" "),
-                    title_attr = if let Some(title) = params.attrlist.named_attribute("title") {
+                    title_attr = if let Some(title) = attrlist.named_attribute("title") {
                         format!(
                             r#" title="{title}""#,
                             title = encode_attribute_value(title.value().to_owned())
@@ -1132,25 +1095,25 @@ impl InlineRenderer for HtmlInlineRenderer {
                     format!(r#"src="{src}""#, src = encode_attribute_value(src.clone())),
                     format!(
                         r#"alt="{alt}""#,
-                        alt = encode_attribute_value(params.alt.to_string())
+                        alt = encode_attribute_value(alt.to_string())
                     ),
                 ];
 
-                if let Some(width) = params.attrlist.named_attribute("width") {
+                if let Some(width) = attrlist.named_attribute("width") {
                     attrs.push(format!(
                         r#"width="{width}""#,
                         width = encode_attribute_value(width.value().to_owned())
                     ));
                 }
 
-                if let Some(height) = params.attrlist.named_attribute("height") {
+                if let Some(height) = attrlist.named_attribute("height") {
                     attrs.push(format!(
                         r#"height="{height}""#,
                         height = encode_attribute_value(height.value().to_owned())
                     ));
                 }
 
-                if let Some(title) = params.attrlist.named_attribute("title") {
+                if let Some(title) = attrlist.named_attribute("title") {
                     attrs.push(format!(
                         r#"title="{title}""#,
                         title = encode_attribute_value(title.value().to_owned())
@@ -1164,15 +1127,15 @@ impl InlineRenderer for HtmlInlineRenderer {
                 )
             }
         } else {
-            format!("[{alt}&#93;", alt = params.alt)
+            format!("[{alt}&#93;", alt = alt)
         };
 
         // `src` is only a real image URI in the image-icon branch (icons enabled
         // and not font-based); the font (`<i>`) and text (`[alt]`) branches have
         // no `src`, so a `link=self` on them stays literal (see
         // `render_icon_or_image`).
-        let link_self_href = if params.context.is_attribute_set("icons")
-            && params.context.attribute_value("icons").as_maybe_str() != Some("font")
+        let link_self_href = if context.is_attribute_set("icons")
+            && context.attribute_value("icons").as_maybe_str() != Some("font")
         {
             Some(src.as_str())
         } else {
@@ -1182,10 +1145,10 @@ impl InlineRenderer for HtmlInlineRenderer {
         // As in `render_image`: a URI-ish target passes through to the icon
         // `src` verbatim, so a `link=self` resolving to it is author-supplied
         // and gets the stricter SVG-data-URI check.
-        let self_href_from_uri_target = is_uri_ish(params.target);
+        let self_href_from_uri_target = is_uri_ish(target);
 
         render_icon_or_image(
-            params.attrlist,
+            attrlist,
             &img,
             "icon",
             link_self_href,

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -19,9 +19,8 @@ pub use include_file_handler::{IncludeContent, IncludeFileHandler, IncludeResolu
 
 mod inline_renderer;
 pub use inline_renderer::{
-    CharacterReplacementType, HtmlInlineRenderer, IconRenderParams, ImageRenderParams,
-    IndexTermRenderParams, InlineRenderer, LinkRenderParams, QuoteScope, QuoteType,
-    SpecialCharacter, XrefRenderParams,
+    CharacterReplacementType, HtmlInlineRenderer, IndexTermRenderParams, InlineRenderer,
+    LinkRenderParams, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
 };
 pub(crate) use inline_renderer::{has_dangerous_scheme, has_dangerous_self_href, is_uri_ish};
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -3460,8 +3460,8 @@ mod tests {
         attributes::Attrlist,
         blocks::Block,
         parser::{
-            CharacterReplacementType, IconRenderParams, ImageRenderParams, InlineRenderer,
-            LinkRenderParams, QuoteScope, QuoteType, SpecialCharacter,
+            CharacterReplacementType, InlineRenderer, LinkRenderParams, QuoteScope, QuoteType,
+            SpecialCharacter,
         },
         tests::prelude::*,
     };
@@ -4537,7 +4537,13 @@ mod tests {
             dest.push_str("[BR]");
         }
 
-        fn render_image(&self, _params: &ImageRenderParams, dest: &mut String) {
+        fn render_image(
+            &self,
+            _image: &crate::inlines::Image<'_>,
+            _attrlist: &Attrlist<'_>,
+            _context: &crate::parser::RenderContext,
+            dest: &mut String,
+        ) {
             dest.push_str("[IMAGE]");
         }
 
@@ -4550,7 +4556,13 @@ mod tests {
             target_image_path.to_string()
         }
 
-        fn render_icon(&self, _params: &IconRenderParams, dest: &mut String) {
+        fn render_icon(
+            &self,
+            _icon: &crate::inlines::Image<'_>,
+            _attrlist: &Attrlist<'_>,
+            _context: &crate::parser::RenderContext,
+            dest: &mut String,
+        ) {
             dest.push_str("[ICON]");
         }
 

--- a/parser/src/tests/inline_renderer.rs
+++ b/parser/src/tests/inline_renderer.rs
@@ -9,7 +9,7 @@
 use crate::{
     Span,
     content::{Content, SubstitutionStep},
-    parser::{ImageRenderParams, InlineRenderer, SpecialCharacter},
+    parser::{InlineRenderer, RenderContext, SpecialCharacter},
     tests::{
         fixtures::{
             image_file_handler::ImageFileHandlerFixture, svg_file_handler::SvgFileHandlerFixture,
@@ -81,16 +81,22 @@ fn overrides_one_method_and_inherits_the_rest() {
 struct FigureImages;
 
 impl InlineRenderer for FigureImages {
-    fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
+    fn render_image(
+        &self,
+        image: &crate::inlines::Image<'_>,
+        _attrlist: &crate::attributes::Attrlist<'_>,
+        context: &RenderContext,
+        dest: &mut String,
+    ) {
         // `image_uri` is not overridden, so this inherits the crate's data-uri
         // embedding, which reads the image bytes through the registered
         // `ImageFileHandler` — behavior a custom renderer previously could not
         // reproduce.
-        let uri = self.image_uri(params.target, params.context, None);
+        let uri = self.image_uri(image.target.as_ref(), context, None);
 
         dest.push_str(&format!(
             r#"<figure data-src="{uri}">{alt}</figure>"#,
-            alt = params.alt
+            alt = image.alt.as_deref().unwrap_or_default()
         ));
     }
 }


### PR DESCRIPTION
## What

§4.6's reshape, slice 3 — the two remaining params whose values are *derivations* rather than folds of children.

| before | after |
| --- | --- |
| `render_image(&ImageRenderParams, …)` | `render_image(&Image<'_>, &Attrlist<'_>, &RenderContext, …)` |
| `render_icon(&IconRenderParams, …)` | `render_icon(&Image<'_>, &Attrlist<'_>, &RenderContext, …)` |

`alt`'s empty default and an icon's `size` lookup move into the renderer. Five of the eight params structs are now gone; three remain.

**Breaking**, to a public seam, and an accepted pre-1.0 break (§4.6).

## `IconRenderParams::size` was dead

Worth calling out on its own. The fold computed it —

```rust
size: attrlist.named_or_positional_attribute("size", 1).map(|a| a.value()),
```

— and stored it in a **public field that nothing read**, because `HtmlInlineRenderer::render_icon` performs the same lookup off the attrlist a few lines later:

```rust
if let Some(size) = attrlist.named_or_positional_attribute("size", 1) { … }
```

Retiring the struct retires the field, the redundant lookup, and the small trap that a downstream renderer reading `params.size` and one reading the attrlist could disagree about the same value.

## Why the attribute list is a separate argument, not just `image.attrs`

Because [`Image::attrs`](https://github.com/asciidoc-rs/asciidoc-parser/blob/inline-ast/parser/src/inlines/image.rs) is an `Option`. A macro-built image always carries its list, but a hand-built node need not, and the fold has always resolved that with an empty list sliced from the node's own location so the lifetime matches:

```rust
let empty;
let attrlist = match &image.attrs {
    Some(attrlist) => attrlist,
    None => { empty = Attrlist::empty(image.location.slice(0..0)); &empty }
};
```

Pushing that into every backend that wants to read `title`, `link`, `format` or a role is the wrong trade for a seam whose whole point is to be easy to implement. So the fold keeps resolving it once and hands it over.

The tidier fix is at the **node** — make `attrs` non-optional, which `Styled` and `Ref` would also want — but that changes a public node's field type across three node kinds and deserves its own increment rather than being smuggled into a seam reshape. Flagging it as a candidate.

## Verification

- No expected-output string changed; all **5,474 tests pass**, so §5.3's oracle pins the same bytes.
- Coverage is **flat at 561** missed regions, with every touched file unchanged from the base: `fold.rs` 3, `inline_renderer.rs` 18, `parser.rs` 66 — exactly as #1327 left them.

### Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5,474 passed, 0 failed)
- `cargo +nightly doc --no-deps --document-private-items` ✅ — again the one that bites: deleting the two structs dangled three intra-doc links, including a two-line link-reference definition in `Image`'s own field docs.

## Also in this diff

- A copy-paste doc comment on `LinkRenderParams`, which said it "provides parsed parameters for an **icon** to be rendered". Noticed while deleting its neighbour.
- §4.6's "note on the old names" gains a second paragraph. #1326 established that a *renamed* symbol is swept through the design doc's prose, including older notes, because the referent still exists. A **retired** type is the opposite case: there is no current name to point at, so those mentions are left as the record of the mechanism that existed when the note was written. Stating the rule once beats annotating each retired type as the count grows.

## What still defers

The last three — `Link`, `Xref` and `IndexTerm`, whose params carry the **fold of the node's children**.

**That one needs a decision before it is built,** and I'd rather have it from you than pick: does a method receive the folded children as a `&str` beside its node (which §4.6's "or node fields" sanctions, and what I'd recommend), or a handle it can fold them with itself — the more genuinely AST-walking seam, and the larger commitment, since it lets a backend suppress, reorder or re-wrap children the fold would otherwise have flattened for it?

Then Landing. Step 7's `Document::to_asg()` also remains, still blocked on reading the Eclipse ASG schema (`gitlab.eclipse.org` is egress-blocked from my environment, no mirror found); see #1326 for what can and cannot be grounded without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK)_