### PR TITLE
chore: Remove the Option from the inline nodes' attrs fields (Phase 5)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -205,7 +205,7 @@ pub struct Styled<'src> {
     pub form: SpanForm,          // Constrained | Unconstrained (ASG `form`)
     pub id: Option<CowStr<'src>>,
     pub roles: Vec<CowStr<'src>>,
-    pub attrs: Option<Attrlist<'src>>,
+    pub attrs: Attrlist<'src>,     // empty when the node carried no list
     pub children: Vec<InlineNode<'src>>,
     pub location: Span<'src>,
 }
@@ -11111,20 +11111,57 @@ Each phase is a reviewable unit with a clear exit gate.
   the small trap that a downstream renderer reading `params.size` and one reading the attrlist
   could disagree.
 
-  *Why the attribute list is a separate argument and not just `image.attrs`.* Because
-  [`Image::attrs`](../../parser/src/inlines/image.rs) is an `Option`: a macro-built image always
-  carries its list, but a hand-built node need not, and the fold has always resolved that with
-  an empty list sliced from the node's own location so the lifetime matches. Pushing that
+  *Why the attribute list was a separate argument and not just `image.attrs`.* Because
+  [`Image::attrs`](../../parser/src/inlines/image.rs) was an `Option`: a macro-built image
+  always carries its list, but a hand-built node need not, and the fold resolved that with an
+  empty list sliced from the node's own location so the lifetime matches. Pushing that
   `let empty; let attrlist = match … ` dance into every backend that wants to read `title`,
   `link`, `format` or a role is the wrong trade for a seam whose whole point is to be easy to
-  implement — so the fold keeps resolving it once and hands it over. The tidier fix is at the
-  *node* (make `attrs` non-optional, as `Styled` and `Ref` would also want), which is a change
-  to a public node's field type and belongs in its own increment, not smuggled into a seam
-  reshape.
+  implement — so the fold kept resolving it once and handed it over. The note flagged the
+  tidier fix as *at the node*, and the maintainer took it: see the slice 3a note below.
 
   *Verification.* No expected-output string changed, all 5,474 tests pass, and coverage is
   flat at 561 missed regions with every touched file unchanged — `fold.rs` 3, `inline_renderer.rs`
   18, `parser.rs` 66, exactly as slice 2 left them.
+
+  *Slice 3a landed as (the `attrs` `Option` removed at the node, on the maintainer's call):*
+  [`Image`](../../parser/src/inlines/image.rs),
+  [`Styled`](../../parser/src/inlines/styled.rs) and
+  [`Ref`](../../parser/src/inlines/ref_node.rs) now hold an `Attrlist<'src>` outright, filled
+  with [`Attrlist::empty`](../../parser/src/attributes/attrlist.rs) — now `pub`, since those
+  node fields are — when the author wrote no list. "Absent attribute list" stops being a state
+  the model can be in, which is what slice 3's own note said the tidier fix would be.
+
+  *The seam simplifies behind it, which was the point.* `render_image` and `render_icon` drop
+  the separate `&Attrlist` argument slice 3 gave them and read `image.attrs`; `render_styled`
+  takes `&Attrlist<'_>` where it took an owned `Option<Attrlist<'_>>`, which also **removes a
+  clone per styled node** — the fold was cloning the list into the `Option` on every span.
+  `fold_image` and `fold_link`'s empty-list resolutions are gone.
+
+  *Two vestiges fell out.* `attributes_of` / `attributes_of_attrlist` in
+  [`quotes.rs`](../../parser/src/content/inline_builder/quotes.rs) declared a return type of
+  `Option<Attrlist>` and never once returned `None` — the `Some(…)` was the last line of the
+  function. And `wrap_body_in_html_tag` took an `_attrlist` parameter it did not read;
+  `render_styled` no longer has an `Option` to pass it, and the dead parameter went with it.
+
+  *Verification.* No expected-output string changed and all 5,475 tests pass. Coverage
+  **improved**, 561 → 551 missed regions, and the files that moved are the ones that held the
+  `Option` branches: `macros/links.rs` 20 → 17, `parser/inline_renderer.rs` 18 → 12,
+  `macros/image.rs` 4 → 3, with `fold.rs`, `quotes.rs` and `attrlist.rs` unchanged. Nothing
+  regressed — a `None` arm that no longer exists cannot be an untested one.
+
+  *One uncovered line was a pre-existing hole this diff walked into.* Codecov measures the
+  **diff**, not the total, and flagged `render_styled`'s
+  `QuoteType::Mark`-with-an-id-or-role branch: dropping the now-dead `attrlist` argument from
+  its `wrap_body_in_html_tag` call made an already-uncovered line a *changed* one. It was
+  uncovered for a reason worth writing down rather than papering over —
+  [`style_variant_of`](../../parser/src/content/inline_builder/quotes.rs) classifies a `#…#`
+  carrying an attribute list as `Unquoted` rather than `Mark`, so **no parse can reach it**.
+  That does not make it dead: `render_styled` is public, and a caller folding a node it built
+  itself can present exactly that combination, so the reference backend has to answer for it.
+  A unit test now pins both halves of the rule (`<span id="…">` with, `<mark>` without) —
+  which is why `inline_renderer.rs` fell to 12 rather than the 16 the `Option` removal alone
+  would have given.
 
   *What still defers:* the last three — `Link`, `Xref` and `IndexTerm`, whose params carry the
   **fold of the node's children**. That one is not a substitution and should not be taken

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -309,17 +309,22 @@ impl<'src> Attrlist<'src> {
     ///
     /// An attribute list with no attributes, located at `source`.
     ///
-    /// For an inline node that carries no attribute list of its own but folds
-    /// through one anyway (a hand-built [`Image`](crate::inlines::Image), which
-    /// the builder never produces without its list). `source` should be a
+    /// This is what "the node carried no attribute list" looks like. The
+    /// inline nodes that can carry one — [`Image`](crate::inlines::Image),
+    /// [`Styled`](crate::inlines::Styled) and [`Ref`](crate::inlines::Ref) —
+    /// hold an `Attrlist` outright rather than an `Option<Attrlist>`, so every
+    /// consumer reads attributes the same way whether the author wrote a list
+    /// or not; the ones written without a list get this. `source` should be a
     /// zero-length slice of the node's own location, so the empty list's
-    /// lifetime and position match the node a consumer reached it from.
+    /// lifetime and position match the node it belongs to.
     ///
-    /// This exists so the fold need not *parse* an empty span — which would
-    /// cost an attribute-reference substitution pass and, more to the point,
-    /// require a [`Parser`] at a place that has only the
-    /// document state a render needs.
-    pub(crate) fn empty(source: Span<'src>) -> Self {
+    /// It is public because those node fields are: a caller building a node by
+    /// hand needs to be able to say "no attributes", and every other route to
+    /// an `Attrlist` goes through parsing — which would cost an
+    /// attribute-reference substitution pass and, more to the point, require a
+    /// [`Parser`] where only a `Span` is at hand.
+    #[must_use]
+    pub fn empty(source: Span<'src>) -> Self {
         Self {
             attributes: vec![],
             anchor: None,

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -702,7 +702,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -357,7 +357,7 @@ fn fold_into_html(
                 renderer.render_styled(
                     quote_type_of(styled.variant),
                     scope,
-                    styled.attrs.clone(),
+                    &styled.attrs,
                     styled.id.as_ref().map(|id| id.to_string()),
                     &body,
                     out,
@@ -408,36 +408,21 @@ pub(super) fn render_char(ch: char, renderer: &dyn InlineRenderer, out: &mut Str
 /// output is byte-for-byte identical — handing over the node itself, since
 /// `target`, `alt`, `width`/`height` and the restored-range list are all on it.
 ///
-/// The one thing that is *not* on the node is a resolved attribute list: a
-/// macro-built image always carries one, but a hand-built node need not, and a
-/// renderer reading `title`, `link`, `format`, roles or an icon's `size` should
-/// not have to write that fallback itself. So this fold resolves it once — the
-/// node's own [`Attrlist`] when it has one, an empty list sliced from the
-/// node's location when it does not — and passes it alongside.
+/// The attribute list — which a renderer reads `title`, `link`, `format`, roles
+/// and an icon's `size` out of — is on the node too, and unconditionally: a
+/// node built without one carries
+/// [`Attrlist::empty`](crate::attributes::Attrlist::empty), so neither this
+/// fold nor a backend has a fallback to write.
 fn fold_image(
     image: &Image<'_>,
     renderer: &dyn InlineRenderer,
     context: &RenderContext,
     out: &mut String,
 ) {
-    // A macro-built image always carries its attribute list; a node hand-built
-    // without one folds through an empty list, sliced (empty) from the node's
-    // own `'src` location so its lifetime matches.
-    let empty;
-    let attrlist = match &image.attrs {
-        Some(attrlist) => attrlist,
-
-        None => {
-            empty = Attrlist::empty(image.location.slice(0..0));
-
-            &empty
-        }
-    };
-
     if image.is_icon {
-        renderer.render_icon(image, attrlist, context, out);
+        renderer.render_icon(image, context, out);
     } else {
-        renderer.render_image(image, attrlist, context, out);
+        renderer.render_image(image, context, out);
     }
 }
 
@@ -471,11 +456,11 @@ fn fold_ui(ui: &Ui<'_>, renderer: &dyn InlineRenderer, context: &RenderContext, 
 /// the string pipeline's macros step calls, reconstructing the
 /// [`LinkRenderParams`] from the node: the display text is the fold of the
 /// children, the extra roles (`bare`) ride on the node's `roles`, and the
-/// target/window come straight off the node. The attribute list is the
-/// node's own [`Ref::attrs`] when its display text carried one (an `id`, a
-/// `title`, a `role=`/`window=`/`nofollow`/`noopener` — see that field's own
-/// docs for why `render_link` needs the real list, not just `roles`/`window`),
-/// or an empty one otherwise.
+/// target/window and the attribute list come straight off the node. That list
+/// is [`Ref::attrs`], which is always present — empty when the display text
+/// carried none — and `render_link` needs the real thing rather than just
+/// `roles`/`window`, because it reads an `id`, a `title` and the `nofollow` /
+/// `noopener` options out of it; see that field's own docs.
 fn fold_link(
     reference: &Ref<'_>,
     renderer: &dyn InlineRenderer,
@@ -494,20 +479,6 @@ fn fold_link(
         &mut link_text,
     );
 
-    // Sliced (empty) from the node's own location so its lifetime matches when
-    // no attribute list was parsed.
-    let empty_attrlist;
-
-    let attrlist: &Attrlist<'_> = match &reference.attrs {
-        Some(attrs) => attrs,
-
-        None => {
-            empty_attrlist = Attrlist::empty(reference.location.slice(0..0));
-
-            &empty_attrlist
-        }
-    };
-
     let extra_roles: Vec<&str> = reference.roles.iter().map(|r| r.as_ref()).collect();
 
     let params = LinkRenderParams {
@@ -515,7 +486,7 @@ fn fold_link(
         link_text,
         extra_roles,
         window: reference.window.as_deref(),
-        attrlist,
+        attrlist: &reference.attrs,
         context,
     };
 
@@ -783,10 +754,14 @@ pub(in crate::content::inline_builder) fn fold_stem(
         StemNotation::LatexMath => QuoteType::LatexMath,
     };
 
+    // A STEM macro carries no attribute list of its own, and the string
+    // pipeline's passthrough restore passed none either.
+    let attrlist = Attrlist::empty(stem.location.slice(0..0));
+
     renderer.render_styled(
         type_,
         QuoteScope::Unconstrained,
-        None,
+        &attrlist,
         None,
         stem.value.as_ref(),
         out,
@@ -954,7 +929,7 @@ mod tests {
             alt: Some(CowStr::from("Sunset")),
             width: None,
             height: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
             location,
         });
 
@@ -982,7 +957,7 @@ mod tests {
             alt: Some(CowStr::from("Sunset")),
             width: None,
             height: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
             location,
         });
 
@@ -1016,7 +991,7 @@ mod tests {
             }),
             derived: None,
             xrefstyle,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
             location: Span::new(""),
         })
     }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1476,7 +1476,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -673,7 +673,7 @@ fn build_image_node<'src>(
         alt,
         width,
         height,
-        attrs: Some(attrlist),
+        attrs: attrlist,
         location,
     })
 }
@@ -1192,7 +1192,7 @@ fn link_self_resolves_to_src(image: &Image<'_>, parser: &Parser) -> bool {
 /// rejection check, returning the target string the renderer would refuse to
 /// promote into an `href`, if any.
 fn rejected_link_target<'a>(image: &'a Image<'_>, parser: &Parser) -> Option<&'a str> {
-    let link = image.attrs.as_ref()?.named_attribute("link")?;
+    let link = image.attrs.named_attribute("link")?;
 
     if link.value() == "self" {
         (link_self_resolves_to_src(image, parser)
@@ -1366,7 +1366,11 @@ mod tests {
 
         // The node captures its own attribute list — the property that makes it
         // self-describing (and unblocks a faithful fold).
-        assert!(image.attrs.is_some(), "the attribute list is retained");
+        assert_ne!(
+            image.attrs.attributes().len(),
+            0,
+            "the attribute list is retained"
+        );
 
         // Its location covers the whole macro, delimiters included.
         assert_eq!(image.location.data(), "image:sunset.jpg[Sunset]");
@@ -1598,7 +1602,7 @@ mod tests {
 
         assert_eq!(image.alt.as_deref(), Some("a &lt; b"));
 
-        let attrs = image.attrs.as_ref().unwrap();
+        let attrs = &image.attrs;
         assert_eq!(attrs.nth_attribute(1).unwrap().value(), "a &lt; b");
         assert_eq!(attrs.named_attribute("role").unwrap().value(), "hl");
 
@@ -1784,7 +1788,7 @@ mod tests {
         assert_eq!(nodes.len(), 1);
         let image = assert_image(&nodes[0]);
 
-        let attrlist = image.attrs.as_ref().unwrap();
+        let attrlist = &image.attrs;
         assert_eq!(
             attrlist.named_attribute("title").unwrap().value(),
             "Pause &#169; Resume"
@@ -2132,7 +2136,7 @@ mod tests {
         let image = assert_image(&nodes[0]);
         assert_eq!(image.alt.as_deref(), Some("abc.myrole#myid"));
 
-        let attrlist = image.attrs.as_ref().unwrap();
+        let attrlist = &image.attrs;
 
         assert_eq!(attrlist.id(), Some("myid"));
         assert_eq!(attrlist.roles(), vec!["myrole"]);
@@ -2200,13 +2204,7 @@ mod tests {
         let image = assert_image(&nodes[0]);
 
         assert_eq!(
-            image
-                .attrs
-                .as_ref()
-                .unwrap()
-                .named_attribute("link")
-                .unwrap()
-                .value(),
+            image.attrs.named_attribute("link").unwrap().value(),
             "javascript:alert(1)"
         );
 
@@ -2742,7 +2740,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
         });
 
@@ -3146,7 +3144,7 @@ mod tests {
 
         assert_eq!(image.alt.as_deref(), Some("Sunset"));
 
-        let attrs = image.attrs.as_ref().unwrap();
+        let attrs = &image.attrs;
         assert_eq!(attrs.nth_attribute(1).unwrap().value(), "Sunset");
         assert_eq!(attrs.named_attribute("role").unwrap().value(), "hl");
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -671,7 +671,7 @@ fn build_inline_link_node<'src>(
         children,
         roles,
         window,
-        attrs,
+        attrs: attrs.unwrap_or_else(|| Attrlist::empty(location.slice(0..0))),
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -824,7 +824,7 @@ fn build_angle_link_node<'src>(
         children,
         roles: vec![CowStr::from("bare")],
         window: None,
-        attrs: None,
+        attrs: Attrlist::empty(location.slice(0..0)),
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -1502,7 +1502,7 @@ pub(super) fn build_link_node<'src>(
         children,
         roles,
         window,
-        attrs,
+        attrs: attrs.unwrap_or_else(|| Attrlist::empty(location.slice(0..0))),
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -1963,7 +1963,7 @@ fn build_email_node<'src>(
         children: macro_text_children(address, range, false, nodes, pieces, root),
         roles: vec![],
         window: None,
-        attrs: None,
+        attrs: Attrlist::empty(location.slice(0..0)),
         resolved: None,
         derived: None,
         xrefstyle: None,
@@ -2936,13 +2936,7 @@ mod tests {
         let reference = assert_link(&nodes[0]);
         assert_eq!(reference.target.as_ref(), "index.html");
         assert_eq!(link_text_of(reference), "Docs");
-        assert_eq!(
-            reference
-                .attrs
-                .as_ref()
-                .and_then(|a| a.roles().into_iter().next()),
-            Some("hl")
-        );
+        assert_eq!(reference.attrs.roles().into_iter().next(), Some("hl"));
 
         assert_eq!(
             fold_html(&nodes, &HtmlInlineRenderer {}),
@@ -3523,8 +3517,8 @@ mod tests {
             );
 
             assert_eq!(
-                reference.attrs.as_ref().map(|attrs| attrs.roles().clone()),
-                Some(vec!["hl"]),
+                reference.attrs.roles(),
+                vec!["hl"],
                 "the parsed list should still split its named attribute for {source:?}"
             );
         }
@@ -4166,7 +4160,7 @@ mod tests {
         assert_eq!(link_text_of(reference), "https://example.org");
         assert_eq!(reference.roles, [CowStr::from("bare")]);
         assert_eq!(reference.window, None);
-        assert!(reference.attrs.is_none());
+        assert_eq!(reference.attrs.attributes().len(), 0);
 
         assert_eq!(reference.location.data(), "<https://example.org>");
         assert_eq!(reference.location.line(), 1);
@@ -4924,7 +4918,7 @@ mod tests {
         let reference = assert_link(&nodes[0]);
         assert_eq!(link_text_of(reference), "a < b");
 
-        let attrs = reference.attrs.as_ref().unwrap();
+        let attrs = &reference.attrs;
         assert_eq!(attrs.roles().into_iter().next(), Some("hl"));
 
         // The parsed positional value is the *escaped* text the string
@@ -4952,13 +4946,7 @@ mod tests {
         let reference = assert_link(&nodes[0]);
         assert_eq!(reference.target.as_ref(), "https://example.org");
         assert_eq!(link_text_of(reference), "Example");
-        assert_eq!(
-            reference
-                .attrs
-                .as_ref()
-                .and_then(|a| a.roles().into_iter().next()),
-            Some("hl")
-        );
+        assert_eq!(reference.attrs.roles().into_iter().next(), Some("hl"));
 
         assert_eq!(
             fold_html(&nodes, &HtmlInlineRenderer {}),
@@ -4978,7 +4966,7 @@ mod tests {
 
         let reference = assert_link(&nodes[0]);
         assert_eq!(link_text_of(reference), "=text");
-        assert!(reference.attrs.is_none() || reference.attrs.as_ref().unwrap().roles().is_empty());
+        assert!(reference.attrs.roles().is_empty());
 
         assert_eq!(
             fold_html(&nodes, &HtmlInlineRenderer {}),
@@ -5434,7 +5422,7 @@ mod tests {
         assert_eq!(link_text_of(reference), "doc.writer@example.com");
         assert!(reference.roles.is_empty());
         assert!(reference.window.is_none());
-        assert!(reference.attrs.is_none());
+        assert_eq!(reference.attrs.attributes().len(), 0);
 
         assert_eq!(reference.location.data(), "doc.writer@example.com");
         assert_eq!(reference.location.line(), 1);
@@ -6780,7 +6768,7 @@ mod tests {
 
         assert_eq!(link_text_of(reference), "Docs");
 
-        let attrs = reference.attrs.as_ref().unwrap();
+        let attrs = &reference.attrs;
         assert_eq!(attrs.roles().into_iter().next(), Some("hl"));
 
         // The positional value is the *expansion*, which no `'src` slice

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1459,7 +1459,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
         });
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -569,7 +569,7 @@ fn build_xref_node<'src>(
         // replacer makes (design §3.3.1 point 1: every order-dependent fact is
         // resolved into node values at build time, so the fold is pure).
         xrefstyle: xrefstyle.or_else(|| document_xrefstyle(parser)),
-        attrs: None,
+        attrs: Attrlist::empty(location.slice(0..0)),
         location,
     })
 }
@@ -849,7 +849,7 @@ fn build_xref_shorthand_node<'src>(
         // the document-wide one, resolved here for the same reason the macro
         // form resolves it here.
         xrefstyle: document_xrefstyle(parser),
-        attrs: None,
+        attrs: Attrlist::empty(location.slice(0..0)),
         location,
     })
 }

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1323,7 +1323,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: vec![],
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 children: vec![],
                 passthrough: None,
                 location,
@@ -1989,7 +1989,11 @@ mod tests {
         match &nodes[0] {
             InlineNode::Styled(styled) => {
                 assert_eq!(styled.roles, vec![CowStr::from("role")]);
-                assert!(styled.attrs.is_some(), "the attribute list is retained");
+                assert_ne!(
+                    styled.attrs.attributes().len(),
+                    0,
+                    "the attribute list is retained"
+                );
             }
 
             other => panic!("expected Styled, got {other:?}"),
@@ -2133,7 +2137,11 @@ mod tests {
         match &nodes[0] {
             InlineNode::Styled(styled) => {
                 assert_eq!(styled.variant, StyleVariant::Code);
-                assert!(styled.attrs.is_some(), "the attribute list is retained");
+                assert_ne!(
+                    styled.attrs.attributes().len(),
+                    0,
+                    "the attribute list is retained"
+                );
             }
 
             other => panic!("expected Styled, got {other:?}"),
@@ -2437,7 +2445,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: vec![],
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(source.slice(8..9).slice(0..0)),
                 children: vec![],
                 passthrough: None,
                 location: source.slice(8..9),
@@ -2848,7 +2856,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: vec![],
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(source.slice(1..2).slice(0..0)),
                 children: vec![],
                 passthrough: None,
                 location: source.slice(1..2),

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -394,7 +394,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: Attrlist::empty(loc.slice(0..0)),
             location: loc,
         });
 

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -580,7 +580,7 @@ fn probe_styled_boundaries_markup(styled: &Styled<'_>) -> (String, String) {
     HtmlInlineRenderer {}.render_styled(
         quote_type_of(styled.variant),
         scope,
-        styled.attrs.clone(),
+        &styled.attrs,
         styled.id.as_ref().map(|id| id.to_string()),
         PROBE,
         &mut rendered,
@@ -1332,10 +1332,12 @@ fn rebuild_level<'src>(
                 let mut children = Vec::new();
                 emit_range(nodes, pieces, body.clone(), &mut children);
 
+                let location = source_slice(pieces, construct.clone(), root);
+
                 let (id, roles, attrs) = match attrlist {
                     Some(range) => quote_attributes(s, range.clone(), pieces, root, parser),
 
-                    None => (None, Vec::new(), None),
+                    None => (None, Vec::new(), Attrlist::empty(location.slice(0..0))),
                 };
 
                 out.push(InlineNode::Styled(Styled {
@@ -1346,7 +1348,7 @@ fn rebuild_level<'src>(
                     attrs,
                     children,
                     passthrough: None,
-                    location: source_slice(pieces, construct.clone(), root),
+                    location,
                 }));
             }
         }
@@ -1397,11 +1399,7 @@ fn quote_attributes<'src>(
     pieces: &[Piece],
     root: Span<'src>,
     parser: &Parser,
-) -> (
-    Option<CowStr<'src>>,
-    Vec<CowStr<'src>>,
-    Option<Attrlist<'src>>,
-) {
+) -> (Option<CowStr<'src>>, Vec<CowStr<'src>>, Attrlist<'src>) {
     let source = source_slice(pieces, range.clone(), root);
 
     if range_is_verbatim(pieces, &range) {
@@ -1428,11 +1426,7 @@ fn quote_attributes<'src>(
 pub(super) fn attributes_of<'src>(
     source: Span<'src>,
     parser: &Parser,
-) -> (
-    Option<CowStr<'src>>,
-    Vec<CowStr<'src>>,
-    Option<Attrlist<'src>>,
-) {
+) -> (Option<CowStr<'src>>, Vec<CowStr<'src>>, Attrlist<'src>) {
     attributes_of_attrlist(parse_attrlist(source, parser))
 }
 
@@ -1448,11 +1442,7 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 /// list itself.
 fn attributes_of_attrlist<'src>(
     attrlist: Attrlist<'src>,
-) -> (
-    Option<CowStr<'src>>,
-    Vec<CowStr<'src>>,
-    Option<Attrlist<'src>>,
-) {
+) -> (Option<CowStr<'src>>, Vec<CowStr<'src>>, Attrlist<'src>) {
     // Extract owned id/roles before the attrlist is moved into the node, exactly
     // as the string pipeline's quote replacer does.
     //
@@ -1470,7 +1460,7 @@ fn attributes_of_attrlist<'src>(
         .map(|role| CowStr::from(role.to_string()))
         .collect();
 
-    (id, roles, Some(attrlist))
+    (id, roles, attrlist)
 }
 
 /// Emits the original nodes covering the match-string range `[range.start,
@@ -1820,7 +1810,7 @@ mod tests {
             form: SpanForm::Constrained,
             id: None,
             roles: vec![],
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(Span::new("x").slice(0..0)),
             children: vec![],
             passthrough: None,
             location: Span::new("x"),
@@ -1884,7 +1874,7 @@ mod tests {
             form: SpanForm::Constrained,
             id: None,
             roles: vec![],
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(Span::new("x").slice(0..0)),
             children: vec![],
             passthrough: None,
             location: Span::new("x"),
@@ -2092,7 +2082,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: Vec::new(),
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(Span::new("x").slice(0..0)),
                 children: Vec::new(),
                 passthrough: None,
                 location: Span::new("x"),
@@ -2239,7 +2229,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: Vec::new(),
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(Span::new("x").slice(0..0)),
                 children,
                 passthrough: None,
                 location: Span::new("x"),
@@ -2495,7 +2485,7 @@ mod tests {
             form: SpanForm::Unconstrained,
             id: Some(CowStr::from("x")),
             roles: Vec::new(),
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(Span::new("[#x]##y##").slice(0..0)),
             children: Vec::new(),
             passthrough: None,
             location: Span::new("[#x]##y##"),
@@ -2546,7 +2536,7 @@ mod tests {
             form: SpanForm::Unconstrained,
             id: None,
             roles: Vec::new(),
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(Span::new("[width=10]##x ##").slice(0..0)),
             children,
             passthrough: None,
             location: Span::new("[width=10]##x ##"),
@@ -3117,7 +3107,7 @@ mod tests {
             form: SpanForm::Constrained,
             id: None,
             roles: vec![],
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(source.slice(0..0)),
             children: vec![],
             passthrough: None,
             location: source,
@@ -3801,13 +3791,17 @@ mod tests {
                 // unquoted span, exactly as the string pipeline does.
                 assert_eq!(styled.variant, StyleVariant::Unquoted);
                 assert_eq!(styled.roles, vec![CowStr::from("lead")]);
-                assert!(styled.attrs.is_some(), "the attribute list is retained");
+                assert_ne!(
+                    styled.attrs.attributes().len(),
+                    0,
+                    "the attribute list is retained"
+                );
 
                 // A wholly verbatim attribute list is parsed from its own
                 // `'src` slice, so the node's list is located exactly there
                 // (its values borrow, per §4.5) rather than falling back to
                 // the coarse span an owned one takes.
-                let attrs = styled.attrs.as_ref().unwrap();
+                let attrs = &styled.attrs;
                 assert_eq!(attrs.span().data(), ".lead");
                 assert_eq!(attrs.span().line(), 1);
                 assert_eq!(attrs.span().col(), 2);
@@ -3836,7 +3830,7 @@ mod tests {
                 // is owned and takes the bracket's coarse source span (design
                 // §4.4) as its location tag — the same fallback an image's
                 // bracket and a link's display-text list already take.
-                let attrs = styled.attrs.as_ref().unwrap();
+                let attrs = &styled.attrs;
                 assert_eq!(attrs.span().data(), "#a&b.c<d");
                 assert_eq!(attrs.span().line(), 1);
                 assert_eq!(attrs.span().col(), 2);

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -691,7 +691,7 @@ mod tests {
             form: SpanForm::Constrained,
             id: None,
             roles: vec![],
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
             children: vec![InlineNode::Text {
                 value: CowStr::from(loc.data()),
                 location: loc,
@@ -734,7 +734,7 @@ mod tests {
             resolved: None,
             derived: None,
             xrefstyle: None,
-            attrs: None,
+            attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
             location: loc,
         });
 
@@ -949,7 +949,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: vec![],
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
                 children: child(),
                 passthrough: None,
                 location: loc,
@@ -964,7 +964,7 @@ mod tests {
                 resolved: None,
                 derived: None,
                 xrefstyle: None,
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
                 location: loc,
             }),
             InlineNode::Anchor(Anchor {

--- a/parser/src/inlines/image.rs
+++ b/parser/src/inlines/image.rs
@@ -43,8 +43,10 @@ pub struct Image<'src> {
     /// The requested height, if any. Not validated as a number.
     pub height: Option<CowStr<'src>>,
 
-    /// The full attribute list, when the image macro carried one.
-    pub attrs: Option<Attrlist<'src>>,
+    /// The image macro's full attribute list —
+    /// [`Attrlist::empty`](crate::attributes::Attrlist::empty) when it carried
+    /// none, so a consumer reads attributes the same way either way.
+    pub attrs: Attrlist<'src>,
 
     /// The source location of the whole image macro.
     pub location: Span<'src>,

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -171,7 +171,7 @@ mod tests {
                 form: SpanForm::Constrained,
                 id: None,
                 roles: vec![],
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 children: vec![],
                 passthrough: None,
                 location,
@@ -186,7 +186,7 @@ mod tests {
                 resolved: None,
                 derived: None,
                 xrefstyle: None,
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 location,
             }),
             InlineNode::Image(Image {
@@ -196,7 +196,7 @@ mod tests {
                 alt: None,
                 width: None,
                 height: None,
-                attrs: None,
+                attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 location,
             }),
             InlineNode::Footnote(Footnote {

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -96,10 +96,14 @@ pub struct Ref<'src> {
     /// than `roles`/`window` alone (an `id`, a `title`, the `nofollow` /
     /// `noopener` options), unlike a cross-reference's own attribute-list
     /// text, whose `window`/`role`/`xrefstyle` the plain fields above already
-    /// cover in full. `None` when the link carries no attribute-list text
-    /// (or the `=` was incidental — see `extract_attributes_from_text`), and
-    /// always `None` for an [`Xref`](RefVariant::Xref).
-    pub attrs: Option<Attrlist<'src>>,
+    /// cover in full.
+    ///
+    /// [`Attrlist::empty`](crate::attributes::Attrlist::empty) when the link
+    /// carries no attribute-list text (or the `=` was incidental — see
+    /// `extract_attributes_from_text`), and always empty for an
+    /// [`Xref`](RefVariant::Xref), whose own attribute-list text is fully
+    /// covered by the plain fields.
+    pub attrs: Attrlist<'src>,
 
     /// For a [`Link`](RefVariant::Link), which of AsciiDoc's three link
     /// spellings the source used; `None` for a cross-reference.

--- a/parser/src/inlines/styled.rs
+++ b/parser/src/inlines/styled.rs
@@ -19,8 +19,10 @@ pub struct Styled<'src> {
     /// The roles (CSS classes) assigned to the span.
     pub roles: Vec<CowStr<'src>>,
 
-    /// The full attribute list, when the span carried one.
-    pub attrs: Option<Attrlist<'src>>,
+    /// The span's full attribute list —
+    /// [`Attrlist::empty`](crate::attributes::Attrlist::empty) when the span
+    /// carried none, so a consumer reads attributes the same way either way.
+    pub attrs: Attrlist<'src>,
 
     /// The span's content, as child inline nodes.
     pub children: Vec<InlineNode<'src>>,

--- a/parser/src/parser/inline_renderer.rs
+++ b/parser/src/parser/inline_renderer.rs
@@ -73,7 +73,7 @@ pub trait InlineRenderer: Debug {
         &self,
         type_: QuoteType,
         scope: QuoteScope,
-        attrlist: Option<Attrlist<'_>>,
+        attrlist: &Attrlist<'_>,
         id: Option<String>,
         body: &str,
         dest: &mut String,
@@ -106,14 +106,8 @@ pub trait InlineRenderer: Debug {
     ///
     /// The renderer should write an appropriate rendering of the specified
     /// image to `dest`.
-    fn render_image(
-        &self,
-        image: &Image<'_>,
-        attrlist: &Attrlist<'_>,
-        context: &RenderContext,
-        dest: &mut String,
-    ) {
-        DEFAULT_HTML_RENDERER.render_image(image, attrlist, context, dest);
+    fn render_image(&self, image: &Image<'_>, context: &RenderContext, dest: &mut String) {
+        DEFAULT_HTML_RENDERER.render_image(image, context, dest);
     }
 
     /// Construct a URI reference or data URI to the target image.
@@ -156,14 +150,8 @@ pub trait InlineRenderer: Debug {
     ///
     /// The renderer should write an appropriate rendering of the specified
     /// icon to `dest`.
-    fn render_icon(
-        &self,
-        icon: &Image<'_>,
-        attrlist: &Attrlist<'_>,
-        context: &RenderContext,
-        dest: &mut String,
-    ) {
-        DEFAULT_HTML_RENDERER.render_icon(icon, attrlist, context, dest);
+    fn render_icon(&self, icon: &Image<'_>, context: &RenderContext, dest: &mut String) {
+        DEFAULT_HTML_RENDERER.render_icon(icon, context, dest);
     }
 
     /// Construct a reference or data URI to an icon image for the specified
@@ -695,16 +683,15 @@ impl InlineRenderer for HtmlInlineRenderer {
         &self,
         type_: QuoteType,
         _scope: QuoteScope,
-        attrlist: Option<Attrlist<'_>>,
+        attrlist: &Attrlist<'_>,
         mut id: Option<String>,
         body: &str,
         dest: &mut String,
     ) {
-        let mut roles: Vec<&str> = attrlist.as_ref().map(|a| a.roles()).unwrap_or_default();
+        let mut roles: Vec<&str> = attrlist.roles();
 
         if let Some(block_style) = attrlist
-            .as_ref()
-            .and_then(|a| a.nth_attribute(1))
+            .nth_attribute(1)
             .and_then(|attr1| attr1.block_style())
         {
             roles.insert(0, block_style);
@@ -712,8 +699,7 @@ impl InlineRenderer for HtmlInlineRenderer {
 
         if id.is_none() {
             id = attrlist
-                .as_ref()
-                .and_then(|a| a.nth_attribute(1))
+                .nth_attribute(1)
                 .and_then(|attr1| attr1.id())
                 .map(|id| id.to_owned())
         }
@@ -724,16 +710,14 @@ impl InlineRenderer for HtmlInlineRenderer {
         // included — so recover it here rather than dropping the role.
         if roles.is_empty()
             && id.is_none()
-            && let Some(role) = attrlist
-                .as_ref()
-                .and_then(|a| a.quoted_text_fallback_role())
+            && let Some(role) = attrlist.quoted_text_fallback_role()
         {
             roles.push(role);
         }
 
         match type_ {
             QuoteType::Strong => {
-                wrap_body_in_html_tag(attrlist.as_ref(), "strong", id, roles, body, dest);
+                wrap_body_in_html_tag("strong", id, roles, body, dest);
             }
 
             QuoteType::DoubleQuote => {
@@ -749,34 +733,34 @@ impl InlineRenderer for HtmlInlineRenderer {
             }
 
             QuoteType::Monospaced => {
-                wrap_body_in_html_tag(attrlist.as_ref(), "code", id, roles, body, dest);
+                wrap_body_in_html_tag("code", id, roles, body, dest);
             }
 
             QuoteType::Emphasis => {
-                wrap_body_in_html_tag(attrlist.as_ref(), "em", id, roles, body, dest);
+                wrap_body_in_html_tag("em", id, roles, body, dest);
             }
 
             QuoteType::Mark => {
                 if roles.is_empty() && id.is_none() {
-                    wrap_body_in_html_tag(attrlist.as_ref(), "mark", id, roles, body, dest);
+                    wrap_body_in_html_tag("mark", id, roles, body, dest);
                 } else {
-                    wrap_body_in_html_tag(attrlist.as_ref(), "span", id, roles, body, dest);
+                    wrap_body_in_html_tag("span", id, roles, body, dest);
                 }
             }
 
             QuoteType::Superscript => {
-                wrap_body_in_html_tag(attrlist.as_ref(), "sup", id, roles, body, dest);
+                wrap_body_in_html_tag("sup", id, roles, body, dest);
             }
 
             QuoteType::Subscript => {
-                wrap_body_in_html_tag(attrlist.as_ref(), "sub", id, roles, body, dest);
+                wrap_body_in_html_tag("sub", id, roles, body, dest);
             }
 
             QuoteType::Unquoted => {
                 if roles.is_empty() && id.is_none() {
                     dest.push_str(body);
                 } else {
-                    wrap_body_in_html_tag(attrlist.as_ref(), "span", id, roles, body, dest);
+                    wrap_body_in_html_tag("span", id, roles, body, dest);
                 }
             }
 
@@ -852,13 +836,8 @@ impl InlineRenderer for HtmlInlineRenderer {
         dest.push_str("<br>");
     }
 
-    fn render_image(
-        &self,
-        image: &Image<'_>,
-        attrlist: &Attrlist<'_>,
-        context: &RenderContext,
-        dest: &mut String,
-    ) {
+    fn render_image(&self, image: &Image<'_>, context: &RenderContext, dest: &mut String) {
+        let attrlist = &image.attrs;
         let target = image.target.as_ref();
         let alt = image.alt.as_deref().unwrap_or_default();
 
@@ -1015,13 +994,8 @@ impl InlineRenderer for HtmlInlineRenderer {
         normalized
     }
 
-    fn render_icon(
-        &self,
-        icon: &Image<'_>,
-        attrlist: &Attrlist<'_>,
-        context: &RenderContext,
-        dest: &mut String,
-    ) {
+    fn render_icon(&self, icon: &Image<'_>, context: &RenderContext, dest: &mut String) {
+        let attrlist = &icon.attrs;
         let target = icon.target.as_ref();
         let alt = icon.alt.as_deref().unwrap_or_default();
 
@@ -1465,7 +1439,6 @@ fn push_attribute_value(dest: &mut String, value: &str) {
 }
 
 fn wrap_body_in_html_tag(
-    _attrlist: Option<&Attrlist<'_>>,
     tag: &'static str,
     id: Option<String>,
     roles: Vec<&str>,
@@ -1971,7 +1944,50 @@ fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&str>) -> Strin
 
 #[cfg(test)]
 mod tests {
-    use super::{data_uri_mimetype, drop_anchor_tags, encode_html_attribute, extname, has_extname};
+    use super::{
+        HtmlInlineRenderer, InlineRenderer, QuoteScope, QuoteType, data_uri_mimetype,
+        drop_anchor_tags, encode_html_attribute, extname, has_extname,
+    };
+    use crate::{Span, attributes::Attrlist};
+
+    #[test]
+    fn a_mark_carrying_an_id_or_a_role_renders_as_a_span() {
+        // Asciidoctor renders `#text#` as `<mark>`, but a *styled* one — given
+        // an id or a role — as a `<span>` instead. The builder reaches the same
+        // outcome one step earlier, by classifying a `#…#` that carries an
+        // attribute list as `Unquoted` rather than `Mark` (see
+        // `style_variant_of`), so no parse ever hands this method a `Mark` with
+        // either. That does not make the rule dead: `render_styled` is public,
+        // and a caller folding a node it built itself can present exactly that
+        // combination — so the reference backend has to answer for it, and this
+        // pins the answer.
+        let renderer = HtmlInlineRenderer {};
+        let attrlist = Attrlist::empty(Span::new(""));
+
+        let mut dest = String::new();
+        renderer.render_styled(
+            QuoteType::Mark,
+            QuoteScope::Constrained,
+            &attrlist,
+            Some("anchor".to_owned()),
+            "text",
+            &mut dest,
+        );
+        assert_eq!(dest, r#"<span id="anchor">text</span>"#);
+
+        // With neither an id nor a role it is a plain `<mark>`, which is the
+        // branch every parsed `#text#` takes.
+        let mut dest = String::new();
+        renderer.render_styled(
+            QuoteType::Mark,
+            QuoteScope::Constrained,
+            &attrlist,
+            None,
+            "text",
+            &mut dest,
+        );
+        assert_eq!(dest, "<mark>text</mark>");
+    }
 
     #[test]
     fn extname_extracts_final_segment_extension() {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -4517,7 +4517,7 @@ mod tests {
             &self,
             _type_: QuoteType,
             _scope: QuoteScope,
-            _attrlist: Option<Attrlist<'_>>,
+            _attrlist: &Attrlist<'_>,
             _id: Option<String>,
             body: &str,
             dest: &mut String,
@@ -4540,7 +4540,6 @@ mod tests {
         fn render_image(
             &self,
             _image: &crate::inlines::Image<'_>,
-            _attrlist: &Attrlist<'_>,
             _context: &crate::parser::RenderContext,
             dest: &mut String,
         ) {
@@ -4559,7 +4558,6 @@ mod tests {
         fn render_icon(
             &self,
             _icon: &crate::inlines::Image<'_>,
-            _attrlist: &Attrlist<'_>,
             _context: &crate::parser::RenderContext,
             dest: &mut String,
         ) {

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -772,7 +772,7 @@ impl crate::parser::InlineRenderer for BracketStrong {
         &self,
         type_: crate::parser::QuoteType,
         scope: crate::parser::QuoteScope,
-        attrlist: Option<crate::attributes::Attrlist<'_>>,
+        attrlist: &crate::attributes::Attrlist<'_>,
         id: Option<String>,
         body: &str,
         dest: &mut String,

--- a/parser/src/tests/inline_renderer.rs
+++ b/parser/src/tests/inline_renderer.rs
@@ -84,7 +84,6 @@ impl InlineRenderer for FigureImages {
     fn render_image(
         &self,
         image: &crate::inlines::Image<'_>,
-        _attrlist: &crate::attributes::Attrlist<'_>,
         context: &RenderContext,
         dest: &mut String,
     ) {

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -1995,7 +1995,7 @@ fn unresolved_xref() -> InlineNode<'static> {
         resolved: None,
         derived: None,
         xrefstyle: None,
-        attrs: None,
+        attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
         location: Span::new(""),
     })
 }
@@ -2023,7 +2023,7 @@ fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         resolved: None,
         derived: None,
         xrefstyle: None,
-        attrs: None,
+        attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
         location: Span::new(""),
     })
 }
@@ -2035,7 +2035,7 @@ fn strong_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         form: SpanForm::Constrained,
         id: None,
         roles: vec![],
-        attrs: None,
+        attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
         children,
         passthrough: None,
         location: Span::new(""),


### PR DESCRIPTION
## What

`Image`, `Styled` and `Ref` now hold their attribute list outright instead of behind an `Option`:

```rust
-    pub attrs: Option<Attrlist<'src>>,
+    pub attrs: Attrlist<'src>,
```

filled with `Attrlist::empty` — now `pub`, since those node fields are — when the author wrote no attribute list.

**"Absent attribute list" stops being a state the model can be in.**

Your call, from the candidate #1328 flagged. **Breaking**, to public node fields and to the renderer seam; an accepted pre-1.0 break (§4.6).

## Why it was worth doing, in the seam

#1328 had to work *around* the `Option`: `render_image`/`render_icon` took the attribute list as a separate argument precisely because the node's own was optional and somebody had to resolve it. That argument now goes away and the methods read `image.attrs`.

```rust
// before                                        after
render_image(&Image, &Attrlist, &RenderContext)  render_image(&Image, &RenderContext)
render_icon (&Image, &Attrlist, &RenderContext)  render_icon (&Image, &RenderContext)
render_styled(…, Option<Attrlist<'_>>, …)        render_styled(…, &Attrlist<'_>, …)
```

The `render_styled` change is the one with teeth: it took the list **owned**, so the fold was doing `styled.attrs.clone()` on *every* styled node just to wrap it in a `Some`. It now borrows. `fold_image` and `fold_link`'s empty-list resolutions are deleted outright.

Behaviour is unchanged because a missing list and an empty one were already indistinguishable inside `render_styled` — every read was `.as_ref().map(…)` / `.and_then(…)`, and the one function that received the list whole ignored it (below).

## Two vestiges fell out

- **`attributes_of` / `attributes_of_attrlist`** (`quotes.rs`) declared an optional return type and never once returned `None` — the `Some(…)` was the function's last line.
- **`wrap_body_in_html_tag`** took an `_attrlist` parameter it did not read. With no `Option` left for `render_styled` to hand it, the dead parameter went too.

## `Attrlist::empty` is now public

It has to be: the node fields are public and non-optional, so a caller building a node by hand needs to be able to say "no attributes", and every other route to an `Attrlist` goes through parsing — which costs an attribute-reference substitution pass and needs a `Parser` where only a `Span` is at hand. Its doc now says that rather than describing itself as a fold-internal convenience.

Each empty list is sliced zero-length from its own node's `location`, so lifetime and position match the node it belongs to.

## The codecov failure, and what it turned up

The first push went red on `codecov/patch` — 1 uncovered line. Worth recording, because my own local check had said the opposite: **codecov measures the diff, my `cargo llvm-cov` run measured the total**, and a total that improves can still hide a changed line that nothing exercises.

The line was `render_styled`'s `Mark`-with-an-id-or-role branch. Dropping the now-dead `attrlist` argument from its `wrap_body_in_html_tag` call made an **already-uncovered** line a *changed* one (it is line 763 on the base, and uncovered there too).

It was uncovered for a reason worth writing down rather than papering over. `style_variant_of` classifies a `#…#` that carries an attribute list as `Unquoted` rather than `Mark`:

```rust
QuoteType::Mark if has_attrlist => StyleVariant::Unquoted,
QuoteType::Mark => StyleVariant::Mark,
```

so **no parse can hand `render_styled` a `Mark` with an id or a role**. That does not make the branch dead, and I did not delete it: `render_styled` is public, and a caller folding a node it built itself can present exactly that combination, so the reference backend has to answer for it. A unit test now pins both halves of Asciidoctor's rule:

```
id or role present  ->  <span id="anchor">text</span>
neither present     ->  <mark>text</mark>
```

It passed on its first run.

## Verification

No expected-output string changed and all **5,475 tests pass**, so §5.3's oracle pins the same bytes.

| | base (`34d6c56`) | this PR |
| --- | --- | --- |
| `content/inline_builder/macros/links.rs` | 20 | **17** |
| `parser/inline_renderer.rs` | 18 | **12** |
| `content/inline_builder/macros/image.rs` | 4 | **3** |
| `content/inline_builder/fold.rs` | 3 | 3 |
| `content/inline_builder/quotes.rs` | 13 | 13 |
| `attributes/attrlist.rs` | 0 | 0 |
| **TOTAL missed regions** | 561 | **551** |
| **TOTAL missed functions** | 41 | 41 |

Nothing regressed — a `None` arm that no longer exists cannot be an untested one — and the `Mark` test accounts for the extra four beyond what the `Option` removal alone would have given.

### Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5,475 passed, 0 failed)
- `cargo +nightly doc --no-deps --document-private-items` ✅

## A note on the test assertions

A handful of tests asserted `reference.attrs.is_none()` — "this link carried no attribute list". That predicate no longer exists, so they now assert `attrs.attributes().len() == 0`. Worth flagging as a genuine, if small, loss of expressiveness: a node that carried an explicitly empty list (`link:x[]`) and one that carried none are now the same value apart from their `source` span. Nothing in the crate distinguished them, and the built-in renderer never could — but it is a distinction the model used to be able to represent and no longer can.

## What still defers

Phase 5's last three — `Link`, `Xref` and `IndexTerm`, whose params carry the **fold of the node's children**, and which still need your call on whether a method receives the folded text as a `&str` beside its node or a handle it folds with itself.

Then Landing. Step 7's `Document::to_asg()` also remains, blocked on reading the Eclipse ASG schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYca6yhrdzh2h6c4waYtrK