### PR TITLE
doc: Audit the phase exit gates and record what each one still needs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,10 +120,11 @@ rather than guessing:
    `Document::to_asg()` are recorded as *not being built* (the latter by §6's decision 7 — the
    ASG schema is a parked 2023 draft that cannot express the crate's inline vocabulary; see
    §3.5). **A ticked step list is not a met exit gate**, though, and the two are easy to
-   conflate: Phases 2, 3 and 4 are all still marked 🔶 *In progress*, and at least one gate
-   item is demonstrably outstanding — Phase 3's *Exit:* requires the README's security section
-   to gain its `Raw`-node anchor, and `README.md` does not mention `Raw` at all. Read each
-   phase's own *Exit:* line; do not infer a phase is done from its step ticks.
+   conflate. §5.2's **"Exit-gate audit (2026-08-29)"** records the current state criterion by
+   criterion: every one of Phases 2–5 still has something outstanding, the two substantial ones
+   being the xref template mechanism (§4.2's third sentinel system, still live in production)
+   and the `asciidoctor`-port review, which gates Phase 3 and Landing alike. Start from that
+   table rather than inferring completion from step ticks, and re-run it if it has aged.
 2. **The "what still defers" sentence** in the newest landed-as note — those are the increments
    already named and sized.
 3. **The observed rate.** Every increment so far is one branch, one PR, one session, so an increment

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -11591,7 +11591,7 @@ failed**, 68 ignored.
 
 | Phase | Criterion | Verdict | Evidence |
 | ----- | --------- | ------- | -------- |
-| 2 | ~277 golden `.rendered()` assertions pass unchanged | ✅ | Suite green; 324 `rendered_html()` and 173 `rendered_html_content()` call sites, asserted strings untouched by the §5.3 rename. |
+| 2 | ~277 golden `.rendered()` assertions pass unchanged | ✅ | Suite green, and the §5.3 rename left every asserted string untouched. The renamed accessors have 324 `.rendered_html()` and 173 `.rendered_html_content()` call sites (`git grep -cF` at `25ad4070`). Those are *accessor call sites*, not a recount of §5.3's ~277 golden assertions — most are ordinary reads rather than golden string comparisons — so they evidence the rename's reach, not the size of the oracle. |
 | 2 | sentinels deleted | ⚠️ **2 of 3** | See below. |
 | 2 | benchmarks within an agreed budget of `main` | ❓ **no budget on record** | CodSpeed reports no alteration across 5 benchmarks, but no *agreed budget* is written down anywhere in this document, so the criterion cannot be checked as stated. |
 | 3 | node vocabulary reviewed against the `asciidoctor` port's needs (§6.6) | ❌ **not started, and gated on Landing** | See below. |

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -918,7 +918,8 @@ with a `&mut String`" to "called by the fold with a node"). This is an accepted 
 break. The method *set* is largely preserved, so a downstream implementer's mental model
 survives; the `*RenderParams` structs are replaced by (or become borrowed views of) the
 corresponding node types. The **naming** half of that break has landed (see the Decision
-below); the signature reshape has not.
+below); the signature reshape is under way — seven of the eight `*RenderParams` structs are
+retired (#1327, #1328, #1330), leaving `XrefRenderParams`.
 
 > **Decision (Phase 5): rename the trait to `InlineRenderer`.** ✅ **Landed.** The word
 > "substitution" names the very mechanism this work removes — post-migration the trait is no
@@ -11576,6 +11577,79 @@ Phases 1–2 are the risk-bearing core; 3–5 are additive and can be paced agai
 demand (echoing the #943/#944 "pin the API with a real consumer" discipline). All of them
 land together in the single merge to `main` — the pacing is *within* the branch, not
 staggered submissions to `main`.
+
+#### Exit-gate audit (2026-08-29)
+
+Every phase above carries an *Exit:* line, and the step lists had drifted far enough ahead of
+them that "the steps are ticked" was being read as "the phase is done". They are not the same
+claim. This is a pass over each outstanding gate, criterion by criterion, against the tree at
+`25ad4070`. **No phase is marked done by this audit** — none passes cleanly — and the marker
+on each bullet above is left as it stands.
+
+Suite state at the time of the audit: `cargo test --workspace` green, **5,482 passed, 0
+failed**, 68 ignored.
+
+| Phase | Criterion | Verdict | Evidence |
+| ----- | --------- | ------- | -------- |
+| 2 | ~277 golden `.rendered()` assertions pass unchanged | ✅ | Suite green; 324 `rendered_html()` and 173 `rendered_html_content()` call sites, asserted strings untouched by the §5.3 rename. |
+| 2 | sentinels deleted | ⚠️ **2 of 3** | See below. |
+| 2 | benchmarks within an agreed budget of `main` | ❓ **no budget on record** | CodSpeed reports no alteration across 5 benchmarks, but no *agreed budget* is written down anywhere in this document, so the criterion cannot be checked as stated. |
+| 3 | node vocabulary reviewed against the `asciidoctor` port's needs (§6.6) | ❌ **not started, and gated on Landing** | See below. |
+| 3 | purely-structural navigation sugar kept minimal | ✅ | The `inlines` module exposes no navigation helpers at all — no `walk`, `descendants`, `children`, `iter`, `visit`, or `find`; the node types are plain public fields (§3.2's sketch). Minimal by construction. |
+| 3 | doc + README updated (the security section gets its `Raw`-node anchor) | ❌ | [`README.md`](../../README.md)'s "Security: rendering untrusted input" section names the two by-design raw-HTML mechanisms (attribute-reference substitution and passthroughs) but never mentions `Raw`, `InlineNode`, or the tree. The anchor the gate asks for does not exist. |
+| 4 | #944 hard-case policies documented and tested | ⚠️ **tested, not documented** | Spans are asserted per-construct across ten `inline_builder` modules. But §4.4 only *promises* the four hard cases "get explicit policies there" — attribute expansion, passthrough mask/restore, synthesized text, lookahead/retry are nowhere written down as policies, and there is no consolidated span/location test file. |
+| 4 | #564 hack removed | ✅ | Landed in step 7; `Content::source_lines`, `from_filtered_lines`'s `line_spans`, and `simple.rs`'s per-paragraph `Vec<Span>` went with it. |
+| 5 | seam documented | ⚠️ | [`README.md`](../../README.md)'s back-end bullet is current: it names `InlineRenderer` and `Content::render_with` and states the seam is *inline*-scoped. §4.6's own prose is stale, though — see below. |
+| 5 | a smoke-test alternate renderer (in tests) walks the tree | ✅ | `BracketStrong` in [`inline_builder_document_parity.rs`](../../parser/src/tests/inline_builder_document_parity.rs) is folded via `content.render_with(&BracketStrong, &parser)`; `OrdinalRenderer` and `FlipRenderer` in [`inline_tree.rs`](../../parser/src/tests/inline_tree.rs) do the same. |
+
+##### Phase 2's third sentinel system is still live
+
+§4.2 names three. Two are gone:
+
+- **Footnote markers** (`\u{E002}`/`\u{E003}`) — deleted, and
+  [`content.rs`](../../parser/src/content/content.rs)'s `is_reserved_sentinel` documents the
+  absence and its cause: the section-title path derives a heading's reference text by folding
+  its inline subtree instead.
+- **Passthroughs** (`\u{96}`/`\u{97}`) — the mechanism is node-based;
+  [`passthroughs.rs`](../../parser/src/content/passthroughs.rs) works in terms of `InlineNode`
+  and `RawOrigin`, and `Content::passthroughs()` is the filtered view over the tree that §4.2
+  predicted. No production code emits the codepoints any more; `PASSTHROUGH_PLACEHOLDER_START`
+  / `_END` survive only as entries in `RESERVED_SENTINELS` and `is_reserved_sentinel`, i.e. the
+  escaping pass still reserves two codepoints nothing produces.
+
+The third has **not** been retired. `XREF_PLACEHOLDER_START` / `_END` are produced (a
+`format!` over the placeholder index) and consumed (`render_template`) in production, because
+one case remains that cannot be a fold: a block whose inline nodes are dropped carries a
+template synthesized from `carried_title_template`, and renders through
+`render_xref_template`. The code says so in as many words. Retiring it is a real increment,
+not a bookkeeping fix, and it is what stands between Phase 2 and its exit gate.
+
+##### Phase 3's first criterion cannot close before Landing
+
+"Node vocabulary reviewed against the `asciidoctor` port's needs (§6.6)" and Landing's
+"`asciidoctor`-port preflight green" are the same activity at two different gates. §6.6 names
+the port as the consumer that pins the API, but nothing in this document records that review
+having happened, and the port is a separate project whose state this audit did not survey.
+Phase 3 therefore cannot be closed on the branch's own evidence — either the review runs early
+(and Phase 3 closes ahead of Landing), or the criterion is acknowledged as deferred *into*
+Landing. That choice is a decision for the maintainer, not something an audit can settle, and
+it is the single largest unknown in any estimate of what remains.
+
+##### §4.6's prose is stale
+
+§4.6 says "the **naming** half of that break has landed …; the signature reshape has not."
+That was true when written and is no longer: seven of the eight `*RenderParams` structs are
+gone (#1327, #1328, #1330), leaving only `XrefRenderParams`. The sentence is corrected
+in place by this audit; the remaining struct is Phase 5's own outstanding work.
+
+##### What this means for "how much further"
+
+Firm, enumerated, and cheap: Phase 3's README `Raw`-node anchor; Phase 4's four hard-case
+policies written down; §4.6's stale sentence (done here). Firm and substantial: retiring the
+xref template mechanism (Phase 2), and the last `XrefRenderParams` fold (Phase 5). Open-ended:
+the `asciidoctor`-port review, which gates both Phase 3 and Landing and whose cost is unknown
+from inside this repository. Any session count that does not separate those three tiers is
+guessing.
 
 ### 5.3 The golden-HTML oracle (the safety net)
 


### PR DESCRIPTION
Runs the exit-gate audit that #1332's Greptile exchange showed was needed, and records the result as a new **"Exit-gate audit (2026-08-29)"** subsection in §5.2. Docs only; no Rust changed.

## Why

§5.2's step lists had drifted ahead of the phases' own `*Exit:*` lines far enough that a ticked step list was being read as a met gate — a conflation I made in #1332 and Greptile caught. This walks every outstanding criterion against the tree at `25ad4070`.

**No phase is marked done.** None of Phases 2–5 passes cleanly, so every 🔶 marker is left exactly as it stands. Six criteria pass, three are partial, two fail, and one cannot be checked as written.

## The substantial findings

**§4.2's third sentinel system is still live.** Two of the three are genuinely retired — footnote markers (`\u{E002}`/`\u{E003}`) are deleted, and `content.rs`'s `is_reserved_sentinel` documents both the absence and its cause; passthroughs are node-based, with `passthroughs.rs` working in `InlineNode`/`RawOrigin` and `Content::passthroughs()` serving as the filtered tree view §4.2 predicted. Their codepoints now survive only as entries the escaping pass reserves but nothing produces. The **deferred-xref template has not been retired**: `XREF_PLACEHOLDER_START`/`_END` are produced and consumed in production for the one case that cannot be a fold — a block whose inline nodes are dropped, rendering from a `carried_title_template` through `render_xref_template`. That is a real increment, and it is what stands between Phase 2 and its gate.

**Phase 3's first criterion cannot close before Landing.** "Node vocabulary reviewed against the `asciidoctor` port's needs (§6.6)" and Landing's "`asciidoctor`-port preflight green" are the same activity at two different gates, and nothing in the document records the review having happened. Either it runs early and Phase 3 closes ahead of Landing, or the criterion is acknowledged as deferred *into* Landing — a maintainer decision an audit can't settle, and the largest unknown in any remaining-work estimate.

**Two cheap gaps.** Phase 3's README `Raw`-node anchor does not exist — the security section names the two by-design raw-HTML mechanisms but never mentions `Raw`, `InlineNode`, or the tree. Phase 4's four #944 hard cases (attribute expansion, passthrough mask/restore, synthesized text, lookahead/retry) are exercised per-construct across ten `inline_builder` modules but never written down as policies; §4.4 only promises them.

**One criterion is uncheckable as written.** Phase 2's "benchmarks within an agreed budget of `main`" — CodSpeed reports no alteration across 5 benchmarks, but no agreed budget is recorded anywhere, so there is nothing to check against.

## Also corrected

§4.6 still said "the signature reshape has not [landed]". Seven of the eight `*RenderParams` structs are retired (#1327, #1328, #1330), leaving only `XrefRenderParams` — that sentence is fixed in place. `CLAUDE.md`'s estimating guidance now points at the audit table rather than restating a single example.

## Preflight

Docs only; no Rust source changed, so the Rust preflight steps don't apply. `cargo test --workspace` was run to establish the audit's own evidence: **green, 5,482 passed, 0 failed, 68 ignored**. All five relative links in the new section resolve, heading nesting is correct (the `####` sits inside §5.2, ahead of §5.3), and no setext-heading hazards were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
