### PR TITLE
doc: Snapshot the ASG schema and record what it says

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -435,6 +435,281 @@ This projection doubles as a **conformance test surface**: we can validate our A
 against the schema and, when the language TCK matures, run it. Where the ASG under-models
 what we support, we document the projection choice and keep the richer native node.
 
+#### Notes for `Document::to_asg()`
+
+Everything below is read directly off the schema now snapshotted at
+[`ref/asciidoc-lang/asg/schema.json`](../../ref/asciidoc-lang/asg/schema.json), whose `$id`
+is `https://schemas.asciidoc.org/asg/1-0-0/draft-01` — a *draft* of 1.0.0, and it shows.
+§2 and §3.5 above record the inline vocabulary but none of the mechanics below, and the
+first finding invalidates a row of the table above.
+
+##### An `inlineSpan` cannot carry a role — nor an id, nor attributes
+
+There is no `metadata` object, no `roles` array, and no `attributes` map on any inline node.
+A span's entire property set is the union of two `$defs`:
+
+```json
+"abstractParentInline": {
+  "type": "object",
+  "required": ["type", "inlines"],
+  "properties": {
+    "type": { "type": "string", "const": "inline" },
+    "inlines": { "$ref": "#/$defs/inlines" },
+    "location": { "$ref": "#/$defs/location" }
+  }
+},
+"inlineSpan": {
+  "type": "object",
+  "allOf": [{ "$ref": "#/$defs/abstractParentInline" }],
+  "unevaluatedProperties": false,
+  "required": ["name", "variant", "form"],
+  "properties": {
+    "name": { "type": "string", "const": "span" },
+    "variant": { "type": "string", "enum": ["strong", "emphasis", "code", "mark"] },
+    "form": { "type": "string", "enum": ["constrained", "unconstrained"] }
+  }
+}
+```
+
+That is `type`, `inlines`, `location`, `name`, `variant`, `form` — and
+`"unevaluatedProperties": false` forbids anything else. `roles` does exist in the schema,
+but only at block level, under `blockMetadata`:
+
+```json
+"blockMetadata": {
+  "type": "object",
+  "defaults": { "attributes": {}, "options": [], "roles": [] },
+  "additionalProperties": false,
+  "properties": {
+    "attributes": { "type": "object", "…": "…" },
+    "options": { "type": "array", "items": { "type": "string" } },
+    "roles": { "type": "array", "items": { "type": "string" } },
+    "location": { "$ref": "#/$defs/location" }
+  }
+}
+```
+
+and `blockMetadata` is reachable only through `abstractBlock`'s `metadata` property. No
+inline node has one. Three consequences for the projection table above:
+
+- **`Styled{Superscript, Subscript}` → "`span` with a role" is not implementable.** There
+  is nowhere to put the role, and `variant` is a closed four-value enum that has no
+  superscript or subscript member, so the ASG has no legal node for either construct. The
+  projection has to be chosen afresh — unwrap to the children's inlines and lose the
+  distinction, emit an out-of-enum `variant` and be knowingly non-conformant, or wait for
+  the schema to grow the variants. This is an open question, not a decided row.
+- **`Styled{Unquoted}` → "`span` carrying only id/roles" has the same problem**, and worse:
+  strip the id and roles and nothing distinguishes the node from its children, so an
+  unquoted span projects to its children directly.
+- **`inlineRef` is role-free too.** §3.2's `Ref::roles` and `Ref::window` have no ASG home
+  either; `inlineRef` evaluates to exactly `type`/`inlines`/`location` plus `name`,
+  `variant` (`link` | `xref`), and `target`, again under `"unevaluatedProperties": false`.
+
+##### Every node carries `type` beside `name`, and it has three values
+
+`name` is the union discriminator — both the block and the inline union say so explicitly:
+
+```json
+"block":  { "type": "object", "discriminator": { "propertyName": "name" }, "oneOf": [ … ] },
+"inline": { "type": "object", "discriminator": { "propertyName": "name" }, "oneOf": [
+  { "$ref": "#/$defs/inlineSpan" },
+  { "$ref": "#/$defs/inlineRef" },
+  { "$ref": "#/$defs/inlineLiteral" }
+] }
+```
+
+`type` is a coarser category tag that sits beside it, with exactly three values:
+
+| `type` value | Carried by |
+| ------------ | ---------- |
+| `"block"`    | the document root, every `block` union member, `section`, `listItem`, `dlistItem` |
+| `"inline"`   | `inlineSpan` and `inlineRef` (both via `abstractParentInline`) |
+| `"string"`   | `inlineLiteral` — i.e. `text`, `charref`, and `raw` |
+
+It is required everywhere, never merely optional: the root has
+`"required": ["name", "type"]`, `abstractBlock` has `"required": ["type"]`,
+`abstractParentInline` has `"required": ["type", "inlines"]`, and `inlineLiteral` has
+`"required": ["name", "type", "value"]`. Note that the three `inlineLiteral` names are
+exactly `text` / `charref` / `raw`, which confirms the trichotomy §3.4 is built on:
+
+```json
+"inlineLiteral": {
+  "type": "object",
+  "required": ["name", "type", "value"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "enum": ["text", "charref", "raw"] },
+    "type": { "type": "string", "const": "string" },
+    "value": { "type": "string" },
+    "location": { "$ref": "#/$defs/location" }
+  }
+}
+```
+
+##### `id` is block-only, and an inline anchor has nowhere to live
+
+The schema contains exactly one `id`, on `abstractBlock`:
+
+```json
+"abstractBlock": {
+  "type": "object",
+  "required": ["type"],
+  "properties": {
+    "type": { "type": "string", "const": "block" },
+    "id": { "type": "string" },
+    "title": { "$ref": "#/$defs/inlines" },
+    "reftext": { "$ref": "#/$defs/inlines" },
+    "metadata": { "$ref": "#/$defs/blockMetadata" },
+    "location": { "$ref": "#/$defs/location" }
+  }
+}
+```
+
+No inline node has one, and none can acquire one: `inlineSpan` and `inlineRef` close with
+`"unevaluatedProperties": false`, `inlineLiteral` with `"additionalProperties": false`. So
+an inline anchor's id belongs, as far as this schema is concerned, to the enclosing
+**block** — `Anchor` (§3.2) has no inline representation at all. The pointing direction is
+modelled but the declaring direction is not: an `inlineRef` with `"variant": "xref"` carries
+the `target` id it refers to, while nothing in the inline layer can *declare* an id for it
+to resolve against.
+
+##### `location` is exactly two boundaries; `line` and `col` required, `file` an array
+
+```json
+"location": {
+  "type": "array",
+  "prefixItems": [
+    { "$ref": "#/$defs/locationBoundary" },
+    { "$ref": "#/$defs/locationBoundary" }
+  ],
+  "minItems": 2,
+  "maxItems": 2
+},
+"locationBoundary": {
+  "type": "object",
+  "required": ["line", "col"],
+  "additionalProperties": false,
+  "properties": {
+    "line": { "type": "integer", "minimum": 1 },
+    "col": { "type": "integer", "minimum": 0 },
+    "file": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+  }
+}
+```
+
+Four things to note. It is a two-element array, never longer or shorter — `prefixItems`
+types both slots and `minItems`/`maxItems` pin the length. `line` and `col` are required and
+`file` is not, so the ordinary boundary is a two-key object. `line` is 1-based
+(`"minimum": 1`) while `col` allows 0. And `file` is an **array of strings**, not a string;
+the schema constrains it no further than `"minItems": 1`, and says nothing about what the
+elements mean (an include stack is the obvious reading, but that is inference, not schema).
+
+`location` itself is optional on every node — it appears in no `required` list anywhere —
+though upstream's fixtures carry it on every node. The end boundary is *inclusive* of the
+last character rather than one past it: `asg/test/fixtures/sample-1.json` gives the
+seven-character source line `* water` the location
+`[{ "line": 1, "col": 1 }, { "line": 1, "col": 7 }]`. That maps onto §3.2.1's `Span`
+without a new type: the start boundary is the span's `line`/`col`, and the end boundary is
+the position of the last character of `location.data()`.
+
+##### The block-level names `Document::to_asg()` has to emit
+
+The root is the `document` node itself: `"name": "document"`, `"type": "block"`, a `blocks`
+array typed as `sectionBody`, and optional `header`, `attributes`, and `location`. One
+conditional applies to it:
+
+```json
+"if": { "required": ["header"] },
+"then": { "required": ["attributes"] }
+```
+
+— a document that emits a `header` must also emit an `attributes` object, even an empty
+one. The `header` in turn holds `title` (an `inlines` array), `authors` (`minItems: 1`, so
+omit the key entirely rather than emitting `[]`), and `location`.
+
+Below the root, every block node and what it requires:
+
+| `name` | `$defs` | Required beyond `name`/`type` | Children |
+| ------ | ------- | ----------------------------- | -------- |
+| `section` | `section` | `title`, `level` | `blocks` (`sectionBody`) |
+| `heading` | `discreteHeading` | `title`, `level` | — |
+| `paragraph`, `listing`, `literal`, `pass`, `stem`, `verse` | `leafBlock` | — (`delimiter` if `form` is `delimited`) | `inlines` |
+| `admonition`, `example`, `sidebar`, `open`, `quote` | `parentBlock` | `form` (`"delimited"`), `delimiter`; `variant` when `admonition` | `blocks` (`nonSectionBlockBody`) |
+| `list` | `list` | `marker`, `variant`, `items` | `items` (`listItem`, `minItems: 1`) |
+| `listItem` | `listItem` | `marker`, `principal` | `blocks` (`nonSectionBlockBody`) |
+| `dlist` | `dlist` | `marker`, `items` | `items` (`dlistItem`, `minItems: 1`) |
+| `dlistItem` | `dlistItem` | `marker`, `terms` | `principal`, `blocks` |
+| `break` | `break` | `variant` | — |
+| `audio`, `video`, `image`, `toc` | `blockMacro` | `form` (`"macro"`) | — (optional `target`) |
+
+The closed enums, in full: `list.variant` is `callout` | `ordered` | `unordered`;
+`break.variant` is `page` | `thematic`; an `admonition`'s `variant` is `caution` |
+`important` | `note` | `tip` | `warning`; `leafBlock.form` is `delimited` | `indented` |
+`paragraph`, gated by
+
+```json
+"if": {
+  "required": ["form"],
+  "properties": { "form": { "const": "delimited" } }
+},
+"then": {
+  "required": ["delimiter"],
+  "properties": { "delimiter": { "type": "string" } }
+}
+```
+
+Six traps in that table:
+
+- **There is no table block.** Nothing in the schema models tables, and the `leafBlock` and
+  `parentBlock` name enums are closed, so a table cannot be smuggled in as either.
+- A discrete heading's `name` is `heading`, not `discreteHeading`; `discreteHeading` is only
+  the `$defs` key. Conversely `listItem` and `dlistItem` *are* their `name` values.
+- `listItem` and `dlistItem` are not members of the `block` union — they are reachable only
+  through `list.items` and `dlist.items`.
+- Sections nest only inside `sectionBody`, which is used by the root's `blocks` and by
+  `section.blocks`. A `parentBlock` or list-item body is `nonSectionBlockBody`, which admits
+  blocks only.
+- Every block inherits `abstractBlock`'s optional `id`, `title`, `reftext`, `metadata`, and
+  `location`; `title` and `reftext` are `inlines` **arrays**, not strings, so a block title
+  is a full inline subtree.
+- `dlistItem.terms` is an array *of* `inlines` arrays (`{ "items": { "$ref":
+  "#/$defs/inlines" }, "minItems": 1 }`) — a list of terms, each of which is itself a list of
+  inline nodes.
+
+##### Two things the schema does not settle
+
+**How an unset document attribute is encoded.** The root's `attributes` is a pattern-keyed
+map of string-or-null:
+
+```json
+"attributes": {
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[a-zA-Z0-9_][-a-zA-Z0-9_]*$": {
+      "oneOf": [{ "type": "string" }, { "type": "null" }]
+    }
+  }
+}
+```
+
+but upstream's own supposedly-*valid* fixture disagrees with it: `sample-2.json` writes
+`"unset-attribute": false`, and running the pinned revision's `npm test` fails that case
+with `must be string` at `/attributes/unset-attribute`. So `null` is what the schema asks
+for and `false` is what the fixture models, and this draft has not reconciled them. Note
+also that `blockMetadata.attributes` is a *different* map: its key pattern
+`^(?:[a-zA-Z_][a-zA-Z0-9_-]*|\$[1-9][0-9]*)$` additionally admits positional `$1`, `$2`
+keys (as `sample-3.json` shows for `[discrete]`), and its values are plain strings with no
+null alternative.
+
+**`defaults` is not JSON Schema.** The `"defaults"` keyword appearing on the root,
+`abstractListItem`, `section`, `leafBlock`, `parentBlock`, and `blockMetadata` is a custom
+Ajv keyword defined in [`asg/lib/ajv-keyword-defaults.js`](../../ref/asciidoc-lang/asg/lib/ajv-keyword-defaults.js);
+it *modifies the data*, filling in `blocks: []`, `inlines: []`, `attributes: {}`,
+`options: []`, and `roles: []` before the rest of validation runs. A validator that does not
+register the keyword ignores it. The practical upshot for us is that omitting an empty
+`blocks` or `inlines` and emitting it explicitly as `[]` are equally conformant.
+
 ---
 
 ## 4. Key implementation details

--- a/ref/asciidoc-lang/README.md
+++ b/ref/asciidoc-lang/README.md
@@ -28,19 +28,30 @@ by the most recent update from upstream (asciidoc-parser
 
 ## What is included
 
-Only the upstream `docs/` folder is snapshotted here, at
-[`docs/`](./docs) (i.e. `ref/asciidoc-lang/docs`). This is the Antora
-documentation site that constitutes the AsciiDoc language description.
+Two upstream folders are snapshotted here, both at the pinned commit above:
 
-The upstream `asg/` and `spec/` folders are **not** included at this time; we may
-revisit importing them later.
+- [`docs/`](./docs) (i.e. `ref/asciidoc-lang/docs`) — the Antora documentation
+  site that constitutes the AsciiDoc language description.
+- [`asg/`](./asg) (i.e. `ref/asciidoc-lang/asg`) — the JSON Schema for AsciiDoc's
+  Abstract Semantic Graph (ASG), which is the structure the AsciiDoc TCK validates
+  an implementation's output against. The schema itself is
+  [`asg/schema.json`](./asg/schema.json); the `package.json`, `bin/`, `lib/`, and
+  `test/` entries alongside it are upstream's own Ajv-based validation harness,
+  copied so the snapshot matches upstream exactly — nothing here runs `npm`. For
+  what the schema says and what it means for this crate, see
+  [`docs/design/inline-ast-architecture.md`](../../docs/design/inline-ast-architecture.md)
+  §3.5.
+
+The upstream `spec/` folder is **not** included at this time; we may revisit
+importing it later.
 
 ## How to update this snapshot
 
 1. Fetch the desired revision from the upstream repository:
    `git fetch https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang main`
-2. Replace the contents of [`docs/`](./docs) with the upstream `docs/` folder at
-   that revision.
+2. Replace the contents of [`docs/`](./docs) and [`asg/`](./asg) with the upstream
+   `docs/` and `asg/` folders at that revision, so that the whole snapshot stays
+   at a single revision.
 3. Update the **Pinned commit**, **Commit date**, and **Commit summary** rows in
    the table above to the new upstream commit.
 4. Review and adjust the `track_file!("ref/asciidoc-lang/docs/...")` markers in
@@ -51,9 +62,19 @@ revisit importing them later.
 
 The user documentation in [`docs/`](./docs) is made available under the terms of
 a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/)
-(CC-BY-4.0); see [`docs/LICENSE`](./docs/LICENSE). The AsciiDoc Language project
-as a whole is made available under the terms of the Eclipse Public License v 2.0
-(EPL-2.0); see the
+(CC-BY-4.0); see [`docs/LICENSE`](./docs/LICENSE).
+
+The ASG schema and harness in [`asg/`](./asg) are covered by the project-wide
+Eclipse Public License v 2.0 (EPL-2.0). Upstream, `asg/` carries neither a
+`LICENSE` file of its own nor any per-file license header, and the CC-BY-4.0
+grant does not extend to it: [`docs/LICENSE`](./docs/LICENSE) scopes itself to
+content "under this directory", and upstream's `NOTICE.adoc` likewise confines
+CC-BY-4.0 to "the end user documentation content" while declaring EPL-2.0
+(`SPDX-License-Identifier: EPL-2.0`) for the technology specification and its
+accompanying materials. Upstream's root `README.adoc` describes the same split.
+
+The AsciiDoc Language project as a whole is made available under the terms of the
+Eclipse Public License v 2.0 (EPL-2.0); see the
 [project LICENSE](https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/blob/main/LICENSE)
 for the full text.
 

--- a/ref/asciidoc-lang/asg/.gitignore
+++ b/ref/asciidoc-lang/asg/.gitignore
@@ -1,0 +1,3 @@
+/node_modules/
+/.nvmrc
+/package-lock.json

--- a/ref/asciidoc-lang/asg/README.adoc
+++ b/ref/asciidoc-lang/asg/README.adoc
@@ -1,0 +1,37 @@
+= AsciiDoc ASG Schema
+
+This subproject of the AsciiDoc Language project hosts the JSON schema for AsciiDoc's Abstract Semantic Graph (ASG).
+The AsciiDoc ASG represents the semantic structure and content of a parsed AsciiDoc document.
+This ASG is used by the TCK to validate the behavior of a compatible AsciiDoc implementation (i.e., parser).
+
+== About the schema
+
+The schema is defined using the JSON schema language.
+The schema is stored in the file _schema.json_ at the root of this subproject.
+The schema identifies the valid structure of the ASG, required and optional properties, and expected types.
+
+== Run tests
+
+The schema is tested by the test suite in this subproject using the https://github.com/ajv-validator/ajv[Ajv JSON schema validator].
+To run the tests, you first need to install the required dependencies:
+
+ $ npm ci
+
+To run the self test suite, invoke the npm `test` task:
+
+ $ npm t
+
+== Validate output files
+
+The TCK asserts that the ASG that an implementation produces the expected ASG for a given AsciiDoc input document.
+You can validate those expected output files using the npm `validate` task:
+
+ $ npm run validate --dir=/path/to/tests
+
+The task will automatically select files that end with _-output.json_ and validate them against the ASG schema.
+
+You can also validate a single file using the `validate-asg` bin script:
+
+ $ npx validate-asg test/fixtures/sample-1.json
+
+The source of the validate-asg bin script can be found at _bin/validate-asg.js_.

--- a/ref/asciidoc-lang/asg/bin/validate-asg.js
+++ b/ref/asciidoc-lang/asg/bin/validate-asg.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import Ajv from 'ajv/dist/2020.js'
+import defaultsKeyword from '../lib/ajv-keyword-defaults.js'
+import fs from 'node:fs'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+
+const options = {
+  out: { type: 'boolean', desc: 'output the validated and compiled data' },
+  'validate-schema': { type: 'boolean', desc: 'validate the schema' },
+}
+const { positionals, values } = parseArgs({ args: process.argv.slice(2), options, allowPositionals: true, strict: true })
+const ajv = new Ajv({ allErrors: false, discriminator: true, keywords: [defaultsKeyword()] })
+const schema = JSON.parse(fs.readFileSync('schema.json'))
+if (values['validate-schema']) ajv.validateSchema(schema)
+const validate = ajv.compile(schema)
+const inputFile = positionals[0] || 'sample-1.json'
+let data = JSON.parse(fs.readFileSync(inputFile))
+if (Array.isArray(data)) {
+  const inlines = data
+  data = {
+    name: 'document',
+    type: 'block',
+    blocks: [{ name: 'paragraph', type: 'block', inlines }]
+  }
+  if (inlines.length) {
+    const location = [inlines[0].location[0], inlines[inlines.length - 1].location[1]]
+    data.location = location
+    data.blocks[0].location = location
+  }
+}
+if (!validate(data)) {
+  console.log(inputFile)
+  console.dir(validate.errors[0], { depth: Infinity })
+}
+if (values.out) console.dir(data, { depth: Infinity })

--- a/ref/asciidoc-lang/asg/lib/ajv-keyword-defaults.js
+++ b/ref/asciidoc-lang/asg/lib/ajv-keyword-defaults.js
@@ -1,0 +1,12 @@
+export default function getDef () {
+  return {
+    keyword: 'defaults',
+    type: 'object',
+    schemaType: 'object',
+    modifying: true,
+    valid: true,
+    compile: (defaults) => (data) => {
+      for (const [name, val] of Object.entries(defaults)) data[name] ??= val
+    },
+  }
+}

--- a/ref/asciidoc-lang/asg/package.json
+++ b/ref/asciidoc-lang/asg/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "asciidoc-asg",
+  "description": "Maintains and tests the JSON schema for the AsciiDoc ASG",
+  "type": "module",
+  "bin": {
+    "validate-asg": "bin/validate-asg.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    "./schema.js": "./schema.js"
+  },
+  "scripts": {
+    "test": "node --test test/*-test.js",
+    "validate": "find $npm_config_dir -name '*-output.json' -exec node bin/validate-asg.js {} \\;"
+  },
+  "dependencies": {
+    "ajv": "latest"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/ref/asciidoc-lang/asg/schema.js
+++ b/ref/asciidoc-lang/asg/schema.js
@@ -1,0 +1,3 @@
+import fs from 'node:fs'
+
+export default JSON.parse(fs.readFileSync('./schema.json'))

--- a/ref/asciidoc-lang/asg/schema.json
+++ b/ref/asciidoc-lang/asg/schema.json
@@ -1,0 +1,496 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.asciidoc.org/asg/1-0-0/draft-01",
+  "title": "AsciiDoc Abstract Semantic Graph (ASG)",
+  "description": "A structured representation of the semantics in an AsciiDoc document, primarily used for validating the compliance of an AsciiDoc processor.",
+  "type": "object",
+  "required": ["name", "type"],
+  "defaults": { "blocks": [] },
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "const": "document"
+    },
+    "type": {
+      "type": "string",
+      "const": "block"
+    },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_][-a-zA-Z0-9_]*$": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "#/$defs/inlines" },
+        "authors": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/author" },
+          "minItems": 1
+        },
+        "location": { "$ref": "#/$defs/location" }
+      }
+    },
+    "blocks": { "$ref": "#/$defs/sectionBody" },
+    "location": { "$ref": "#/$defs/location" }
+  },
+  "if": {
+    "required": ["header"]
+  },
+  "then": {
+    "required": ["attributes"]
+  },
+  "$defs": {
+    "abstractBlock": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "title": { "$ref": "#/$defs/inlines" },
+        "reftext": { "$ref": "#/$defs/inlines" },
+        "metadata": { "$ref": "#/$defs/blockMetadata" },
+        "location": { "$ref": "#/$defs/location" }
+      }
+    },
+    "abstractHeading": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "required": ["title", "level"],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "abstractListItem": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "required": ["marker"],
+      "defaults": { "blocks": [] },
+      "properties": {
+        "marker": {
+          "type": "string"
+        },
+        "principal": { "$ref": "#/$defs/inlines" },
+        "blocks": { "$ref": "#/$defs/nonSectionBlockBody" }
+      }
+    },
+    "sectionBody": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/$defs/block" },
+          { "$ref": "#/$defs/section" }
+        ]
+      }
+    },
+    "nonSectionBlockBody": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/block" }
+    },
+    "section": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractHeading" }],
+      "unevaluatedProperties": false,
+      "required": ["name"],
+      "defaults": { "blocks": [] },
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "section"
+        },
+        "blocks": { "$ref": "#/$defs/sectionBody" }
+      }
+    },
+    "block": {
+      "type": "object",
+      "discriminator": { "propertyName": "name" },
+      "oneOf": [
+        { "$ref": "#/$defs/list" },
+        { "$ref": "#/$defs/dlist" },
+        { "$ref": "#/$defs/discreteHeading" },
+        { "$ref": "#/$defs/break" },
+        { "$ref": "#/$defs/blockMacro" },
+        { "$ref": "#/$defs/leafBlock" },
+        { "$ref": "#/$defs/parentBlock" }
+      ]
+    },
+    "list": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "marker", "variant", "items"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "list"
+        },
+        "marker": {
+          "type": "string"
+        },
+        "variant": {
+          "type": "string",
+          "enum": ["callout", "ordered", "unordered"]
+        },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/listItem" },
+          "minItems": 1
+        }
+      }
+    },
+    "dlist": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "marker", "items"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "dlist"
+        },
+        "marker": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/dlistItem" },
+          "minItems": 1
+        }
+      }
+    },
+    "listItem": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractListItem" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "principal"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "listItem"
+        }
+      }
+    },
+    "dlistItem": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractListItem" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "terms"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "dlistItem"
+        },
+        "terms": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/inlines" },
+          "minItems": 1
+        }
+      }
+    },
+    "discreteHeading": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractHeading" }],
+      "unevaluatedProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "heading"
+        }
+      }
+    },
+    "break": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "variant"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "break"
+        },
+        "variant": {
+          "type": "string",
+          "enum": ["page", "thematic"]
+        }
+      }
+    },
+    "blockMacro": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractBlock" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "form"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["audio", "video", "image", "toc"]
+        },
+        "form": {
+          "type": "string",
+          "const": "macro"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    },
+    "leafBlock": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/abstractBlock" },
+        {
+          "if": {
+            "required": ["form"],
+            "properties": { "form": { "const": "delimited" } }
+          },
+          "then": {
+            "required": ["delimiter"],
+            "properties": {
+              "delimiter": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false,
+      "required": ["name"],
+      "defaults": { "inlines": [] },
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["listing", "literal", "paragraph", "pass", "stem", "verse"]
+        },
+        "form": {
+          "type": "string",
+          "enum": ["delimited", "indented", "paragraph"]
+        },
+        "inlines": { "$ref": "#/$defs/inlines" }
+      }
+    },
+    "parentBlock": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/abstractBlock" },
+        {
+          "if": {
+            "required": ["name"],
+            "properties": { "name": { "const": "admonition" } }
+          },
+          "then": {
+            "required": ["variant"],
+            "properties": {
+              "variant": {
+                "type": "string",
+                "enum": ["caution", "important", "note", "tip", "warning"]
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false,
+      "required": ["name", "form", "delimiter"],
+      "defaults": { "blocks": [] },
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["admonition", "example", "sidebar", "open", "quote"]
+        },
+        "form": {
+          "type": "string",
+          "const": "delimited"
+        },
+        "delimiter": {
+          "type": "string"
+        },
+        "blocks": { "$ref": "#/$defs/nonSectionBlockBody" }
+      }
+    },
+    "blockMetadata": {
+      "type": "object",
+      "defaults": { "attributes": {}, "options": [], "roles": [] },
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(?:[a-zA-Z_][a-zA-Z0-9_-]*|\\$[1-9][0-9]*)$": {
+              "type": "string"
+            }
+          }
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": { "$ref": "#/$defs/location" }
+      }
+    },
+    "inlines": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/inline" }
+    },
+    "inline": {
+      "type": "object",
+      "discriminator": { "propertyName": "name" },
+      "oneOf": [
+        { "$ref": "#/$defs/inlineSpan" },
+        { "$ref": "#/$defs/inlineRef" },
+        { "$ref": "#/$defs/inlineLiteral" }
+      ]
+    },
+    "abstractParentInline": {
+      "type": "object",
+      "required": ["type", "inlines"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "inline"
+        },
+        "inlines": { "$ref": "#/$defs/inlines" },
+        "location": { "$ref": "#/$defs/location" }
+      }
+    },
+    "inlineSpan": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractParentInline" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "variant", "form"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "span"
+        },
+        "variant": {
+          "type": "string",
+          "enum": ["strong", "emphasis", "code", "mark"]
+        },
+        "form": {
+          "type": "string",
+          "enum": ["constrained", "unconstrained"]
+        }
+      }
+    },
+    "inlineRef": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/$defs/abstractParentInline" }],
+      "unevaluatedProperties": false,
+      "required": ["name", "variant", "target"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "const": "ref"
+        },
+        "variant": {
+          "type": "string",
+          "enum": ["link", "xref"]
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    },
+    "inlineLiteral": {
+      "type": "object",
+      "required": ["name", "type", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["text", "charref", "raw"]
+        },
+        "type": {
+          "type": "string",
+          "const": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "location": { "$ref": "#/$defs/location" }
+      }
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fullname": {
+          "type": "string"
+        },
+        "initials": {
+          "type": "string"
+        },
+        "firstname": {
+          "type": "string"
+        },
+        "middlename": {
+          "type": "string"
+        },
+        "lastname": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        }
+      }
+    },
+    "location": {
+      "type": "array",
+      "prefixItems": [
+        { "$ref": "#/$defs/locationBoundary" },
+        { "$ref": "#/$defs/locationBoundary" }
+      ],
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "locationBoundary": {
+      "type": "object",
+      "required": ["line", "col"],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "col": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "file": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/ref/asciidoc-lang/asg/test/fixtures/sample-1.json
+++ b/ref/asciidoc-lang/asg/test/fixtures/sample-1.json
@@ -1,0 +1,30 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "list",
+      "type": "block",
+      "variant": "unordered",
+      "marker": "*",
+      "items": [
+        {
+          "name": "listItem",
+          "type": "block",
+          "marker": "*",
+          "principal": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "water",
+              "location": [ { "line": 1, "col": 3 }, { "line": 1, "col": 7 } ]
+            }
+          ],
+          "location": [ { "line": 1, "col": 1 }, { "line": 1, "col": 7 } ]
+        }
+      ],
+      "location": [ { "line": 1, "col": 1 }, { "line": 1, "col": 7 } ]
+    }
+  ],
+  "location": [ { "line": 1, "col": 1 }, { "line": 1, "col": 7 } ]
+}

--- a/ref/asciidoc-lang/asg/test/fixtures/sample-2.json
+++ b/ref/asciidoc-lang/asg/test/fixtures/sample-2.json
@@ -1,0 +1,32 @@
+{
+  "name": "document",
+  "type": "block",
+  "attributes": { "set-attribute": "foo", "unset-attribute": false },
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Document Title",
+        "location": [{ "line": 1, "col": 3 }, { "line": 1, "col": 16 }]
+      }
+    ],
+    "location": [{ "line": 1, "col": 1 }, { "line": 1, "col": 16 }]
+  },
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "body",
+          "location": [{ "line": 3, "col": 1 }, { "line": 3, "col": 4 }]
+        }
+      ],
+      "location": [{ "line": 3, "col": 1 }, { "line": 3, "col": 4 }]
+    }
+  ],
+  "location": [{ "line": 1, "col": 1 }, { "line": 3, "col": 4 }]
+}

--- a/ref/asciidoc-lang/asg/test/fixtures/sample-3.json
+++ b/ref/asciidoc-lang/asg/test/fixtures/sample-3.json
@@ -1,0 +1,26 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "heading",
+      "type": "block",
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Discrete Heading",
+          "location": [{ "line": 2, "col": 4 }, { "line": 2, "col": 19 }]
+        }
+      ],
+      "level": 1,
+      "unknown": "value",
+      "location": [{ "line": 2, "col": 1 }, { "line": 2, "col": 19 }],
+      "metadata": {
+        "attributes": { "$1": "discrete", "style": "discrete" },
+        "location": [{ "line": 1, "col": 1 }, { "line": 1, "col": 10 }]
+      }
+    }
+  ],
+  "location": [{ "line": 1, "col": 1 }, { "line": 2, "col": 19 }]
+}

--- a/ref/asciidoc-lang/asg/test/schema-test.js
+++ b/ref/asciidoc-lang/asg/test/schema-test.js
@@ -1,0 +1,46 @@
+import Ajv from 'ajv/dist/2020.js'
+import defaultsKeyword from '../lib/ajv-keyword-defaults.js'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
+import ospath from 'node:path'
+import { before, describe, it } from 'node:test'
+import schema from 'asciidoc-asg/schema.js'
+
+describe('asg schema', () => {
+  let ajv
+  let fixturesDir = ospath.join(ospath.dirname(fileURLToPath(import.meta.url)), 'fixtures')
+
+  before(() => {
+    ajv = new Ajv({ allErrors: false, discriminator: true, keywords: [defaultsKeyword()] })
+  })
+
+  it('should be valid', () => {
+    assert.ok(ajv.validateSchema(schema))
+  })
+
+  it('should compile', () => {
+    assert.doesNotThrow(() => ajv.compile(schema))
+  })
+
+  it('should validate sample data with list', () => {
+    const fixturePath = ospath.join(fixturesDir, 'sample-1.json')
+    const data = JSON.parse(fs.readFileSync(fixturePath))
+    const validate = ajv.getSchema(schema.$id) || ajv.compile(schema)
+    assert.ok(validate(data))
+  })
+
+  it('should validate sample data with header and paragraph', () => {
+    const fixturePath = ospath.join(fixturesDir, 'sample-2.json')
+    const data = JSON.parse(fs.readFileSync(fixturePath))
+    const validate = ajv.getSchema(schema.$id) || ajv.compile(schema)
+    assert.ok(validate(data))
+  })
+
+  it('should validate sample data with unknown property', () => {
+    const fixturePath = ospath.join(fixturesDir, 'sample-3.json')
+    const data = JSON.parse(fs.readFileSync(fixturePath))
+    const validate = ajv.getSchema(schema.$id) || ajv.compile(schema)
+    assert.ok(!validate(data))
+  })
+})


### PR DESCRIPTION
Imports the AsciiDoc Language project's `asg/` folder into the existing reference snapshot at `ref/asciidoc-lang`, and records what the schema says in the inline-AST design doc. This is the "we may revisit importing them later" revisit that [`ref/asciidoc-lang/README.md`](../blob/inline-ast/ref/asciidoc-lang/README.md) called for, for `asg/` only — `spec/` is still not imported.

No `to_asg()` implementation here; this is only about getting the schema and its answers into the repo.

## The snapshot

Taken at the commit the snapshot is already pinned to, `d335f56572b656a7c9f84a5e0c76ea6f41f281e1`, not upstream `main`, so the whole snapshot stays at one revision. As it happens the two are identical for this folder: upstream has four commits on `main` since the pinned revision and **none of them touch `asg/`** (`git log d335f56..origin/main -- asg/` is empty), so there is no newer `schema.json` to consider and no reason to run the README's four-step refresh procedure.

All 11 upstream files are copied verbatim (`diff -r` clean), including the Node harness (`package.json`, `bin/`, `lib/`, `test/`) so the snapshot matches upstream exactly. Nothing here runs `npm`.

`track_file!` markers are untouched and `sdd` was not run — `sdd/src/main.rs:25` only walks `ref/asciidoc-lang/docs/modules`, and nothing in `asg/` is an `.adoc` page under it.

## Licensing

Checked rather than assumed. Upstream `asg/` has **no `LICENSE` file of its own and no per-file license headers** (`grep -rniE 'licen[cs]e|spdx|copyright' asg/` is empty). The CC-BY-4.0 grant does not reach it:

- `docs/LICENSE` scopes itself to "Content under this directory".
- `NOTICE.adoc` confines CC-BY-4.0 to "The end user documentation content for the AsciiDoc Language", and declares `SPDX-License-Identifier: EPL-2.0` for "This technology specification and its accompanying materials".
- The root `README.adoc` describes the same split.

So `asg/` is **EPL-2.0**, and the README's License section now states that with the reasoning.

## The notes

New `#### Notes for `Document::to_asg()`` subsection in §3.5 of `docs/design/inline-ast-architecture.md`, quoting the schema fragments. Heading level is `####`, not `##` as the request wrote it — §3.5 is a `###`, and a `##` there would have closed §3 and started a new top-level section. It matches the existing unnumbered `#### The escaping pass, and where escaped form stops`.

The headline finding is negative and **invalidates a row of §3.5's projection table**:

> **An `inlineSpan` cannot carry a role — nor an id, nor attributes.** Its evaluated property set is exactly `type`, `inlines`, `location`, `name`, `variant`, `form`, closed by `"unevaluatedProperties": false`. `roles` exists only at block level under `blockMetadata`, reachable through `abstractBlock.metadata`.

Since `variant` is also a closed enum (`strong` | `emphasis` | `code` | `mark`), there is **no ASG-legal node for superscript or subscript at all**, so §3.5's "`span` with a role" mapping for `Styled{Superscript, Subscript}` is not implementable. The subsection reopens it as a question (unwrap and lose the distinction / emit an out-of-enum `variant` / wait for the schema) rather than leaving a row that reads as decided. `Styled{Unquoted}` and `Ref::roles`/`Ref::window` hit the same wall.

The other four answers:

- **`type` beside `name`:** yes, required on every node, three values — `"block"` (root, every block, `section`, `listItem`, `dlistItem`), `"inline"` (`inlineSpan`, `inlineRef`), `"string"` (`inlineLiteral`). `name` is the union discriminator; `type` is the coarse category. `inlineLiteral`'s three names are exactly `text` / `charref` / `raw`, confirming §3.4's trichotomy.
- **`id`:** block-only, on `abstractBlock`. No inline node has one and none can gain one. An inline anchor's id therefore belongs to the enclosing block — `Anchor` has no ASG representation. `inlineRef`/`xref` models pointing *at* an id, but nothing declares one.
- **`location`:** a two-element array (`prefixItems` + `minItems`/`maxItems` both 2). `line` (1-based) and `col` (0-allowed) required, `file` optional and an **array of strings**, not a string. Optional on every node. End boundary is *inclusive* of the last character (`* water` → `col 1`–`col 7`), which maps onto `Span` without a new type.
- **Block names:** full table with required fields and child-collection names — `section`, `heading` (not `discreteHeading`), the six `leafBlock` names, the five `parentBlock` names, `list`/`listItem`/`dlist`/`dlistItem`, `break`, and the four `blockMacro` names. Plus traps: **there is no table block**; `listItem`/`dlistItem` are not in the `block` union; sections nest only in `sectionBody`; block `title`/`reftext` are `inlines` arrays, not strings.

Two loose ends recorded as loose ends:

- **How an unset document attribute is encoded is unsettled upstream.** The schema says `string` or `null`; upstream's own supposedly-valid fixture `sample-2.json` writes `"unset-attribute": false`. Running the pinned revision's `npm test` fails that case with `must be string` at `/attributes/unset-attribute` — so the draft contradicts itself here and we should not read either form as settled.
- **`defaults` is not a JSON Schema keyword** — it is a custom, data-modifying Ajv keyword in `asg/lib/ajv-keyword-defaults.js`. It means omitting an empty `blocks`/`inlines` and emitting `[]` are equally conformant.

The schema `$id` is `https://schemas.asciidoc.org/asg/1-0-0/draft-01` — a draft, and several of the findings above show it.

## Preflight

Docs and reference data only; no Rust source changed, so the Rust preflight steps do not apply. Verified: `diff -r` against upstream is clean, all new relative links in both files resolve, and `sdd`'s walk root is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
