### PR TITLE
chore: Reformat for the 2026-08-29 nightly rustfmt

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -198,9 +198,10 @@ impl<'src> Attrlist<'src> {
                 attrlist_context,
             );
 
-            // Because we do attribute value substitution early on in parsing, we can't
-            // pinpoint the exact location of warnings in an attribute list. For that
-            // reason, individual attribute parsing only returns the warning type and we
+            // Because we do attribute value substitution early on in parsing,
+            // we can't pinpoint the exact location of warnings in
+            // an attribute list. For that reason, individual
+            // attribute parsing only returns the warning type and we
             // then map it back to the entire attrlist source.
             for warning_type in warning_types {
                 warnings.push(Warning::new(source, warning_type));
@@ -219,8 +220,8 @@ impl<'src> Attrlist<'src> {
             // A completely empty (or whitespace-only) attribute list: the first
             // entry is an empty, *unquoted* positional with nothing after it.
             // Yield no attributes. An explicit empty *quoted* positional
-            // (`""` / `''`) carries a value and is kept below, so it is excluded
-            // here by `!attr.value_is_quoted()`.
+            // (`""` / `''`) carries a value and is kept below, so it is
+            // excluded here by `!attr.value_is_quoted()`.
             if attr.name().is_none()
                 && attr.value().is_empty()
                 && !attr.value_is_quoted()
@@ -231,9 +232,9 @@ impl<'src> Attrlist<'src> {
             }
 
             if attr.name().is_some() {
-                // A named attribute whose value is the literal `None` unsets the
-                // attribute (Asciidoctor semantics); it still consumes a
-                // position but is not stored.
+                // A named attribute whose value is the literal `None` unsets
+                // the attribute (Asciidoctor semantics); it
+                // still consumes a position but is not stored.
                 if attr.value() != "None" {
                     attributes.push(attr);
                 }
@@ -258,8 +259,9 @@ impl<'src> Attrlist<'src> {
                     if after.starts_with(',') {
                         warnings.push(Warning::new(source, WarningType::EmptyAttributeValue));
 
-                        // Consume the blank slot between consecutive commas here,
-                        // advancing the position counter past it.
+                        // Consume the blank slot between consecutive commas
+                        // here, advancing the position
+                        // counter past it.
                         entry_number += 1;
                         after = after.discard(1);
                         index = after.byte_offset();
@@ -722,11 +724,12 @@ impl<'src> Attrlist<'src> {
 
         // Asciidoctor's `parse_quoted_text_attributes` considers only the first
         // positional attribute — the source up to the first comma — and uses it
-        // verbatim (quote characters included) as the role. The comma split is on
-        // the raw source, matching Asciidoctor's `str.slice 0, (str.index ',')`,
-        // so a comma *inside* the quotes truncates the role there too (e.g.
-        // `['a,b']` yields the role `'a`) rather than being treated as quoted
-        // content. A quote-delimited first positional always leaves at least its
+        // verbatim (quote characters included) as the role. The comma split is
+        // on the raw source, matching Asciidoctor's `str.slice 0,
+        // (str.index ',')`, so a comma *inside* the quotes truncates
+        // the role there too (e.g. `['a,b']` yields the role `'a`)
+        // rather than being treated as quoted content. A
+        // quote-delimited first positional always leaves at least its
         // opening quote here, so the slice is never empty.
         let raw = self.source_text();
         Some(raw.split_once(',').map_or(raw, |(first, _)| first).trim())
@@ -818,7 +821,8 @@ impl<'src> Attrlist<'src> {
     ///
     /// [`options()`]: Self::options
     pub fn has_option<N: AsRef<str>>(&'src self, name: N) -> bool {
-        // PERF: Might help to optimize away the construction of the options Vec.
+        // PERF: Might help to optimize away the construction of the options
+        // Vec.
         let options = self.options();
         let name = name.as_ref();
         options.contains(&name)
@@ -2658,7 +2662,8 @@ mod tests {
             assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
 
             // Only the first positional (the source up to the first comma) is
-            // considered, mirroring Asciidoctor's `parse_quoted_text_attributes`.
+            // considered, mirroring Asciidoctor's
+            // `parse_quoted_text_attributes`.
             let mi = crate::attributes::Attrlist::parse(
                 crate::Span::new("'role',keep=dropped"),
                 &p,
@@ -2669,9 +2674,9 @@ mod tests {
             assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
 
             // The comma boundary is applied to the raw source, matching
-            // Asciidoctor's `str.slice 0, (str.index ',')`, so a comma inside the
-            // quotes truncates the role there too rather than being kept as
-            // quoted content.
+            // Asciidoctor's `str.slice 0, (str.index ',')`, so a comma inside
+            // the quotes truncates the role there too rather than
+            // being kept as quoted content.
             let mi = crate::attributes::Attrlist::parse(
                 crate::Span::new("'a,b'"),
                 &p,

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -166,9 +166,10 @@ impl<'src> ElementAttribute<'src> {
 
             // Skip any leading, non-semantic whitespace before this entry
             // (Asciidoctor's `skip_blank`). Name detection has to run first, so
-            // without this a name with leading blanks — e.g. `[  first = value]`
-            // or the second/third entries once a comma is consumed — would fail
-            // to be recognized and fall through to a positional literal.
+            // without this a name with leading blanks — e.g. `[  first =
+            // value]` or the second/third entries once a comma is
+            // consumed — would fail to be recognized and fall
+            // through to a positional literal.
             source = source.take_whitespace_with_newline().after;
 
             let (name, after): (Option<Span<'_>>, Span) = match source.take_attr_name() {
@@ -178,11 +179,13 @@ impl<'src> ElementAttribute<'src> {
                         Some(equals) => {
                             let space = equals.after.take_whitespace_with_newline();
 
-                            // `name=` with nothing (or only a comma) after the `=`
-                            // is a named attribute with an empty value, not a
+                            // `name=` with nothing (or only a comma) after the
+                            // `=` is a named
+                            // attribute with an empty value, not a
                             // positional one. The empty value falls out of the
-                            // value scan below (`take_while(c != ',')` yields the
-                            // empty string), so the name is all we need to keep.
+                            // value scan below (`take_while(c != ',')` yields
+                            // the empty string), so
+                            // the name is all we need to keep.
                             (Some(name.item), space.after)
                         }
                         None => (None, source),
@@ -1583,9 +1586,10 @@ mod tests {
         fn named_with_empty_value() {
             let p = Parser::default();
 
-            // `name=` with nothing after the `=` is a named attribute whose value
-            // is the empty string (e.g. `[caption=]` clears a label), not a
-            // positional attribute with the literal value "abc=".
+            // `name=` with nothing after the `=` is a named attribute whose
+            // value is the empty string (e.g. `[caption=]` clears a
+            // label), not a positional attribute with the literal
+            // value "abc=".
             let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
                 &CowStr::from("abc="),
                 0,

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -217,11 +217,12 @@ impl<'src> AdmonitionBlock<'src> {
         }
 
         // Unreachable in practice: `parse_paragraph` is only called after
-        // `admonition_paragraph_prefix` matched, which requires a non-whitespace
-        // character after the label on the first line (trailing whitespace is
-        // trimmed before the match). `content_start` therefore points at
-        // non-empty content, so `SimpleBlock::parse` always returns `Some`. This
-        // fall-through is kept as a defensive default that mirrors
+        // `admonition_paragraph_prefix` matched, which requires a
+        // non-whitespace character after the label on the first line
+        // (trailing whitespace is trimmed before the match).
+        // `content_start` therefore points at non-empty content, so
+        // `SimpleBlock::parse` always returns `Some`. This fall-through
+        // is kept as a defensive default that mirrors
         // `parse_masquerade`.
         MatchAndWarnings {
             item: None,

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -225,9 +225,10 @@ impl<'src> Block<'src> {
         parent_list_markers: Option<&[ListItemMarker<'src>]>,
         is_continuation: bool,
     ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
-        // The span at which the block's content begins, once its metadata (title,
-        // anchor, attribute list) has been read. `parse_internal_inner` fills this
-        // in so an unknown-style diagnostic can anchor at the block's delimiter or
+        // The span at which the block's content begins, once its metadata
+        // (title, anchor, attribute list) has been read.
+        // `parse_internal_inner` fills this in so an unknown-style
+        // diagnostic can anchor at the block's delimiter or
         // first content line rather than at the preceding style-attribute line.
         let mut content_start: Option<Span<'src>> = None;
 
@@ -249,11 +250,13 @@ impl<'src> Block<'src> {
             && let Some(warning) = unknown_block_style_warning(&matched_item.item)
         {
             // Anchor the diagnostic at the block's first content line — the
-            // delimiter of a delimited block, or the opening line of a paragraph
-            // — matching Asciidoctor, which reports `unknown style for …` at that
-            // line rather than at the `[style]` line above it. `content_start` is
-            // always set when a block carries a declared style (that requires an
-            // attribute list, which only the metadata path parses).
+            // delimiter of a delimited block, or the opening line of a
+            // paragraph — matching Asciidoctor, which reports
+            // `unknown style for …` at that line rather than at the
+            // `[style]` line above it. `content_start` is
+            // always set when a block carries a declared style (that requires
+            // an attribute list, which only the metadata path
+            // parses).
             let span = content_start
                 .unwrap_or_else(|| matched_item.item.span())
                 .take_normalized_line()
@@ -273,13 +276,15 @@ impl<'src> Block<'src> {
         is_continuation: bool,
         content_start: &mut Option<Span<'src>>,
     ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
-        // Optimization: If the first line doesn't match any of the early indications
-        // for delimited blocks, titles, or attrlists, we can skip directly to treating
-        // this as a simple block. That saves quite a bit of parsing time.
+        // Optimization: If the first line doesn't match any of the early
+        // indications for delimited blocks, titles, or attrlists, we
+        // can skip directly to treating this as a simple block. That
+        // saves quite a bit of parsing time.
         let first_line = source.take_line().item.discard_whitespace();
 
-        // If it does contain any of those markers, we fall through to the more costly
-        // tests below which can more accurately classify the upcoming block.
+        // If it does contain any of those markers, we fall through to the more
+        // costly tests below which can more accurately classify the
+        // upcoming block.
         if let Some(first_char) = first_line.chars().next()
             && !matches!(
                 first_char,
@@ -314,8 +319,9 @@ impl<'src> Block<'src> {
             let mut warnings = vec![];
             let block = Self::Simple(simple_block);
 
-            // This fast path only handles a metadata-free simple block, so there
-            // is no `[[id,reftext]]` anchor reftext to resolve.
+            // This fast path only handles a metadata-free simple block, so
+            // there is no `[[id,reftext]]` anchor reftext to
+            // resolve.
             Self::register_block_id(
                 block.id(),
                 Self::block_reftext(&block, None).as_deref(),
@@ -331,7 +337,8 @@ impl<'src> Block<'src> {
             };
         }
 
-        // Look for document attributes first since these don't support block metadata.
+        // Look for document attributes first since these don't support block
+        // metadata.
         if first_line.starts_with(':')
             && (first_line.ends_with(':') || first_line.contains(": "))
             && let Some(attr) = Attribute::parse(source, parser)
@@ -348,8 +355,8 @@ impl<'src> Block<'src> {
             };
         }
 
-        // Optimization not possible; start by looking for block metadata (title,
-        // attrlist, etc.).
+        // Optimization not possible; start by looking for block metadata
+        // (title, attrlist, etc.).
         let MatchAndWarnings {
             item: mut metadata,
             mut warnings,
@@ -396,25 +403,28 @@ impl<'src> Block<'src> {
         // Expose the content start (past the metadata) so `parse_internal` can
         // anchor an unknown-style diagnostic at the block's delimiter or first
         // content line. Every block-type dispatch below reads its content from
-        // here, so this is the block's true starting line whichever branch wins.
+        // here, so this is the block's true starting line whichever branch
+        // wins.
         *content_start = Some(metadata.block_start);
 
-        // Resolve attribute references in a `[[id,reftext]]` anchor reftext now,
-        // while the parser still holds the attributes in effect where the anchor
-        // appears. A compound block's body (parsed below) can redefine those
-        // attributes, so deferring this to registration — after the body — would
-        // record the wrong value. The result is threaded into `block_reftext`.
+        // Resolve attribute references in a `[[id,reftext]]` anchor reftext
+        // now, while the parser still holds the attributes in effect
+        // where the anchor appears. A compound block's body (parsed
+        // below) can redefine those attributes, so deferring this to
+        // registration — after the body — would record the wrong value.
+        // The result is threaded into `block_reftext`.
         let anchor_reftext = metadata
             .anchor_reftext
             .as_ref()
             .map(|span| substitute_attributes_in_reftext(*span, parser));
 
         // The `[literal]` block style normally marks a literal *paragraph*,
-        // which is handled directly as a simple (literal) block below, bypassing
-        // the delimited-block parsers. The exception is when `[literal]` is set
-        // on the delimiter line of a structural container, where it masquerades
-        // over that container (e.g. `[literal]` on a `----` listing, on a `....`
-        // literal, or on a `--` open block); those cases must fall through to the
+        // which is handled directly as a simple (literal) block below,
+        // bypassing the delimited-block parsers. The exception is when
+        // `[literal]` is set on the delimiter line of a structural
+        // container, where it masquerades over that container (e.g.
+        // `[literal]` on a `----` listing, on a `....` literal, or on a
+        // `--` open block); those cases must fall through to the
         // delimited-block parsers.
         let is_literal =
             metadata.attrlist.as_ref().and_then(|a| a.block_style()) == Some("literal") && {
@@ -426,8 +436,8 @@ impl<'src> Block<'src> {
 
         // A simple block may be parsed speculatively inside the `!is_literal`
         // branch below (to detect the "metadata with no block" edge case). When
-        // that speculative parse succeeds it is reused as the final result rather
-        // than re-parsed, so that the captioning side effect of
+        // that speculative parse succeeds it is reused as the final result
+        // rather than re-parsed, so that the captioning side effect of
         // `SimpleBlock::parse` (which can consume a caption counter) happens at
         // most once per block.
         let mut simple_block_mi = None;
@@ -578,8 +588,9 @@ impl<'src> Block<'src> {
                 let mut media_block_maw = MediaBlock::parse(&metadata, parser);
 
                 if let Some(mut media_block) = media_block_maw.item {
-                    // Only propagate warnings from media block parsing if we think this
-                    // *is* a media block. Otherwise, there would likely be too many false
+                    // Only propagate warnings from media block parsing if we
+                    // think this *is* a media block.
+                    // Otherwise, there would likely be too many false
                     // positives.
                     if !media_block_maw.warnings.is_empty() {
                         warnings.append(&mut media_block_maw.warnings);
@@ -628,8 +639,9 @@ impl<'src> Block<'src> {
                 let mut toc_block_maw = TocBlock::parse(&metadata, parser);
 
                 if let Some(toc_block) = toc_block_maw.item {
-                    // Only propagate warnings from TOC block parsing if we think
-                    // this *is* a TOC block. Otherwise, there would likely be too
+                    // Only propagate warnings from TOC block parsing if we
+                    // think this *is* a TOC block.
+                    // Otherwise, there would likely be too
                     // many false positives.
                     if !toc_block_maw.warnings.is_empty() {
                         warnings.append(&mut toc_block_maw.warnings);
@@ -663,8 +675,9 @@ impl<'src> Block<'src> {
                 && let Some(mi_section_block) =
                     SectionBlock::parse(&metadata, parser, &mut warnings)
             {
-                // A line starting with `=` or `#` might be some other kind of block, so we
-                // continue quietly if `SectionBlock` parser rejects this block.
+                // A line starting with `=` or `#` might be some other kind of
+                // block, so we continue quietly if
+                // `SectionBlock` parser rejects this block.
 
                 return MatchAndWarnings {
                     item: BlockParseOutcome::Parsed(MatchedItem {
@@ -693,9 +706,10 @@ impl<'src> Block<'src> {
                 };
             }
 
-            // Only try to parse as a new list if we're NOT inside a list item context.
-            // If we are inside a list context, lists can only be created when the first
-            // line is a list item marker (handled above).
+            // Only try to parse as a new list if we're NOT inside a list item
+            // context. If we are inside a list context, lists can
+            // only be created when the first line is a list item
+            // marker (handled above).
             if parent_list_markers.is_none()
                 && let Some(mi_list) = ListBlock::parse(&metadata, parser, &mut warnings)
             {
@@ -708,9 +722,10 @@ impl<'src> Block<'src> {
                 };
             }
 
-            // First, let's look for a fun edge case. Perhaps the text contains block
-            // metadata but no block immediately following. If we're not careful, we could
-            // spin in a loop (for example, `parse_blocks_until`) thinking there will be
+            // First, let's look for a fun edge case. Perhaps the text contains
+            // block metadata but no block immediately following. If
+            // we're not careful, we could spin in a loop (for
+            // example, `parse_blocks_until`) thinking there will be
             // another block, but there isn't.
 
             // The following check disables that spin loop.
@@ -722,16 +737,17 @@ impl<'src> Block<'src> {
 
             if simple_block_mi.is_none() {
                 if !metadata.is_empty() {
-                    // We have a metadata with no block. Treat it as a simple block but issue a
-                    // warning.
+                    // We have a metadata with no block. Treat it as a simple
+                    // block but issue a warning.
 
                     warnings.push(Warning::new(
                         metadata.source,
                         WarningType::MissingBlockAfterTitleOrAttributeList,
                     ));
 
-                    // Remove the metadata content so that SimpleBlock will read the title/attrlist
-                    // line(s) as regular content. The speculative parse failed, so the
+                    // Remove the metadata content so that SimpleBlock will read
+                    // the title/attrlist line(s) as regular
+                    // content. The speculative parse failed, so the
                     // block is re-parsed below with this stripped metadata.
                     metadata.title_source = None;
                     metadata.title = None;
@@ -743,8 +759,9 @@ impl<'src> Block<'src> {
                     // (e.g. a lone empty `[[]]` anchor) that produced no title,
                     // anchor, or attribute list, and no block follows them. The
                     // lines are still consumed, so report the source as dropped
-                    // (resuming at `block_start`) rather than falling through to
-                    // `NoMatch`: a non-blank source left unadvanced would spin
+                    // (resuming at `block_start`) rather than falling through
+                    // to `NoMatch`: a non-blank source left
+                    // unadvanced would spin
                     // the block-collection loop.
                     //
                     // The test is that `block_start` actually moved past the
@@ -764,9 +781,10 @@ impl<'src> Block<'src> {
             }
         }
 
-        // If no other block kind matches, we can always use SimpleBlock. Reuse the
-        // speculative parse from the `!is_literal` branch when it succeeded;
-        // otherwise (a literal block, or metadata stripped above) parse now.
+        // If no other block kind matches, we can always use SimpleBlock. Reuse
+        // the speculative parse from the `!is_literal` branch when it
+        // succeeded; otherwise (a literal block, or metadata stripped
+        // above) parse now.
         let simple_block_mi = match simple_block_mi {
             Some(mi) => Some(mi),
             None => {
@@ -828,9 +846,10 @@ impl<'src> Block<'src> {
 
         // Exclude explicit caption overrides, which are not numbered. This is
         // *not* the same as `block.number().is_none()`: an auto-numbered block
-        // whose context counter holds a non-integer value (e.g. `:figure-number:
-        // A`, rendering "Figure B") also has no bare integer number, yet it is
-        // genuinely numbered and must keep its signifier ("Figure B").
+        // whose context counter holds a non-integer value (e.g.
+        // `:figure-number: A`, rendering "Figure B") also has no bare
+        // integer number, yet it is genuinely numbered and must keep
+        // its signifier ("Figure B").
         if Self::has_caption_override(block, parser) {
             return None;
         }
@@ -916,7 +935,8 @@ impl<'src> Block<'src> {
                     }
                 }
                 Err(_duplicate_error) => {
-                    // If registration fails due to duplicate ID, issue a warning.
+                    // If registration fails due to duplicate ID, issue a
+                    // warning.
                     warnings.push(Warning::new(span, WarningType::DuplicateId(id.to_string())));
                 }
             }
@@ -1262,17 +1282,18 @@ impl<'src> IsBlock<'src> for Block<'src> {
     fn id(&'src self) -> Option<&'src str> {
         // Three variants override the trait default:
         //
-        // * A `MediaBlock` additionally recognizes a named `id=` _inside_ its macro
-        //   attribute list (e.g. `image::sunset.jpg[id=sunset-img]`).
+        // * A `MediaBlock` additionally recognizes a named `id=` _inside_ its
+        //   macro attribute list (e.g. `image::sunset.jpg[id=sunset-img]`).
         //
-        // * A `TocBlock` likewise recognizes a named `id=` _inside_ its macro attribute
-        //   list (e.g. `toc::[id=contents]`).
+        // * A `TocBlock` likewise recognizes a named `id=` _inside_ its macro
+        //   attribute list (e.g. `toc::[id=contents]`).
         //
-        // * A `SectionBlock` falls back to its auto-generated (`_slug`) ID when no
-        //   explicit ID was supplied, so `block.id()` yields the same ID the section is
-        //   registered and cross-referenced under. Delegating here (rather than
-        //   applying the trait default) avoids the footgun of `block.id()` silently
-        //   returning `None` for a section that plainly has an ID.
+        // * A `SectionBlock` falls back to its auto-generated (`_slug`) ID when
+        //   no explicit ID was supplied, so `block.id()` yields the same ID the
+        //   section is registered and cross-referenced under. Delegating here
+        //   (rather than applying the trait default) avoids the footgun of
+        //   `block.id()` silently returning `None` for a section that plainly
+        //   has an ID.
         //
         // Every other variant keeps the trait default (explicit anchor or block
         // attribute list only).
@@ -1456,13 +1477,14 @@ fn unknown_block_style_warning(block: &Block<'_>) -> Option<WarningType> {
     let context = block.raw_context();
     let context = context.as_ref();
 
-    // Only diagnose something that actually looks like a style name. A malformed
-    // attribute list (for example a mangled `[[anchor]`, or a positional whose
-    // value is `-foo = bar`) can leave debris in the first positional slot that
-    // is not a plausible style; reporting it as an "unknown style" would be
-    // noise. Asciidoctor only reaches this check with a properly-parsed style
-    // token, so a value carrying spaces, brackets, or other punctuation is not
-    // one this diagnostic is meant for.
+    // Only diagnose something that actually looks like a style name. A
+    // malformed attribute list (for example a mangled `[[anchor]`, or a
+    // positional whose value is `-foo = bar`) can leave debris in the first
+    // positional slot that is not a plausible style; reporting it as an
+    // "unknown style" would be noise. Asciidoctor only reaches this check
+    // with a properly-parsed style token, so a value carrying spaces,
+    // brackets, or other punctuation is not one this diagnostic is meant
+    // for.
     if !is_plausible_style_name(style) {
         return None;
     }
@@ -1643,9 +1665,9 @@ mod tests {
             // arm with a document that contains one of each block kind, and
             // confirm the forwarded value: none of these blocks acquires an
             // implicit style, so the resolved style equals the declared style
-            // for every one. (The one case where the two differ — a bibliography
-            // list that inherits its style from its section — is covered by the
-            // list block's own tests.)
+            // for every one. (The one case where the two differ — a
+            // bibliography list that inherits its style from its
+            // section — is covered by the list block's own tests.)
             let doc = Parser::default().parse(
                 "= Doc Title\n\nPreamble para.\n\nimage::pic.png[]\n\n'''\n\ntoc::[]\n\n== Section One\n\n:body-attr: x\n\nA paragraph.\n\n* list item\n\n[quote]\n____\nA quote.\n____\n\n[NOTE]\n====\nAn admonition.\n====\n\n----\nlisting\n----\n\n|===\n| cell\n|===\n\n--\nopen block\n--\n",
             );
@@ -1656,8 +1678,8 @@ mod tests {
                 count += 1;
             }
 
-            // Guard against the document silently parsing into fewer blocks than
-            // the variants it is meant to cover.
+            // Guard against the document silently parsing into fewer blocks
+            // than the variants it is meant to cover.
             assert!(
                 count >= 14,
                 "expected the sample document to yield every block variant, saw {count} blocks"

--- a/parser/src/blocks/caption.rs
+++ b/parser/src/blocks/caption.rs
@@ -128,10 +128,11 @@ pub(crate) fn assign_caption(
     explicit_caption: Option<&str>,
 ) -> Option<Caption> {
     // An untitled block is never captioned or counted. Likewise, captioning
-    // applies only to captionable contexts: this gate matches Asciidoctor, where
-    // `assign_caption` is only invoked when the block's context is a key in
-    // `CAPTION_ATTRIBUTE_NAMES`, so an override such as a document-wide `caption`
-    // attribute never leaks onto, say, an ordinary titled paragraph.
+    // applies only to captionable contexts: this gate matches Asciidoctor,
+    // where `assign_caption` is only invoked when the block's context is a
+    // key in `CAPTION_ATTRIBUTE_NAMES`, so an override such as a
+    // document-wide `caption` attribute never leaks onto, say, an ordinary
+    // titled paragraph.
     if !has_title {
         return None;
     }
@@ -175,15 +176,16 @@ pub(crate) fn assign_caption(
     }
 
     // Otherwise build "<label> <n>. " from the context's caption attribute,
-    // consuming the next value of that context's document-wide counter. When the
-    // caption attribute is unset (or empty), the block keeps its title but
-    // receives no caption and no number.
+    // consuming the next value of that context's document-wide counter. When
+    // the caption attribute is unset (or empty), the block keeps its title
+    // but receives no caption and no number.
     match parser.attribute_value(attr_name) {
         InterpretedValue::Value(label) if !label.is_empty() => {
-            // The caption number is the counter named `<context>-number`, shared
-            // with any `{counter:<context>-number}` reference in the document.
-            // A captioning counter advances (and stays readable as) its
-            // attribute even when locked, mirroring Asciidoctor's
+            // The caption number is the counter named `<context>-number`,
+            // shared with any `{counter:<context>-number}`
+            // reference in the document. A captioning counter
+            // advances (and stays readable as) its attribute even
+            // when locked, mirroring Asciidoctor's
             // `increment_and_store_counter`.
             let value = parser.counter_for_caption(&format!("{context}-number"), None);
             let prefix = format!("{label} {value}. ");
@@ -332,8 +334,8 @@ mod tests {
             (None, None)
         );
 
-        // ... and an explicitly empty value (resolving to `Value("")`) leave the
-        // block with just its title and no number.
+        // ... and an explicitly empty value (resolving to `Value("")`) leave
+        // the block with just its title and no number.
         assert_eq!(
             first_block_caption(":caption: \n\n.Title\n====\nbody.\n===="),
             (None, None)
@@ -342,11 +344,11 @@ mod tests {
 
     #[test]
     fn empty_document_caption_attribute_consumes_no_counter() {
-        // A block suppressed by an empty document `caption` must not advance the
-        // context counter: toggling `caption` on, then off, then relabeling must
-        // number the surviving example blocks 1 and 2 (not 1 and 3). This
-        // mirrors Asciidoctor's `blocks_test.rb` "automatic caption can be turned
-        // off and on and modified".
+        // A block suppressed by an empty document `caption` must not advance
+        // the context counter: toggling `caption` on, then off, then
+        // relabeling must number the surviving example blocks 1 and 2
+        // (not 1 and 3). This mirrors Asciidoctor's `blocks_test.rb`
+        // "automatic caption can be turned off and on and modified".
         let doc = Parser::default().parse(concat!(
             ".first example\n====\nan example\n====\n\n",
             ":caption:\n\n",
@@ -375,8 +377,9 @@ mod tests {
 
     #[test]
     fn collapsible_example_is_unnumbered() {
-        // A collapsible example suppresses its caption (and number), and does not
-        // consume a counter value, so a following example is still "Example 1".
+        // A collapsible example suppresses its caption (and number), and does
+        // not consume a counter value, so a following example is still
+        // "Example 1".
         let doc = Parser::default()
             .parse("[%collapsible]\n====\nhidden\n====\n\n.Title\n====\nbody.\n====");
         let numbers: Vec<_> = doc.child_blocks().map(|b| b.number()).collect();
@@ -385,8 +388,8 @@ mod tests {
 
     #[test]
     fn listing_caption_is_unset_by_default() {
-        // Unlike the other captionable contexts, `listing-caption` is not set by
-        // default, so a titled listing keeps only its title.
+        // Unlike the other captionable contexts, `listing-caption` is not set
+        // by default, so a titled listing keeps only its title.
         assert_eq!(
             first_block_caption(".Title\n----\ncode\n----"),
             (None, None)
@@ -424,9 +427,9 @@ mod tests {
 
     #[test]
     fn image_uses_figure_caption_and_number() {
-        // An image is captioned under the `figure` context: its label comes from
-        // `figure-caption` and its number from the `figure-number` counter (both
-        // set by default).
+        // An image is captioned under the `figure` context: its label comes
+        // from `figure-caption` and its number from the `figure-number`
+        // counter (both set by default).
         assert_eq!(
             first_block_caption(".Sunset\nimage::sunset.jpg[]"),
             (Some("Figure 1. ".to_string()), Some(1))
@@ -436,7 +439,8 @@ mod tests {
     #[test]
     fn image_caption_override_on_macro_wins() {
         // A `caption` attribute on the macro itself is a verbatim, unnumbered
-        // override, and it takes precedence over one on the block attribute list.
+        // override, and it takes precedence over one on the block attribute
+        // list.
         assert_eq!(
             first_block_caption(
                 "[caption=\"Block. \"]\n.Sunset\nimage::sunset.jpg[caption=\"Photo. \"]"
@@ -522,10 +526,10 @@ mod tests {
 
     #[test]
     fn dropped_image_does_not_consume_figure_number() {
-        // Under `attribute-missing=drop-line`, an image whose target references a
-        // missing attribute is dropped *before* its caption is assigned, so it
-        // does not consume the `figure-number` counter: the next titled image is
-        // still "Figure 1.".
+        // Under `attribute-missing=drop-line`, an image whose target references
+        // a missing attribute is dropped *before* its caption is
+        // assigned, so it does not consume the `figure-number` counter:
+        // the next titled image is still "Figure 1.".
         let doc = Parser::default().parse(
             ":attribute-missing: drop-line\n\n.Gone\nimage::{undefined}.jpg[]\n\n.Kept\nimage::ok.jpg[]",
         );

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -167,10 +167,10 @@ impl<'src> CompoundDelimitedBlock<'src> {
         let inside_delimiters = delimiter.after.trim_remainder(closing_delimiter);
 
         // A `== …` line inside a delimited block is literal content, not a
-        // section heading (sections are only recognized at the document level or
-        // within a section body). Flag the nested parse so `SectionBlock::parse`
-        // declines; the flag is saved and restored so nested delimited blocks
-        // compose correctly.
+        // section heading (sections are only recognized at the document level
+        // or within a section body). Flag the nested parse so
+        // `SectionBlock::parse` declines; the flag is saved and
+        // restored so nested delimited blocks compose correctly.
         let previously_in_delimited_block = parser.in_delimited_block;
         parser.in_delimited_block = true;
 
@@ -2225,7 +2225,8 @@ mod tests {
         fn assert_literal_heading(input: &str) {
             let doc = Parser::default().parse(input);
 
-            // No section heading was recognized, so nothing renders as an `<h2>`.
+            // No section heading was recognized, so nothing renders as an
+            // `<h2>`.
             assert_xpath(&doc, "//h2", 0);
 
             // The line survives as ordinary paragraph content.
@@ -2250,7 +2251,8 @@ mod tests {
         #[test]
         fn discrete_heading_is_still_recognized() {
             // A discrete heading is an ordinary block, not a section, so it is
-            // still recognized inside a delimited block and renders as a heading.
+            // still recognized inside a delimited block and renders as a
+            // heading.
             let doc = Parser::default().parse("====\n[discrete]\n== Sub\n====\n");
             assert_xpath(&doc, "//h2", 1);
         }

--- a/parser/src/blocks/find.rs
+++ b/parser/src/blocks/find.rs
@@ -572,8 +572,8 @@ mod tests {
     #[test]
     fn document_order_and_nesting() {
         // A section containing a list (which owns its items) and a source
-        // listing. The walk should yield each in document order, descending into
-        // the section and the list.
+        // listing. The walk should yield each in document order, descending
+        // into the section and the list.
         let doc = Parser::default()
             .parse("== Section\n\n* one\n* two\n\n[source,rust]\n----\nfn main() {}\n----\n");
 
@@ -705,8 +705,8 @@ mod tests {
             })
             .collect();
 
-        // Only the outer sidebar: the inner sidebar is behind the prune, and the
-        // trailing paragraph is rejected.
+        // Only the outer sidebar: the inner sidebar is behind the prune, and
+        // the trailing paragraph is rejected.
         assert_eq!(sidebars.len(), 1);
     }
 
@@ -785,9 +785,10 @@ mod tests {
 
     #[test]
     fn traverse_documents_skips_non_asciidoc_cells() {
-        // One plain cell and one AsciiDoc (`a|`) cell. With `traverse_documents`
-        // the plain cell contributes no blocks (its content is inline), while the
-        // AsciiDoc cell contributes its paragraph.
+        // One plain cell and one AsciiDoc (`a|`) cell. With
+        // `traverse_documents` the plain cell contributes no blocks
+        // (its content is inline), while the AsciiDoc cell contributes
+        // its paragraph.
         let doc = Parser::default().parse("|===\n| plain\na| AsciiDoc _text_.\n|===\n");
 
         let deep = doc
@@ -905,9 +906,9 @@ mod tests {
 
     #[test]
     fn child_blocks_does_not_enter_table_cells() {
-        // A table reports no direct child blocks; its AsciiDoc cell content is a
-        // separate nested document, reachable only through `find_blocks` with
-        // `traverse_documents`.
+        // A table reports no direct child blocks; its AsciiDoc cell content is
+        // a separate nested document, reachable only through
+        // `find_blocks` with `traverse_documents`.
         let doc = Parser::default().parse("|===\na| Cell _text_.\n|===\n");
 
         let table = doc.child_blocks().next().unwrap();

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -80,17 +80,18 @@ impl<'src> ListBlock<'src> {
         // A list carries the `bibliography` style in two ways, which differ in
         // scope (matching Asciidoctor):
         //
-        // * An explicit `[bibliography]` attribute marks the list a bibliography
-        //   regardless of its type (even an ordered list).
-        // * A `bibliography` section implicitly marks each of its top-level *unordered*
-        //   lists (only) a bibliography. A nested list never inherits the section
-        //   style, so this is gated on `parent_list_markers` being empty; the list-type
-        //   restriction is applied below, once the type is known.
+        // * An explicit `[bibliography]` attribute marks the list a
+        //   bibliography regardless of its type (even an ordered list).
+        // * A `bibliography` section implicitly marks each of its top-level
+        //   *unordered* lists (only) a bibliography. A nested list never
+        //   inherits the section style, so this is gated on
+        //   `parent_list_markers` being empty; the list-type restriction is
+        //   applied below, once the type is known.
         //
-        // The section only propagates its style to a list that declares no style
-        // of its own — Asciidoctor applies it with `!style && …`, so a list with
-        // an explicit style (e.g. `[square]`) keeps that style and is not treated
-        // as a bibliography.
+        // The section only propagates its style to a list that declares no
+        // style of its own — Asciidoctor applies it with `!style && …`,
+        // so a list with an explicit style (e.g. `[square]`) keeps that
+        // style and is not treated as a bibliography.
         let declared_style = metadata
             .attrlist
             .as_ref()
@@ -109,10 +110,11 @@ impl<'src> ListBlock<'src> {
         loop {
             let next_line_mi = next_item_source.take_normalized_line();
 
-            // A leading blank line ends the list. `ListItem::parse` discards the
-            // blank lines that merely separate items of the same list, so a blank
-            // line surfacing here means it deliberately stopped short of
-            // blank-separated block metadata, which decorates a new, separate
+            // A leading blank line ends the list. `ListItem::parse` discards
+            // the blank lines that merely separate items of the
+            // same list, so a blank line surfacing here means it
+            // deliberately stopped short of blank-separated block
+            // metadata, which decorates a new, separate
             // block rather than the next item (matching Asciidoctor).
             if next_line_mi.item.data().is_empty() {
                 break;
@@ -131,16 +133,18 @@ impl<'src> ListBlock<'src> {
 
             // Parse any block metadata (title, anchor, attribute list) that
             // precedes this item's marker so it is captured on the item rather
-            // than dropped. A metadata line with no intervening blank line keeps
-            // the item in this list (matching Asciidoctor); the blank-separated
-            // case is handled in `ListItem::parse`, which finalizes the previous
+            // than dropped. A metadata line with no intervening blank line
+            // keeps the item in this list (matching Asciidoctor);
+            // the blank-separated case is handled in
+            // `ListItem::parse`, which finalizes the previous
             // item before such metadata.
             //
-            // Only subsequent items can carry their own metadata: the caller has
-            // already consumed any that precedes the list, so the first item's
-            // marker sits at `next_item_source`. Skipping the parse there keeps
-            // the common speculative `ListBlock::parse` on a non-list paragraph
-            // (tried and rejected for every such block) from re-parsing metadata
+            // Only subsequent items can carry their own metadata: the caller
+            // has already consumed any that precedes the list, so
+            // the first item's marker sits at `next_item_source`.
+            // Skipping the parse there keeps the common speculative
+            // `ListBlock::parse` on a non-list paragraph (tried and
+            // rejected for every such block) from re-parsing metadata
             // it has already parsed once.
             //
             // The metadata's own warnings are held until the item is actually
@@ -172,20 +176,21 @@ impl<'src> ListBlock<'src> {
 
             let this_item_marker = list_item_marker_mi.item;
 
-            // If this item's marker doesn't match the existing list marker, we are changing
-            // levels in the list hierarchy.
+            // If this item's marker doesn't match the existing list marker, we
+            // are changing levels in the list hierarchy.
             if let Some(ref first_marker) = first_marker {
                 if !first_marker.is_match_for(&this_item_marker)
                     && parent_list_markers
                         .iter()
                         .any(|parent| parent.is_match_for(&this_item_marker))
                 {
-                    // We matched a parent marker type. This list is complete; roll up the
-                    // hierarchy.
+                    // We matched a parent marker type. This list is complete;
+                    // roll up the hierarchy.
                     break;
                 }
 
-                // Check if the marker is in sequence for explicit ordered lists.
+                // Check if the marker is in sequence for explicit ordered
+                // lists.
                 if let Some(actual_ordinal) = this_item_marker.ordinal_value() {
                     if let Some(expected) = expected_ordinal
                         && actual_ordinal != expected
@@ -212,11 +217,12 @@ impl<'src> ListBlock<'src> {
                 }
             }
 
-            // The bibliography anchor (`[[[id]]]`) is recognized in the principal
-            // text of any item of an explicitly-styled bibliography list, or of an
-            // unordered-list item when the style is inherited from the section.
-            // Pass that context down so the item's inline substitution can detect
-            // it.
+            // The bibliography anchor (`[[[id]]]`) is recognized in the
+            // principal text of any item of an explicitly-styled
+            // bibliography list, or of an unordered-list item when
+            // the style is inherited from the section.
+            // Pass that context down so the item's inline substitution can
+            // detect it.
             let item_is_bibliography = own_style_bibliography
                 || (section_propagated_bibliography
                     && matches!(
@@ -303,17 +309,19 @@ impl<'src> ListBlock<'src> {
             parser.close_callout_list();
         }
 
-        // An unordered list is a checklist (i.e. task list) when at least one of
-        // its items has checkbox syntax. This mirrors Asciidoctor, which sets the
-        // `checklist` option on the list once any item carries a checkbox.
+        // An unordered list is a checklist (i.e. task list) when at least one
+        // of its items has checkbox syntax. This mirrors Asciidoctor,
+        // which sets the `checklist` option on the list once any item
+        // carries a checkbox.
         let is_checklist = type_ == ListType::Unordered
             && items.iter().any(|item| {
                 item.as_list_item()
                     .is_some_and(|li| li.checkbox().is_some())
             });
 
-        // An explicit `[bibliography]` style applies to any list type; the style
-        // inherited from a section applies only to unordered lists.
+        // An explicit `[bibliography]` style applies to any list type; the
+        // style inherited from a section applies only to unordered
+        // lists.
         let is_bibliography = own_style_bibliography
             || (section_propagated_bibliography && type_ == ListType::Unordered);
 
@@ -475,11 +483,12 @@ impl<'src> IsBlock<'src> for ListBlock<'src> {
     }
 
     fn resolved_style(&'src self) -> Option<&'src str> {
-        // A list's resolved style is its declared style, except that a top-level
-        // unordered list in a `bibliography` section resolves to `bibliography`
-        // even though the author declared no style on the list itself (see
-        // [`is_bibliography()`]). The explicit `[bibliography]` case is already
-        // covered by the declared style.
+        // A list's resolved style is its declared style, except that a
+        // top-level unordered list in a `bibliography` section resolves
+        // to `bibliography` even though the author declared no style on
+        // the list itself (see [`is_bibliography()`]). The explicit
+        // `[bibliography]` case is already covered by the declared
+        // style.
         //
         // [`is_bibliography()`]: Self::is_bibliography
         self.declared_style()
@@ -1420,9 +1429,10 @@ mod tests {
 
         #[test]
         fn a_declared_style_suppresses_the_inherited_bibliography() {
-            // A list that declares its own style keeps it and is not treated as a
-            // bibliography, mirroring Asciidoctor's `!style` guard: the section
-            // style is applied only when the list has no style of its own.
+            // A list that declares its own style keeps it and is not treated as
+            // a bibliography, mirroring Asciidoctor's `!style`
+            // guard: the section style is applied only when the
+            // list has no style of its own.
             with_first_section_list(
                 "[bibliography]\n== References\n\n[square]\n* An entry.\n",
                 |list| {
@@ -1448,10 +1458,11 @@ mod tests {
     fn orphaned_title_after_continuation_is_discarded() {
         // Exercises the "If there's block metadata but no block, just discard
         // it and continue." path in ListItem::parse (circa line 368 of
-        // list_item.rs). A `+` continuation followed by a block title (`.Title`)
-        // and then an empty line means the title is orphaned (no block
-        // immediately follows). The title metadata is discarded and the
-        // subsequent paragraph is parsed as a continuation block.
+        // list_item.rs). A `+` continuation followed by a block title
+        // (`.Title`) and then an empty line means the title is orphaned
+        // (no block immediately follows). The title metadata is
+        // discarded and the subsequent paragraph is parsed as a
+        // continuation block.
         let list = list_parse("* item one\n+\n.Title\n\nsecond paragraph").unwrap();
 
         // The list should have one item.
@@ -1646,11 +1657,12 @@ mod tests {
 
         #[test]
         fn empty_principal_with_continuation_keeps_attached_block() {
-            // An empty (`{empty}`) principal followed by a continuation-attached
-            // listing: the principal-text node is dropped, so the listing is the
-            // item's only child block, but the item records the empty principal
-            // text so a renderer knows the listing is an attached block (and can
-            // emit the empty principal paragraph ahead of it).
+            // An empty (`{empty}`) principal followed by a
+            // continuation-attached listing: the principal-text
+            // node is dropped, so the listing is the item's only
+            // child block, but the item records the empty principal
+            // text so a renderer knows the listing is an attached block (and
+            // can emit the empty principal paragraph ahead of it).
             let doc = crate::Parser::default().parse(". {empty}\n+\n----\nprint(\"one\")\n----\n");
             let items = items(&doc);
 
@@ -1673,14 +1685,16 @@ mod tests {
             assert!(items[0].has_empty_principal_text());
             assert_eq!(items[0].child_blocks().count(), 0);
 
-            // The second item has ordinary principal text, so the flag is clear.
+            // The second item has ordinary principal text, so the flag is
+            // clear.
             assert!(!items[1].has_empty_principal_text());
         }
 
         #[test]
         fn non_empty_principal_with_continuation_is_not_flagged() {
-            // The contrasting case from the issue: with non-empty principal text,
-            // the principal is the first child block and the flag is clear.
+            // The contrasting case from the issue: with non-empty principal
+            // text, the principal is the first child block and the
+            // flag is clear.
             let doc = crate::Parser::default().parse(". text\n+\n----\nprint(\"one\")\n----\n");
             let items = items(&doc);
 

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -56,8 +56,8 @@ impl<'src> ListItem<'src> {
         let marker_mi = ListItemMarker::parse(source, parser)?;
         let mut marker = marker_mi.item;
 
-        // Register any leading inline anchors in the description list term and apply
-        // macros substitution to render the anchor.
+        // Register any leading inline anchors in the description list term and
+        // apply macros substitution to render the anchor.
         marker.register_leading_anchors(parser, warnings);
 
         let mut list_markers_including_peer = parent_list_markers.to_vec();
@@ -65,12 +65,13 @@ impl<'src> ListItem<'src> {
 
         let mut blocks: Vec<Block<'src>> = vec![];
 
-        // Detect checklist (i.e. task list) syntax on unordered list items. When
-        // the principal text begins with `[ ] `, `[x] `, or `[*] ` (the closing
-        // bracket immediately followed by a single space character), the item is
-        // a checklist item. `[ ]` is unchecked; `[x]`/`[*]` are checked. The
-        // four-character checkbox marker is then stripped from the principal text.
-        // This mirrors Asciidoctor's `parse_list_item`.
+        // Detect checklist (i.e. task list) syntax on unordered list items.
+        // When the principal text begins with `[ ] `, `[x] `, or `[*] `
+        // (the closing bracket immediately followed by a single space
+        // character), the item is a checklist item. `[ ]` is unchecked;
+        // `[x]`/`[*]` are checked. The four-character checkbox marker
+        // is then stripped from the principal text. This mirrors
+        // Asciidoctor's `parse_list_item`.
         let checkbox: Option<bool> = if matches!(
             marker,
             ListItemMarker::Hyphen(_) | ListItemMarker::Asterisks(_) | ListItemMarker::Bullet(_)
@@ -88,16 +89,18 @@ impl<'src> ListItem<'src> {
         };
 
         // When a checkbox marker is present, the principal text begins four
-        // characters later (after `[x] `). Any whitespace re-exposed by stripping
-        // the checkbox is discarded so the principal text never starts indented
-        // (which would otherwise be misread as a literal block).
+        // characters later (after `[x] `). Any whitespace re-exposed by
+        // stripping the checkbox is discarded so the principal text
+        // never starts indented (which would otherwise be misread as a
+        // literal block).
         let principal_start = if checkbox.is_some() {
             marker_mi.after.slice_from(4..).discard_whitespace()
         } else {
             marker_mi.after
         };
 
-        // Text after list item marker is always a simple block with no metadata.
+        // Text after list item marker is always a simple block with no
+        // metadata.
         let no_metadata = BlockMetadata {
             title_source: None,
             title: None,
@@ -109,10 +112,11 @@ impl<'src> ListItem<'src> {
         };
 
         // In a bibliography list, the principal text may begin with a
-        // bibliography anchor (`[[[id]]]`). Flag the parser so the inline macros
-        // substitution applied while parsing this principal text recognizes it.
-        // The flag is cleared immediately afterward so it never leaks into any
-        // nested blocks (e.g. a nested list) attached to this item.
+        // bibliography anchor (`[[[id]]]`). Flag the parser so the inline
+        // macros substitution applied while parsing this principal text
+        // recognizes it. The flag is cleared immediately afterward so
+        // it never leaks into any nested blocks (e.g. a nested list)
+        // attached to this item.
         parser.in_bibliography_list_item.set(is_bibliography);
 
         // For description lists, the content after the marker can be empty.
@@ -130,11 +134,12 @@ impl<'src> ListItem<'src> {
 
         let mut next = if let Some(simple_block_mi) = simple_block_for_list_item {
             // If the principal text is present but renders empty (e.g. from an
-            // `{empty}` attribute reference), the node for the principal text is
-            // dropped from the parse tree rather than emitted as an empty child
-            // block. We record that it was present, however: the item still has
-            // an (empty) principal text distinct from a list item that carries
-            // no principal text at all. A renderer uses this to emit the empty
+            // `{empty}` attribute reference), the node for the principal text
+            // is dropped from the parse tree rather than emitted as
+            // an empty child block. We record that it was present,
+            // however: the item still has an (empty) principal text
+            // distinct from a list item that carries no principal
+            // text at all. A renderer uses this to emit the empty
             // principal paragraph ahead of any continuation-attached blocks,
             // matching Asciidoctor (whose `text?` is true with `text` empty).
             if simple_block_mi.item.content().is_empty() {
@@ -145,12 +150,13 @@ impl<'src> ListItem<'src> {
 
             simple_block_mi.after
         } else if matches!(marker, ListItemMarker::DefinedTerm { .. }) {
-            // Description list items can have empty content on the same line as the marker.
-            // The content may be on subsequent lines, so we try to parse from the next
-            // non-empty line.
+            // Description list items can have empty content on the same line as
+            // the marker. The content may be on subsequent lines,
+            // so we try to parse from the next non-empty line.
             let mut next_source = marker_mi.after.discard_empty_lines();
 
-            // Skip comment lines (// but not ///) between term and continuation/content.
+            // Skip comment lines (// but not ///) between term and
+            // continuation/content.
             loop {
                 let peek = next_source.take_normalized_line();
                 if peek.item.data().starts_with("//") && !peek.item.data().starts_with("///") {
@@ -160,17 +166,20 @@ impl<'src> ListItem<'src> {
                 }
             }
 
-            // Check for continuation marker before parsing. If a continuation marker is
-            // present, skip directly to the main loop which handles continuations properly.
+            // Check for continuation marker before parsing. If a continuation
+            // marker is present, skip directly to the main loop
+            // which handles continuations properly.
             let next_line_mi = next_source.take_normalized_line();
 
             if next_line_mi.item.data() == "+" {
                 // Continuation marker found; skip straight to the main loop.
-                // Use next_source (not marker_mi.after) since we already skipped empty lines.
+                // Use next_source (not marker_mi.after) since we already
+                // skipped empty lines.
                 next_source
             } else if ListItemMarker::parse(next_source, parser).is_some() {
-                // Next line is another list item marker (possibly a sibling term).
-                // Don't parse it as content; let the list parser handle it.
+                // Next line is another list item marker (possibly a sibling
+                // term). Don't parse it as content; let the
+                // list parser handle it.
                 marker_mi.after
             } else if RawDelimitedBlock::is_valid_delimiter(&next_line_mi.item)
                 || CompoundDelimitedBlock::is_valid_delimiter(&next_line_mi.item)
@@ -199,8 +208,9 @@ impl<'src> ListItem<'src> {
                     block_start: next_source,
                 };
 
-                // For definition lists, indented content is treated as a paragraph
-                // (not literal), with the indentation stripped.
+                // For definition lists, indented content is treated as a
+                // paragraph (not literal), with the indentation
+                // stripped.
                 if let Some(simple_block_mi) =
                     SimpleBlock::parse_for_definition_list(&next_line_metadata, parser)
                 {
@@ -227,10 +237,10 @@ impl<'src> ListItem<'src> {
             let next_line_mi: MatchedItem<'_, Span<'_>> = next.take_normalized_line();
 
             // Don't consume `+` as continuation if:
-            // - A continuation is already active (consecutive `+` - second one becomes
-            //   content)
-            // - We've already had a block that started with `+` as content (trailing `+`
-            //   markers)
+            // - A continuation is already active (consecutive `+` - second one
+            //   becomes content)
+            // - We've already had a block that started with `+` as content
+            //   (trailing `+` markers)
             if next_line_mi.item.data() == "+"
                 && !continuation_active
                 && !had_content_starting_with_plus
@@ -252,11 +262,12 @@ impl<'src> ListItem<'src> {
                     // Asciidoctor). Leave `next` at the blank line so
                     // `ListBlock::parse` stops here.
                     //
-                    // Existing content is required so the phantom line-end after
-                    // an empty description-list term - not a real blank line -
-                    // still lets that term's own metadata-prefixed nested list
-                    // attach. A continuation marker likewise keeps such metadata
-                    // as part of this item.
+                    // Existing content is required so the phantom line-end
+                    // after an empty description-list term
+                    // - not a real blank line - still lets
+                    // that term's own metadata-prefixed nested list
+                    // attach. A continuation marker likewise keeps such
+                    // metadata as part of this item.
                     if !continuation_active
                         && !blocks.is_empty()
                         && !BlockMetadata::parse(after_blanks, parser).item.is_empty()
@@ -303,12 +314,13 @@ impl<'src> ListItem<'src> {
             if let Some(list_item_marker_mi) =
                 ListItemMarker::parse(metadata.item.block_start, parser)
             {
-                // We've found a new list item. How does it compare with the existing item in
-                // the hierarchy?
+                // We've found a new list item. How does it compare with the
+                // existing item in the hierarchy?
                 let new_item_marker = list_item_marker_mi.item;
 
                 if marker.is_match_for(&new_item_marker) {
-                    // New item is a peer to this item; nothing further for the current item.
+                    // New item is a peer to this item; nothing further for the
+                    // current item.
                     break;
                 }
 
@@ -316,19 +328,21 @@ impl<'src> ListItem<'src> {
                     .iter()
                     .any(|parent| parent.is_match_for(&new_item_marker))
                 {
-                    // We matched a parent marker type. This list is complete; roll up the
-                    // hierarchy.
+                    // We matched a parent marker type. This list is complete;
+                    // roll up the hierarchy.
                     break;
                 }
 
-                // We haven't encountered this marker before. Add a new nesting level. The new
-                // list will be a child block of this list item.
+                // We haven't encountered this marker before. Add a new nesting
+                // level. The new list will be a child block of
+                // this list item.
 
                 // But if we're after a blank line and the block is not indented
-                // (and no continuation is active), and there is a block attribute
-                // line or anchor before the new list marker, break the list
-                // instead of nesting. A blank line followed by a block attribute
-                // line signals the start of a new, separate list.
+                // (and no continuation is active), and there is a block
+                // attribute line or anchor before the new list
+                // marker, break the list instead of nesting. A
+                // blank line followed by a block attribute line
+                // signals the start of a new, separate list.
                 if next_block_must_be_indented
                     && !is_indented
                     && !continuation_active
@@ -351,8 +365,9 @@ impl<'src> ListItem<'src> {
                 let mut nested_list_markers = parent_list_markers.to_owned();
                 nested_list_markers.push(marker.clone());
 
-                // NOTE: The call to `ListBlock::parse` *should* succeed (as in I can't think of
-                // a test case where it would fail). We use the `?` to provide a safe escape in
+                // NOTE: The call to `ListBlock::parse` *should* succeed (as in
+                // I can't think of a test case where it would
+                // fail). We use the `?` to provide a safe escape in
                 // case it doesn't.
                 parser.block_nesting_depth += 1;
                 let nested_list_result = ListBlock::parse_inside_list(
@@ -430,7 +445,8 @@ impl<'src> ListItem<'src> {
                         break;
                     }
 
-                    // Found a nested list after metadata separated by empty lines.
+                    // Found a nested list after metadata separated by empty
+                    // lines.
                     let ext_metadata = BlockMetadata {
                         title_source: ext_title_source,
                         title: ext_title,
@@ -484,15 +500,16 @@ impl<'src> ListItem<'src> {
                 }
             }
 
-            // A block attribute line or block anchor without a continuation marker
-            // breaks the list.
+            // A block attribute line or block anchor without a continuation
+            // marker breaks the list.
             if !continuation_active
                 && (metadata.item.attrlist.is_some() || metadata.item.anchor.is_some())
             {
                 break;
             }
 
-            // If there's block metadata but no block, just discard it and continue.
+            // If there's block metadata but no block, just discard it and
+            // continue.
             if metadata
                 .item
                 .block_start
@@ -504,8 +521,8 @@ impl<'src> ListItem<'src> {
                 continue;
             }
 
-            // A list item does not terminate if subsequent blocks are indented (i.e. use
-            // literal syntax).
+            // A list item does not terminate if subsequent blocks are indented
+            // (i.e. use literal syntax).
             let indented_block_maw = Block::parse_for_list_item(
                 next,
                 parser,
@@ -542,15 +559,17 @@ impl<'src> ListItem<'src> {
                 break;
             };
 
-            // After a continuation marker, subsequent blocks don't need to be indented.
-            // However, document attributes don't consume the continuation status.
+            // After a continuation marker, subsequent blocks don't need to be
+            // indented. However, document attributes don't consume
+            // the continuation status.
             let is_document_attribute =
                 matches!(indented_block_mi.item, Block::DocumentAttribute(_));
 
             // Document attributes should not be added to the list item blocks.
-            // They're processed for their side effects but don't appear in the output.
-            // Similarly, orphaned metadata blocks shouldn't be added; they'll be
-            // re-parsed on the next iteration where they can attach to a real block.
+            // They're processed for their side effects but don't appear in the
+            // output. Similarly, orphaned metadata blocks shouldn't
+            // be added; they'll be re-parsed on the next iteration
+            // where they can attach to a real block.
             if !is_document_attribute {
                 blocks.push(indented_block_mi.item);
             }
@@ -562,11 +581,12 @@ impl<'src> ListItem<'src> {
                 // and next_block_must_be_indented unchanged.
             } else if continuation_active {
                 // This block consumed the continuation.
-                // The next block after this one will need to be indented (or have another
-                // continuation).
+                // The next block after this one will need to be indented (or
+                // have another continuation).
                 //
-                // If the block started with `+` as content (not as continuation), mark it
-                // so we don't allow more continuation markers. This handles odd input like
+                // If the block started with `+` as content (not as
+                // continuation), mark it so we don't allow more
+                // continuation markers. This handles odd input like
                 // consecutive `+` markers.
                 if next_line_mi.item.data() == "+" {
                     had_content_starting_with_plus = true;

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -142,7 +142,8 @@ impl<'src> ListItemMarker<'src> {
             {
                 Self::ArabicNumeral(marker)
             } else {
-                // Regex and if-else chain should be exhaustive. If not, treat as non-match.
+                // Regex and if-else chain should be exhaustive. If not, treat
+                // as non-match.
                 return None;
             };
 
@@ -174,9 +175,10 @@ impl<'src> ListItemMarker<'src> {
             let term = source.slice(0..term_len);
             let mut term: Content<'src> = term.into();
 
-            // Apply attribute substitution to the term so that attribute references
-            // like `{blank}` are resolved before determining if this is a valid
-            // definition list marker.
+            // Apply attribute substitution to the term so that attribute
+            // references like `{blank}` are resolved before
+            // determining if this is a valid definition list
+            // marker.
             SubstitutionStep::AttributeReferences.apply(&mut term, parser, None);
 
             let marker = source.slice_from(term_len..);
@@ -636,10 +638,11 @@ mod tests {
 
     #[test]
     fn term_special_characters_are_escaped() {
-        // A description-list term receives the full `normal` substitution group,
-        // so the special characters `&`, `<`, and `>` are escaped rather than
-        // passed through verbatim. The horizontal and qanda list variants share
-        // this code path, since their terms are the same `DefinedTerm` marker.
+        // A description-list term receives the full `normal` substitution
+        // group, so the special characters `&`, `<`, and `>` are
+        // escaped rather than passed through verbatim. The horizontal
+        // and qanda list variants share this code path, since their
+        // terms are the same `DefinedTerm` marker.
         assert_eq!(term_rendered("a & b:: desc"), "a &amp; b");
         assert_eq!(term_rendered("a < b:: desc"), "a &lt; b");
         assert_eq!(term_rendered("a > b:: desc"), "a &gt; b");

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -145,8 +145,9 @@ impl<'src> MediaBlock<'src> {
         // Asciidoctor's block-macro regex requires the target to begin and end
         // with a non-space character. A target with leading or trailing
         // whitespace is not recognized as a block macro at all; the line falls
-        // through to be parsed as a description list or paragraph instead. Reject
-        // it here (with no warning) so it is not mistaken for a media block.
+        // through to be parsed as a description list or paragraph instead.
+        // Reject it here (with no warning) so it is not mistaken for a
+        // media block.
         let target_data = target.item.data();
 
         if target_data.starts_with(char::is_whitespace)

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -57,9 +57,9 @@ impl<'src> BlockMetadata<'src> {
         let mut warnings: Vec<Warning<'src>> = vec![];
         let source = source.discard_empty_lines();
 
-        // Block metadata items (title, anchor, and attribute list) can appear in any
-        // order. We loop through lines until we can't parse any more metadata
-        // items.
+        // Block metadata items (title, anchor, and attribute list) can appear
+        // in any order. We loop through lines until we can't parse any
+        // more metadata items.
         let mut title_source: Option<Span<'src>> = None;
         let mut anchor: Option<Span<'src>> = None;
         let mut reftext: Option<Span<'src>> = None;
@@ -88,10 +88,12 @@ impl<'src> BlockMetadata<'src> {
             // permitted and the last one wins (`[[bar]]` / `[[foo]]` → `foo`),
             // matching Asciidoctor, which simply overwrites the running `id`
             // (and its reftext) for each anchor line. There is deliberately no
-            // `anchor.is_none()` guard: a later anchor overrides an earlier one.
+            // `anchor.is_none()` guard: a later anchor overrides an earlier
+            // one.
             let mut anchor_maw = parse_maybe_block_anchor(block_start);
 
-            // Collect any warnings from the anchor parsing (e.g., empty anchor).
+            // Collect any warnings from the anchor parsing (e.g., empty
+            // anchor).
             if !anchor_maw.warnings.is_empty() {
                 warnings.append(&mut anchor_maw.warnings);
             }
@@ -128,9 +130,11 @@ impl<'src> BlockMetadata<'src> {
                         if anchor_content.is_xml_name() {
                             anchor = Some(anchor_content);
 
-                            // A later plain anchor (`[[foo]]`) clears any reftext
-                            // carried by an earlier `[[bar,text]]`, keeping the
-                            // last-wins semantics consistent across both fields.
+                            // A later plain anchor (`[[foo]]`) clears any
+                            // reftext carried by an
+                            // earlier `[[bar,text]]`, keeping the
+                            // last-wins semantics consistent across both
+                            // fields.
                             reftext = None;
                             block_start = mi.after;
                         } else {
@@ -188,11 +192,12 @@ impl<'src> BlockMetadata<'src> {
             // comment blocks as ordinary blocks, so the transparency is scoped
             // to the section-transfer case the wider divergence would otherwise
             // break. A comment that a metadata line directly decorates (with no
-            // following section) is therefore left in place for normal dispatch.
+            // following section) is therefore left in place for normal
+            // dispatch.
             //
             // This only applies once at least one metadata item has been
-            // collected, so a standalone comment (with no preceding metadata) is
-            // untouched.
+            // collected, so a standalone comment (with no preceding metadata)
+            // is untouched.
             if !(title_source.is_none() && anchor.is_none() && attrlist.is_none())
                 && let Some(after_comments) =
                     skip_comments_before_section(block_start, parser.level_offset())
@@ -219,17 +224,20 @@ impl<'src> BlockMetadata<'src> {
                     // A single-quoted `title=` value already had the normal
                     // substitution group applied when the attribute list was
                     // parsed; substituting it again here would double-escape
-                    // special characters (and re-process inline markup), so it is
-                    // used verbatim. Any other form receives the title (normal)
+                    // special characters (and re-process inline markup), so it
+                    // is used verbatim. Any other form
+                    // receives the title (normal)
                     // substitutions now, matching a `.Title` line. (Attribute
                     // references in the value were resolved when the attribute
                     // list was parsed, so they are not re-evaluated here.)
                     //
-                    // A `title=` value's rendered text is anchored at the block's
-                    // source (rather than at the attribute value, which is
+                    // A `title=` value's rendered text is anchored at the
+                    // block's source (rather than at the
+                    // attribute value, which is
                     // borrowed from `attrlist` and would outlive this borrow):
-                    // any cross-reference in it is rendered to its fallback here
-                    // and not re-resolved later, matching the pre-existing
+                    // any cross-reference in it is rendered to its fallback
+                    // here and not re-resolved later,
+                    // matching the pre-existing
                     // treatment of a substituted value.
                     let rendered = if value_is_substituted {
                         value.to_string()
@@ -586,10 +594,11 @@ mod tests {
     #[test]
     fn title_does_not_extend_via_plus_syntax() {
         // A trailing ` +` on a block title does not join the following line
-        // (`def`) into the title: the title is a single line and `def` remains a
-        // separate paragraph. The ` +` is, however, still a hard line break, so
-        // the post_replacements step renders it as `<br>` within the title
-        // itself (the raw `title_source` keeps the literal ` +`).
+        // (`def`) into the title: the title is a single line and `def` remains
+        // a separate paragraph. The ` +` is, however, still a hard line
+        // break, so the post_replacements step renders it as `<br>`
+        // within the title itself (the raw `title_source` keeps the
+        // literal ` +`).
         let doc: crate::Document<'_> =
             Parser::default().parse(".Title abc +\ndef\n****\nStuff > nonsense\n****");
 
@@ -889,8 +898,8 @@ mod tests {
         #[test]
         fn later_line_carrying_both_formal_and_shorthand_roles() {
             // When a single later line carries both a formal `role=` and a
-            // shorthand `.role`, the formal value replaces the running roles and
-            // that same line's shorthand then appends after it.
+            // shorthand `.role`, the formal value replaces the running roles
+            // and that same line's shorthand then appends after it.
             let metadata = crate::blocks::metadata::BlockMetadata::new(
                 "[role=formal]\n[.sh,role=formal2]\ncontent\n",
             );
@@ -992,21 +1001,22 @@ mod tests {
 
         #[test]
         fn sets_title_from_attribute() {
-            // A `title=` entry in a block's attribute list sets the block title,
-            // equivalent to a `.Title` line.
+            // A `title=` entry in a block's attribute list sets the block
+            // title, equivalent to a `.Title` line.
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title=\"My Title\"]\ncontent\n");
 
             assert_eq!(metadata.title_str(), Some("My Title"));
 
-            // A title supplied through an attribute has no `.Title` source line.
+            // A title supplied through an attribute has no `.Title` source
+            // line.
             assert!(metadata.title_source.is_none());
         }
 
         #[test]
         fn dot_title_line_wins_over_attribute() {
-            // When both a `.Title` line and a `title=` attribute are present, the
-            // `.Title` line takes precedence.
+            // When both a `.Title` line and a `title=` attribute are present,
+            // the `.Title` line takes precedence.
             let metadata = crate::blocks::metadata::BlockMetadata::new(
                 ".Line Title\n[title=\"Attr Title\"]\ncontent\n",
             );
@@ -1028,10 +1038,11 @@ mod tests {
 
         #[test]
         fn single_quoted_value_is_not_double_substituted() {
-            // A single-quoted value already had the normal substitutions applied
-            // when the attribute list was parsed. Substituting it again would
-            // double-escape the `>` to `&amp;gt;`; the title must instead render
-            // `a &gt; b`, matching the double-quoted form.
+            // A single-quoted value already had the normal substitutions
+            // applied when the attribute list was parsed.
+            // Substituting it again would double-escape the `>` to
+            // `&amp;gt;`; the title must instead render `a &gt; b`,
+            // matching the double-quoted form.
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title='a > b']\ncontent\n");
 
@@ -1061,8 +1072,8 @@ mod tests {
         #[test]
         fn resolves_attribute_references_in_value() {
             // Attribute references in a `title=` value are resolved (when the
-            // attribute list is parsed), then the title substitutions render the
-            // result.
+            // attribute list is parsed), then the title substitutions render
+            // the result.
             let doc =
                 Parser::default().parse(":who: World\n\n[title=\"Hello {who}\"]\n====\nbody\n====");
 
@@ -1073,8 +1084,8 @@ mod tests {
         #[test]
         fn straddles_a_second_attribute_line() {
             // A `title=` attribute merges across multiple attribute lines just
-            // like any other named attribute, so it still supplies the title when
-            // it sits on a separate line from the block style.
+            // like any other named attribute, so it still supplies the title
+            // when it sits on a separate line from the block style.
             let metadata = crate::blocks::metadata::BlockMetadata::new(
                 "[title=\"Merged Title\"]\n[sidebar]\ncontent\n",
             );

--- a/parser/src/blocks/preamble.rs
+++ b/parser/src/blocks/preamble.rs
@@ -31,9 +31,10 @@ impl<'src> Preamble<'src> {
             let after_last = last_block.span().discard_all();
             source.trim_remainder(after_last)
         } else {
-            // This clause is here as a fallback, but should not be reachable in practice. A
-            // Preamble should only be constructed if there are content-bearing blocks
-            // before the first section.
+            // This clause is here as a fallback, but should not be reachable in
+            // practice. A Preamble should only be constructed if
+            // there are content-bearing blocks before the first
+            // section.
             source.trim_remainder(source)
         };
 

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -166,9 +166,10 @@ impl<'src> QuoteBlock<'src> {
             }
 
             // A `[quote]`/`[verse]` style also masquerades over an open block
-            // (`--`): the open delimiter adopts the quote/verse context. This is
-            // unique to the open block — every other structural container (below)
-            // keeps its own context and ignores the style.
+            // (`--`): the open delimiter adopts the quote/verse context. This
+            // is unique to the open block — every other structural
+            // container (below) keeps its own context and ignores
+            // the style.
             if first_line.data() == "--" {
                 return Some(Self::parse_delimited(metadata, parser, type_));
             }
@@ -187,8 +188,9 @@ impl<'src> QuoteBlock<'src> {
             return Self::parse_styled_paragraph(metadata, parser, type_);
         }
 
-        // A bare quote-delimited block (no `[quote]`/`[verse]` style) is a quote
-        // block. Any other style on it (e.g. an admonition label) is ignored.
+        // A bare quote-delimited block (no `[quote]`/`[verse]` style) is a
+        // quote block. Any other style on it (e.g. an admonition label)
+        // is ignored.
         if is_quote_delimiter {
             return Some(Self::parse_delimited(metadata, parser, QuoteType::Quote));
         }
@@ -231,9 +233,10 @@ impl<'src> QuoteBlock<'src> {
         let (content_model, content, blocks, mut warnings) = match type_ {
             // A quote block contains other blocks.
             QuoteType::Quote => {
-                // A `== …` line inside the quote block is literal content, not a
-                // section heading; suppress section recognition for the nested
-                // parse (saved and restored to compose with outer contexts).
+                // A `== …` line inside the quote block is literal content, not
+                // a section heading; suppress section
+                // recognition for the nested parse (saved and
+                // restored to compose with outer contexts).
                 let previously_in_delimited_block = parser.in_delimited_block;
                 parser.in_delimited_block = true;
 
@@ -342,14 +345,16 @@ impl<'src> QuoteBlock<'src> {
         parser: &mut Parser,
     ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
         // A quoted paragraph must begin with a double quote. Test that on the
-        // block's first byte *before* scanning the whole paragraph. `read_paragraph`
-        // (below) walks every line up to the next blank line, so testing the first
-        // byte here avoids that scan for the common non-quoted paragraph: without
-        // it, a long run of non-blank lines that never forms a quoted paragraph is
-        // rescanned in full for every block, making the parse O(n²) on pathological
-        // input (e.g. thousands of consecutive delimiter lines with no blank line
-        // between them). `read_paragraph` starts at `block_start`, so a paragraph
-        // beginning with `"` shares this first byte — testing it here loses nothing.
+        // block's first byte *before* scanning the whole paragraph.
+        // `read_paragraph` (below) walks every line up to the next
+        // blank line, so testing the first byte here avoids that scan
+        // for the common non-quoted paragraph: without it, a long run
+        // of non-blank lines that never forms a quoted paragraph is
+        // rescanned in full for every block, making the parse O(n²) on
+        // pathological input (e.g. thousands of consecutive delimiter
+        // lines with no blank line between them). `read_paragraph`
+        // starts at `block_start`, so a paragraph beginning with `"`
+        // shares this first byte — testing it here loses nothing.
         if !metadata.block_start.data().starts_with('"') {
             return None;
         }
@@ -378,7 +383,8 @@ impl<'src> QuoteBlock<'src> {
         let mut content = Content::from(inner_span);
         SubstitutionGroup::Normal.apply(&mut content, parser, None);
 
-        // The attribution line provides the attribution and (optional) citation.
+        // The attribution line provides the attribution and (optional)
+        // citation.
         let (attribution, citetitle) = split_attribution_line(attribution_text.trim(), parser);
 
         let source = metadata
@@ -422,9 +428,9 @@ impl<'src> QuoteBlock<'src> {
     ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
         let first_line = metadata.block_start.take_normalized_line().item;
 
-        // The first line must begin the Markdown blockquote: a `>` followed by a
-        // space, or a bare `>`. A `>` immediately followed by other text (e.g.
-        // `>foo`) is not a blockquote.
+        // The first line must begin the Markdown blockquote: a `>` followed by
+        // a space, or a bare `>`. A `>` immediately followed by other
+        // text (e.g. `>foo`) is not a blockquote.
         if !is_markdown_marker_line(first_line.data()) {
             return None;
         }
@@ -467,24 +473,27 @@ impl<'src> QuoteBlock<'src> {
 
         let body = lines.join("\n");
 
-        // The stripped body owns its source; its blocks borrow from it. Warnings
-        // from the owned parse reference spans in that owned source, so they
-        // cannot be returned to the caller as `Warning<'src>`. Their
-        // [`WarningType`]s (which carry no borrowed data) are collected instead
-        // and re-anchored at the blockquote's own source span below: the
-        // `>`-stripped body is not contiguous in the document source, so a
-        // precise location is not available anyway, but the diagnostic itself
+        // The stripped body owns its source; its blocks borrow from it.
+        // Warnings from the owned parse reference spans in that owned
+        // source, so they cannot be returned to the caller as
+        // `Warning<'src>`. Their [`WarningType`]s (which carry no
+        // borrowed data) are collected instead and re-anchored at the
+        // blockquote's own source span below: the `>`-stripped body is
+        // not contiguous in the document source, so a precise location
+        // is not available anyway, but the diagnostic itself
         // must not be lost.
         let mut nested_warning_types: Vec<WarningType> = vec![];
         let owned = OwnedQuoteBlocks::new(body, |source| {
-            // The blocks parse from `source`, an owned copy that does not map to
-            // the document. Mark that so a footnote defined inside records no
-            // (misleading) document location; see `Parser::owned_subsource_depth`.
+            // The blocks parse from `source`, an owned copy that does not map
+            // to the document. Mark that so a footnote defined
+            // inside records no (misleading) document location; see
+            // `Parser::owned_subsource_depth`.
             parser.owned_subsource_depth += 1;
 
             // A `== …` line inside the blockquote is literal content, not a
-            // section heading; suppress section recognition for the nested parse
-            // (saved and restored to compose with outer contexts).
+            // section heading; suppress section recognition for the nested
+            // parse (saved and restored to compose with outer
+            // contexts).
             let previously_in_delimited_block = parser.in_delimited_block;
             parser.in_delimited_block = true;
 
@@ -582,9 +591,9 @@ impl<'src> QuoteBlock<'src> {
     ) {
         let source = self.source;
 
-        // The owned store is shared behind an `Arc`, but references are resolved
-        // immediately after parsing while the block is still its sole owner, so
-        // `get_mut` succeeds.
+        // The owned store is shared behind an `Arc`, but references are
+        // resolved immediately after parsing while the block is still
+        // its sole owner, so `get_mut` succeeds.
         if let Some(owned) = self.markdown_blocks.as_mut()
             && let Some(owned) = Arc::get_mut(owned)
         {
@@ -749,8 +758,8 @@ fn split_at_attribution_line(data: &str) -> Option<(&str, &str)> {
         {
             let attribution_text = rest.trim_start_matches([' ', '\t']);
 
-            // `line_start > 0` ensures there is at least one line of quoted text
-            // before the attribution line.
+            // `line_start > 0` ensures there is at least one line of quoted
+            // text before the attribution line.
             if !attribution_text.is_empty() && line_start > 0 {
                 attribution = Some((line_start, attribution_text));
             }
@@ -759,8 +768,8 @@ fn split_at_attribution_line(data: &str) -> Option<(&str, &str)> {
         line_start += line.len();
     }
 
-    // `line_start` is always a line boundary, so `split_at` never lands inside a
-    // character.
+    // `line_start` is always a line boundary, so `split_at` never lands inside
+    // a character.
     attribution.map(|(start, text)| (data.split_at(start).0, text))
 }
 
@@ -998,8 +1007,8 @@ mod tests {
 
     #[test]
     fn quote_or_verse_style_over_other_container_is_not_a_quote() {
-        // A `quote`/`verse` style over an example, sidebar, listing, literal, or
-        // passthrough block keeps that container's own context.
+        // A `quote`/`verse` style over an example, sidebar, listing, literal,
+        // or passthrough block keeps that container's own context.
         assert_eq!(
             parse_one("[quote]\n====\nx\n====").raw_context().deref(),
             "example"
@@ -1131,10 +1140,10 @@ mod tests {
 
     #[test]
     fn markdown_blockquote_propagates_nested_warning() {
-        // A warning produced while parsing the (owned, `>`-stripped) body — here
-        // an unterminated nested delimited block — is re-anchored at the
-        // blockquote's own span and surfaced to the caller, rather than being
-        // dropped (or panicking a debug build).
+        // A warning produced while parsing the (owned, `>`-stripped) body —
+        // here an unterminated nested delimited block — is re-anchored
+        // at the blockquote's own span and surfaced to the caller,
+        // rather than being dropped (or panicking a debug build).
         let mut parser = Parser::default();
         let maw = Block::parse(crate::Span::new("> ____\n> unclosed"), &mut parser);
 
@@ -1167,8 +1176,9 @@ mod tests {
         assert_eq!(quote.content_model(), ContentModel::Compound);
         assert_eq!(quote.blocks().len(), 1);
 
-        // A Markdown blockquote's nested blocks borrow the block's owned source,
-        // but `child_blocks()` still exposes them (matching `blocks()`).
+        // A Markdown blockquote's nested blocks borrow the block's owned
+        // source, but `child_blocks()` still exposes them (matching
+        // `blocks()`).
         assert_eq!(quote.child_blocks().count(), 1);
     }
 
@@ -1335,7 +1345,8 @@ mod tests {
         fn assert_literal_heading(input: &str) {
             let doc = Parser::default().parse(input);
 
-            // No section heading was recognized, so nothing renders as an `<h2>`.
+            // No section heading was recognized, so nothing renders as an
+            // `<h2>`.
             assert_xpath(&doc, "//h2", 0);
 
             // The line survives as ordinary paragraph content.

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -88,10 +88,11 @@ impl<'src> RawDelimitedBlock<'src> {
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 
-        // The fenced code block delimiter is exactly three backticks, optionally
-        // followed by a language on the opening fence (```ruby). Unlike the
-        // four-character verbatim/raw delimiters, its backtick run has a fixed
-        // length (as with the two-character open-block delimiter): a run of four
+        // The fenced code block delimiter is exactly three backticks,
+        // optionally followed by a language on the opening fence
+        // (```ruby). Unlike the four-character verbatim/raw delimiters,
+        // its backtick run has a fixed length (as with the
+        // two-character open-block delimiter): a run of four
         // or more backticks is not a fence.
         if data == "```" || fenced_code_language(line).is_some() {
             return true;
@@ -133,23 +134,26 @@ impl<'src> RawDelimitedBlock<'src> {
         // (```ruby), whose closing fence is a bare ``` — set below.
         let mut close_delimiter = delimiter_data;
 
-        // The attribute list synthesized for a language-aware fenced code block.
-        // For every other block the author's own attribute list (if any) is used.
+        // The attribute list synthesized for a language-aware fenced code
+        // block. For every other block the author's own attribute list
+        // (if any) is used.
         let mut fenced_attrlist: Option<Attrlist<'src>> = None;
 
-        // A `--` open-block delimiter normally forms a compound (open) block, but
-        // a verbatim masquerade style (`source`, `listing`, or `literal`) set on
-        // it turns the block into a verbatim raw block. Every other delimiter
-        // must be at least four characters long.
+        // A `--` open-block delimiter normally forms a compound (open) block,
+        // but a verbatim masquerade style (`source`, `listing`, or
+        // `literal`) set on it turns the block into a verbatim raw
+        // block. Every other delimiter must be at least four characters
+        // long.
         let (content_model, context, mut substitution_group) = if delimiter_data == "--" {
             // A plain or compound-styled open block returns `None` here and is
             // handled by `CompoundDelimitedBlock` instead.
             open_block_verbatim_masquerade(metadata.attrlist.as_ref())?
         } else if delimiter_data == "```" {
-            // A fenced code block (three backticks) is a verbatim listing block.
-            // Its delimiter has a fixed length, so no trailing-character
-            // validity check is required. The closing fence must match the
-            // opening delimiter exactly, which the scan loop below enforces.
+            // A fenced code block (three backticks) is a verbatim listing
+            // block. Its delimiter has a fixed length, so no
+            // trailing-character validity check is required. The
+            // closing fence must match the opening delimiter
+            // exactly, which the scan loop below enforces.
             (
                 ContentModel::Verbatim,
                 "listing",

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -65,9 +65,9 @@ impl<'src> SectionBlock<'src> {
         // within another section's body. Inside a delimited block (example,
         // sidebar, open, or quote), a `== …` line is literal content — a
         // paragraph — not a section, so decline here and let the line fall
-        // through to `SimpleBlock`. A discrete heading is an ordinary block, not
-        // a section, and remains valid in these contexts, so it is not
-        // suppressed.
+        // through to `SimpleBlock`. A discrete heading is an ordinary block,
+        // not a section, and remains valid in these contexts, so it is
+        // not suppressed.
         if !discrete && parser.in_delimited_block {
             return None;
         }
@@ -78,25 +78,26 @@ impl<'src> SectionBlock<'src> {
         // document attribute. A positive offset (the usual case, from
         // `include::[leveloffset=+1]`) pushes headings down — notably promoting
         // an included file's level-0 document title (`=`) into a real section —
-        // while a negative offset pulls them up. A heading whose effective level
-        // is below 1 is rejected as an unsupported level-0 heading (the warning
-        // is raised inside `parse_title_line`).
+        // while a negative offset pulls them up. A heading whose effective
+        // level is below 1 is rejected as an unsupported level-0
+        // heading (the warning is raised inside `parse_title_line`).
         let level_and_title = parse_title_line(source, parser.level_offset(), discrete, warnings)?;
 
-        // Take a snapshot of `sectids` value before reading child blocks because
-        // the value might be altered while parsing.
+        // Take a snapshot of `sectids` value before reading child blocks
+        // because the value might be altered while parsing.
         let sectids = parser.is_attribute_set("sectids");
 
         let level = level_and_title.item.0;
 
         // A level-0 section heading in the document body (a bare `=` that no
-        // positive `leveloffset` promoted to a real section) is only valid under
-        // `:doctype: book`, where it is a book part. Under any other doctype
-        // Asciidoctor logs "level 0 sections can only be used when doctype is
-        // book"; raise that warning here, where the doctype is known. The heading
-        // is still modeled as a level-0 section either way, so a renderer can emit
-        // `<h1 class="sect0">`. A discrete level-0 heading is a floating `<h1>`,
-        // not a section, and is exempt.
+        // positive `leveloffset` promoted to a real section) is only valid
+        // under `:doctype: book`, where it is a book part. Under any
+        // other doctype Asciidoctor logs "level 0 sections can only be
+        // used when doctype is book"; raise that warning here, where
+        // the doctype is known. The heading is still modeled as a
+        // level-0 section either way, so a renderer can emit
+        // `<h1 class="sect0">`. A discrete level-0 heading is a floating
+        // `<h1>`, not a section, and is exempt.
         if !discrete && level == 0 && !is_book_doctype(parser) {
             warnings.push(Warning::new(
                 source.take_normalized_line().item,
@@ -114,19 +115,21 @@ impl<'src> SectionBlock<'src> {
             .and_then(|a| a.id())
             .or_else(|| metadata.anchor.as_ref().map(|anchor| anchor.data()));
 
-        // AsciiDoc lets a section define its ID via an anchor embedded at the end
-        // of the title (`== Title [[id]] ==`, optionally `[[id,reftext]]`). When
-        // present (and not already overridden by an explicit ID above), the anchor
-        // is consumed to set the section ID and removed from the rendered title,
-        // rather than being rendered as an inline anchor.
+        // AsciiDoc lets a section define its ID via an anchor embedded at the
+        // end of the title (`== Title [[id]] ==`, optionally
+        // `[[id,reftext]]`). When present (and not already overridden
+        // by an explicit ID above), the anchor is consumed to set the
+        // section ID and removed from the rendered title, rather than
+        // being rendered as an inline anchor.
         let (title_span, embedded_id, embedded_reftext) = if attr_or_anchor_id.is_none() {
             match_embedded_section_anchor(level_and_title.item.1)
         } else {
             (level_and_title.item.1, None, None)
         };
 
-        // Assign the section type. At level 1, we look for an `appendix` section style;
-        // at all other levels, we inherit the section type from parent.
+        // Assign the section type. At level 1, we look for an `appendix`
+        // section style; at all other levels, we inherit the section
+        // type from parent.
         let section_type = if discrete {
             SectionType::Discrete
         } else if level == 1 {
@@ -144,18 +147,20 @@ impl<'src> SectionBlock<'src> {
             parser.topmost_section_type
         };
 
-        // Assign section number BEFORE parsing child blocks so that sections are
-        // numbered in document order (parent before children).
+        // Assign section number BEFORE parsing child blocks so that sections
+        // are numbered in document order (parent before children).
         //
-        // Appendix sections are lettered (A, B, ...) independently of `sectnums`
-        // because their title prefix is governed by the `appendix-caption`
-        // attribute (see the "Appendix label" section of the spec). An appendix
-        // root — the section that directly carries the `appendix` style —
-        // therefore always advances the appendix counter so it (and the numbering
-        // of any subsection) can derive its letter, even when `sectnums` is unset.
+        // Appendix sections are lettered (A, B, ...) independently of
+        // `sectnums` because their title prefix is governed by the
+        // `appendix-caption` attribute (see the "Appendix label"
+        // section of the spec). An appendix root — the section that
+        // directly carries the `appendix` style — therefore always
+        // advances the appendix counter so it (and the numbering of any
+        // subsection) can derive its letter, even when `sectnums` is unset.
         // A level-0 section (a book part) is not numbered through `sectnums`
-        // (parts use the separate `partnums` attribute, which this crate does not
-        // yet model), so section numbering is restricted to level 1 and deeper.
+        // (parts use the separate `partnums` attribute, which this crate does
+        // not yet model), so section numbering is restricted to level 1
+        // and deeper.
         let sectnums_active = parser.is_attribute_set("sectnums")
             && level >= MIN_SECTION_LEVEL as usize
             && level <= parser.sectnumlevels
@@ -163,12 +168,13 @@ impl<'src> SectionBlock<'src> {
 
         let is_appendix_root = !discrete && level == 1 && section_type == SectionType::Appendix;
 
-        // A cross-reference builds `full`/`short` xrefstyle text from a section's
-        // signifier and number, but only when the section has a number *and* no
-        // explicit reftext (an explicit reftext is used verbatim instead). An
-        // explicit reftext can come from a `reftext` attribute, the second field
-        // of a `[[id,reftext]]` block anchor, or the second field of an anchor
-        // embedded in the section title.
+        // A cross-reference builds `full`/`short` xrefstyle text from a
+        // section's signifier and number, but only when the section has
+        // a number *and* no explicit reftext (an explicit reftext is
+        // used verbatim instead). An explicit reftext can come from a
+        // `reftext` attribute, the second field of a `[[id,reftext]]`
+        // block anchor, or the second field of an anchor embedded in
+        // the section title.
         let has_explicit_reftext = metadata
             .attrlist
             .as_ref()
@@ -180,11 +186,11 @@ impl<'src> SectionBlock<'src> {
         // An anchor reftext can carry attribute references (`[[install,install
         // on {platform-name}]]`), whether the anchor sits above the heading
         // (`metadata.anchor_reftext`) or is embedded in the title
-        // (`embedded_reftext`). Resolve them against the attributes in effect at
-        // the anchor's location — captured here, before the section body is
-        // parsed and can itself redefine those attributes — mirroring how the
-        // anchor ID and a `reftext=` attribute are already substituted when the
-        // attribute list is parsed.
+        // (`embedded_reftext`). Resolve them against the attributes in effect
+        // at the anchor's location — captured here, before the section
+        // body is parsed and can itself redefine those attributes —
+        // mirroring how the anchor ID and a `reftext=` attribute are
+        // already substituted when the attribute list is parsed.
         let anchor_reftext = metadata
             .anchor_reftext
             .as_ref()
@@ -250,15 +256,17 @@ impl<'src> SectionBlock<'src> {
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
         //
         // A footnote in the title is a real, document-order footnote, but its
-        // marker must not leak into the section's reference text (an xref's link
-        // text) or auto-generated ID. The title's tree is what answers that: a
-        // footnote is a node, so the heading's own rendering and its
-        // footnote-free reference text are two folds of one tree
-        // ([`fold_reference_text`]), and "which regions were footnote markers"
-        // is a question about node kinds rather than about bytes. Still a single
-        // substitution pass, so counters and attribute-expanded footnotes are
-        // processed exactly once — which is what the sentinel pair this replaces
-        // existed to buy (design §4.2's first sentinel system).
+        // marker must not leak into the section's reference text (an xref's
+        // link text) or auto-generated ID. The title's tree is what
+        // answers that: a footnote is a node, so the heading's own
+        // rendering and its footnote-free reference text are two folds
+        // of one tree ([`fold_reference_text`]), and "which regions
+        // were footnote markers" is a question about node kinds rather
+        // than about bytes. Still a single substitution pass, so
+        // counters and attribute-expanded footnotes are
+        // processed exactly once — which is what the sentinel pair this
+        // replaces existed to buy (design §4.2's first sentinel
+        // system).
         let mut section_title = Content::from(title_span);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
 
@@ -270,10 +278,11 @@ impl<'src> SectionBlock<'src> {
             &parser.render_context(),
         );
 
-        // A section carrying the `bibliography` style implicitly adds that style
-        // to each top-level unordered list in its body (see the "Bibliography
-        // section syntax" section of the spec). Record that we are parsing such a
-        // section's body so `ListBlock::parse` can detect it, and restore the
+        // A section carrying the `bibliography` style implicitly adds that
+        // style to each top-level unordered list in its body (see the
+        // "Bibliography section syntax" section of the spec). Record
+        // that we are parsing such a section's body so
+        // `ListBlock::parse` can detect it, and restore the
         // previous value afterward so the style does not leak into sibling
         // sections (or, via a non-bibliography subsection, into its children).
         let is_bibliography_section = !discrete
@@ -286,12 +295,14 @@ impl<'src> SectionBlock<'src> {
         let previously_in_bibliography_section = parser.parsing_bibliography_section_body;
         parser.parsing_bibliography_section_body = is_bibliography_section;
 
-        // A special section that does not support nested sections (a `glossary`,
-        // `bibliography`, `colophon`, `dedication`, or `index` section) logs an
-        // error for each subsection found directly within it. Only a level-1
-        // section carries a special-section style, and a discrete heading is not
+        // A special section that does not support nested sections (a
+        // `glossary`, `bibliography`, `colophon`, `dedication`, or
+        // `index` section) logs an error for each subsection found
+        // directly within it. Only a level-1 section carries a
+        // special-section style, and a discrete heading is not
         // part of the section hierarchy, so the check is limited accordingly.
-        // The offending subsections are detected below, once the body is parsed.
+        // The offending subsections are detected below, once the body is
+        // parsed.
         let no_subsection_style = if !discrete && level == 1 {
             metadata
                 .attrlist
@@ -337,12 +348,13 @@ impl<'src> SectionBlock<'src> {
         let source = metadata.source.trim_remainder(blocks.after);
 
         // Emit an error for each subsection found directly inside a special
-        // section that does not support nested sections. The error points at the
-        // offending subsection's heading line, mirroring Asciidoctor's
-        // `<sectname> sections do not support nested sections` diagnostic. The
-        // subsection's title source is used rather than its whole span, whose
-        // first line is any block metadata (an anchor, attribute list, or block
-        // title) that precedes the heading.
+        // section that does not support nested sections. The error points at
+        // the offending subsection's heading line, mirroring
+        // Asciidoctor's `<sectname> sections do not support nested
+        // sections` diagnostic. The subsection's title source is used
+        // rather than its whole span, whose first line is any block
+        // metadata (an anchor, attribute list, or block title) that
+        // precedes the heading.
         if let Some(style) = no_subsection_style {
             for block in &blocks.item {
                 if let Block::Section(subsection) = block
@@ -361,14 +373,14 @@ impl<'src> SectionBlock<'src> {
 
         let proposed_base_id = generate_section_id(&title_reftext, parser);
 
-        // An explicit ID above the heading wins; otherwise an anchor embedded in
-        // the title supplies the ID.
+        // An explicit ID above the heading wins; otherwise an anchor embedded
+        // in the title supplies the ID.
         let manual_id = attr_or_anchor_id.or(embedded_id);
 
         // Reftext precedence mirrors `Block::block_reftext`: an explicit
-        // `reftext` attribute, then a `[[id,reftext]]` block-anchor reftext, then
-        // an embedded-anchor reftext (both with their attribute references
-        // already resolved above), then the section title.
+        // `reftext` attribute, then a `[[id,reftext]]` block-anchor reftext,
+        // then an embedded-anchor reftext (both with their attribute
+        // references already resolved above), then the section title.
         let reftext: CowStr<'_> = metadata
             .attrlist
             .as_ref()
@@ -414,7 +426,8 @@ impl<'src> SectionBlock<'src> {
             embedded_id.map(str::to_string)
         };
 
-        // Restore "normal" top-level section type if exiting a level 1 appendix.
+        // Restore "normal" top-level section type if exiting a level 1
+        // appendix.
         if level == 1 && !discrete {
             parser.topmost_section_type = SectionType::Normal;
         }
@@ -825,10 +838,11 @@ fn match_embedded_section_anchor<'src>(
     let title_text = caps.get(1).map_or("", |m| m.as_str());
     let id = caps.get(3).map(|m| m.as_str());
 
-    // Trailing whitespace is trimmed from the reftext, matching the inline-anchor
-    // substitution's handling of a shorthand `[[id,reftext]]`. The reftext is
-    // returned as a source span (rather than a `&str`) so its attribute
-    // references can be resolved against the document source at the caller.
+    // Trailing whitespace is trimmed from the reftext, matching the
+    // inline-anchor substitution's handling of a shorthand
+    // `[[id,reftext]]`. The reftext is returned as a source span (rather
+    // than a `&str`) so its attribute references can be resolved against
+    // the document source at the caller.
     let reftext = caps
         .get(4)
         .map(|m| title.slice(m.start()..m.end()).trim_trailing_whitespace());
@@ -907,24 +921,25 @@ fn parse_title_line<'src>(
 
     let title_span = strip_symmetric_title_close(title.after, marker_char, count);
 
-    // A bare `=` (syntactic level 0) that no positive offset lifts to level 1 or
-    // beyond is a document title appearing in the body. Rather than the document
-    // title (the single-document-title rule forbids a second one), it models a
-    // level-0 section — Asciidoctor's `sect0`, rendered as `<h1 class="sect0">`,
-    // a book part under `:doctype: book`. It is carried through with level 0 so
-    // the block model can represent it; `SectionBlock::parse` raises
-    // [`WarningType::Level0SectionHeadingNotSupported`] for it under any doctype
-    // other than `book`, where it knows the doctype.
+    // A bare `=` (syntactic level 0) that no positive offset lifts to level 1
+    // or beyond is a document title appearing in the body. Rather than the
+    // document title (the single-document-title rule forbids a second one),
+    // it models a level-0 section — Asciidoctor's `sect0`, rendered as `<h1
+    // class="sect0">`, a book part under `:doctype: book`. It is carried
+    // through with level 0 so the block model can represent it;
+    // `SectionBlock::parse` raises
+    // [`WarningType::Level0SectionHeadingNotSupported`] for it under any
+    // doctype other than `book`, where it knows the doctype.
     //
-    // A `discrete`/`float` heading is likewise valid at level 0: it renders as a
-    // floating `<h1>` rather than the document title.
+    // A `discrete`/`float` heading is likewise valid at level 0: it renders as
+    // a floating `<h1>` rather than the document title.
     //
     // A real section heading whose offset-adjusted level lands outside the
     // supported range is clamped into range and reported, rather than producing
     // an out-of-range (or, under a hostile offset, absurd) level. The lower
-    // bound is [`MIN_SECTION_LEVEL`] normally, but 0 for a `discrete` heading or
-    // a bare `=` (syntactic level 0), each of which may legitimately occupy
-    // level 0.
+    // bound is [`MIN_SECTION_LEVEL`] normally, but 0 for a `discrete` heading
+    // or a bare `=` (syntactic level 0), each of which may legitimately
+    // occupy level 0.
     let min_level = if discrete || syntactic_level == 0 {
         0
     } else {
@@ -1000,8 +1015,8 @@ fn peer_or_ancestor_section<'src>(
     // path. Block metadata may be separated from its block by blank lines
     // (including the blank lines around a comment that block-metadata parsing
     // skips over), and `parse_title_line` requires a non-blank first line, so
-    // without this the boundary check would miss such a heading and wrongly fold
-    // the following peer/ancestor section into the current one.
+    // without this the boundary check would miss such a heading and wrongly
+    // fold the following peer/ancestor section into the current one.
     let source_after_metadata = block_metadata.block_start.discard_empty_lines();
 
     // Compare effective levels: the boundary heading's `leveloffset` is read
@@ -1020,8 +1035,8 @@ fn peer_or_ancestor_section<'src>(
     let mut ignored_warnings = vec![];
 
     // A `discrete` heading has already been excluded above, so the boundary
-    // look-ahead never needs the level-0 exemption; pass `discrete = false` so a
-    // bare `=` here is treated as ordinary content, exactly as before.
+    // look-ahead never needs the level-0 exemption; pass `discrete = false` so
+    // a bare `=` here is treated as ordinary content, exactly as before.
     if let Some(mi) = parse_title_line(
         source_after_metadata,
         parser.level_offset(),
@@ -1156,11 +1171,11 @@ fn generate_section_id(title: &str, parser: &Parser) -> String {
             gen_id.pop();
         }
 
-        // Strip a leading separator (e.g. from a title beginning with a space or
-        // hyphen) before the prefix is applied, matching Ruby Asciidoctor. This
-        // keeps a leading separator out of the final ID and avoids doubling it
-        // up against a non-empty `idprefix` (e.g. `=== {sp}Heading` → `_heading`,
-        // not `__heading`).
+        // Strip a leading separator (e.g. from a title beginning with a space
+        // or hyphen) before the prefix is applied, matching Ruby
+        // Asciidoctor. This keeps a leading separator out of the final
+        // ID and avoids doubling it up against a non-empty `idprefix`
+        // (e.g. `=== {sp}Heading` → `_heading`, not `__heading`).
         if gen_id.starts_with(&sep) {
             gen_id = gen_id[sep.len()..].to_string();
         }
@@ -2221,9 +2236,10 @@ mod tests {
             let mut parser = Parser::default();
             let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 
-            // A bare `=` in the body is modeled as a level-0 section (Asciidoctor's
-            // `sect0`), not declined. Under the default (article) doctype it also
-            // raises the level-0 warning.
+            // A bare `=` in the body is modeled as a level-0 section
+            // (Asciidoctor's `sect0`), not declined. Under the
+            // default (article) doctype it also raises the level-0
+            // warning.
             let mi = crate::blocks::SectionBlock::parse(
                 &BlockMetadata::new("= Document Title"),
                 &mut parser,
@@ -3162,9 +3178,9 @@ mod tests {
             let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 
             // A bare `#` (the Markdown-style level-0 marker) in the body is
-            // modeled as a level-0 section (Asciidoctor's `sect0`), not declined.
-            // Under the default (article) doctype it also raises the level-0
-            // warning.
+            // modeled as a level-0 section (Asciidoctor's `sect0`), not
+            // declined. Under the default (article) doctype it also
+            // raises the level-0 warning.
             let mi = crate::blocks::SectionBlock::parse(
                 &BlockMetadata::new("# Document Title"),
                 &mut parser,
@@ -4315,8 +4331,9 @@ mod tests {
         #[test]
         fn level_0() {
             // A `[discrete]`/`[float]` style makes a level-0 (`=`) heading a
-            // discrete floating title rather than the (rejected) document title,
-            // so it parses to a level-0 discrete section with no warning.
+            // discrete floating title rather than the (rejected) document
+            // title, so it parses to a level-0 discrete section
+            // with no warning.
             let mut parser = Parser::default();
             let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -309,13 +309,15 @@ fn parse_lines<'src>(
     let source_after_whitespace = source.discard_whitespace();
     let first_line_indent = source_after_whitespace.col() - 1;
 
-    // Track if we're in "indented literal" mode (literal style from indentation).
-    // In this mode, we should still stop for list markers that are NOT indented.
+    // Track if we're in "indented literal" mode (literal style from
+    // indentation). In this mode, we should still stop for list markers
+    // that are NOT indented.
     let mut indented_literal_mode = false;
 
     let mut style = if source_after_whitespace.col() == source.col() || force_paragraph_style {
-        // When force_paragraph_style is true, we still need to track that the content
-        // is indented so we can properly stop at unindented list markers.
+        // When force_paragraph_style is true, we still need to track that the
+        // content is indented so we can properly stop at unindented
+        // list markers.
         if source_after_whitespace.col() != source.col() {
             indented_literal_mode = true;
         }
@@ -365,10 +367,10 @@ fn parse_lines<'src>(
     let mut next = source;
     let mut filtered_lines: Vec<&'src str> = vec![];
 
-    // Source span of each surviving line, kept in lockstep with `filtered_lines`
-    // so the attribute-references substitution can locate an
-    // `attribute-missing=warn` warning at the precise source offset of the
-    // offending reference (see `Content::from_filtered_lines`).
+    // Source span of each surviving line, kept in lockstep with
+    // `filtered_lines` so the attribute-references substitution can locate
+    // an `attribute-missing=warn` warning at the precise source offset of
+    // the offending reference (see `Content::from_filtered_lines`).
     let mut skipped_comment_line = false;
 
     // Determine how much indentation to strip from literal paragraphs.
@@ -409,9 +411,10 @@ fn parse_lines<'src>(
     while let Some(line_mi) = next.take_non_empty_line() {
         let mut line = line_mi.item;
 
-        // If we've skipped a comment line and this is a section header, stop here
-        // so the section can be parsed as a separate block. Only do this at the
-        // top level (not inside lists), indicated by stop_for_list_items being false.
+        // If we've skipped a comment line and this is a section header, stop
+        // here so the section can be parsed as a separate block. Only
+        // do this at the top level (not inside lists), indicated by
+        // stop_for_list_items being false.
         if !stop_for_list_items
             && skipped_comment_line
             && style == SimpleBlockStyle::Paragraph
@@ -420,13 +423,14 @@ fn parse_lines<'src>(
             break;
         }
 
-        // A leading line comment sitting directly above a line that begins a new
-        // block — block metadata (a `.Title`, or a `[...]` attribute list or
-        // `[[...]]` anchor) or a block delimiter (a delimited block or a table)
-        // — must not absorb that line as paragraph content. Terminate the
-        // comment-only block here so the following line gets a fresh dispatch
-        // and can attach as metadata to (or open) the block it decorates.
-        // Without this, the first such line after the comment is swallowed as
+        // A leading line comment sitting directly above a line that begins a
+        // new block — block metadata (a `.Title`, or a `[...]`
+        // attribute list or `[[...]]` anchor) or a block delimiter (a
+        // delimited block or a table) — must not absorb that line as
+        // paragraph content. Terminate the comment-only block here so
+        // the following line gets a fresh dispatch and can attach as
+        // metadata to (or open) the block it decorates. Without this,
+        // the first such line after the comment is swallowed as
         // paragraph text. This is scoped to the case where only comment lines
         // have been consumed so far (`filtered_lines` still empty); once real
         // content has accumulated, the general stop conditions below take over.
@@ -450,17 +454,18 @@ fn parse_lines<'src>(
 
         // There are several stop conditions for simple paragraph blocks. These
         // "shouldn't" be encountered on the first line (we shouldn't be calling
-        // `SimpleBlock::parse` in these conditions), but in case it is, we simply
-        // ignore them on the first line.
+        // `SimpleBlock::parse` in these conditions), but in case it is, we
+        // simply ignore them on the first line.
         if !filtered_lines.is_empty() {
-            // In indented literal mode, only stop for list markers that are NOT indented
-            // (at column 1). This allows definition list items to be properly separated.
+            // In indented literal mode, only stop for list markers that are NOT
+            // indented (at column 1). This allows definition list
+            // items to be properly separated.
             let should_check_for_list_marker =
                 stop_for_list_items && (!indented_literal_mode || line.col() == 1);
 
-            // If we've already started accumulating content for this list item paragraph,
-            // we don't stop for list markers at any level other than our own or a parent
-            // level.
+            // If we've already started accumulating content for this list item
+            // paragraph, we don't stop for list markers at any
+            // level other than our own or a parent level.
             if should_check_for_list_marker
                 && let Some(marker_mi) = ListItemMarker::parse(line, parser)
             {
@@ -501,9 +506,10 @@ fn parse_lines<'src>(
 
         next = line_mi.after;
 
-        // Only strip comment lines in paragraph style. In literal/listing/source
-        // blocks, "//" lines are preserved as content; likewise a `[comment]`
-        // paragraph retains its content verbatim (raw).
+        // Only strip comment lines in paragraph style. In
+        // literal/listing/source blocks, "//" lines are preserved as
+        // content; likewise a `[comment]` paragraph retains its content
+        // verbatim (raw).
         if !comment_style
             && style == SimpleBlockStyle::Paragraph
             && line.starts_with("//")
@@ -966,8 +972,8 @@ mod tests {
         #[test]
         fn multi_marker_is_always_a_section_regardless_of_offset() {
             // Two or more markers followed by a space are always a section, at
-            // any offset (a negative offset that would push the level below 1 is
-            // clamped in `parse_title_line`, not rejected).
+            // any offset (a negative offset that would push the level below 1
+            // is clamped in `parse_title_line`, not rejected).
             assert!(is_section_header("== Section", 0));
             assert!(is_section_header("=== Section", 0));
             assert!(is_section_header("## Section", 0));
@@ -1006,7 +1012,8 @@ mod tests {
         fn non_marker_and_over_long_marker_are_not_sections() {
             assert!(!is_section_header("paragraph", 1));
 
-            // Seven markers exceed the level-5 maximum, so this is not a heading.
+            // Seven markers exceed the level-5 maximum, so this is not a
+            // heading.
             assert!(!is_section_header("======= Too deep", 0));
         }
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -274,11 +274,12 @@ impl<'src> TableBlock<'src> {
             .as_ref()
             .is_some_and(|a| a.has_option("autowidth"));
 
-        // The first row is an (implicit) header row when the line directly after
-        // the opening delimiter is non-empty and is itself followed by an empty
-        // line. The `header` option forces the same interpretation; the
-        // `noheader` option suppresses only the implicit detection, so an
-        // explicit `header` still wins when both are present.
+        // The first row is an (implicit) header row when the line directly
+        // after the opening delimiter is non-empty and is itself
+        // followed by an empty line. The `header` option forces the
+        // same interpretation; the `noheader` option suppresses only
+        // the implicit detection, so an explicit `header` still wins
+        // when both are present.
         let opts_header = metadata
             .attrlist
             .as_ref()
@@ -296,19 +297,20 @@ impl<'src> TableBlock<'src> {
             .as_ref()
             .is_some_and(|a| a.has_option("footer"));
 
-        // The blank line must genuinely exist after the first row; the end of the
-        // table (an empty remainder) does not count, so a single-row table is not
-        // mistaken for an all-header table.
+        // The blank line must genuinely exist after the first row; the end of
+        // the table (an empty remainder) does not count, so a
+        // single-row table is not mistaken for an all-header table.
         let line1 = inside.take_line();
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
 
-        // An implicit header additionally requires that the first row be complete
-        // on the first line. If the first cell spans multiple lines — for PSV,
-        // the first non-blank line after the blank gap continues the cell instead
-        // of starting a new one; for CSV/TSV, the first line opens a quoted value
-        // that is not closed on that line — there is no implicit header (matching
+        // An implicit header additionally requires that the first row be
+        // complete on the first line. If the first cell spans multiple
+        // lines — for PSV, the first non-blank line after the blank gap
+        // continues the cell instead of starting a new one; for
+        // CSV/TSV, the first line opens a quoted value that is not
+        // closed on that line — there is no implicit header (matching
         // Asciidoctor, which cancels the implicit header in these cases).
         let first_row_complete = match data_format {
             DataFormat::Psv => first_nonblank_line(line1.after)
@@ -321,17 +323,19 @@ impl<'src> TableBlock<'src> {
             opts_header || (!opts_noheader && !line1_blank && line2_blank && first_row_complete);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
-        // prepends to the title, drawn from the `table-caption` attribute (which
-        // defaults to "Table"); each such captioned table consumes the next
-        // value of a document-wide table counter. An explicit `caption`
-        // attribute sets the label verbatim with no number; an explicitly empty
-        // `caption` (e.g. `[caption=]`) removes the label entirely. When
-        // `table-caption` is unset and no explicit `caption` is given, no caption
-        // (and no number) is assigned. See [`assign_block_caption`] for the full,
+        // prepends to the title, drawn from the `table-caption` attribute
+        // (which defaults to "Table"); each such captioned table
+        // consumes the next value of a document-wide table counter. An
+        // explicit `caption` attribute sets the label verbatim with no
+        // number; an explicitly empty `caption` (e.g. `[caption=]`)
+        // removes the label entirely. When `table-caption` is unset and
+        // no explicit `caption` is given, no caption (and no number) is
+        // assigned. See [`assign_block_caption`] for the full,
         // shared rules.
         //
-        // Computed before the cell iterator below borrows `parser` immutably, so
-        // that the mutable counter update does not conflict with that borrow.
+        // Computed before the cell iterator below borrows `parser` immutably,
+        // so that the mutable counter update does not conflict with
+        // that borrow.
         let caption = assign_block_caption(
             parser,
             "table",
@@ -341,13 +345,14 @@ impl<'src> TableBlock<'src> {
         let number = caption.as_ref().and_then(|caption| caption.number);
         let caption = caption.map(|caption| caption.prefix);
 
-        // The `frame` and `grid` attributes control the table's borders, and the
-        // `stripes` attribute controls zebra striping. The borders each default
-        // to `all` and stripes defaults to `none`; the default can be changed for
-        // the whole document with the `table-frame` / `table-grid` /
-        // `table-stripes` attribute, and an explicit attribute on the table
-        // overrides both. Each value is resolved here (while `parser` is borrowed
-        // only immutably) and stored on the block so the accessors need no further
+        // The `frame` and `grid` attributes control the table's borders, and
+        // the `stripes` attribute controls zebra striping. The borders
+        // each default to `all` and stripes defaults to `none`; the
+        // default can be changed for the whole document with the
+        // `table-frame` / `table-grid` / `table-stripes` attribute, and
+        // an explicit attribute on the table overrides both. Each value
+        // is resolved here (while `parser` is borrowed only immutably)
+        // and stored on the block so the accessors need no further
         // document lookup.
         let frame = resolve_table_attribute::<Frame>(metadata, parser, "frame", "table-frame");
         let grid = resolve_table_attribute::<Grid>(metadata, parser, "grid", "table-grid");
@@ -378,8 +383,8 @@ impl<'src> TableBlock<'src> {
         let mut body_rows: Vec<TableRow<'src>> = rows.collect();
 
         // The footer row, when requested, is the last row of the table. It is
-        // moved out of the body so the caller sees it as a distinct footer. When
-        // the table has no rows to spare, no footer is produced.
+        // moved out of the body so the caller sees it as a distinct footer.
+        // When the table has no rows to spare, no footer is produced.
         let footer_row = if opts_footer { body_rows.pop() } else { None };
 
         let source = metadata
@@ -1156,10 +1161,10 @@ fn build_psv_table<'src>(
 
     let separator = separator.as_str();
 
-    // When the column count is implicit, it is the number of column slots in the
-    // first non-empty line: a cell that spans columns (`<n>+`) counts as `<n>`
-    // slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts as `<n>`
-    // single-column slots (one per clone).
+    // When the column count is implicit, it is the number of column slots in
+    // the first non-empty line: a cell that spans columns (`<n>+`) counts
+    // as `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`)
+    // counts as `<n>` single-column slots (one per clone).
     let first_line_cells: usize =
         scan_cells(inside.discard_empty_lines().take_line().item, separator)
             .0
@@ -1188,10 +1193,10 @@ fn build_psv_table<'src>(
     // A table can never have more rows than it has cells, so a row span is
     // clamped to the cell count for the `active_rowspans` bookkeeping below: a
     // larger span carries into rows that can't exist and so has no additional
-    // layout effect. The clamp also bounds the `active_rowspans` allocation, so a
-    // hostile specifier such as `.1000000000+` can't trigger a multi-gigabyte
-    // allocation. (The cell's reported [`rowspan`] keeps the literal parsed
-    // value, matching Asciidoctor.)
+    // layout effect. The clamp also bounds the `active_rowspans` allocation, so
+    // a hostile specifier such as `.1000000000+` can't trigger a
+    // multi-gigabyte allocation. (The cell's reported [`rowspan`] keeps the
+    // literal parsed value, matching Asciidoctor.)
     //
     // [`rowspan`]: TableCell::rowspan
     let max_rowspan = raw_cells.len().saturating_add(1);
@@ -1199,10 +1204,11 @@ fn build_psv_table<'src>(
     let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
 
     if ncols > 0 {
-        // A queue: each completed row consumes the slots carried into it from the
-        // front (`pop_front`), while a multi-row cell reserves slots in the rows it
-        // extends into via the back. `VecDeque` keeps both ends O(1); a `Vec` would
-        // pay an O(n) shift on every `remove(0)`.
+        // A queue: each completed row consumes the slots carried into it from
+        // the front (`pop_front`), while a multi-row cell reserves
+        // slots in the rows it extends into via the back. `VecDeque`
+        // keeps both ends O(1); a `Vec` would pay an O(n) shift on
+        // every `remove(0)`.
         let mut active_rowspans: VecDeque<usize> = VecDeque::from([0]);
         let mut column_visits = 0usize;
         let mut current_row: Vec<RawCell<'src>> = vec![];
@@ -1226,8 +1232,9 @@ fn build_psv_table<'src>(
             let cell_source = raw.content;
             current_row.push(raw);
 
-            // The slots carried into the current row are `active_rowspans[0]`; the
-            // deque is never empty here, so the fallback is unreachable.
+            // The slots carried into the current row are `active_rowspans[0]`;
+            // the deque is never empty here, so the fallback is
+            // unreachable.
             let carried = active_rowspans.front().copied().unwrap_or(0);
             let effective = column_visits + carried;
             if effective >= ncols {
@@ -1235,8 +1242,8 @@ fn build_psv_table<'src>(
                     raw_rows.push(std::mem::take(&mut current_row));
                 } else {
                     // Overrun: this cell's span pushes the row past `ncols`.
-                    // Discard the whole row so the remaining cells stay aligned to
-                    // the grid.
+                    // Discard the whole row so the remaining cells stay aligned
+                    // to the grid.
                     current_row.clear();
                     warnings.push(Warning::new(
                         cell_source,
@@ -1263,12 +1270,12 @@ fn build_psv_table<'src>(
         }
     }
 
-    // Each cell is processed according to the style of the column it falls in. A
-    // cell's column is its ordinal position within its row (matching Asciidoctor,
-    // which assigns the column by cell count, not grid slot). The header row
-    // (when present) is the first row and is always processed as plain header
-    // content, regardless of the column styles, so that a style operator doesn't
-    // affect the header row.
+    // Each cell is processed according to the style of the column it falls in.
+    // A cell's column is its ordinal position within its row (matching
+    // Asciidoctor, which assigns the column by cell count, not grid slot).
+    // The header row (when present) is the first row and is always
+    // processed as plain header content, regardless of the column styles,
+    // so that a style operator doesn't affect the header row.
     let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
     for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
         let is_header = has_header && row_idx == 0;
@@ -1311,9 +1318,9 @@ fn build_data_table<'src>(
 
     let separator = separator.as_str();
 
-    // DSV is parsed by its own, simpler rules; CSV and TSV share their rules and
-    // differ only in the default separator (resolved by the caller). PSV never
-    // reaches this builder.
+    // DSV is parsed by its own, simpler rules; CSV and TSV share their rules
+    // and differ only in the default separator (resolved by the caller).
+    // PSV never reaches this builder.
     let (fields, first_row_len) = if data_format == DataFormat::Dsv {
         parse_dsv_fields(inside, separator)
     } else {
@@ -1328,8 +1335,8 @@ fn build_data_table<'src>(
 
     let columns = finalize_columns(cols_attr, ncols, autowidth);
 
-    // Integer division drops any partial trailing row; `checked_div` yields zero
-    // rows when there are no columns.
+    // Integer division drops any partial trailing row; `checked_div` yields
+    // zero rows when there are no columns.
     let nrows = fields.len().checked_div(ncols).unwrap_or(0);
     let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(nrows);
     let mut fields = fields.into_iter();
@@ -1395,8 +1402,8 @@ fn parse_csv_fields<'src>(
     let mut first_row_done = false;
     let mut fields_in_row = 0usize;
 
-    // The raw text of the cell currently being accumulated runs from `cell_start`
-    // to the next boundary.
+    // The raw text of the cell currently being accumulated runs from
+    // `cell_start` to the next boundary.
     let mut cell_start = 0usize;
     let mut i = 0usize;
 
@@ -1419,9 +1426,10 @@ fn parse_csv_fields<'src>(
             continue;
         }
 
-        // A wholly blank physical line (or trailing blank text at the end of the
-        // region) between rows is skipped rather than emitted as an empty cell. A
-        // blank cell that follows a separator on a populated line is kept.
+        // A wholly blank physical line (or trailing blank text at the end of
+        // the region) between rows is skipped rather than emitted as an
+        // empty cell. A blank cell that follows a separator on a
+        // populated line is kept.
         let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
         if !blank_skip {
             fields.push(make_csv_field(region, cell_start, i, warnings));
@@ -1436,8 +1444,8 @@ fn parse_csv_fields<'src>(
         }
 
         if at_nl {
-            // The newline ends the row. The first populated row fixes the implicit
-            // column count.
+            // The newline ends the row. The first populated row fixes the
+            // implicit column count.
             if fields_in_row > 0 {
                 first_row_done = true;
             }
@@ -1680,49 +1688,54 @@ fn process_content<'src>(
 ) -> TableCellContent<'src> {
     if style == ColumnStyle::AsciiDoc {
         // The AsciiDoc style effectively creates a nested, standalone AsciiDoc
-        // document in the cell. It inherits the parent document's attributes, but
-        // any attribute it defines is scoped to the cell and must not leak back
-        // into the parent. Snapshot the attribute set before parsing and restore
-        // it afterward to enforce that boundary (matching Asciidoctor, where a
-        // `:foo:` set inside a cell is not visible after the table).
+        // document in the cell. It inherits the parent document's attributes,
+        // but any attribute it defines is scoped to the cell and must
+        // not leak back into the parent. Snapshot the attribute set
+        // before parsing and restore it afterward to enforce that
+        // boundary (matching Asciidoctor, where a `:foo:` set inside a
+        // cell is not visible after the table).
         let saved_attributes = parser.attribute_values.clone();
 
         // An attribute that is set in the parent document cannot be modified
-        // inside the cell. Lock every inherited attribute that currently holds a
-        // value for the duration of the cell (other than the handful of
-        // exceptions the spec carves out), so a body assignment to one of them is
-        // ignored. An attribute that is unset in the parent is not locked: the
-        // cell may assign it (matching Asciidoctor, which here diverges from the
-        // spec's "set or explicitly unset" wording). The lock set is saved and
+        // inside the cell. Lock every inherited attribute that currently holds
+        // a value for the duration of the cell (other than the handful
+        // of exceptions the spec carves out), so a body assignment to
+        // one of them is ignored. An attribute that is unset in the
+        // parent is not locked: the cell may assign it (matching
+        // Asciidoctor, which here diverges from the spec's "set or
+        // explicitly unset" wording). The lock set is saved and
         // restored so it applies only within the cell and nests correctly.
         // An attribute set in the parent is locked, as is one hard set or unset
-        // through the API (its modification context is `ApiOnly`) even though it
-        // is unset — matching Asciidoctor, where an API-controlled attribute can
-        // never be overridden in a cell. An attribute merely unset in the parent
-        // document is not locked, so the cell may assign it.
+        // through the API (its modification context is `ApiOnly`) even though
+        // it is unset — matching Asciidoctor, where an API-controlled
+        // attribute can never be overridden in a cell. An attribute
+        // merely unset in the parent document is not locked, so the
+        // cell may assign it.
         //
         // The inherited attribute set is the shared built-in defaults with the
         // parent's per-parser entries (`saved_attributes`) layered on top, so
         // walk both, letting a per-parser entry shadow a like-named built-in.
         // The synthesized backend-family and `safe-mode-*` flags need no lock
-        // here: they are read-only intrinsics that reject a cell-body assignment
-        // on their own (see `DERIVED_FAMILY_FLAG` / `SAFE_MODE_ACTIVE_FLAG`),
-        // which a static lock could not do anyway once the cell changes its own
-        // doctype.
+        // here: they are read-only intrinsics that reject a cell-body
+        // assignment on their own (see `DERIVED_FAMILY_FLAG` /
+        // `SAFE_MODE_ACTIVE_FLAG`), which a static lock could not do
+        // anyway once the cell changes its own doctype.
         let saved_locks = parser.locked_attribute_names.clone();
 
         // The cached section-numbering depth is frozen at the end of the
-        // enclosing document's header, so it holds the parent's value throughout
-        // the cell. A cell that assigns its own `sectnumlevels` refreshes it (see
-        // `Parser::set_attribute_from_body`); snapshot and restore it here so that
-        // refresh cannot leak back into the parent's numbering.
+        // enclosing document's header, so it holds the parent's value
+        // throughout the cell. A cell that assigns its own
+        // `sectnumlevels` refreshes it (see
+        // `Parser::set_attribute_from_body`); snapshot and restore it here so
+        // that refresh cannot leak back into the parent's numbering.
         let saved_sectnumlevels = parser.sectnumlevels;
         {
             // Whether `name` (holding `value` in the inherited set) must be
             // locked for the cell. Kept separate from the insert so each source
             // can own its name only when it is actually locked: a built-in name
-            // is `&'static` and stored borrowed (no allocation), while a dynamic
-            // parent-defined name is cloned into an owned entry.
+            // is `&'static` and stored borrowed (no allocation), while a
+            // dynamic parent-defined name is cloned into an owned
+            // entry.
             let should_lock = |name: &str, value: &AttributeValue| {
                 let api_locked = value.modification_context == ModificationContext::ApiOnly;
                 (!matches!(value.value, InterpretedValue::Unset) || api_locked)
@@ -1746,9 +1759,9 @@ fn process_content<'src>(
         // The modifiable attributes may always be changed inside a cell, even
         // when the parent or the API set them with a restrictive modification
         // context. Materialize each into the per-parser map (a built-in such as
-        // `toc` otherwise lives only in the shared table) with a relaxed context
-        // for the duration of the cell so a body assignment is honored; the
-        // snapshot restore reverts it afterward.
+        // `toc` otherwise lives only in the shared table) with a relaxed
+        // context for the duration of the cell so a body assignment is
+        // honored; the snapshot restore reverts it afterward.
         let attrs = Arc::make_mut(&mut parser.attribute_values);
         for name in ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES {
             if let Some(mut attr) = attrs.get(*name).or_else(|| built_in_attr(name)).cloned() {
@@ -1757,23 +1770,26 @@ fn process_content<'src>(
             }
         }
 
-        // A cell does not inherit the parent's doctype; it resets to the default
-        // (`article`). The cell body may still set its own doctype, and the
-        // derived `backend-html5-doctype-*` attribute is refreshed to match.
+        // A cell does not inherit the parent's doctype; it resets to the
+        // default (`article`). The cell body may still set its own
+        // doctype, and the derived `backend-html5-doctype-*` attribute
+        // is refreshed to match.
         parser.force_doctype("article");
 
-        // Likewise, a cell does not inherit the parent's `toc` setting: a nested
-        // document starts without a table of contents and may enable its own.
-        // Reset the value to unset; the relax loop above already made `toc`
-        // modifiable inside the cell, so a cell-body `:toc:` is still honored.
+        // Likewise, a cell does not inherit the parent's `toc` setting: a
+        // nested document starts without a table of contents and may
+        // enable its own. Reset the value to unset; the relax loop
+        // above already made `toc` modifiable inside the cell, so a
+        // cell-body `:toc:` is still honored.
         if let Some(toc) = Arc::make_mut(&mut parser.attribute_values).get_mut("toc") {
             toc.value = InterpretedValue::Unset;
         }
 
         // A cell whose content holds a preprocessor directive (an `include::`)
-        // is parsed from an owned, expanded source the cell carries; every other
-        // cell is parsed in place from the parent document's source, which keeps
-        // its spans (and line numbers) and avoids a copy.
+        // is parsed from an owned, expanded source the cell carries; every
+        // other cell is parsed in place from the parent document's
+        // source, which keeps its spans (and line numbers) and avoids a
+        // copy.
         let cell = if content_has_directive(trimmed.data()) {
             // `trimmed` indexes the document source unless this cell is itself
             // being parsed from some *other* cell's owned (include-expanded)
@@ -1803,10 +1819,11 @@ fn process_content<'src>(
             let cell_origin_file = cell_origin.as_ref().and_then(|sl| sl.0.clone());
 
             // Re-run the preprocessor over the cell content, naming the file it
-            // came from so an unresolved directive is attributed to it. Keep the
-            // resulting source map: while this cell's owned source is parsed it
-            // lets a directive buried deeper (e.g. in a nested table cell) map
-            // its position back to the file and line it originally came from.
+            // came from so an unresolved directive is attributed to it. Keep
+            // the resulting source map: while this cell's owned
+            // source is parsed it lets a directive buried deeper
+            // (e.g. in a nested table cell) map its position back
+            // to the file and line it originally came from.
             let (expanded, cell_source_map, preprocessor_warnings, cell_includes) =
                 preprocess_with_initial_file_name(
                     trimmed.data(),
@@ -1848,10 +1865,12 @@ fn process_content<'src>(
             if at_document_level {
                 // `directive_line` indexes the document source, so re-anchor
                 // each warning to it: its cursor then maps back to the
-                // directive's true (file, line) through the document source map.
+                // directive's true (file, line) through the document source
+                // map.
                 for pw in preprocessor_warnings {
-                    // A no-output directive (a malformed/unterminated conditional
-                    // or a tag-filter diagnostic) carries a pre-resolved `origin`;
+                    // A no-output directive (a malformed/unterminated
+                    // conditional or a tag-filter
+                    // diagnostic) carries a pre-resolved `origin`;
                     // resolve it to an absolute location (see
                     // `absolute_cell_directive_origin`). Warnings without an
                     // `origin` (e.g. an unresolved include target) keep
@@ -1882,8 +1901,9 @@ fn process_content<'src>(
                 // failure rather than a silent loss.
                 let mut owned_warnings: Vec<Warning<'_>> = vec![];
 
-                // Substitution warnings (e.g. `attribute-missing=warn`) recorded
-                // while parsing this owned source carry offsets into it, not the
+                // Substitution warnings (e.g. `attribute-missing=warn`)
+                // recorded while parsing this owned source
+                // carry offsets into it, not the
                 // primary document source, so they too must be discarded.
                 let substitution_warnings_mark = parser.substitution_warnings_len();
 
@@ -1901,9 +1921,10 @@ fn process_content<'src>(
                     let warning_source = owned_root.slice(sw.offset..sw.offset + sw.len);
 
                     // A substitution warning locates itself by offset into the
-                    // owned source, so it has no pre-resolved origin; resolve it
-                    // through this cell's source map (the directive-warning
-                    // override path does not apply).
+                    // owned source, so it has no pre-resolved origin; resolve
+                    // it through this cell's source map
+                    // (the directive-warning override path
+                    // does not apply).
                     parser.record_owned_cell_warning(warning_source.line(), sw.warning, None);
                 }
                 parser.pop_owned_cell_source_map();
@@ -1929,9 +1950,10 @@ fn process_content<'src>(
             // with a pre-resolved origin while the owned source was parsed
             // above. At document level, surface those now: anchor each to this
             // cell's directive line (a real document span) so it still has a
-            // cursor, and carry its true origin so consumers can report the file
-            // and line the failing directive actually lives at. Deeper owned
-            // cells leave them queued for the document-level cell enclosing them.
+            // cursor, and carry its true origin so consumers can report the
+            // file and line the failing directive actually lives
+            // at. Deeper owned cells leave them queued for the
+            // document-level cell enclosing them.
             if at_document_level {
                 for rw in parser.take_owned_cell_warnings() {
                     warnings.push(Warning::with_origin(
@@ -2036,21 +2058,23 @@ fn parse_asciidoc_cell_body<'src>(
     let saved_pending_block_title = parser.pending_block_title.take();
 
     // Mark that we are inside an AsciiDoc cell (a nested document) for the
-    // duration of the parse, so a table found within defaults its cell separator
-    // to `!` rather than `|` (matching Asciidoctor's `Document#nested?`).
+    // duration of the parse, so a table found within defaults its cell
+    // separator to `!` rather than `|` (matching Asciidoctor's
+    // `Document#nested?`).
     parser.nested_document_depth += 1;
 
-    // The cell body parses from its own owned source (whether include-expanded or
-    // a borrowed `a|` cell), whose offsets do not map to the document. Mark that
-    // so a footnote defined inside records no (misleading) document location; see
-    // `Parser::owned_subsource_depth`.
+    // The cell body parses from its own owned source (whether include-expanded
+    // or a borrowed `a|` cell), whose offsets do not map to the document.
+    // Mark that so a footnote defined inside records no (misleading)
+    // document location; see `Parser::owned_subsource_depth`.
     parser.owned_subsource_depth += 1;
 
     // An AsciiDoc cell is a nested document, where a section heading is again
     // valid — it is not a delimited-block body. Clear `in_delimited_block` for
     // the cell parse (saved and restored) so a `== …` line inside the cell is
-    // recognized as a section even when the table itself sits inside a delimited
-    // block, whose flag the parser would otherwise still be carrying.
+    // recognized as a section even when the table itself sits inside a
+    // delimited block, whose flag the parser would otherwise still be
+    // carrying.
     let previously_in_delimited_block = parser.in_delimited_block;
     parser.in_delimited_block = false;
 
@@ -2176,10 +2200,11 @@ impl<'src> TableCell<'src> {
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
-        // A cell's own alignment operator overrides the column's alignment; with
-        // no operator, the cell inherits the column's alignment. This applies to
-        // header and body cells alike: only the column *style* is ignored for a
-        // header row (see below), not the column alignment.
+        // A cell's own alignment operator overrides the column's alignment;
+        // with no operator, the cell inherits the column's alignment.
+        // This applies to header and body cells alike: only the column
+        // *style* is ignored for a header row (see below), not the
+        // column alignment.
         let (h_align, v_align) = (
             raw.spec.h_align.unwrap_or(column.h_align),
             raw.spec.v_align.unwrap_or(column.v_align),
@@ -2198,11 +2223,11 @@ impl<'src> TableCell<'src> {
         let trimmed = trim_cell_content(raw.content, style);
 
         // An escaped cell separator (a backslash in front of the table's
-        // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
-        // the active separator is unescaped, so a `\|` in a `!`-separated table
-        // is left untouched. The replacement is computed only for the inline
-        // styles; an AsciiDoc cell parses its content verbatim (see
-        // [`process_content`]).
+        // separator, e.g. `\|` or `\!`) is unescaped to the bare separator.
+        // Only the active separator is unescaped, so a `\|` in a
+        // `!`-separated table is left untouched. The replacement is
+        // computed only for the inline styles; an AsciiDoc cell parses
+        // its content verbatim (see [`process_content`]).
         let escaped = format!("\\{separator}");
         let replacement = if style != ColumnStyle::AsciiDoc && trimmed.data().contains(&escaped) {
             Some(trimmed.data().replace(&escaped, separator))
@@ -2250,9 +2275,10 @@ impl<'src> TableCell<'src> {
             column.style
         };
 
-        // A data field carries no cell specifier, so its alignment comes from the
-        // column. This applies to header and body cells alike: only the column
-        // style is ignored for a header row, not the column alignment.
+        // A data field carries no cell specifier, so its alignment comes from
+        // the column. This applies to header and body cells alike: only
+        // the column style is ignored for a header row, not the column
+        // alignment.
         let (h_align, v_align) = (column.h_align, column.v_align);
 
         let source = field.content;
@@ -2562,9 +2588,10 @@ impl<'src> AsciiDocCell<'src> {
 
                 let mut folded = crate::document::folds_by_index(warnings.take_footnote_texts());
 
-                // A cell footnote records no document location (it is defined in
-                // an owned sub-source), so resolution falls back to `source`,
-                // the cell's span, for any unresolved-reference warning.
+                // A cell footnote records no document location (it is defined
+                // in an owned sub-source), so resolution falls
+                // back to `source`, the cell's span, for any
+                // unresolved-reference warning.
                 for footnote in &mut cell.footnotes {
                     let mine = folded.remove(&footnote.index);
                     footnote.resolve_references(resolver, renderer, warnings, source, mine);
@@ -2595,8 +2622,9 @@ impl<'src> AsciiDocCell<'src> {
                         }
 
                         // A cell footnote records no document location, so its
-                        // resolution falls back to the owned source span for any
-                        // warning; those warnings are re-homed to the cell's span
+                        // resolution falls back to the owned source span for
+                        // any warning; those warnings
+                        // are re-homed to the cell's span
                         // in the document below regardless.
                         let owned_root = Span::new(owned_source);
 
@@ -2691,9 +2719,9 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
         return vec![TableColumn::default(); count];
     }
 
-    // Split on commas when present, otherwise on semicolons (Asciidoctor accepts
-    // either as the column-spec separator, but not a mix). Empty records are
-    // kept: each one contributes a default column.
+    // Split on commas when present, otherwise on semicolons (Asciidoctor
+    // accepts either as the column-spec separator, but not a mix). Empty
+    // records are kept: each one contributes a default column.
     let parts: Vec<&str> = if records.contains(',') {
         records.split(',').collect()
     } else {
@@ -3007,8 +3035,9 @@ fn scan_cells<'src>(
 
                 None => {
                     // No cell has been opened yet, so this is the table's first
-                    // separator. Non-blank content in front of it means the first
-                    // cell is missing its leading separator; recover that content
+                    // separator. Non-blank content in front of it means the
+                    // first cell is missing its leading
+                    // separator; recover that content
                     // as the first cell (with the default specifier) and record
                     // its span so the caller can warn, matching Asciidoctor.
                     let leading = region.slice(0..content_end);
@@ -3071,10 +3100,11 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     let mut i = 0;
 
     // Optional span/duplication: an optional span factor followed by `+` (span)
-    // or `*` (duplication). The factor is a column count, an optional dot, and an
-    // optional row count (`<n>`, `.<n>`, or `<n>.<n>`). The factor is committed
-    // only when the operator that must follow it is present; otherwise the
-    // leading digits remain and the token fails the full-consumption check below.
+    // or `*` (duplication). The factor is a column count, an optional dot, and
+    // an optional row count (`<n>`, `.<n>`, or `<n>.<n>`). The factor is
+    // committed only when the operator that must follow it is present;
+    // otherwise the leading digits remain and the token fails the
+    // full-consumption check below.
     let mut colspan = 1;
     let mut rowspan = 1;
     let mut repeat = 1;
@@ -3104,8 +3134,8 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
         // column or row count defaults to 1, so `2+` spans two columns, `.3+`
         // spans three rows, and `2.3+` spans a 2x3 block.
         Some(b'+') => {
-            // The factor consists only of ASCII digits and dots, so these ranges
-            // are always valid `str` slices.
+            // The factor consists only of ASCII digits and dots, so these
+            // ranges are always valid `str` slices.
             let col_digits = token.get(col_start..col_end).unwrap_or_default();
             if !col_digits.is_empty() {
                 colspan = col_digits.parse().unwrap_or(1);
@@ -3339,8 +3369,8 @@ mod tests {
             Some(SourceLine(Some("inc.adoc".to_owned()), 3))
         );
 
-        // The cell's own file, first line (pass-relative line 1): resolves to the
-        // cell's own location.
+        // The cell's own file, first line (pass-relative line 1): resolves to
+        // the cell's own location.
         assert_eq!(
             absolute_cell_directive_origin(
                 Some(SourceLine(Some("outer.adoc".to_owned()), 1)),
@@ -3349,8 +3379,9 @@ mod tests {
             Some(SourceLine(Some("outer.adoc".to_owned()), 5))
         );
 
-        // The cell's own file, a later line (pass-relative line 3): translated to
-        // two lines past the cell's first line — not collapsed onto line 5.
+        // The cell's own file, a later line (pass-relative line 3): translated
+        // to two lines past the cell's first line — not collapsed onto
+        // line 5.
         assert_eq!(
             absolute_cell_directive_origin(
                 Some(SourceLine(Some("outer.adoc".to_owned()), 3)),
@@ -3449,9 +3480,10 @@ mod tests {
         };
 
         // The faithful port of Ruby Asciidoctor `tables_test.rb` 1728 (an
-        // unresolved directive in a cell reached via an outer `include::`) lives
-        // in `tests::asciidoctor_rb::tables_test`. These are additional
-        // regression tests for the same fix, kept next to the code under test.
+        // unresolved directive in a cell reached via an outer `include::`)
+        // lives in `tests::asciidoctor_rb::tables_test`. These are
+        // additional regression tests for the same fix, kept next to
+        // the code under test.
 
         // The table is in the primary document itself, so the unresolved
         // directive is attributed to the root file (not an included one).
@@ -3479,11 +3511,12 @@ mod tests {
             );
         }
 
-        // A table nested inside a *borrowed* AsciiDoc cell (one whose own content
-        // is not include-expanded) is still parsed in place from the document
-        // source, so an unresolved directive in the inner cell maps through the
-        // document source map like any other. Here the whole document is the root
-        // file, so the cursor is the root file at the inner directive's line.
+        // A table nested inside a *borrowed* AsciiDoc cell (one whose own
+        // content is not include-expanded) is still parsed in place
+        // from the document source, so an unresolved directive in the
+        // inner cell maps through the document source map like any
+        // other. Here the whole document is the root file, so the
+        // cursor is the root file at the inner directive's line.
         #[test]
         fn nested_table_cell_maps_through_document_source() {
             let doc = Parser::default()
@@ -3507,9 +3540,9 @@ mod tests {
             );
         }
 
-        // Greptile #639: a table nested inside a (borrowed) cell of an *included*
-        // file must attribute an inner unresolved directive to that included
-        // file, not the root file.
+        // Greptile #639: a table nested inside a (borrowed) cell of an
+        // *included* file must attribute an inner unresolved directive
+        // to that included file, not the root file.
         #[test]
         fn nested_table_cell_in_included_file_reports_include_cursor() {
             let handler = InlineFileHandler::from_pairs([(
@@ -3594,19 +3627,21 @@ mod tests {
             assert_rendered_contains(&doc, "Deepest content.");
         }
 
-        // A table nested inside an *owned* (include-expanded) cell is parsed from
-        // that cell's private source, whose spans index the cell's own source map
-        // rather than the document's. An unresolved directive in the inner cell
-        // is resolved against that owned source map: it is rendered naming the
-        // file it came from, and its warning carries a pre-resolved origin
-        // (`Warning::origin`) pointing at that file and line, anchored to the
+        // A table nested inside an *owned* (include-expanded) cell is parsed
+        // from that cell's private source, whose spans index the cell's
+        // own source map rather than the document's. An unresolved
+        // directive in the inner cell is resolved against that owned
+        // source map: it is rendered naming the file it came from, and
+        // its warning carries a pre-resolved origin (`Warning::origin`)
+        // pointing at that file and line, anchored to the
         // enclosing document-level cell's directive line. Fixes
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/641.
         #[test]
         fn unresolved_directive_inside_owned_cell_source_reports_origin() {
-            // `cell.adoc` is pulled in as the top cell's owned source; it holds a
-            // nested table (so its cells use the `!` separator) whose own cell has
-            // an unresolvable include on its line 2.
+            // `cell.adoc` is pulled in as the top cell's owned source; it holds
+            // a nested table (so its cells use the `!` separator)
+            // whose own cell has an unresolvable include on its
+            // line 2.
             let handler = InlineFileHandler::from_pairs([(
                 "cell.adoc",
                 "!===\na!include::does-not-exist.adoc[]\n!===",
@@ -3724,15 +3759,17 @@ mod tests {
         #[test]
         fn leading_anchor_in_asciidoc_body_cell_is_cataloged() {
             // Two `|` rows with no blank line between them defeat the implicit-
-            // header heuristic (which requires a blank line after the first row),
-            // so both cells are AsciiDoc-style *body* cells rather than a header.
+            // header heuristic (which requires a blank line after the first
+            // row), so both cells are AsciiDoc-style *body* cells
+            // rather than a header.
             let doc = Parser::default()
                 .parse("[cols=1a]\n|===\n|[[foo,Foo]]body anchor\n|second cell\n|===");
 
             // Guard the premise: the anchored cell is a genuine AsciiDoc-style
-            // body cell (each `a` cell renders its content as a nested document in
-            // `div.content`), not a header cell — no `th` is produced, and the
-            // anchor renders as a target inside the cell.
+            // body cell (each `a` cell renders its content as a nested document
+            // in `div.content`), not a header cell — no `th` is
+            // produced, and the anchor renders as a target inside
+            // the cell.
             assert_css(&doc, "th", 0);
             assert_css(&doc, "table.tableblock td.tableblock > div.content", 2);
             assert_xpath(&doc, "//td//div[@class=\"content\"]//a[@id=\"foo\"]", 1);

--- a/parser/src/blocks/tests/break.rs
+++ b/parser/src/blocks/tests/break.rs
@@ -501,7 +501,8 @@ fn break_with_attrlist() {
 
 #[test]
 fn break_trait_methods_without_metadata() {
-    // Test that IsBlock trait methods work correctly for a break without metadata.
+    // Test that IsBlock trait methods work correctly for a break without
+    // metadata.
     let mut parser = Parser::default();
 
     let mi = crate::blocks::Block::parse(crate::Span::new("<<<"), &mut parser)

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -420,9 +420,10 @@ mod error_cases {
 
     #[test]
     fn title_with_only_blank_lines_after_still_warns() {
-        // A title followed by nothing but blank lines has no block to attach to,
-        // so the `MissingBlockAfterTitleOrAttributeList` warning still fires and
-        // the title line is demoted to paragraph content.
+        // A title followed by nothing but blank lines has no block to attach
+        // to, so the `MissingBlockAfterTitleOrAttributeList` warning
+        // still fires and the title line is demoted to paragraph
+        // content.
         let doc = Parser::default().parse(".My Title\n\n");
 
         let blocks: Vec<_> = doc.child_blocks().collect();

--- a/parser/src/blocks/tests/raw_delimited.rs
+++ b/parser/src/blocks/tests/raw_delimited.rs
@@ -888,9 +888,10 @@ mod fenced {
     fn language_on_fence_sets_source_style() {
         // A language on the opening fence (```ruby) is shorthand for a source
         // block: the block resolves like `[source,ruby]` over a listing block.
-        // The synthesized attribute list carries the `source` block style in the
-        // first position and the language in the second, so a downstream renderer
-        // can read the source language without this parser highlighting it.
+        // The synthesized attribute list carries the `source` block style in
+        // the first position and the language in the second, so a
+        // downstream renderer can read the source language without this
+        // parser highlighting it.
         let mut parser = Parser::default();
 
         let mi =
@@ -968,9 +969,9 @@ mod fenced {
 
     #[test]
     fn language_on_fence_closes_on_bare_fence() {
-        // The closing fence of a language-aware fenced block is a bare ``` — the
-        // language appears only on the opening fence, so the closing fence never
-        // repeats it.
+        // The closing fence of a language-aware fenced block is a bare ``` —
+        // the language appears only on the opening fence, so the
+        // closing fence never repeats it.
         let mut parser = Parser::default();
 
         let mi =
@@ -1048,8 +1049,8 @@ mod fenced {
 
     #[test]
     fn four_backticks_with_language_is_not_a_fence() {
-        // A run of four (or more) backticks is not a fence, even when followed by
-        // a language token; it is ordinary paragraph text.
+        // A run of four (or more) backticks is not a fence, even when followed
+        // by a language token; it is ordinary paragraph text.
         let mut parser = Parser::default();
 
         let mi = crate::blocks::Block::parse(
@@ -1107,8 +1108,9 @@ mod fenced {
 
     #[test]
     fn closing_fence_must_match_exactly() {
-        // A line of four backticks does not close a three-backtick fence, so the
-        // block runs to the end of the input and is reported as unterminated.
+        // A line of four backticks does not close a three-backtick fence, so
+        // the block runs to the end of the input and is reported as
+        // unterminated.
         let mut parser = Parser::default();
 
         let maw =

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -1502,8 +1502,8 @@ mod comment_directly_above_metadata {
 
     #[test]
     fn bare_table_delimiter_after_comment() {
-        // A comment directly above a bare table delimiter opens the table rather
-        // than swallowing the whole table as paragraph text.
+        // A comment directly above a bare table delimiter opens the table
+        // rather than swallowing the whole table as paragraph text.
         let doc = Parser::default().parse("= T\n\n// note\n|===\n|a |b\n|===\n");
         let blocks = top_blocks(&doc);
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -90,8 +90,8 @@ fn multiple_cells_on_one_line() {
 
 #[test]
 fn implicit_header_row() {
-    // From <<ex-header>>: the first line after the delimiter is non-empty and is
-    // followed by a blank line, so it becomes the header row.
+    // From <<ex-header>>: the first line after the delimiter is non-empty and
+    // is followed by a blank line, so it becomes the header row.
     let table = parse_table(
         "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
     );
@@ -110,9 +110,9 @@ fn implicit_header_row() {
 
 #[test]
 fn implicit_columns_from_first_row() {
-    // From add-columns.adoc <<ex-implicit>>: with no `cols` attribute and a blank
-    // line before the first row, the column count comes from the first row's cell
-    // count and there is no header.
+    // From add-columns.adoc <<ex-implicit>>: with no `cols` attribute and a
+    // blank line before the first row, the column count comes from the
+    // first row's cell count and there is no header.
     let table = parse_table(
         "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
     );
@@ -210,8 +210,8 @@ fn cell_content_is_substituted() {
 
 #[test]
 fn leading_and_trailing_whitespace_stripped() {
-    // From <<ex-more-cells>>: leading and trailing spaces around cell content are
-    // stripped.
+    // From <<ex-more-cells>>: leading and trailing spaces around cell content
+    // are stripped.
     let table = parse_table("[cols=\"1,1\"]\n|===\n|a |    b spaced\n|===");
 
     assert_eq!(
@@ -273,8 +273,8 @@ fn block_level_accessors() {
 
 #[test]
 fn escaped_cell_separator() {
-    // A backslash-escaped separator (`\|`) is not a cell boundary; the backslash
-    // is stripped from the rendered cell content.
+    // A backslash-escaped separator (`\|`) is not a cell boundary; the
+    // backslash is stripped from the rendered cell content.
     let table = parse_table("|===\n|a \\| b\n|===");
 
     assert_eq!(table.body_rows().len(), 1);
@@ -297,8 +297,9 @@ fn separator_after_backslash_is_escaped() {
 
 #[test]
 fn cols_with_empty_specifier() {
-    // An empty entry in the `cols` list (e.g. from a doubled comma) contributes a
-    // default column, matching Asciidoctor: `cols="1,,1"` yields three columns.
+    // An empty entry in the `cols` list (e.g. from a doubled comma) contributes
+    // a default column, matching Asciidoctor: `cols="1,,1"` yields three
+    // columns.
     let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b |c\n|===");
 
     assert_eq!(table.columns().len(), 3);
@@ -306,8 +307,9 @@ fn cols_with_empty_specifier() {
 
 #[test]
 fn no_cols_and_first_line_without_a_cell() {
-    // With no `cols` attribute and a first line that contains no cell separator,
-    // the column count is zero and the body loop is skipped entirely.
+    // With no `cols` attribute and a first line that contains no cell
+    // separator, the column count is zero and the body loop is skipped
+    // entirely.
     let table = parse_table("|===\nnot a cell\n|===");
 
     assert!(table.columns().is_empty());
@@ -350,8 +352,8 @@ fn untitled_table_has_no_caption() {
 #[test]
 fn caption_and_number_are_reported_through_the_isblock_trait() {
     // A generic `T: IsBlock` consumer resolves to the trait methods rather than
-    // the inherent ones, so a captioned table must be reported correctly through
-    // the trait interface too (not silently `None`).
+    // the inherent ones, so a captioned table must be reported correctly
+    // through the trait interface too (not silently `None`).
     fn via_trait<'src>(block: &impl IsBlock<'src>) -> (Option<String>, Option<usize>) {
         (block.caption().map(str::to_string), block.number())
     }
@@ -404,8 +406,8 @@ fn table_caption_can_be_relabeled() {
 
 #[test]
 fn unsetting_table_caption_suppresses_the_label() {
-    // When `table-caption` is unset, a titled table keeps its title but receives
-    // no caption (and no number).
+    // When `table-caption` is unset, a titled table keeps its title but
+    // receives no caption (and no number).
     let doc = Parser::default().parse(":!table-caption:\n\n.Numbers\n|===\n|a\n|===");
 
     let table = doc
@@ -423,10 +425,10 @@ fn unsetting_table_caption_suppresses_the_label() {
 #[test]
 fn empty_table_caption_suppresses_the_label() {
     // An explicitly empty `table-caption` value (a distinct AsciiDoc operation
-    // from a hard unset, e.g. `:!table-caption:`) is also treated as "no label":
-    // each titled table keeps its title but receives no caption and does not
-    // consume a table number. This exercises the empty-label guard separately
-    // from the `Unset` path.
+    // from a hard unset, e.g. `:!table-caption:`) is also treated as "no
+    // label": each titled table keeps its title but receives no caption and
+    // does not consume a table number. This exercises the empty-label guard
+    // separately from the `Unset` path.
     let mut parser = Parser::default().with_intrinsic_attribute(
         "table-caption",
         "",
@@ -461,9 +463,9 @@ fn caption_attribute_sets_the_label_verbatim() {
 
 #[test]
 fn caption_attribute_does_not_consume_a_table_number() {
-    // A table labeled with an explicit `caption` is skipped by the document-wide
-    // counter, so a following `table-caption` table is numbered as if the
-    // explicitly captioned table were not there.
+    // A table labeled with an explicit `caption` is skipped by the
+    // document-wide counter, so a following `table-caption` table is
+    // numbered as if the explicitly captioned table were not there.
     let doc = Parser::default().parse(
         ".First\n|===\n|a\n|===\n\n[caption=\"Table A. \"]\n.Custom\n|===\n|b\n|===\n\n.Third\n|===\n|c\n|===",
     );
@@ -489,8 +491,9 @@ fn caption_attribute_does_not_consume_a_table_number() {
 
 #[test]
 fn caption_attribute_applies_even_when_table_caption_is_unset() {
-    // The `caption` attribute is honored independently of `table-caption`, so it
-    // still labels a titled table even when `table-caption` has been unset.
+    // The `caption` attribute is honored independently of `table-caption`, so
+    // it still labels a titled table even when `table-caption` has been
+    // unset.
     let doc = Parser::default()
         .parse(":!table-caption:\n\n[caption=\"Forced. \"]\n.Numbers\n|===\n|a\n|===");
 
@@ -514,9 +517,9 @@ fn caption_attribute_is_ignored_without_a_title() {
 
 #[test]
 fn empty_caption_attribute_suppresses_the_label() {
-    // An explicitly empty `caption` (e.g. `[caption=]`) removes the label on the
-    // table: the title is kept but no caption (and no number) is assigned, so the
-    // title renders with no prefix.
+    // An explicitly empty `caption` (e.g. `[caption=]`) removes the label on
+    // the table: the title is kept but no caption (and no number) is
+    // assigned, so the title renders with no prefix.
     let table = parse_table("[caption=]\n.A table with a title but no label\n|===\n|a\n|===");
 
     assert_eq!(table.title(), Some("A table with a title but no label"));
@@ -526,8 +529,8 @@ fn empty_caption_attribute_suppresses_the_label() {
 #[test]
 fn empty_caption_attribute_does_not_consume_a_table_number() {
     // A table whose label is removed with an empty `caption` is skipped by the
-    // document-wide counter, so a following `table-caption` table is numbered as
-    // if the unlabeled table were not there.
+    // document-wide counter, so a following `table-caption` table is numbered
+    // as if the unlabeled table were not there.
     let doc = Parser::default().parse(
         ".First\n|===\n|a\n|===\n\n[caption=]\n.Unlabeled\n|===\n|b\n|===\n\n.Third\n|===\n|c\n|===",
     );
@@ -552,12 +555,13 @@ fn empty_caption_attribute_does_not_consume_a_table_number() {
 
 #[test]
 fn malformed_vertical_operator_falls_back_to_defaults() {
-    // A dot in a column specifier introduces a vertical alignment operator, which
-    // must be followed by `<`, `>`, or `^`. When the dot is followed by anything
-    // else (here the letter `x`), the operator is malformed; rather than panic,
-    // the parser leaves the dot unconsumed so the column falls back to the
-    // default vertical alignment (top) and default width. The leftover `.x` is
-    // not a recognized single-letter style operator, so the style also defaults.
+    // A dot in a column specifier introduces a vertical alignment operator,
+    // which must be followed by `<`, `>`, or `^`. When the dot is followed
+    // by anything else (here the letter `x`), the operator is malformed;
+    // rather than panic, the parser leaves the dot unconsumed so the column
+    // falls back to the default vertical alignment (top) and default width.
+    // The leftover `.x` is not a recognized single-letter style operator,
+    // so the style also defaults.
     let table = parse_table("[cols=\".x,1\"]\n|===\n|a |b\n|===");
 
     let columns = table.columns();
@@ -616,8 +620,8 @@ fn header_cell_inherits_column_alignment() {
     assert_eq!(header_cells[1].h_align(), HorizontalAlignment::Left);
     assert_eq!(header_cells[1].v_align(), VerticalAlignment::Top);
 
-    // The body cells resolve to the same column alignment, confirming the header
-    // now matches the body.
+    // The body cells resolve to the same column alignment, confirming the
+    // header now matches the body.
     let body_cells = table.body_rows()[0].cells();
 
     assert_eq!(body_cells[0].h_align(), HorizontalAlignment::Center);
@@ -659,8 +663,9 @@ fn csv_header_cell_inherits_column_alignment() {
 
 #[test]
 fn asciidoc_cell_resolves_references_in_nested_blocks() {
-    // Cross-references inside an AsciiDoc cell are resolved during the document's
-    // reference-resolution pass, which descends into the cell's nested blocks.
+    // Cross-references inside an AsciiDoc cell are resolved during the
+    // document's reference-resolution pass, which descends into the cell's
+    // nested blocks.
     let doc = Parser::default()
         .parse("[#target]\nTarget paragraph.\n\n[cols=\"a\"]\n|===\n|See xref:target[].\n|===");
 
@@ -687,8 +692,8 @@ fn asciidoc_cell_resolves_references_in_nested_blocks() {
 #[test]
 fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     // An AsciiDoc cell inherits the parent document's attributes, but an
-    // attribute it defines is scoped to the cell and does not leak back into the
-    // parent document (matching Asciidoctor).
+    // attribute it defines is scoped to the cell and does not leak back into
+    // the parent document (matching Asciidoctor).
     let mut parser = Parser::default();
     let doc = parser.parse(
         ":parent-attr: inherited\n\n[cols=\"a\"]\n|===\n|\n:cell-attr: leaked\ncell sees: {parent-attr} {cell-attr}\n|===",
@@ -751,11 +756,12 @@ fn asciidoc_cell_is_always_nested() {
 
 #[test]
 fn asciidoc_cell_exposes_inherited_attributes_for_introspection() {
-    // The cell's attribute state is scoped to the cell and restored on the parser
-    // once the cell is parsed, so it can no longer be read from the parser. The
-    // cell nonetheless retains a snapshot of it, letting a caller introspect the
-    // nested document's attributes — both those inherited from the parent and any
-    // the cell set for itself — after parsing has finished.
+    // The cell's attribute state is scoped to the cell and restored on the
+    // parser once the cell is parsed, so it can no longer be read from the
+    // parser. The cell nonetheless retains a snapshot of it, letting a
+    // caller introspect the nested document's attributes — both those
+    // inherited from the parent and any the cell set for itself — after
+    // parsing has finished.
     let doc = Parser::default().parse(
         ":parent-attr: inherited\n\n[cols=\"a\"]\n|===\n|\n:cell-attr: local\ncontent\n|===",
     );
@@ -772,8 +778,8 @@ fn asciidoc_cell_exposes_inherited_attributes_for_introspection() {
         panic!("expected AsciiDoc cell content");
     };
 
-    // The inherited parent attribute is visible on the nested document and equal
-    // to what the parent document sees.
+    // The inherited parent attribute is visible on the nested document and
+    // equal to what the parent document sees.
     assert!(cell.is_attribute_set("parent-attr"));
     assert_eq!(
         cell.attribute_value("parent-attr"),
@@ -901,9 +907,9 @@ fn include_expanded_asciidoc_cell_exposes_its_own_footnotes() {
 
 #[test]
 fn asciidoc_cell_footnote_resolves_cross_reference() {
-    // A cross-reference inside a cell footnote is resolved during the document's
-    // reference-resolution pass, against the shared catalog. The resolved link
-    // is reflected in the exposed footnote text.
+    // A cross-reference inside a cell footnote is resolved during the
+    // document's reference-resolution pass, against the shared catalog. The
+    // resolved link is reflected in the exposed footnote text.
     let doc = Parser::default()
         .parse("[[target]]Anchored text.\n\n|===\na|Cell footnote:[See <<target>>.]\n|===");
 
@@ -942,10 +948,10 @@ fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String 
 
 #[test]
 fn asciidoc_cell_cannot_modify_a_parent_attribute() {
-    // An attribute set in the parent document is locked inside an AsciiDoc cell:
-    // a reassignment is silently ignored, so the inherited value is what the cell
-    // sees. The lock is scoped to the cell, so the parent value is unchanged
-    // afterward.
+    // An attribute set in the parent document is locked inside an AsciiDoc
+    // cell: a reassignment is silently ignored, so the inherited value is
+    // what the cell sees. The lock is scoped to the cell, so the parent
+    // value is unchanged afterward.
     let mut parser = Parser::default();
     let doc = parser.parse(
         ":locked: parent\n\n[cols=\"a\"]\n|===\n|\n:locked: child\n\nvalue is {locked}\n|===",
@@ -967,10 +973,11 @@ fn asciidoc_cell_cannot_modify_a_parent_attribute() {
 
 #[test]
 fn asciidoc_cell_may_set_an_attribute_unset_in_the_parent() {
-    // Only attributes that are *set* in the parent are locked. An attribute that
-    // is explicitly unset in the parent is not locked, so the cell may assign it
-    // and the cell sees its own value (matching Asciidoctor, which here diverges
-    // from the spec's "set or explicitly unset" wording).
+    // Only attributes that are *set* in the parent are locked. An attribute
+    // that is explicitly unset in the parent is not locked, so the cell may
+    // assign it and the cell sees its own value (matching Asciidoctor,
+    // which here diverges from the spec's "set or explicitly unset"
+    // wording).
     let mut parser = Parser::default();
     let doc = parser.parse(
         ":locked: value\n:locked!:\n\n[cols=\"a\"]\n|===\n|\n:locked: child\n\nvalue is {locked}\n|===",
@@ -988,13 +995,13 @@ fn asciidoc_cell_may_set_an_attribute_unset_in_the_parent() {
 
 #[test]
 fn asciidoc_cell_may_set_sectnumlevels() {
-    // `sectnumlevels` has a built-in default value (`3`), but the parent did not
-    // set it, so the built-in default must not lock it inside the cell. An
-    // AsciiDoc cell is a nested, standalone document whose leading attribute lines
-    // are its own header, and `sectnumlevels` is header-settable, so a cell-body
-    // assignment is honored: the cell's resolved `sectnumlevels` reflects the
-    // value the cell set (`1`), not the inherited default (`3`), matching
-    // Asciidoctor.
+    // `sectnumlevels` has a built-in default value (`3`), but the parent did
+    // not set it, so the built-in default must not lock it inside the cell.
+    // An AsciiDoc cell is a nested, standalone document whose leading
+    // attribute lines are its own header, and `sectnumlevels` is
+    // header-settable, so a cell-body assignment is honored: the cell's
+    // resolved `sectnumlevels` reflects the value the cell set (`1`), not
+    // the inherited default (`3`), matching Asciidoctor.
     let doc = Parser::default()
         .parse("|===\na|\n:toc:\n:sectnums:\n:sectnumlevels: 1\n\n== Alpha\n\n=== Beta\n\nx\n|===");
 
@@ -1015,16 +1022,17 @@ fn asciidoc_cell_may_set_sectnumlevels() {
         crate::document::InterpretedValue::Value("1".to_string())
     );
 
-    // The other attributes the cell set are likewise honored (a bare `:sectnums:`
-    // resolves to its `all` default).
+    // The other attributes the cell set are likewise honored (a bare
+    // `:sectnums:` resolves to its `all` default).
     assert_eq!(
         cell.attribute_value("sectnums"),
         crate::document::InterpretedValue::Value("all".to_string())
     );
 
-    // Section numbering within the cell honors the cell-local depth, not just the
-    // resolved attribute: `Alpha` (level 1) is numbered, while `Beta` (level 2)
-    // falls beyond the cell's `sectnumlevels` of 1 and is left unnumbered.
+    // Section numbering within the cell honors the cell-local depth, not just
+    // the resolved attribute: `Alpha` (level 1) is numbered, while `Beta`
+    // (level 2) falls beyond the cell's `sectnumlevels` of 1 and is left
+    // unnumbered.
     let alpha = cell
         .blocks()
         .iter()
@@ -1044,7 +1052,8 @@ fn asciidoc_cell_may_set_sectnumlevels() {
         .unwrap();
     assert!(beta.section_number().is_none());
 
-    // The parent document is unaffected: its `sectnumlevels` stays at the default.
+    // The parent document is unaffected: its `sectnumlevels` stays at the
+    // default.
     assert_eq!(
         doc.attribute_value("sectnumlevels"),
         crate::document::InterpretedValue::Value("3".to_string())
@@ -1053,9 +1062,9 @@ fn asciidoc_cell_may_set_sectnumlevels() {
 
 #[test]
 fn asciidoc_cell_may_modify_an_exempt_attribute() {
-    // A handful of attributes are exempt from the cell lock; `compat-mode` is one
-    // of them, so a cell may modify it even though the parent set it, while a
-    // non-exempt attribute (`locked`) stays at the inherited value.
+    // A handful of attributes are exempt from the cell lock; `compat-mode` is
+    // one of them, so a cell may modify it even though the parent set it,
+    // while a non-exempt attribute (`locked`) stays at the inherited value.
     let mut parser = Parser::default();
     let doc = parser.parse(
         ":compat-mode: parent\n:locked: parent\n\n[cols=\"a\"]\n|===\n|\n:compat-mode: child\n:locked: child\n\nc={compat-mode} l={locked}\n|===",
@@ -1089,10 +1098,11 @@ fn cell_specifier_style_operator_locates_separator() {
 
 #[test]
 fn unrecognized_cell_style_operator_inherits_column_style() {
-    // A single lowercase letter that isn't a recognized style operator (here `z`)
-    // still locates the cell separator, but it leaves the cell's style unset, so
-    // the cell inherits its column's style rather than reverting to the default.
-    // This matches Asciidoctor, which ignores an unrecognized cell style operator.
+    // A single lowercase letter that isn't a recognized style operator (here
+    // `z`) still locates the cell separator, but it leaves the cell's style
+    // unset, so the cell inherits its column's style rather than reverting
+    // to the default. This matches Asciidoctor, which ignores an
+    // unrecognized cell style operator.
     let table = parse_table("[cols=\"m,m\"]\n|===\n|head1 |head2\n\nz|zee s|ess\n|===");
 
     let cells = table.body_rows()[0].cells();
@@ -1102,10 +1112,11 @@ fn unrecognized_cell_style_operator_inherits_column_style() {
 
 #[test]
 fn cell_specifier_span_operator_without_factor_locates_separator() {
-    // The span (`+`) and duplication (`*`) operators may appear without a count.
-    // A bare `+` directly in front of a `|` is still a valid cell specifier, so
-    // `a +|b` is two cells. With no count the span factor defaults to 1, so the
-    // bare `+` cell spans a single column (no layout effect).
+    // The span (`+`) and duplication (`*`) operators may appear without a
+    // count. A bare `+` directly in front of a `|` is still a valid cell
+    // specifier, so `a +|b` is two cells. With no count the span factor
+    // defaults to 1, so the bare `+` cell spans a single column (no layout
+    // effect).
     let table = parse_table("|===\n|a +|b\n|===");
 
     assert_eq!(table.columns().len(), 2);
@@ -1115,10 +1126,10 @@ fn cell_specifier_span_operator_without_factor_locates_separator() {
 
 #[test]
 fn non_specifier_token_is_a_plain_cell_separator() {
-    // A token in front of a `|` that does not parse as a cell specifier (here the
-    // word `foo`, which is more than a single style letter) is ordinary content:
-    // the `|` is still a plain cell separator, so `a foo|b` is two cells (matching
-    // Asciidoctor).
+    // A token in front of a `|` that does not parse as a cell specifier (here
+    // the word `foo`, which is more than a single style letter) is ordinary
+    // content: the `|` is still a plain cell separator, so `a foo|b` is two
+    // cells (matching Asciidoctor).
     let table = parse_table("|===\n|a foo|b\n|===");
 
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
@@ -1127,10 +1138,10 @@ fn non_specifier_token_is_a_plain_cell_separator() {
 
 #[test]
 fn dot_not_followed_by_vertical_operator_is_a_plain_cell_separator() {
-    // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
-    // followed by anything else (here `.x`) is not a valid cell specifier, so the
-    // `.x` is content and the `|` is a plain cell separator: `a .x|b` is two cells
-    // (matching Asciidoctor).
+    // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A
+    // dot followed by anything else (here `.x`) is not a valid cell
+    // specifier, so the `.x` is content and the `|` is a plain cell
+    // separator: `a .x|b` is two cells (matching Asciidoctor).
     let table = parse_table("|===\n|a .x|b\n|===");
 
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
@@ -1140,9 +1151,10 @@ fn dot_not_followed_by_vertical_operator_is_a_plain_cell_separator() {
 #[test]
 fn cell_span_exceeding_columns_drops_overrunning_row() {
     // A span wider than the table overruns the grid. Matching Asciidoctor, the
-    // whole overrunning row is dropped and a warning is emitted: here the leading
-    // `x` cell is discarded along with the `3+|y` cell that overshoots the two
-    // columns, and the following row (`z`, `w`) stays aligned to the grid.
+    // whole overrunning row is dropped and a warning is emitted: here the
+    // leading `x` cell is discarded along with the `3+|y` cell that
+    // overshoots the two columns, and the following row (`z`, `w`) stays
+    // aligned to the grid.
     let mut parser = Parser::default();
     let maw = Block::parse(
         Span::new("[cols=\"2*\"]\n|===\n|x 3+|y\n|z |w\n|==="),
@@ -1164,13 +1176,14 @@ fn cell_span_exceeding_columns_drops_overrunning_row() {
 
 #[test]
 fn row_fully_covered_by_rowspans_drops_following_cell() {
-    // Two row-spanning cells (`.2+`) together cover every column of the next row,
-    // so that row has no cells of its own to close it. The following cell (`c1`)
-    // therefore overruns the pre-filled row and is dropped with it (a column-count
-    // overrun warning), leaving `c2` and `d1` aligned as the second body row. The
-    // trailing `d2` cell can't fill a row of its own, so the table ends on an
-    // incomplete row that is dropped with an end-of-table warning (matching
-    // Asciidoctor, which renders only two rows here).
+    // Two row-spanning cells (`.2+`) together cover every column of the next
+    // row, so that row has no cells of its own to close it. The following
+    // cell (`c1`) therefore overruns the pre-filled row and is dropped with
+    // it (a column-count overrun warning), leaving `c2` and `d1` aligned as
+    // the second body row. The trailing `d2` cell can't fill a row of its
+    // own, so the table ends on an incomplete row that is dropped with an
+    // end-of-table warning (matching Asciidoctor, which renders only two
+    // rows here).
     let mut parser = Parser::default();
     let maw = Block::parse(
         Span::new("[cols=\"2*\"]\n|===\n.2+|a .2+|b\n|c1 |c2\n|d1 |d2\n|==="),
@@ -1215,8 +1228,9 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
 #[test]
 fn dropped_overrunning_cell_keeps_its_rowspan_carryover() {
     // When a cell that carries a row span is itself part of an overrunning row,
-    // its already-reserved slots in the next rows are *not* rolled back when the
-    // row is dropped. Matching Asciidoctor, the `2.2+|b` cell (colspan 2, rowspan
+    // its already-reserved slots in the next rows are *not* rolled back when
+    // the row is dropped. Matching Asciidoctor, the `2.2+|b` cell (colspan
+    // 2, rowspan
     // 2) overruns the two-column row and is dropped with `a`, but its rowspan
     // still pre-fills the next row, so `c` overruns that pre-filled row and is
     // dropped too. Only `d` and `e` survive.
@@ -1247,12 +1261,12 @@ fn dropped_overrunning_cell_keeps_its_rowspan_carryover() {
 
 #[test]
 fn huge_row_span_factor_does_not_overallocate() {
-    // A row span factor far larger than the table can never carry into rows that
-    // don't exist, so it is clamped for the grid bookkeeping; without the clamp,
-    // `.1000000000+` would resize the `active_rowspans` vector to a billion
-    // entries (a multi-gigabyte allocation). The cell still reports its literal
-    // parsed `rowspan` (matching Asciidoctor), and the following cell, covered by
-    // the span, overruns and is dropped.
+    // A row span factor far larger than the table can never carry into rows
+    // that don't exist, so it is clamped for the grid bookkeeping; without
+    // the clamp, `.1000000000+` would resize the `active_rowspans` vector
+    // to a billion entries (a multi-gigabyte allocation). The cell still
+    // reports its literal parsed `rowspan` (matching Asciidoctor), and the
+    // following cell, covered by the span, overruns and is dropped.
     let mut parser = Parser::default();
     let maw = Block::parse(Span::new("|===\n.1000000000+|a\n|b\n|==="), &mut parser);
 
@@ -1274,10 +1288,10 @@ fn huge_row_span_factor_does_not_overallocate() {
 
 #[test]
 fn duplication_clones_content_and_properties() {
-    // A duplication factor (`<n>*`) clones the cell into `<n>` independent cells,
-    // each an ordinary single-slot cell (colspan and rowspan of 1) that carries
-    // the original's content and style. Here `3*e|x` becomes three emphasized
-    // cells, each holding `x`.
+    // A duplication factor (`<n>*`) clones the cell into `<n>` independent
+    // cells, each an ordinary single-slot cell (colspan and rowspan of 1)
+    // that carries the original's content and style. Here `3*e|x` becomes
+    // three emphasized cells, each holding `x`.
     let table = parse_table("[cols=\"3*\"]\n|===\n3*e|x\n|===");
     let cells = table.body_rows()[0].cells();
     assert_eq!(cells.len(), 3);
@@ -1295,8 +1309,8 @@ fn duplication_clones_content_and_properties() {
 #[test]
 fn duplication_factor_ignores_row_part() {
     // Only the column part of the factor is the duplication count; a row part
-    // (`<n>.<n>*`) is ignored, matching Asciidoctor. So `2.3*` duplicates the cell
-    // twice (not six times), and each clone keeps a rowspan of 1.
+    // (`<n>.<n>*`) is ignored, matching Asciidoctor. So `2.3*` duplicates the
+    // cell twice (not six times), and each clone keeps a rowspan of 1.
     let table = parse_table("[cols=\"4*\"]\n|===\n2.3*|a |b |c\n|===");
     let cells = table.body_rows()[0].cells();
     assert_eq!(cells.len(), 4);
@@ -1314,9 +1328,10 @@ fn duplication_factor_ignores_row_part() {
 
 #[test]
 fn duplication_factor_of_zero_drops_the_cell() {
-    // A duplication factor of zero (`0*`) clones the cell zero times, dropping it
-    // entirely; the following cells flow normally into the grid. Matching
-    // Asciidoctor, `0*|x |a |b |c` yields a single row of `a`, `b`, `c`.
+    // A duplication factor of zero (`0*`) clones the cell zero times, dropping
+    // it entirely; the following cells flow normally into the grid.
+    // Matching Asciidoctor, `0*|x |a |b |c` yields a single row of `a`,
+    // `b`, `c`.
     let table = parse_table("[cols=\"3*\"]\n|===\n0*|x |a |b |c\n|===");
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
     assert_eq!(
@@ -1327,8 +1342,9 @@ fn duplication_factor_of_zero_drops_the_cell() {
 
 #[test]
 fn bare_duplication_operator_clones_once() {
-    // A bare duplication operator (`*`) with no factor defaults to a count of 1,
-    // so `*|a` is a single cell and locates the separator just like a plain `|`.
+    // A bare duplication operator (`*`) with no factor defaults to a count of
+    // 1, so `*|a` is a single cell and locates the separator just like a
+    // plain `|`.
     let table = parse_table("|===\n|a *|b\n|===");
     assert_eq!(table.columns().len(), 2);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
@@ -1340,9 +1356,9 @@ fn huge_duplication_factor_does_not_overallocate() {
     // A duplication factor is an amplifier — `1000000000*` would otherwise
     // materialize a billion cells (a multi-gigabyte allocation). The factor is
     // clamped to `MAX_DUPLICATION_FACTOR` (1,000), so the expansion stays
-    // bounded. This is the one place the implementation diverges from Asciidoctor,
-    // which would expand the literal factor. The table is built from the clamped
-    // cells without hanging or exhausting memory.
+    // bounded. This is the one place the implementation diverges from
+    // Asciidoctor, which would expand the literal factor. The table is
+    // built from the clamped cells without hanging or exhausting memory.
     let table = parse_table("|===\n1000000000*|x\n|===");
     let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
     assert_eq!(total, 1_000);
@@ -1391,8 +1407,8 @@ fn csv_unclosed_quote_is_literal() {
     assert_eq!(table.columns().len(), 2);
     assert_eq!(row_text(&table.body_rows()[0]), ["x", "\"unterminated"]);
 
-    // A bare leading quote leaves the value unclosed, so the following separator
-    // is absorbed into the (single) cell rather than ending it.
+    // A bare leading quote leaves the value unclosed, so the following
+    // separator is absorbed into the (single) cell rather than ending it.
     let table = parse_table("[format=csv]\n|===\n\",a\n|===");
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
@@ -1400,8 +1416,8 @@ fn csv_unclosed_quote_is_literal() {
 
 #[test]
 fn csv_lone_quote_is_unclosed_and_empty_with_warning() {
-    // A cell that is a single bare quote is an unclosed, empty quoted value: it is
-    // set to empty and an error is logged (matching Asciidoctor).
+    // A cell that is a single bare quote is an unclosed, empty quoted value: it
+    // is set to empty and an error is logged (matching Asciidoctor).
     let mut parser = Parser::default();
     let maw = Block::parse(Span::new("[format=csv]\n|===\n\"\n|==="), &mut parser);
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1984,9 +1984,9 @@ mod tests {
 
         #[test]
         fn borrows_source_when_filter_is_a_no_op() {
-            // A filtered view byte-identical to the source span is borrowed from
-            // the span rather than allocating an owned copy of text we already
-            // hold.
+            // A filtered view byte-identical to the source span is borrowed
+            // from the span rather than allocating an owned copy of
+            // text we already hold.
             let content = Content::from_filtered(Span::new("plain text"), "plain text");
 
             assert!(matches!(content.rendered, CowStr::Borrowed(_)));
@@ -1995,8 +1995,8 @@ mod tests {
 
         #[test]
         fn owns_rendered_text_when_filter_changes_it() {
-            // A filtered view that differs from the source is materialized as an
-            // owned copy.
+            // A filtered view that differs from the source is materialized as
+            // an owned copy.
             let content = Content::from_filtered(Span::new("a|b"), "ab");
 
             assert!(matches!(content.rendered, CowStr::Boxed(_)));
@@ -2113,8 +2113,8 @@ mod tests {
         #[test]
         fn passes_a_dangling_escape_introducer_through() {
             // Cannot arise from `escape_sentinels` (which always writes a tag),
-            // so this only pins down that a malformed sequence is content, not a
-            // dropped character.
+            // so this only pins down that a malformed sequence is content, not
+            // a dropped character.
             let dangling = format!("x{SENTINEL_ESCAPE}");
             assert_eq!(unescape_sentinels(&dangling), dangling);
 

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -362,9 +362,9 @@ mod tests {
     fn replacement_type_of_round_trips_every_variant() {
         use super::replacement_type_of;
 
-        // Every replacement value the classifier assigns maps back to a type, so
-        // the fold always routes through the renderer. An unknown value is the
-        // defensive `None`.
+        // Every replacement value the classifier assigns maps back to a type,
+        // so the fold always routes through the renderer. An unknown
+        // value is the defensive `None`.
         for value in [
             "\u{a9}",
             "\u{ae}",

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -296,9 +296,10 @@ fn rebuild_replacements<'src>(
             }
 
             ReplacementKind::Replace { consumed, value } => {
-                // The gap runs up to `consumed`, absorbing any kept leading word
-                // character; the cursor stops at `consumed.end`, so a kept
-                // trailing letter (the second letter of a `w'w` apostrophe) is
+                // The gap runs up to `consumed`, absorbing any kept leading
+                // word character; the cursor stops at
+                // `consumed.end`, so a kept trailing letter
+                // (the second letter of a `w'w` apostrophe) is
                 // absorbed by the next gap.
                 emit_range(nodes, pieces, cursor..consumed.start, &mut out);
 
@@ -595,7 +596,8 @@ mod tests {
     #[test]
     fn an_arrow_replacement_spans_a_text_and_charref_boundary() {
         // `->` is `-` (text) followed by `&gt;` (a `CharRef::Special` from the
-        // special-characters step), so the arrow rule must match across the two.
+        // special-characters step), so the arrow rule must match across the
+        // two.
         let nodes = build_src(Span::new("a -> b"));
 
         // "a " kept, the arrow leaf over "->", then " b".

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -865,8 +865,8 @@ mod tests {
 
     #[test]
     fn fold_emits_raw_verbatim() {
-        // A `Raw` leaf is emitted without HTML-escaping, unlike `Text`; its `<`,
-        // `>`, and `&` pass straight through.
+        // A `Raw` leaf is emitted without HTML-escaping, unlike `Text`; its
+        // `<`, `>`, and `&` pass straight through.
         let location = Span::new("<b>raw &amp;</b>");
 
         let raw = InlineNode::Raw {

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1492,7 +1492,8 @@ mod tests {
         // `link_macro_level`), the link's brackets are already consumed into
         // a `Ref` node (no literal `[`/`]` left to collide with) by the time
         // the footnote's own lazy bracket match runs, unlike the reverse
-        // nesting (see `a_footnote_nested_in_link_text_is_a_documented_divergence`
+        // nesting (see
+        // `a_footnote_nested_in_link_text_is_a_documented_divergence`
         // just below, which explains why that direction can never be clean).
         let source = "footnote:[outer] footnote:[see link:https://example.org[inner]]";
         let folded = fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {});

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -152,10 +152,11 @@ pub(super) fn biblio_anchor_level<'src>(
 
     // The id, by contrast, rides on the node as logical text, so it is sliced
     // back to `'src` (borrowing where it can) exactly as an ordinary anchor's
-    // own id is. Its character class admits neither a special nor a placeholder,
-    // so the two readings coincide — and, for the same reason, the `None` arm
-    // (the id crossing an atomic piece) is not actually reachable, kept only
-    // for symmetry with [`build_anchor_node`]'s own gate.
+    // own id is. Its character class admits neither a special nor a
+    // placeholder, so the two readings coincide — and, for the same reason,
+    // the `None` arm (the id crossing an atomic piece) is not actually
+    // reachable, kept only for symmetry with [`build_anchor_node`]'s own
+    // gate.
     let Some(id) = text_slice(&nodes, &pieces, id_range) else {
         return nodes;
     };
@@ -199,8 +200,8 @@ pub(super) fn anchor_macros_level<'src>(
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
-    // `anchor:` macro prefix. The `[` characters are not special, so a shorthand
-    // reaches the macros step with its `[[` intact.
+    // `anchor:` macro prefix. The `[` characters are not special, so a
+    // shorthand reaches the macros step with its `[[` intact.
     if !s.contains("[[") && !s.contains("anchor:") {
         return nodes;
     }
@@ -257,10 +258,11 @@ pub(super) fn find_anchor_matches<'src>(
 
         // An escape (`\[[…` / `\anchor:…`) is honored by dropping the backslash
         // and keeping the rest literal, mirroring the string replacer's leading
-        // `caps.get(1)` check. [`rebuild_macro_level`] emits the kept range with
-        // [`emit_range`], which clones an atomic piece (a rendered-span reference
-        // text) whole, so the unescape works even across a non-verbatim reference
-        // text — just as the id itself is always verbatim, the whole anchor
+        // `caps.get(1)` check. [`rebuild_macro_level`] emits the kept range
+        // with [`emit_range`], which clones an atomic piece (a
+        // rendered-span reference text) whole, so the unescape works
+        // even across a non-verbatim reference text — just as the id
+        // itself is always verbatim, the whole anchor
         // unescapes regardless.
         if caps.get(1).is_some() {
             matches.push(MacroMatch {
@@ -347,8 +349,8 @@ fn build_anchor_node<'src>(
     let location = source_slice(pieces, full.clone(), root);
 
     // Exactly one id group matches: group 2 for the `[[…]]` shorthand (with its
-    // reference text in group 3), else group 4 for the `anchor:…[…]` macro (with
-    // its reference text in group 5).
+    // reference text in group 3), else group 4 for the `anchor:…[…]` macro
+    // (with its reference text in group 5).
     #[allow(clippy::unwrap_used)]
     let (id_match, reftext_match, is_shorthand) = if let Some(id) = caps.get(2) {
         (id, caps.get(3), true)
@@ -952,7 +954,8 @@ mod tests {
         let anchor = assert_anchor(&nodes[0]);
         let reftext = anchor.reftext.as_ref().unwrap();
 
-        // `[[install, ` is 11 characters, so the trimmed text starts at column 12.
+        // `[[install, ` is 11 characters, so the trimmed text starts at column
+        // 12.
         assert_text(&reftext[0], "Installation", 1, 12);
     }
 
@@ -960,8 +963,9 @@ mod tests {
     fn an_anchor_shorthand_reftext_that_is_whitespace_only_has_no_reftext() {
         // A shorthand reference text that trims to empty (the pattern's `(.+?)`
         // matched only the whitespace the string replacer's `trim_end` strips)
-        // leaves `reftext` `None`, the same shape as the bare `[[id]]` form — and
-        // it still folds to the same `<a id="…"></a>` the string pipeline emits.
+        // leaves `reftext` `None`, the same shape as the bare `[[id]]` form —
+        // and it still folds to the same `<a id="…"></a>` the string
+        // pipeline emits.
         let source = "[[install, ]]";
         let nodes = build_src(Span::new(source));
 
@@ -980,9 +984,9 @@ mod tests {
 
     #[test]
     fn an_anchor_macro_reftext_unescapes_a_bracket() {
-        // A macro reference text unescapes `\]` into `]`, making the logical text
-        // a synthesized (owned) value whose `location` still covers the raw
-        // source it derives from.
+        // A macro reference text unescapes `\]` into `]`, making the logical
+        // text a synthesized (owned) value whose `location` still
+        // covers the raw source it derives from.
         let nodes = build_src(Span::new("anchor:foo[a\\]b]"));
 
         let anchor = assert_anchor(&nodes[0]);
@@ -1020,8 +1024,8 @@ mod tests {
     #[test]
     fn an_escaped_anchor_stays_literal() {
         // `\[[…]]` and `\anchor:…[…]` drop the backslash and keep the anchor as
-        // literal text — no anchor node — exactly as the string replacer's escape
-        // branch does.
+        // literal text — no anchor node — exactly as the string replacer's
+        // escape branch does.
         for source in ["\\[[install]]", "\\anchor:install[Installation]"] {
             let nodes = build_src(Span::new(source));
 
@@ -1665,9 +1669,9 @@ mod tests {
     #[test]
     fn a_bibliography_anchor_is_recognized_only_inside_a_bibliography_list_item() {
         // The same source, built against a parser that is *not* flagged: the
-        // triple bracket falls through to the ordinary inline-anchor pass, whose
-        // node carries no bibliography flag (and whose id the side-effect pass
-        // deliberately does not catalog — see
+        // triple bracket falls through to the ordinary inline-anchor pass,
+        // whose node carries no bibliography flag (and whose id the
+        // side-effect pass deliberately does not catalog — see
         // `does_not_register_the_inner_anchor_of_a_bibliography_style_triple_bracket`).
         let nodes = build_src(Span::new("[[[gof]]]"));
 
@@ -1801,8 +1805,8 @@ mod tests {
         // The pass is `^`-anchored to the whole content, so it is a no-op for a
         // level whose text merely *contains* a triple bracket, and for one that
         // starts with it but under a parser that is not inside a bibliography
-        // list item. Driven directly, since `apply_macros` only ever calls it at
-        // the content's top level.
+        // list item. Driven directly, since `apply_macros` only ever calls it
+        // at the content's top level.
         let root = Span::new("x [[[gof]]]");
         let nodes = vec![InlineNode::Text {
             value: CowStr::from(root.data()),

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -639,9 +639,10 @@ fn build_image_node<'src>(
     });
 
     // Pre-extract the resolved alt/width/height into owned values, ending the
-    // `&'src self`-tied borrows before the attribute list is moved into the node
-    // (the same read-then-move shape [`attributes_of`] uses). An icon carries a
-    // `size` rather than width/height, recomputed at fold time from `attrs`.
+    // `&'src self`-tied borrows before the attribute list is moved into the
+    // node (the same read-then-move shape [`attributes_of`] uses). An icon
+    // carries a `size` rather than width/height, recomputed at fold time
+    // from `attrs`.
     let (alt, width, height) = if is_icon {
         let alt = attrlist.named_attribute("alt").map_or(default_alt, |a| {
             normalize_text_lf_escaped_bracket(a.value())
@@ -1390,8 +1391,8 @@ mod tests {
 
     #[test]
     fn image_default_alt_derives_from_the_basename() {
-        // With no alt, the default is the target's basename with `_`/`-` read as
-        // spaces and the extension dropped.
+        // With no alt, the default is the target's basename with `_`/`-` read
+        // as spaces and the extension dropped.
         let nodes = build_src(Span::new("image:a_b-c.png[]"));
 
         let image = assert_image(&nodes[0]);
@@ -2721,7 +2722,8 @@ mod tests {
     fn registers_an_image_nested_inside_a_refs_display_children() {
         // A `Ref`'s display children can hold an `Image` too — `apply_macros`
         // itself descends into a `Ref`'s own children before matching at its
-        // level (see `apply_macros_recognizes_a_macro_inside_reference_children`
+        // level (see
+        // `apply_macros_recognizes_a_macro_inside_reference_children`
         // in `macros/mod.rs`'s own tests), so a hand-built `Ref` exercises the
         // same container here.
         use crate::inlines::{Ref, RefVariant};

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -56,21 +56,24 @@ pub(super) fn indexterm_macros_level<'src>(
         return nodes;
     }
 
-    // The string replacer runs the shorthand through [`replace_with_lookahead`],
-    // whose look-ahead retry (a shorthand absorbing trailing parens) has a subtle
-    // consequence: if the whole substitution accumulates *no* output and the last
-    // event is such a retry, the helper returns `Cow::Borrowed` and the caller
-    // keeps the original text **unchanged**. Concretely, content that is nothing
-    // but concealed shorthand terms (`(((coffee)))`, `(((a)))(((b)))`) is left
-    // *literal*, where the same terms with any surrounding output render to
-    // nothing. Detect that no-op and mirror it: leave the level untouched.
+    // The string replacer runs the shorthand through
+    // [`replace_with_lookahead`], whose look-ahead retry (a shorthand
+    // absorbing trailing parens) has a subtle consequence: if the whole
+    // substitution accumulates *no* output and the last event is such a
+    // retry, the helper returns `Cow::Borrowed` and the caller
+    // keeps the original text **unchanged**. Concretely, content that is
+    // nothing but concealed shorthand terms (`(((coffee)))`,
+    // `(((a)))(((b)))`) is left *literal*, where the same terms with any
+    // surrounding output render to nothing. Detect that no-op and mirror
+    // it: leave the level untouched.
     //
     // This mirrors a **known string-pipeline bug**
     // (asciidoc-rs/asciidoc-parser#1123): a whole-content concealed term should
     // render empty, not literal. The additive builder reproduces it here to
     // keep byte-for-byte parity (design §5.3); the fix for both is to drop this
     // call at the cutover (design §5.2, Phase 4, step 6),
-    // where `rendered_html()` becomes the fold and the golden output is updated.
+    // where `rendered_html()` becomes the fold and the golden output is
+    // updated.
     if indexterm_substitution_is_a_noop(&matches) {
         return nodes;
     }
@@ -229,12 +232,13 @@ fn find_indexterm_matches<'src>(
         }
 
         // Shorthand form: group 3 is the text enclosed by the outermost `((` …
-        // `))`. Absorb any `)` immediately after the matched `))` so the closing
-        // pair is the *last* in the run, mirroring the string replacer's
-        // `(?!\))` look-ahead re-creation. `captures_iter` cannot skip ahead, so
-        // the absorbed parens are folded into this match's `full` range instead;
-        // a run of `)` never starts a new match, so the next `captures_iter`
-        // match still lands past them.
+        // `))`. Absorb any `)` immediately after the matched `))` so the
+        // closing pair is the *last* in the run, mirroring the string
+        // replacer's `(?!\))` look-ahead re-creation. `captures_iter`
+        // cannot skip ahead, so the absorbed parens are folded into
+        // this match's `full` range instead; a run of `)` never starts
+        // a new match, so the next `captures_iter` match still lands
+        // past them.
         #[allow(clippy::unwrap_used)]
         let inner = caps.get(3).unwrap().range();
 
@@ -536,9 +540,10 @@ fn build_indexterm_macro_match<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Option<RecognizedIndexterm<'src>> {
-    // An escape (`\indexterm:…`) drops the backslash and keeps the rest literal,
-    // mirroring the string replacer's `caps[0][1..]`. A macro form always
-    // `Continue`s (no look-ahead retry), and the unescaped literal is non-empty.
+    // An escape (`\indexterm:…`) drops the backslash and keeps the rest
+    // literal, mirroring the string replacer's `caps[0][1..]`. A macro form
+    // always `Continue`s (no look-ahead retry), and the unescaped literal
+    // is non-empty.
     if escaped {
         return Some(RecognizedIndexterm {
             macro_match: MacroMatch {
@@ -751,8 +756,8 @@ fn push_indexterm_shorthand_matches<'src>(
     root: Span<'src>,
     matches: &mut Vec<RecognizedIndexterm<'src>>,
 ) {
-    // `encl_text` = the enclosed text plus any absorbed trailing parens, exactly
-    // as the string replacer builds it before classifying.
+    // `encl_text` = the enclosed text plus any absorbed trailing parens,
+    // exactly as the string replacer builds it before classifying.
     let encl_text = encl.text(s);
 
     if escaped {
@@ -791,9 +796,10 @@ fn push_indexterm_shorthand_matches<'src>(
             is_skip: false,
         });
 
-        // Everything after it: the nested term, with the wrapping parenthesis at
-        // each end left outside `consumed` so `rebuild_macro_level` emits both
-        // as the literal text the replacer pushes around the rendered term.
+        // Everything after it: the nested term, with the wrapping parenthesis
+        // at each end left outside `consumed` so `rebuild_macro_level`
+        // emits both as the literal text the replacer pushes around the
+        // rendered term.
         let term_full = (full.start + 1)..full.end;
         let consumed = (term_full.start + 1)..(term_full.end - 1);
 
@@ -826,10 +832,10 @@ fn push_indexterm_shorthand_matches<'src>(
         return;
     }
 
-    // Classify the term, mirroring the string replacer's paren stripping. `term`
-    // is the inner text whose primary term is shown (visible) or indexed only
-    // (concealed); `before`/`after` flag a single literal parenthesis kept
-    // beside the term.
+    // Classify the term, mirroring the string replacer's paren stripping.
+    // `term` is the inner text whose primary term is shown (visible) or
+    // indexed only (concealed); `before`/`after` flag a single literal
+    // parenthesis kept beside the term.
     let len = encl_text.len();
 
     let (term_sub, visible, before, after): (std::ops::Range<usize>, bool, bool, bool) =
@@ -881,9 +887,9 @@ fn push_indexterm_shorthand_matches<'src>(
         )
     };
 
-    // A kept literal parenthesis is left outside the node's `consumed` sub-range
-    // so [`rebuild_macro_level`] emits it as literal text: a `before` keeps the
-    // match's first `(`; an `after` keeps its last `)`.
+    // A kept literal parenthesis is left outside the node's `consumed`
+    // sub-range so [`rebuild_macro_level`] emits it as literal text: a
+    // `before` keeps the match's first `(`; an `after` keeps its last `)`.
     let consumed = (full.start + usize::from(before))..(full.end - usize::from(after));
 
     matches.push(RecognizedIndexterm {
@@ -1078,9 +1084,10 @@ mod tests {
         //
         // Note the `(((coffee))) trailing` case: **trailing** text does *not*
         // rescue recognition, because it is appended only on the replacer's
-        // normal completion — the `Cow::Borrowed` early-return on the empty-`new`
-        // retry happens first and discards it. Only output emitted *before* the
-        // retry (a leading/between gap, or a shown term) makes `new` non-empty;
+        // normal completion — the `Cow::Borrowed` early-return on the
+        // empty-`new` retry happens first and discards it. Only output
+        // emitted *before* the retry (a leading/between gap, or a shown
+        // term) makes `new` non-empty;
         // see `a_concealed_term_after_leading_output_is_consumed` for that
         // contrast. (Both mirror the string pipeline exactly — verified below.)
         for source in [
@@ -1109,11 +1116,12 @@ mod tests {
     #[test]
     fn a_concealed_term_after_leading_output_is_consumed() {
         // The contrast to the all-concealed no-op: **leading** text makes the
-        // replacer's accumulator non-empty *before* the look-ahead retry, so the
-        // substitution is `Cow::Owned` and the concealed term is recognized and
-        // consumed (renders nothing) — leaving only the leading text. The builder
-        // reproduces this byte-for-byte, so `leading (((coffee)))` folds to
-        // `leading `, not the literal source.
+        // replacer's accumulator non-empty *before* the look-ahead retry, so
+        // the substitution is `Cow::Owned` and the concealed term is
+        // recognized and consumed (renders nothing) — leaving only the
+        // leading text. The builder reproduces this byte-for-byte, so
+        // `leading (((coffee)))` folds to `leading `, not the literal
+        // source.
         for source in ["leading (((coffee)))", "((a)) (((b)))"] {
             let folded = fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {});
             assert_eq!(

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -423,8 +423,9 @@ fn build_inline_link_node<'src>(
     let raw_text = raw_text_m.map_or("", |m| m.as_str());
 
     if let Some(attrlist_m) = raw_text_m {
-        // A formal URL link: the bracketed text is the display text (empty means
-        // a bare link, handled by the shared post-processing below).
+        // A formal URL link: the bracketed text is the display text (empty
+        // means a bare link, handled by the shared post-processing
+        // below).
         if !attrlist_m.is_empty() {
             link_text = Some(attrlist_m.as_str().to_string());
         }
@@ -452,15 +453,15 @@ fn build_inline_link_node<'src>(
             }
         }
 
-        // A bare scheme with nothing left after trimming is not a link; leave it
-        // literal, exactly as the string step does.
+        // A bare scheme with nothing left after trimming is not a link; leave
+        // it literal, exactly as the string step does.
         if target.ends_with("://") {
             return None;
         }
 
         // The bare group is the last group in the match, so the URL ends at
-        // `full.end`; the node stops short of the stripped punctuation, which the
-        // stripped bytes (ASCII) place `stripped` bytes back.
+        // `full.end`; the node stops short of the stripped punctuation, which
+        // the stripped bytes (ASCII) place `stripped` bytes back.
         consumed_end = full.end - stripped;
         url_end = consumed_end;
 
@@ -486,12 +487,13 @@ fn build_inline_link_node<'src>(
     // A target crossing a **masked** construct finishes into the restored
     // bytes — the node's own rendered body ([`restorable_body`]) substituted
     // for its placeholder, the same rewrite `Passthroughs::restore_to`
-    // performs on the emitted `href` — and only the node's values take them. Every
-    // *decision* the string replacer makes over the bytes as matched is already
-    // behind us (the quoted-prefix rejection and the trailing-punctuation strip
-    // above), each reading a placeholder exactly as the sentinel-holding
-    // haystack reads its own sentinel: neither spelling is a quote, and neither
-    // ends in the `;` or `:` the strip keys off.
+    // performs on the emitted `href` — and only the node's values take them.
+    // Every *decision* the string replacer makes over the bytes as matched
+    // is already behind us (the quoted-prefix rejection and the
+    // trailing-punctuation strip above), each reading a placeholder exactly
+    // as the sentinel-holding haystack reads its own sentinel: neither
+    // spelling is a quote, and neither ends in the `;` or `:` the strip
+    // keys off.
     //
     // `target` is the match string's own bytes from the scheme through the
     // URL — one contiguous run, less whatever the strip truncated — so its
@@ -1015,10 +1017,10 @@ fn find_link_macro_matches<'src>(
         // dropping the backslash keeps the rest of the match as its **own
         // original nodes** (a rendered span or an escaped special among them),
         // which fold back to exactly the bytes the replacer's `caps[0][1..]`
-        // emits. (This is the same check-order fix the `footnoteref:`, menu, and
-        // cross-reference increments made for their own families; before it, an
-        // escaped `\link:x[*bold*]` whose match the gate rejected was left
-        // unrecognized, backslash and all.)
+        // emits. (This is the same check-order fix the `footnoteref:`, menu,
+        // and cross-reference increments made for their own families;
+        // before it, an escaped `\link:x[*bold*]` whose match the gate
+        // rejected was left unrecognized, backslash and all.)
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -2230,11 +2232,12 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_with_hide_uri_scheme() {
         // Under `hide-uri-scheme`, a bare link's display text drops the URI
-        // scheme; the builder reproduces the string step's `URI_SNIFF` stripping,
-        // including the fall-back to the whole target when the strip leaves
-        // nothing. Every fixture is a non-`://` `link:` target, so the string
-        // pipeline routes it through the same `INLINE_LINK_MACRO` the builder
-        // uses (a `://` target is `INLINE_LINK`'s territory, a later increment).
+        // scheme; the builder reproduces the string step's `URI_SNIFF`
+        // stripping, including the fall-back to the whole target when
+        // the strip leaves nothing. Every fixture is a non-`://`
+        // `link:` target, so the string pipeline routes it through the
+        // same `INLINE_LINK_MACRO` the builder uses (a `://` target is
+        // `INLINE_LINK`'s territory, a later increment).
         use crate::parser::ModificationContext;
 
         let parser = Parser::default().with_intrinsic_attribute_bool(
@@ -2668,7 +2671,8 @@ mod tests {
     #[test]
     fn a_mailto_macro_targets_the_address() {
         // A labeled mailto prefixes the address with `mailto:` and shows the
-        // label; a bare mailto shows the address itself and takes no `bare` role.
+        // label; a bare mailto shows the address itself and takes no `bare`
+        // role.
         let labeled = build_src(Span::new("mailto:hello@example.org[Email us]"));
         let reference = assert_link(&labeled[0]);
         assert_eq!(reference.target.as_ref(), "mailto:hello@example.org");
@@ -2698,8 +2702,8 @@ mod tests {
 
     #[test]
     fn an_escaped_link_macro_stays_literal() {
-        // `\link:…` drops the backslash and keeps the macro as literal text — no
-        // link node.
+        // `\link:…` drops the backslash and keeps the macro as literal text —
+        // no link node.
         let nodes = build_src(Span::new("\\link:index.html[Docs]"));
 
         assert!(
@@ -3006,8 +3010,8 @@ mod tests {
 
     #[test]
     fn a_link_is_recognized_inside_a_span() {
-        // A macro can appear inside a rendered span; the transducer descends into
-        // the span body and builds the node there.
+        // A macro can appear inside a rendered span; the transducer descends
+        // into the span body and builds the node there.
         let nodes = build_src(Span::new("*see link:x.html[X]*"));
 
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -3023,13 +3027,14 @@ mod tests {
     fn fold_matches_the_string_pipeline_through_inline_links() {
         // For each fixture, folding the single-pass tree (all five steps)
         // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the auto-link / formal-URL
-        // link increment. A fixture may cross an escaped special anywhere but
-        // its own attribute-list text; the forms still deferred (an
-        // attribute-list text crossing a special, a multi-line attribute-list
-        // text, a display text crossing a rendered span, and a bare URL whose
-        // trailing-punctuation strip would split a special) each live in a
-        // divergence test below. The pattern's ANGLE branch has its own corpus,
+        // differential corpus (design §5.3) that pins the auto-link /
+        // formal-URL link increment. A fixture may cross an escaped
+        // special anywhere but its own attribute-list text; the forms
+        // still deferred (an attribute-list text crossing a special, a
+        // multi-line attribute-list text, a display text crossing a
+        // rendered span, and a bare URL whose trailing-punctuation
+        // strip would split a special) each live in a divergence test
+        // below. The pattern's ANGLE branch has its own corpus,
         // alongside its own structural tests.
         let fixtures = [
             // No auto-link despite a colon or a `//`.
@@ -3143,8 +3148,9 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_for_auto_links_with_hide_uri_scheme() {
-        // Under `hide-uri-scheme`, a bare auto-link's display text drops the URI
-        // scheme; the builder reproduces the string step's `URI_SNIFF` stripping.
+        // Under `hide-uri-scheme`, a bare auto-link's display text drops the
+        // URI scheme; the builder reproduces the string step's
+        // `URI_SNIFF` stripping.
         use crate::parser::ModificationContext;
 
         let parser = Parser::default().with_intrinsic_attribute_bool(

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -399,9 +399,9 @@ fn apply_reference_families<'src>(
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
     // families and before the anchor pass, exactly where the string step runs
-    // `InlineEmailReplacer` — so an address that is really the tail of a URL, or
-    // a `mailto:` macro's own target, is already inside an opaque node (there,
-    // already-rendered `<a …>` markup) and is not re-recognized.
+    // `InlineEmailReplacer` — so an address that is really the tail of a URL,
+    // or a `mailto:` macro's own target, is already inside an opaque node
+    // (there, already-rendered `<a …>` markup) and is not re-recognized.
     let nodes = email_level(nodes, root, ctx, masked);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
@@ -652,8 +652,8 @@ pub(super) fn macro_text_children<'src>(
         None => {
             // The text crosses an escaped special (the only atomic piece the
             // callers' gate admits) — or, degenerately, is a range `text_slice`
-            // declined to recover. Rebuild it out of the nodes it covers, so each
-            // special stays the `CharRef` it already is.
+            // declined to recover. Rebuild it out of the nodes it covers, so
+            // each special stays the `CharRef` it already is.
             let mut children = Vec::new();
 
             if unescape_bracket {
@@ -1376,21 +1376,23 @@ mod tests {
         // take the same lift, closing the escaped-special / restored-entity
         // boundary for every macro family:
         //
-        // - The **UI** family (`kbd:`/`btn:`/`menu:`) swapped its own gate for the
-        //   shared opaque-piece one. Every value a `Ui` node holds is
-        //   already-substituted text read out of the match string, which is exactly
-        //   what the string replacer computes from its own escaped haystack.
+        // - The **UI** family (`kbd:`/`btn:`/`menu:`) swapped its own gate for
+        //   the shared opaque-piece one. Every value a `Ui` node holds is
+        //   already-substituted text read out of the match string, which is
+        //   exactly what the string replacer computes from its own escaped
+        //   haystack.
         //
         // - A **footnote's text** needed no code change at all: its content is
-        //   structured children (`emit_range` keeps a `CharRef` leaf as its own child),
-        //   so it never sliced `'src` for a value in the first place. What made this
-        //   look like a boundary was the *harness*: the test that pinned it drove the
-        //   golden pipeline and the builder from one shared `Parser`, so each fixture's
-        //   footnote was numbered twice (`1` on the golden side, `2` on the built side)
-        //   and the two sides "diverged" for a reason that had nothing to do with the
-        //   entity. Hence `parity`, below, which configures one parser per side — the
-        //   two-independent-parsers discipline every footnote-bearing corpus in this
-        //   module already uses.
+        //   structured children (`emit_range` keeps a `CharRef` leaf as its own
+        //   child), so it never sliced `'src` for a value in the first place.
+        //   What made this look like a boundary was the *harness*: the test
+        //   that pinned it drove the golden pipeline and the builder from one
+        //   shared `Parser`, so each fixture's footnote was numbered twice (`1`
+        //   on the golden side, `2` on the built side) and the two sides
+        //   "diverged" for a reason that had nothing to do with the entity.
+        //   Hence `parity`, below, which configures one parser per side — the
+        //   two-independent-parsers discipline every footnote-bearing corpus in
+        //   this module already uses.
         let configure = || {
             Parser::default().with_intrinsic_attribute(
                 "experimental",

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -423,10 +423,11 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_ui_macros() {
         // For each fixture, folding the single-pass tree (all five steps, under
-        // `experimental`) reproduces the string pipeline's output byte-for-byte.
-        // This is the differential corpus (design §5.3) that pins the UI-macro
-        // increment. Every fixture is deliberately *verbatim* (no `<`/`>`/`&`
-        // inside a macro), the boundary this increment claims.
+        // `experimental`) reproduces the string pipeline's output
+        // byte-for-byte. This is the differential corpus (design §5.3)
+        // that pins the UI-macro increment. Every fixture is
+        // deliberately *verbatim* (no `<`/`>`/`&` inside a macro), the
+        // boundary this increment claims.
         let fixtures = [
             // No UI macro despite macro-ish characters.
             "kbd is a word, not a macro",

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -289,9 +289,10 @@ fn find_xref_matches<'src>(
 
         let recoverable = match &shorthand_inner {
             Some(inner) => {
-                // The shorthand's id is its inner up to the first `,` — the very
-                // split `build_xref_shorthand_node` (and the string replacer)
-                // makes. A comma the *markup* of an opaque piece contributes
+                // The shorthand's id is its inner up to the first `,` — the
+                // very split `build_xref_shorthand_node` (and
+                // the string replacer) makes. A comma the
+                // *markup* of an opaque piece contributes
                 // cannot move that split unnoticed: such a piece would have to
                 // sit in the id half, which this gate then rejects.
                 let id_range = shorthand_id_range(s, inner);
@@ -1088,8 +1089,8 @@ mod tests {
 
     #[test]
     fn an_xref_display_text_is_located_at_its_source() {
-        // The display text's `Text` child locates at the bracketed text, not the
-        // whole macro.
+        // The display text's `Text` child locates at the bracketed text, not
+        // the whole macro.
         let nodes = build_src(Span::new("xref:install[Installation]"));
 
         let reference = assert_xref(&nodes[0]);
@@ -1099,12 +1100,13 @@ mod tests {
 
     #[test]
     fn an_explicit_same_document_xref_stores_the_interpreted_id() {
-        // `xref:#install[]` uses the explicit-`#` same-document form. The node's
-        // `target` is the *interpreted* id (`install`), not the raw `#install`:
-        // it is the value the renderer builds the `href` from and resolution
-        // keys on, matching the string pipeline and the recorder tree (see the
-        // `Ref::target` field docs). Storing `#install` would fold to
-        // `href="##install"` and break parity.
+        // `xref:#install[]` uses the explicit-`#` same-document form. The
+        // node's `target` is the *interpreted* id (`install`), not the
+        // raw `#install`: it is the value the renderer builds the
+        // `href` from and resolution keys on, matching the string
+        // pipeline and the recorder tree (see the `Ref::target` field
+        // docs). Storing `#install` would fold to `href="##install"`
+        // and break parity.
         let nodes = build_src(Span::new("xref:#install[Install]"));
 
         let reference = assert_xref(&nodes[0]);
@@ -1134,8 +1136,9 @@ mod tests {
 
     #[test]
     fn an_escaped_xref_stays_literal() {
-        // `\xref:…` drops the backslash and keeps the macro as literal text — no
-        // reference node — exactly as the string replacer's escape branch does.
+        // `\xref:…` drops the backslash and keeps the macro as literal text —
+        // no reference node — exactly as the string replacer's escape
+        // branch does.
         let source = "\\xref:install[Installation]";
         let nodes = build_src(Span::new(source));
 
@@ -1170,8 +1173,9 @@ mod tests {
     #[test]
     fn an_xref_shorthand_becomes_a_ref_node() {
         // The `<<id,text>>` shorthand builds the same `Ref{Xref}` node the
-        // `xref:` macro does, even though its `&lt;&lt;` / `&gt;&gt;` delimiters
-        // are `CharRef`s: the node consumes them and slices its verbatim inner.
+        // `xref:` macro does, even though its `&lt;&lt;` / `&gt;&gt;`
+        // delimiters are `CharRef`s: the node consumes them and slices
+        // its verbatim inner.
         let nodes = build_src(Span::new("<<install,Install Now>>"));
 
         assert_eq!(nodes.len(), 1);
@@ -1208,9 +1212,10 @@ mod tests {
 
     #[test]
     fn an_xref_shorthand_display_text_is_located_at_its_trimmed_source() {
-        // The reference text's `Text` child locates at the *trimmed* text within
-        // the shorthand, not at the whole shorthand and not including the
-        // surrounding whitespace the string replacer trims.
+        // The reference text's `Text` child locates at the *trimmed* text
+        // within the shorthand, not at the whole shorthand and not
+        // including the surrounding whitespace the string replacer
+        // trims.
         let nodes = build_src(Span::new("<<install, Install Now >>"));
 
         let reference = assert_xref(&nodes[0]);
@@ -1223,8 +1228,8 @@ mod tests {
 
     #[test]
     fn an_xref_shorthand_is_recognized_inside_a_span() {
-        // A shorthand can appear inside a rendered span; the transducer descends
-        // into the span body and builds the node there.
+        // A shorthand can appear inside a rendered span; the transducer
+        // descends into the span body and builds the node there.
         let nodes = build_src(Span::new("*see <<x,X>>*"));
 
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -1238,10 +1243,11 @@ mod tests {
 
     #[test]
     fn an_escaped_xref_shorthand_stays_literal() {
-        // `\<<id>>` drops the backslash and keeps the shorthand as literal text —
-        // no reference node — exactly as the string replacer's escape branch
-        // does. Its delimiters are non-verbatim `CharRef`s, so this also exercises
-        // the escape path that does not require a verbatim inner.
+        // `\<<id>>` drops the backslash and keeps the shorthand as literal text
+        // — no reference node — exactly as the string replacer's escape
+        // branch does. Its delimiters are non-verbatim `CharRef`s, so
+        // this also exercises the escape path that does not require a
+        // verbatim inner.
         let source = "\\<<install,Install Now>>";
         let nodes = build_src(Span::new(source));
 
@@ -1285,9 +1291,10 @@ mod tests {
 
     #[test]
     fn an_empty_xref_shorthand_becomes_a_ref_node() {
-        // `<<>>` names the document as a whole: an empty id that resolves through
-        // a *derived* destination computed from the document's own attributes,
-        // exactly as the empty `xref:#[]` macro form does.
+        // `<<>>` names the document as a whole: an empty id that resolves
+        // through a *derived* destination computed from the document's
+        // own attributes, exactly as the empty `xref:#[]` macro form
+        // does.
         let source = "<<>>";
         let nodes = build_src(Span::new(source));
 
@@ -2458,9 +2465,10 @@ mod tests {
 
     #[test]
     fn a_fragmentless_this_document_xref_target_is_document_as_a_whole() {
-        // A target naming *this* document with no fragment (`xref:mydoc.adoc[]`)
-        // is, like the empty target (`xref:#[]`), a reference to the document as
-        // a whole: the same `this_document_reference` derived destination, not a
+        // A target naming *this* document with no fragment
+        // (`xref:mydoc.adoc[]`) is, like the empty target (`xref:#[]`),
+        // a reference to the document as a whole: the same
+        // `this_document_reference` derived destination, not a
         // same-document id to resolve through the catalog.
         let parser = Parser::default().with_primary_file_name("mydoc.adoc");
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -587,15 +587,15 @@ pub(crate) fn build_for_group<'src>(
     // alone. Two consumers read it, which is why it is taken unconditionally
     // rather than only for the order that needs the first:
     //
-    //   - `flatten_prior_markup`, for a `subs=` list that puts the escaping step
-    //     *after* a step that already produced markup: the string pipeline escapes
-    //     the tags that step wrote, and this is what tells those from a passthrough
-    //     body the escaping step never touches.
+    //   - `flatten_prior_markup`, for a `subs=` list that puts the escaping
+    //     step *after* a step that already produced markup: the string pipeline
+    //     escapes the tags that step wrote, and this is what tells those from a
+    //     passthrough body the escaping step never touches.
     //
-    //   - recognition itself (`build_match_string`, via `Masked`), for every order:
-    //     a sibling reads a rendered span's own markup, and a wrapper — which the
-    //     string pipeline is still holding as a `\u{96}…\u{97}` placeholder —
-    //     presents no markup to read.
+    //   - recognition itself (`build_match_string`, via `Masked`), for every
+    //     order: a sibling reads a rendered span's own markup, and a wrapper —
+    //     which the string pipeline is still holding as a `\u{96}…\u{97}`
+    //     placeholder — presents no markup to read.
     let masked = masked_locations(&nodes);
 
     for (position, step) in steps.iter().enumerate() {

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1284,9 +1284,9 @@ mod tests {
 
     #[test]
     fn apply_passthroughs_is_a_noop_without_passthrough_syntax() {
-        // The cheap pre-filter returns the seed unchanged when no `++`, `$$`, or
-        // `ss:` substring is present, so ordinary content never pays for the
-        // level-building machinery.
+        // The cheap pre-filter returns the seed unchanged when no `++`, `$$`,
+        // or `ss:` substring is present, so ordinary content never pays
+        // for the level-building machinery.
         let source = Span::new("plain text, no passthrough syntax here");
         let seeded = seed(source);
         let nodes = apply_passthroughs(seeded.clone(), source, &Parser::default());
@@ -1345,8 +1345,9 @@ mod tests {
 
     #[test]
     fn triple_plus_borrows_its_content_unescaped() {
-        // `SubstitutionGroup::None` applies nothing, so the content is genuinely
-        // raw — not even special characters are escaped — and borrows `'src`.
+        // `SubstitutionGroup::None` applies nothing, so the content is
+        // genuinely raw — not even special characters are escaped — and
+        // borrows `'src`.
         let nodes = build_src(Span::new("+++<b>*not quotes*</b>+++"));
 
         assert_eq!(nodes.len(), 1);
@@ -1370,9 +1371,9 @@ mod tests {
 
     #[test]
     fn double_plus_and_double_dollar_escape_specials_only() {
-        // `SubstitutionGroup::Verbatim` applies only special characters: `<`/`>`
-        // are escaped, but `*not quotes*` is left alone (quotes never runs over
-        // passthrough content).
+        // `SubstitutionGroup::Verbatim` applies only special characters:
+        // `<`/`>` are escaped, but `*not quotes*` is left alone (quotes
+        // never runs over passthrough content).
         for source in ["++<b>*not quotes*</b>++", "$$<b>*not quotes*</b>$$"] {
             let nodes = build_src(Span::new(source));
 
@@ -1438,7 +1439,8 @@ mod tests {
 
     #[test]
     fn an_escaped_double_plus_reveals_a_nested_bare_passthrough() {
-        // Same mechanism as `an_escaped_triple_plus_reveals_a_nested_bare_passthrough`,
+        // Same mechanism as
+        // `an_escaped_triple_plus_reveals_a_nested_bare_passthrough`,
         // one delimiter layer down: de-escaping `\++text++` to `++text++`
         // leaves a leading `++` the bare-form pass now legitimately
         // re-consumes as a bare passthrough wrapping `+text`, leaving a
@@ -1543,11 +1545,11 @@ mod tests {
         // which form a passthrough body takes, and the two are not the same
         // thing wearing different labels:
         //
-        //   - `+++…+++` and bare `pass:[…]` apply *nothing*, so the author's bytes are
-        //     the output bytes — raw output by design.
-        //   - `++…++` and `$$…$$` apply special characters and nothing else, so the
-        //     body is the author's *literal text*. Escaping it is the fold's job, with
-        //     whatever renderer the fold is given.
+        //   - `+++…+++` and bare `pass:[…]` apply *nothing*, so the author's
+        //     bytes are the output bytes — raw output by design.
+        //   - `++…++` and `$$…$$` apply special characters and nothing else, so
+        //     the body is the author's *literal text*. Escaping it is the
+        //     fold's job, with whatever renderer the fold is given.
         //
         // Both stay opaque to every later step — that is what keeps them one
         // node kind — so this pins the distinction the kind alone cannot.
@@ -1610,12 +1612,12 @@ mod tests {
         // time, through whichever renderer the `Parser` carried, and frozen
         // into the node. Two things followed, and both are wrong:
         //
-        //   1. folding the tree with a *different* renderer — which is the whole point
-        //      of `render_with` — silently emitted the parse-time renderer's escaping
-        //      instead;
-        //   2. building the tree *invoked* the document's renderer for a value nothing
-        //      reads, so a renderer with state saw extra calls and a later block's
-        //      authoritative output shifted under it.
+        //   1. folding the tree with a *different* renderer — which is the
+        //      whole point of `render_with` — silently emitted the parse-time
+        //      renderer's escaping instead;
+        //   2. building the tree *invoked* the document's renderer for a value
+        //      nothing reads, so a renderer with state saw extra calls and a
+        //      later block's authoritative output shifted under it.
         //
         // Folding the same tree through two different backends is the sharpest
         // statement of the fix: one tree, two renderings, neither frozen.
@@ -2466,12 +2468,13 @@ mod tests {
 
     #[test]
     fn a_bare_attrlisted_form_wrapping_an_embedded_macro_pass_is_a_documented_divergence() {
-        // `[method x-]+pass:[<b>]+`: the *macro* pass (`apply_pass_macro_level`,
-        // which runs first) recognizes the embedded `pass:[<b>]` on its own —
-        // `INLINE_PASS_MACRO`'s `pass:` alternative matches that substring
-        // regardless of surrounding context — *before* the bare-form second
-        // pass gets a chance to see `[method x-]+…+` as one attrlisted
-        // construct. The candidate bare-form match's body then spans the
+        // `[method x-]+pass:[<b>]+`: the *macro* pass
+        // (`apply_pass_macro_level`, which runs first) recognizes the
+        // embedded `pass:[<b>]` on its own — `INLINE_PASS_MACRO`'s
+        // `pass:` alternative matches that substring regardless of
+        // surrounding context — *before* the bare-form second pass gets
+        // a chance to see `[method x-]+…+` as one attrlisted construct.
+        // The candidate bare-form match's body then spans the
         // already-built (opaque) node the macro pass left behind, so
         // `range_is_verbatim` defers it — the real-world trigger for
         // `a_bare_attrlisted_match_whose_content_crosses_an_already_built_node_is_deferred`'s

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1443,15 +1443,15 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 fn attributes_of_attrlist<'src>(
     attrlist: Attrlist<'src>,
 ) -> (Option<CowStr<'src>>, Vec<CowStr<'src>>, Attrlist<'src>) {
-    // Extract owned id/roles before the attrlist is moved into the node, exactly
-    // as the string pipeline's quote replacer does.
+    // Extract owned id/roles before the attrlist is moved into the node,
+    // exactly as the string pipeline's quote replacer does.
     //
-    // Unlike that replacer, this deliberately performs *no* side effect: it does
-    // not `register_ref` an assigned id in the catalog, because the builder is
-    // additive and not yet the recognition sink — the authoritative string
-    // pipeline still registers it. The cutover (design §5.2 Phase 4, step 6)
-    // must add that registration so cross-references to an inline id resolve
-    // (tracked by #1087).
+    // Unlike that replacer, this deliberately performs *no* side effect: it
+    // does not `register_ref` an assigned id in the catalog, because the
+    // builder is additive and not yet the recognition sink — the
+    // authoritative string pipeline still registers it. The cutover (design
+    // §5.2 Phase 4, step 6) must add that registration so cross-references
+    // to an inline id resolve (tracked by #1087).
     let id = attrlist.id().map(|id| CowStr::from(id.to_string()));
 
     let roles = attrlist
@@ -1732,8 +1732,8 @@ fn s_to_src(pieces: &[Piece], x: usize, bias: Bias) -> usize {
         }
     }
 
-    // Past the last piece: the end of the source the pieces cover, or the anchor
-    // for an empty level.
+    // Past the last piece: the end of the source the pieces cover, or the
+    // anchor for an empty level.
     pieces
         .last()
         .map_or(0, |last| last.src_offset + last.src_len)
@@ -2479,7 +2479,8 @@ mod tests {
         // An id rather than a role, so the probe sees a `<span …>`: the fold
         // hands the renderer the span's `attrs` and `id` and lets it derive
         // the roles, so a `roles` field with no attribute list behind it
-        // renders nothing (see `styled_boundaries_match_the_built_in_renderer`).
+        // renders nothing (see
+        // `styled_boundaries_match_the_built_in_renderer`).
         let styled = Styled {
             variant: StyleVariant::Unquoted,
             form: SpanForm::Unconstrained,
@@ -2569,10 +2570,10 @@ mod tests {
         assert_eq!(s, SPAN_PLACEHOLDER.to_string());
         assert_eq!(pieces[0].s_start, 0);
 
-        // And a node the identity *names* is such a wrapper — `[width=10]++x ++`
-        // renders its body and nothing else too, and the string pipeline is
-        // holding its `\u{96}…\u{97}` sentinel there, which is exactly what a
-        // bare placeholder reads as.
+        // And a node the identity *names* is such a wrapper — `[width=10]++x
+        // ++` renders its body and nothing else too, and the string
+        // pipeline is holding its `\u{96}…\u{97}` sentinel there, which
+        // is exactly what a bare placeholder reads as.
         let wrapper = styled(body());
 
         let identity = (
@@ -2779,8 +2780,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_quotes() {
         // For each fixture, folding the single-pass tree (special characters +
-        // quotes) reproduces the string pipeline's output byte-for-byte. This is
-        // the differential corpus (design §5.3) that pins the quotes increment.
+        // quotes) reproduces the string pipeline's output byte-for-byte. This
+        // is the differential corpus (design §5.3) that pins the quotes
+        // increment.
         let fixtures = [
             // No quotes.
             "plain text",
@@ -3626,9 +3628,10 @@ mod tests {
         // flat string, emits crossed — malformed — HTML tags (`<code>…<strong>…
         // </code>…</strong>`) that no tree can represent. The single-pass
         // builder instead treats an earlier span as opaque, so it produces a
-        // well-formed tree (here, monospace wrapping a strong span). This is the
-        // documented boundary of the single-pass recognition (see the module
-        // docs): for pathological cross-span input the two intentionally differ.
+        // well-formed tree (here, monospace wrapping a strong span). This is
+        // the documented boundary of the single-pass recognition (see
+        // the module docs): for pathological cross-span input the two
+        // intentionally differ.
         let source = "`a *b` c*";
 
         let folded = fold_html(
@@ -3656,8 +3659,8 @@ mod tests {
         assert_eq!(nodes.len(), 1);
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
 
-        // The delimiters are consumed; the child is the borrowed body, precisely
-        // located just past the opening `*`.
+        // The delimiters are consumed; the child is the borrowed body,
+        // precisely located just past the opening `*`.
         assert_eq!(children.len(), 1);
         assert_text(&children[0], "bold", 1, 2);
 
@@ -3681,8 +3684,8 @@ mod tests {
 
     #[test]
     fn emphasis_nests_inside_strong() {
-        // The canonical nesting example: constrained emphasis matches inside the
-        // body of the strong span an earlier sub created.
+        // The canonical nesting example: constrained emphasis matches inside
+        // the body of the strong span an earlier sub created.
         let nodes = build_src(Span::new("*a _b_ c*"));
 
         assert_eq!(nodes.len(), 1);
@@ -3766,8 +3769,8 @@ mod tests {
         // Regression guard for the escape-after-a-boundary case (`a \*x*`): the
         // backslash immediately before the delimiter is the constrained match's
         // *leading boundary group*, hence the first character of the whole
-        // match, so it is still recognized as an escape. The construct must stay
-        // literal rather than becoming a span.
+        // match, so it is still recognized as an escape. The construct must
+        // stay literal rather than becoming a span.
         let nodes = build_src(Span::new("a \\*x*"));
 
         assert!(
@@ -4017,7 +4020,8 @@ mod tests {
         // (`['{myrole}']*bold*`), and no longer does: that one was never
         // really about a later step reading emitted markup, but about
         // `Attrlist::parse` discarding the substituted text one accessor
-        // needs — see `a_quoted_role_reads_the_attribute_lists_substituted_text`
+        // needs — see
+        // `a_quoted_role_reads_the_attribute_lists_substituted_text`
         // above. What is left here is genuinely markup-reading.
         let parser = crate::Parser::default();
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -662,8 +662,8 @@ mod tests {
         assert_text(&nodes[0], "a", 1, 1);
         assert_special(&nodes[1], '<', 2, 1);
 
-        // The middle run is "\nb": it starts right after `<` (line 1, col 3) and
-        // carries into line 2.
+        // The middle run is "\nb": it starts right after `<` (line 1, col 3)
+        // and carries into line 2.
         assert_text(&nodes[2], "\nb", 1, 3);
 
         // The closing `>` lands on line 2.
@@ -682,8 +682,8 @@ mod tests {
 
     #[test]
     fn special_characters_recurses_into_styled_children() {
-        // A custom `subs` order can run quotes before special characters, so the
-        // step must descend into a `Styled` span's children.
+        // A custom `subs` order can run quotes before special characters, so
+        // the step must descend into a `Styled` span's children.
         let loc = Span::new("a<b");
 
         let styled = InlineNode::Styled(Styled {
@@ -857,8 +857,9 @@ mod tests {
 
     #[test]
     fn classification_splits_specials_into_raw_with_precise_spans() {
-        // The `Raw` counterpart of `splits_text_and_specials_with_precise_spans`
-        // above: the same split, keeping the same honest per-node spans, but
+        // The `Raw` counterpart of
+        // `splits_text_and_specials_with_precise_spans` above: the same
+        // split, keeping the same honest per-node spans, but
         // classifying each special as the verbatim leaf an order that never
         // runs `SpecialCharacters` calls for (design §3.4.1).
         let nodes = classify_unescaped_specials(seed("a<b>c&d"));

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1359,15 +1359,16 @@ mod tests {
             // Regression for https://github.com/asciidoc-rs/asciidoc-parser/issues/503:
             // a bare URL abutting `>;` (rendered to `&gt;;`) with NO matching
             // leading `<`. Ruby Asciidoctor treats the whole run as a bare link
-            // (keeping the literal `&gt;` in the URL) and strips a single trailing
-            // `;`.
+            // (keeping the literal `&gt;` in the URL) and strips a single
+            // trailing `;`.
             //
             // Reference (Ruby Asciidoctor 2.0.23):
             //   $ printf '%s' 'foo https://example.org>;' | asciidoctor -e -o - -
             //   <p>foo <a href="https://example.org&gt;" class="bare">https://example.org&gt;</a>;</p>
             //
             // Previously the ungated angle-URL alternative fired for the stray
-            // `&gt;` and split the run, dropping the `;` from the `&gt;` entity.
+            // `&gt;` and split the run, dropping the `;` from the `&gt;`
+            // entity.
             let doc = Parser::default().parse("foo https://example.org>;");
 
             let rendered = doc
@@ -1387,8 +1388,9 @@ mod tests {
         fn angle_bracketed_url_still_matches() {
             // Companion to `stray_gt_followed_by_punctuation` (issue #503): the
             // genuine angle-bracketed autolink (`<url>`) must keep working. The
-            // `&lt;` prefix gates the angle-URL alternative back on, so the `&gt;`
-            // delimiter is consumed and the brackets are dropped from the link.
+            // `&lt;` prefix gates the angle-URL alternative back on, so the
+            // `&gt;` delimiter is consumed and the brackets are
+            // dropped from the link.
             let doc = Parser::default().parse("See <https://example.org> for details.");
 
             let rendered = doc
@@ -2340,9 +2342,10 @@ mod tests {
         #[test]
         fn recognized_only_when_it_prefixes_the_entry() {
             // A `[[[id]]]` that does not prefix the entry is not a bibliography
-            // anchor: it falls through to the regular inline-anchor pass (matching
-            // Asciidoctor), rendering as `[<a id="mid"></a>]` rather than the
-            // bibliography form `<a id="mid"></a>[mid]`.
+            // anchor: it falls through to the regular inline-anchor pass
+            // (matching Asciidoctor), rendering as `[<a
+            // id="mid"></a>]` rather than the bibliography form `<a
+            // id="mid"></a>[mid]`.
             let doc = Parser::default().parse("[bibliography]\n* Smith. See [[[mid]]] inline.\n");
 
             let rendered = &rendered_paragraphs(&doc)[0];
@@ -2353,18 +2356,19 @@ mod tests {
             assert!(!rendered.contains("<a id=\"mid\"></a>[mid]"));
 
             // The inner `[[mid]]` is preceded by a `[`, so — like Asciidoctor's
-            // inline-anchor scan (`InlineAnchorScanRx`) — the id is rendered but
-            // not registered in the catalog, neither as a bibliography anchor nor
-            // as a normal one. See #769.
+            // inline-anchor scan (`InlineAnchorScanRx`) — the id is rendered
+            // but not registered in the catalog, neither as a
+            // bibliography anchor nor as a normal one. See #769.
             assert!(doc.catalog().get_ref("mid").is_none());
         }
 
         #[test]
         fn leading_backslash_is_not_a_bibliography_escape() {
-            // A leading backslash does not escape a bibliography anchor (the only
-            // documented escape is `[\[[id]]]`). `\[[[id]]]` does not begin with
-            // `[[[`, so it is not a bibliography anchor; the backslash stays
-            // literal and the inner `[[id]]` becomes a normal inline anchor,
+            // A leading backslash does not escape a bibliography anchor (the
+            // only documented escape is `[\[[id]]]`). `\[[[id]]]`
+            // does not begin with `[[[`, so it is not a
+            // bibliography anchor; the backslash stays literal and
+            // the inner `[[id]]` becomes a normal inline anchor,
             // matching Asciidoctor's `\[<a id="x"></a>]`.
             let doc = Parser::default().parse("[bibliography]\n* \\[[[x]]] Leading backslash.\n");
 
@@ -2377,9 +2381,10 @@ mod tests {
 
         #[test]
         fn explicit_style_applies_to_an_ordered_list() {
-            // An explicit `[bibliography]` attribute applies to any list type, so
-            // an ordered list's entries are recognized as bibliography anchors,
-            // matching Asciidoctor (`<div class="olist bibliography">`).
+            // An explicit `[bibliography]` attribute applies to any list type,
+            // so an ordered list's entries are recognized as
+            // bibliography anchors, matching Asciidoctor (`<div
+            // class="olist bibliography">`).
             let doc = Parser::default().parse("[bibliography]\n. [[[ord]]] Ordered entry.\n");
 
             assert_css(&doc, ".olist.bibliography", 1);
@@ -2390,7 +2395,8 @@ mod tests {
         fn section_style_does_not_apply_to_an_ordered_list() {
             // The style inherited from a `bibliography` section applies only to
             // unordered lists, so an ordered list in that section is not a
-            // bibliography list; its leading `[[[id]]]` is a regular inline anchor.
+            // bibliography list; its leading `[[[id]]]` is a regular inline
+            // anchor.
             let doc = Parser::default()
                 .parse("[bibliography]\n== References\n\n. [[[ord]]] Ordered entry.\n");
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -324,10 +324,11 @@ impl SubstitutionGroup {
             // with the branch that fed it.
             parser.truncate_substitution_warnings(warnings_before_build);
 
-            // The recognition **diagnostics** the string pipeline's copy of this
-            // content raised into the discarded clone, raised again here where
-            // they are kept — the warning half of "re-attach the recognition
-            // side effects" (design §5.2's step 6).
+            // The recognition **diagnostics** the string pipeline's copy of
+            // this content raised into the discarded clone, raised
+            // again here where they are kept — the warning half of
+            // "re-attach the recognition side effects" (design
+            // §5.2's step 6).
             //
             // A registration has a node to hang on, so it is replayed from the
             // tree below. These five do not: `attribute-missing` drops a
@@ -533,10 +534,11 @@ impl SubstitutionGroup {
             // A declared block style reinterprets a simple-content (paragraph)
             // block as another context, which can change the substitution group
             // that applies. This masquerade only affects blocks whose default
-            // group is `Normal`: a delimited block's delimiter already fixes its
-            // group (verbatim, pass, stem, etc.), and Asciidoctor does not let a
-            // style keyword override it. So the mapping below is scoped to
-            // `Normal` blocks, matching Asciidoctor's parser.
+            // group is `Normal`: a delimited block's delimiter already fixes
+            // its group (verbatim, pass, stem, etc.), and
+            // Asciidoctor does not let a style keyword override it.
+            // So the mapping below is scoped to `Normal` blocks,
+            // matching Asciidoctor's parser.
             if result == SubstitutionGroup::Normal
                 && let Some(block_style) = attrlist.nth_attribute(1).and_then(|a| a.block_style())
             {
@@ -612,9 +614,10 @@ mod tests {
 
         #[test]
         fn applies_special_characters_only() {
-            // The `Stem` group applies only the special characters substitution:
-            // `<` is escaped, but quotes (`*bold*`) and attribute references
-            // (`{color}`) are left untouched.
+            // The `Stem` group applies only the special characters
+            // substitution: `<` is escaped, but quotes (`*bold*`)
+            // and attribute references (`{color}`) are left
+            // untouched.
             let mut content = Content::from(crate::Span::new("*a* < {color}"));
             let p = Parser::default();
             SubstitutionGroup::Stem.apply(&mut content, &p, None);
@@ -1264,9 +1267,9 @@ mod tests {
 
         #[test]
         fn non_masquerade_styles_keep_normal() {
-            // Styles whose content model is simple (or compound) keep the normal
-            // substitution group; e.g. `verse` uses normal subs even though its
-            // content model is verbatim.
+            // Styles whose content model is simple (or compound) keep the
+            // normal substitution group; e.g. `verse` uses normal
+            // subs even though its content model is verbatim.
             for style in ["normal", "verse", "quote", "sidebar", "example"] {
                 assert_eq!(
                     resolve(SubstitutionGroup::Normal, style),
@@ -1278,10 +1281,11 @@ mod tests {
 
         #[test]
         fn style_does_not_override_a_delimited_block_group() {
-            // A delimited block's delimiter fixes its substitution group; a style
-            // keyword must not override it (matching Asciidoctor). A `[pass]`
-            // style on a `----`/`....` verbatim block keeps verbatim subs, and a
-            // `[source]` style on a `++++` pass block keeps the pass group.
+            // A delimited block's delimiter fixes its substitution group; a
+            // style keyword must not override it (matching
+            // Asciidoctor). A `[pass]` style on a `----`/`....`
+            // verbatim block keeps verbatim subs, and a `[source]`
+            // style on a `++++` pass block keeps the pass group.
             assert_eq!(
                 resolve(SubstitutionGroup::Verbatim, "pass"),
                 SubstitutionGroup::Verbatim
@@ -1300,8 +1304,9 @@ mod tests {
 
         #[test]
         fn subs_attribute_still_overrides() {
-            // An explicit `subs=` attribute overrides the group regardless of the
-            // block style, and takes precedence over the style masquerade.
+            // An explicit `subs=` attribute overrides the group regardless of
+            // the block style, and takes precedence over the style
+            // masquerade.
             assert_eq!(
                 resolve(SubstitutionGroup::Normal, "listing,subs=normal"),
                 SubstitutionGroup::Normal

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -109,8 +109,9 @@ struct SpecialCharacterReplacer<'r> {
 
 impl Replacer for SpecialCharacterReplacer<'_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
-        // The SPECIAL_CHARS regex only matches '<', '>', and '&'. This sequence is
-        // specifically constructed to avoid having any unreachable code.
+        // The SPECIAL_CHARS regex only matches '<', '>', and '&'. This sequence
+        // is specifically constructed to avoid having any unreachable
+        // code.
         let ch = &caps[0];
 
         if ch == "<" {
@@ -328,7 +329,8 @@ pub(crate) static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
     //
     // The counter expression is matched non-greedily (`+?`) so a trailing
     // escape backslash (`{counter:n\}`) is left for group 5 rather than being
-    // swallowed into the expression, again matching Asciidoctor's `#{CC_ANY}+?`.
+    // swallowed into the expression, again matching Asciidoctor's
+    // `#{CC_ANY}+?`.
     //
     // The attribute-name class `\w` (Unicode `\p{Word}`) accepts any Unicode
     // word character, matching Asciidoctor's `#{CG_WORD}[#{CC_WORD}-]*`, so
@@ -500,16 +502,17 @@ impl<'p> AttributeReplacer<'p> {
 
 impl Replacer for AttributeReplacer<'_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
-        // A backslash immediately before the opening brace (`\{name}`) or before
-        // the closing brace (`{name\}`) — or both, as in `\{name\}` — escapes
-        // the reference: it is emitted literally with the escaping backslash(es)
-        // removed and left unexpanded, whether or not the attribute is set. An
-        // escaped reference is never treated as a missing reference, so it
-        // neither drops the line nor warns, and an escaped counter directive
+        // A backslash immediately before the opening brace (`\{name}`) or
+        // before the closing brace (`{name\}`) — or both, as in
+        // `\{name\}` — escapes the reference: it is emitted literally
+        // with the escaping backslash(es) removed and left unexpanded,
+        // whether or not the attribute is set. An escaped reference is
+        // never treated as a missing reference, so it neither drops the
+        // line nor warns, and an escaped counter directive
         // does not advance the counter. This mirrors Asciidoctor, whose
-        // `sub_attributes` returns `{#{name}}` when either its leading (`$1`) or
-        // trailing (`$4`) backslash capture is present, before any counter,
-        // missing-attribute, or resolution handling runs.
+        // `sub_attributes` returns `{#{name}}` when either its leading (`$1`)
+        // or trailing (`$4`) backslash capture is present, before any
+        // counter, missing-attribute, or resolution handling runs.
         if caps.get(1).is_some() || caps.get(5).is_some() {
             dest.push('{');
 
@@ -1272,10 +1275,10 @@ mod tests {
 
         #[test]
         fn escaped_reference_with_both_braces_escaped_drops_backslashes() {
-            // `\{name\}` escapes the reference the same way `\{name}` does: both
-            // backslashes are removed and the reference is left unexpanded, even
-            // when the attribute is set. This is the form Asciidoctor produces
-            // for `\{group-id\}`.
+            // `\{name\}` escapes the reference the same way `\{name}` does:
+            // both backslashes are removed and the reference is
+            // left unexpanded, even when the attribute is set. This
+            // is the form Asciidoctor produces for `\{group-id\}`.
             let p = Parser::default().with_intrinsic_attribute(
                 "group-id",
                 "42",
@@ -1292,8 +1295,9 @@ mod tests {
 
         #[test]
         fn escaped_reference_with_only_trailing_brace_escaped_drops_backslash() {
-            // A backslash before the closing brace alone (`{name\}`) also escapes
-            // the reference, matching Asciidoctor's trailing-backslash capture.
+            // A backslash before the closing brace alone (`{name\}`) also
+            // escapes the reference, matching Asciidoctor's
+            // trailing-backslash capture.
             let p = Parser::default().with_intrinsic_attribute(
                 "group-id",
                 "42",
@@ -1310,9 +1314,10 @@ mod tests {
 
         #[test]
         fn escaped_counter_with_trailing_backslash_is_literal_and_does_not_advance() {
-            // A trailing escape backslash on a counter directive (`{counter:n\}`)
-            // emits the reference literally (without the backslash) and does not
-            // advance the counter, so the following unescaped reference is `1`.
+            // A trailing escape backslash on a counter directive
+            // (`{counter:n\}`) emits the reference literally
+            // (without the backslash) and does not advance the
+            // counter, so the following unescaped reference is `1`.
             let mut content = Content::from(crate::Span::new("{counter:n\\} {counter:n}"));
             let p = Parser::default();
             SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
@@ -1482,8 +1487,9 @@ mod tests {
 
             #[test]
             fn drop_line_records_one_warning_per_missing_reference() {
-                // Two missing references on the same dropped line each produce a
-                // diagnostic, matching Asciidoctor's per-reference logging.
+                // Two missing references on the same dropped line each produce
+                // a diagnostic, matching Asciidoctor's
+                // per-reference logging.
                 let p = parser_with_mode("drop-line");
                 assert_eq!(render("a {x} b {y} c\ntail", &p), "tail");
                 assert_eq!(p.take_substitution_warnings().len(), 2);
@@ -1492,7 +1498,8 @@ mod tests {
             #[test]
             fn drop_line_does_not_warn_for_a_line_without_a_missing_reference() {
                 // Only the line carrying the missing reference is dropped and
-                // warned about; a line whose references all resolve is untouched.
+                // warned about; a line whose references all resolve is
+                // untouched.
                 let p = parser_with_mode("drop-line");
                 assert_eq!(
                     render("first {sp}line\nsecond {missing} line\nthird line", &p),
@@ -1510,7 +1517,8 @@ mod tests {
             #[test]
             fn drop_line_points_at_the_precise_reference() {
                 // With per-line source spans retained, the drop-line diagnostic
-                // names the exact offending reference rather than the whole line.
+                // names the exact offending reference rather than the whole
+                // line.
                 let p = parser_with_mode("drop-line");
                 let text = "first {alpha} line\nsecond {beta} line";
                 let mut content = Content::from(Span::new(text));
@@ -1562,9 +1570,9 @@ mod tests {
             #[test]
             fn escaped_missing_reference_drops_the_backslash_and_never_drops_the_line() {
                 // An escaped reference has its backslash removed and is passed
-                // through literally; it is never treated as a missing reference,
-                // so even under `drop-line` the line survives and no warning is
-                // recorded.
+                // through literally; it is never treated as a missing
+                // reference, so even under `drop-line` the line
+                // survives and no warning is recorded.
                 let p = parser_with_mode("drop-line");
                 assert_eq!(
                     render("In the path /items/\\{id}, x.", &p),
@@ -1646,9 +1654,10 @@ mod tests {
             #[test]
             fn warn_span_survives_earlier_special_character_expansion() {
                 // The key regression guard: special characters run before the
-                // attributes step and lengthen the rendered text (`<` -> `&lt;`),
-                // so a naive rendered-offset would be wrong. The warning must
-                // still name the reference's *original* source offset.
+                // attributes step and lengthen the rendered text (`<` ->
+                // `&lt;`), so a naive rendered-offset would be
+                // wrong. The warning must still name the
+                // reference's *original* source offset.
                 let p = parser_with_mode("warn");
                 let text = "a < b {foo} c";
                 let mut content = Content::from(Span::new(text));

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -87,16 +87,17 @@ impl<'src> Attribute<'src> {
             let first_line = line.after.take_normalized_line();
 
             if first_line.item.is_empty() {
-                // `:name:` with nothing (but optional trailing whitespace) after
-                // the closing colon is a set-only entry.
+                // `:name:` with nothing (but optional trailing whitespace)
+                // after the closing colon is a set-only entry.
                 (InterpretedValue::Set, None, first_line.after)
             } else {
                 // Asciidoctor requires at least one space or tab between the
-                // closing colon and the value. A non-blank character immediately
-                // after the colon means the line is not a valid attribute entry:
-                // the name either contains a colon (`:foo:bar: baz`) or ends with
-                // one (`:foo:: bar`), so the whole line falls through to be parsed
-                // as an ordinary block. See #728.
+                // closing colon and the value. A non-blank character
+                // immediately after the colon means the line is
+                // not a valid attribute entry: the name either
+                // contains a colon (`:foo:bar: baz`) or ends with
+                // one (`:foo:: bar`), so the whole line falls through to be
+                // parsed as an ordinary block. See #728.
                 let extent = line
                     .after
                     .take_required_whitespace()?
@@ -210,19 +211,20 @@ impl InterpretedValue {
     fn from_raw_value(raw_value: &Span<'_>, parser: &Parser) -> Self {
         let mut content = Content::from(*raw_value);
 
-        // Fold any soft-wrap (`\`) or legacy (`+`) line continuation. When there
-        // is no continuation marker, the value is a plain single line and is
-        // left untouched.
+        // Fold any soft-wrap (`\`) or legacy (`+`) line continuation. When
+        // there is no continuation marker, the value is a plain single
+        // line and is left untouched.
         let folded = fold_continuation_value(raw_value.data());
         if let Some(ref folded) = folded {
             content.rendered = CowStr::Boxed(folded.clone().into_boxed_str());
         }
 
-        // Asciidoctor's `apply_attribute_value_subs`: when the *entire* value is
-        // a `pass:subs[…]` macro, its bracketed content is taken greedily (up to
-        // the final `]`) and only the named substitutions are applied to it.
-        // Because the capture is greedy and anchored to the whole value, content
-        // that itself contains `[…]` — e.g. a link macro — is not truncated at
+        // Asciidoctor's `apply_attribute_value_subs`: when the *entire* value
+        // is a `pass:subs[…]` macro, its bracketed content is taken
+        // greedily (up to the final `]`) and only the named
+        // substitutions are applied to it. Because the capture is
+        // greedy and anchored to the whole value, content that itself
+        // contains `[…]` — e.g. a link macro — is not truncated at
         // the first inner bracket, unlike the general inline pass macro. Any
         // other value gets the normal header substitutions.
         let value = folded.as_deref().unwrap_or_else(|| raw_value.data());
@@ -313,17 +315,18 @@ fn fold_continuation_value(data: &str) -> Option<String> {
         .split('\n')
         .map(|line| line.strip_suffix('\r').unwrap_or(line));
 
-    // `str::split` always yields at least one item, so `first` is always present.
-    // The first line is never left-trimmed (its leading whitespace was consumed
-    // with the `:name:` prefix), but it is right-trimmed so marker detection
-    // tolerates trailing whitespace, matching the extent scanner.
+    // `str::split` always yields at least one item, so `first` is always
+    // present. The first line is never left-trimmed (its leading whitespace
+    // was consumed with the `:name:` prefix), but it is right-trimmed so
+    // marker detection tolerates trailing whitespace, matching the extent
+    // scanner.
     let first = lines
         .next()
         .unwrap_or_default()
         .trim_end_matches(ASCII_WHITESPACE);
 
-    // The continuation marker is fixed by the first line. Without one, the value
-    // is a single line and needs no folding.
+    // The continuation marker is fixed by the first line. Without one, the
+    // value is a single line and needs no folding.
     let con: &str = if first.ends_with(" \\") {
         " \\"
     } else if first.ends_with(" +") {
@@ -344,8 +347,8 @@ fn fold_continuation_value(data: &str) -> Option<String> {
         }
 
         // Continuation lines are left- and right-trimmed before the marker is
-        // tested, matching the extent scanner (`take_value_with_continuation`) so
-        // the two never disagree about where the value ends.
+        // tested, matching the extent scanner (`take_value_with_continuation`)
+        // so the two never disagree about where the value ends.
         let line = line.trim_matches(ASCII_WHITESPACE);
 
         // A line still carrying the marker keeps the value open; strip the
@@ -711,10 +714,11 @@ mod tests {
 
     #[test]
     fn name_with_spaces() {
-        // A name containing spaces is captured verbatim up to the closing colon.
-        // It is sanitized to `authorinitials` before it is stored as an
-        // attribute (see the parser's `remap_attr_name`); here we only check
-        // that the entry parses and preserves the raw name span.
+        // A name containing spaces is captured verbatim up to the closing
+        // colon. It is sanitized to `authorinitials` before it is
+        // stored as an attribute (see the parser's `remap_attr_name`);
+        // here we only check that the entry parses and preserves the
+        // raw name span.
         let mi = crate::document::Attribute::parse(
             crate::Span::new(":Author Initials: SJR"),
             &Parser::default(),
@@ -806,9 +810,9 @@ mod tests {
 
     #[test]
     fn bare_trailing_backslash_is_literal() {
-        // A bare trailing backslash (no preceding space) is not a soft-wrap line
-        // continuation; it is a literal character and the value ends at that line.
-        // See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
+        // A bare trailing backslash (no preceding space) is not a soft-wrap
+        // line continuation; it is a literal character and the value
+        // ends at that line. See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
         let mi = crate::document::Attribute::parse(
             crate::Span::new(":longpath: very/long/path/to/some/\\\nsubdirectory"),
             &Parser::default(),
@@ -922,8 +926,8 @@ mod tests {
         // followed by a single `+`) with no following non-blank line has that
         // marker stripped from the interpreted value, matching Asciidoctor. The
         // raw `value_source` still contains the literal ` +`. Contrast with
-        // `legacy_multi_line_value_is_fused`, where a following line _is_ folded
-        // in.
+        // `legacy_multi_line_value_is_fused`, where a following line _is_
+        // folded in.
         let mi =
             crate::document::Attribute::parse(crate::Span::new(":foo: bar +"), &Parser::default())
                 .unwrap();
@@ -1018,10 +1022,11 @@ mod tests {
 
     #[test]
     fn legacy_hard_break_marker_edge_cases() {
-        // The legacy continuation marker is exactly a space followed by a single
-        // `+`. When a following non-blank line is present, the marker fuses the
-        // lines (stripping the marker and right-trimming). Contrast with markers
-        // that are _not_ legacy continuations (`++`, a bare `+`, a tab before the
+        // The legacy continuation marker is exactly a space followed by a
+        // single `+`. When a following non-blank line is present, the
+        // marker fuses the lines (stripping the marker and
+        // right-trimming). Contrast with markers that are _not_ legacy
+        // continuations (`++`, a bare `+`, a tab before the
         // `+`, or a lone `+`), which leave the value on a single line.
         let value = |src| {
             crate::document::Attribute::parse(crate::Span::new(src), &Parser::default())
@@ -1031,17 +1036,19 @@ mod tests {
                 .clone()
         };
 
-        // Extra space(s) before the `+` are trimmed away with the marker, and the
-        // following line is folded in with a single space.
+        // Extra space(s) before the `+` are trimmed away with the marker, and
+        // the following line is folded in with a single space.
         assert_eq!(value(":foo: bar  +\nx"), InterpretedValue::Value("bar x"));
 
         // A tab preceding the marker's space is also trimmed.
         assert_eq!(value(":foo: bar\t +\nx"), InterpretedValue::Value("bar x"));
 
-        // `++` is not a continuation marker; the value stays on one line verbatim.
+        // `++` is not a continuation marker; the value stays on one line
+        // verbatim.
         assert_eq!(value(":foo: bar ++\nx"), InterpretedValue::Value("bar ++"));
 
-        // A `+` with no preceding space is a literal character (no continuation).
+        // A `+` with no preceding space is a literal character (no
+        // continuation).
         assert_eq!(value(":foo: bar+\nx"), InterpretedValue::Value("bar+"));
 
         // A tab (rather than a space) before the `+` does not form a marker.
@@ -1059,7 +1066,8 @@ mod tests {
         );
 
         // Right-trimming after the marker uses ASCII whitespace rules (Ruby
-        // `rstrip`); a preceding non-breaking space is significant and preserved.
+        // `rstrip`); a preceding non-breaking space is significant and
+        // preserved.
         assert_eq!(
             value(":foo: bar\u{00a0} +\nx"),
             InterpretedValue::Value("bar\u{00a0} x")
@@ -1069,9 +1077,10 @@ mod tests {
     #[test]
     fn bare_marker_only_continuation_line_does_not_swallow_next_line() {
         // A continuation line that is only a bare marker (` +`) terminates the
-        // value. The line after it must remain in the stream, not be consumed by
-        // the extent scanner and then dropped by the folder. The extent scanner
-        // and the folder must agree on where the value ends.
+        // value. The line after it must remain in the stream, not be consumed
+        // by the extent scanner and then dropped by the folder. The
+        // extent scanner and the folder must agree on where the value
+        // ends.
         let mi = crate::document::Attribute::parse(
             crate::Span::new(":foo: text +\n +\nmore"),
             &Parser::default(),
@@ -1388,10 +1397,12 @@ mod tests {
         #[test]
         fn bare_marker_only_line_terminates_value() {
             // A continuation line that is *only* the marker (a bare ` +` after
-            // left-trimming) does not keep the value open. It terminates the fold
-            // and its literal `+` is appended, matching Asciidoctor. The folder
-            // and `Span::take_value_with_continuation` must agree on this so the
-            // line after the bare marker is not consumed-then-dropped.
+            // left-trimming) does not keep the value open. It terminates the
+            // fold and its literal `+` is appended, matching
+            // Asciidoctor. The folder
+            // and `Span::take_value_with_continuation` must agree on this so
+            // the line after the bare marker is not
+            // consumed-then-dropped.
             assert_eq!(
                 fold_continuation_value("text +\n +\nmore"),
                 Some("text +".to_string())
@@ -1401,8 +1412,8 @@ mod tests {
         #[test]
         fn trailing_whitespace_after_marker_still_continues() {
             // Trailing whitespace after the marker is tolerated (right-trimmed)
-            // consistently with the extent scanner, so the following line is still
-            // folded in rather than dropped.
+            // consistently with the extent scanner, so the following line is
+            // still folded in rather than dropped.
             assert_eq!(
                 fold_continuation_value("a +\nb + \nmore"),
                 Some("a b more".to_string())

--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -81,16 +81,16 @@ impl Author {
         }
 
         // Parse the raw input first to extract components, then apply attribute
-        // substitution to individual components afterwards. Special case: If the entire
-        // input is a single attribute reference, treat the expanded result as a single
-        // name.
+        // substitution to individual components afterwards. Special case: If
+        // the entire input is a single attribute reference, treat the
+        // expanded result as a single name.
         let is_single_attribute = source.trim().starts_with('{')
             && source.trim().ends_with('}')
             && source.matches('{').count() == 1;
 
         if is_single_attribute {
-            // Entire input is a single attribute reference: Expand and treat as single
-            // name.
+            // Entire input is a single attribute reference: Expand and treat as
+            // single name.
             let expanded_source = apply_author_subs(source, parser);
 
             // The raw value expands the reference without applying special
@@ -100,9 +100,10 @@ impl Author {
             let raw_expanded = resolve_attribute_references(source, parser);
 
             if names_only {
-                // An attribute-entry value is partitioned *after* its references
-                // are expanded, so a reference that resolves to a multi-part name
-                // (or one with a trailing email) yields the same metadata as the
+                // An attribute-entry value is partitioned *after* its
+                // references are expanded, so a reference that
+                // resolves to a multi-part name (or one with a
+                // trailing email) yields the same metadata as the
                 // equivalent literal value.
                 Some(partition_names_only(&expanded_source, &raw_expanded))
             } else {
@@ -112,9 +113,10 @@ impl Author {
                 ))
             }
         } else if let Some(captures) = AUTHOR.captures(source) {
-            // Raw input matches author pattern: Extract each component and apply
-            // substitutions to it. The rendered components escape literal special
-            // characters (`apply_author_subs`); the raw components resolve
+            // Raw input matches author pattern: Extract each component and
+            // apply substitutions to it. The rendered components
+            // escape literal special characters
+            // (`apply_author_subs`); the raw components resolve
             // attribute references only, leaving those characters as written.
             let (name, firstname, middlename, lastname, email) =
                 matched_parts(&captures, |s| apply_author_subs(s, parser));
@@ -135,8 +137,8 @@ impl Author {
                 raw_email,
             })
         } else if source.contains('{') {
-            // Input contains attributes that prevent regex match: Expand first, then try
-            // parsing.
+            // Input contains attributes that prevent regex match: Expand first,
+            // then try parsing.
             let expanded_source = apply_author_subs(source, parser);
             let raw_expanded = resolve_attribute_references(source, parser);
 
@@ -147,9 +149,10 @@ impl Author {
                 let (name, firstname, middlename, lastname, email) =
                     matched_parts(&captures, str::to_string);
 
-                // Derive the raw components from the raw expansion, but only when
-                // it matches the same pattern *and* agrees on whether a trailing
-                // `<email>` is present, so the two representations keep the same
+                // Derive the raw components from the raw expansion, but only
+                // when it matches the same pattern *and* agrees
+                // on whether a trailing `<email>` is present,
+                // so the two representations keep the same
                 // structure and differ only in escaping. They can disagree only
                 // if a literal author-line bracket was escaped in the rendered
                 // value; in that case fall back to the rendered components.
@@ -184,14 +187,16 @@ impl Author {
                 // An attribute-entry value that still fails the pattern after
                 // expansion is partitioned by the names-only rules, so a
                 // reference resolving to a four-plus-part name behaves like its
-                // literal equivalent. The expanded value is used before any HTML
-                // encoding so a trailing `<email>` can still be split off.
+                // literal equivalent. The expanded value is used before any
+                // HTML encoding so a trailing `<email>` can
+                // still be split off.
                 Some(partition_names_only(&expanded_source, &raw_expanded))
             } else {
                 // Even after expansion the value does not match the author
-                // pattern, so it becomes a single name. The rendered value has the
-                // header substitution group applied (escaping any literal `<`,
-                // `>`, or `&`), mirroring Asciidoctor's `apply_header_subs`; the
+                // pattern, so it becomes a single name. The rendered value has
+                // the header substitution group applied
+                // (escaping any literal `<`, `>`, or `&`),
+                // mirroring Asciidoctor's `apply_header_subs`; the
                 // raw value expands the references without that escaping.
                 Some(single_name_author(
                     replace_underscores_with_spaces(expanded_source),
@@ -199,24 +204,27 @@ impl Author {
                 ))
             }
         } else if names_only {
-            // Input comes from an attribute entry (e.g. `:author:`) and does not
-            // match the author pattern — typically a name with four or more parts
-            // or one containing punctuation such as a comma. Asciidoctor still
-            // partitions it by splitting on whitespace into at most three parts,
+            // Input comes from an attribute entry (e.g. `:author:`) and does
+            // not match the author pattern — typically a name with
+            // four or more parts or one containing punctuation such
+            // as a comma. Asciidoctor still partitions it by
+            // splitting on whitespace into at most three parts,
             // assigning any trailing parts to `lastname`. This path applies no
-            // special-characters substitution, so the raw and rendered values are
-            // identical.
+            // special-characters substitution, so the raw and rendered values
+            // are identical.
             Some(partition_names_only(source, source))
         } else {
             // Input doesn't contain attributes and doesn't match the author
             // pattern. Asciidoctor stores the whole line as the author,
-            // condensing interior whitespace. Underscores are left literal here:
-            // Asciidoctor only converts underscore-joined names while
-            // partitioning a *matching* line, not in this fallback.
+            // condensing interior whitespace. Underscores are left literal
+            // here: Asciidoctor only converts underscore-joined
+            // names while partitioning a *matching* line, not in
+            // this fallback.
             //
-            // The rendered value has the header substitution group applied, so any
-            // literal `<`, `>`, or `&` is escaped — matching Asciidoctor's
-            // `apply_header_subs`. The raw value keeps those characters as written.
+            // The rendered value has the header substitution group applied, so
+            // any literal `<`, `>`, or `&` is escaped — matching
+            // Asciidoctor's `apply_header_subs`. The raw value
+            // keeps those characters as written.
             let raw_name = condense_whitespace(source);
             let name = apply_author_special_characters(&raw_name, parser);
             Some(single_name_author(name, raw_name))
@@ -315,9 +323,10 @@ impl Author {
     /// separately.
     pub(crate) fn with_email(mut self, email: Option<String>) -> Self {
         if let Some(email) = email {
-            // The email arrives from a companion `email_N` attribute value, which
-            // carries no author-line special-characters escaping of its own, so
-            // the raw and rendered emails are the same.
+            // The email arrives from a companion `email_N` attribute value,
+            // which carries no author-line special-characters
+            // escaping of its own, so the raw and rendered emails
+            // are the same.
             self.raw_email = Some(email.clone());
             self.email = Some(email);
         }
@@ -555,12 +564,13 @@ fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&
 /// attribute entry that carries no literal special characters the two arguments
 /// are identical.
 fn partition_names_only(escaped_source: &str, raw_source: &str) -> Author {
-    // Partition the rendered value first, then partition the raw value using the
-    // *rendered* value's trailing-email decision so the two representations keep
-    // the same structure and differ only in escaping. A literal author-line
-    // bracket is escaped in the rendered value and so is not recognized as an
-    // email delimiter; the raw value, whose bracket is still literal, must follow
-    // that same decision rather than splitting an email off on its own.
+    // Partition the rendered value first, then partition the raw value using
+    // the *rendered* value's trailing-email decision so the two
+    // representations keep the same structure and differ only in escaping.
+    // A literal author-line bracket is escaped in the rendered value and so
+    // is not recognized as an email delimiter; the raw value, whose bracket
+    // is still literal, must follow that same decision rather than
+    // splitting an email off on its own.
     let escaped = partition_parts(escaped_source, EmailSplit::Detect);
 
     let raw = partition_parts(
@@ -930,8 +940,8 @@ mod tests {
     // The `raw_*` accessors return the author value with attribute references
     // resolved but the header substitution group's special-characters escaping
     // *not* applied — the value Asciidoctor keeps in its internal `metadata`
-    // hash. The rendered accessors are unaffected and keep escaping literal `<`,
-    // `>`, and `&` to match `doc.author`/`{author}`.
+    // hash. The rendered accessors are unaffected and keep escaping literal
+    // `<`, `>`, and `&` to match `doc.author`/`{author}`.
     mod raw_accessors {
         use crate::{Parser, document::Author};
 
@@ -960,9 +970,10 @@ mod tests {
 
         #[test]
         fn implicit_line_with_literal_angle_brackets_keeps_them_raw() {
-            // A line that does not match the author pattern (here because of the
-            // comma) becomes a single name. The rendered value escapes the literal
-            // angle brackets — matching Asciidoctor's `doc.author` — while the raw
+            // A line that does not match the author pattern (here because of
+            // the comma) becomes a single name. The rendered value
+            // escapes the literal angle brackets — matching
+            // Asciidoctor's `doc.author` — while the raw
             // value keeps them as written.
             let a = only_author(
                 "= Doc\nStuart Rackham, founder of AsciiDoc <founder@asciidoc.org>\n\nbody\n",
@@ -986,8 +997,9 @@ mod tests {
 
         #[test]
         fn literal_ampersand_is_escaped_only_in_the_rendered_value() {
-            // A downstream converter that HTML-escapes the raw name gets a single
-            // level of escaping rather than the double-escaped `&amp;amp;` it would
+            // A downstream converter that HTML-escapes the raw name gets a
+            // single level of escaping rather than the
+            // double-escaped `&amp;amp;` it would
             // get from re-escaping the already-escaped rendered value.
             let a = only_author("= Doc\nBen & Jerry\n\nbody\n");
 
@@ -1008,10 +1020,11 @@ mod tests {
         #[test]
         fn attribute_reference_resolves_then_stays_a_single_raw_name() {
             // The literal `<`/`>` around the referenced email keep the expanded
-            // value from matching the author pattern, so it is stored as a single
-            // name. The rendered value escapes the brackets; the raw value resolves
-            // the references but leaves the brackets literal, and — importantly —
-            // keeps the same single-name structure as the rendered value rather
+            // value from matching the author pattern, so it is stored as a
+            // single name. The rendered value escapes the brackets;
+            // the raw value resolves the references but leaves the
+            // brackets literal, and — importantly — keeps the same
+            // single-name structure as the rendered value rather
             // than re-splitting into name parts.
             let src = concat!(
                 ":first-name: Jane\n",
@@ -1038,10 +1051,11 @@ mod tests {
             // `names_only_email_split_stays_aligned_between_raw_and_rendered`.
             // Escaping the literal brackets makes the rendered expansion
             // (`Jane Smith &lt;Third&gt;`) match the author pattern as three
-            // *names*, while the raw expansion (`Jane Smith <Third>`) matches it
-            // as two names plus an `<email>`. The two disagree about whether a
-            // trailing email is present, so the raw components fall back to the
-            // rendered ones rather than storing a differently-shaped split.
+            // *names*, while the raw expansion (`Jane Smith <Third>`) matches
+            // it as two names plus an `<email>`. The two disagree
+            // about whether a trailing email is present, so the raw
+            // components fall back to the rendered ones rather than
+            // storing a differently-shaped split.
             let src = concat!(
                 ":first-name: Jane\n",
                 "= Doc\n",
@@ -1055,10 +1069,10 @@ mod tests {
             assert_eq!(a.email(), None);
             assert_eq!(a.lastname(), Some("&lt;Third&gt;"));
 
-            // The fallback: every raw component equals its rendered counterpart,
-            // brackets escaped and all, rather than the `Jane Smith` +
-            // `<Third>`-as-email split the raw expansion would have yielded on
-            // its own.
+            // The fallback: every raw component equals its rendered
+            // counterpart, brackets escaped and all, rather than
+            // the `Jane Smith` + `<Third>`-as-email split the raw
+            // expansion would have yielded on its own.
             assert_eq!(a.raw_name(), "Jane Smith &lt;Third&gt;");
             assert_eq!(a.raw_firstname(), "Jane");
             assert_eq!(a.raw_middlename(), Some("Smith"));
@@ -1068,9 +1082,9 @@ mod tests {
 
         #[test]
         fn unresolved_attribute_reference_warns_only_once() {
-            // The raw pass resolves the same references as the rendered pass, so
-            // an author line with an unresolved reference must not record the
-            // `attribute-missing` warning twice.
+            // The raw pass resolves the same references as the rendered pass,
+            // so an author line with an unresolved reference must
+            // not record the `attribute-missing` warning twice.
             let mut parser = Parser::default();
             let doc =
                 parser.parse(":attribute-missing: warn\n= Doc\nJane {undefined} Smith\n\nbody\n");
@@ -1081,10 +1095,11 @@ mod tests {
         #[test]
         fn names_only_email_split_stays_aligned_between_raw_and_rendered() {
             // A four-part `:author:` entry that wraps an attribute reference in
-            // literal brackets fails the author pattern, so it is partitioned. The
-            // rendered value escapes the brackets and keeps no email; the raw
-            // value must follow that decision rather than splitting the still-
-            // literal `<…>` off as an email, so the two stay structurally aligned.
+            // literal brackets fails the author pattern, so it is partitioned.
+            // The rendered value escapes the brackets and keeps no
+            // email; the raw value must follow that decision rather
+            // than splitting the still- literal `<…>` off as an
+            // email, so the two stay structurally aligned.
             let a = only_author(":mail: someone@example.com\n:author: A B C D <{mail}>\n\nbody\n");
 
             assert_eq!(a.name(), "A B C D &lt;someone@example.com&gt;");
@@ -1098,9 +1113,10 @@ mod tests {
         #[test]
         fn names_only_email_from_an_attribute_still_splits_in_both() {
             // When the trailing `<email>` survives into the rendered expansion
-            // unescaped (here from an intrinsic attribute value, so the bracket is
-            // literal in *both* the rendered and raw expansions), the email is
-            // split off in both — the alignment fix only suppresses a raw split
+            // unescaped (here from an intrinsic attribute value, so the bracket
+            // is literal in *both* the rendered and raw
+            // expansions), the email is split off in both — the
+            // alignment fix only suppresses a raw split
             // the rendered value did not also make.
             let mut parser = Parser::default().with_intrinsic_attribute(
                 "tail",
@@ -1119,8 +1135,9 @@ mod tests {
     // The `<`-branch of Asciidoctor's `process_authors` (`names_only`), reached
     // when an `:author:` attribute value's substitution produced inline HTML.
     // The rendered markup — with name-joiner underscores turned to spaces —
-    // becomes `name`, while the name parts are partitioned from the tag-stripped
-    // text so the formatting does not leak into them. No email is split off.
+    // becomes `name`, while the name parts are partitioned from the
+    // tag-stripped text so the formatting does not leak into them. No email
+    // is split off.
     mod parse_substituted_names_only {
         use super::Author;
 
@@ -1190,8 +1207,9 @@ mod tests {
 
         #[test]
         fn pass_macro_with_markup_is_partitioned_from_the_substituted_value() {
-            // The raw is the macro syntax; the substituted value is its rendered
-            // output, which is what gets partitioned (tags stripped).
+            // The raw is the macro syntax; the substituted value is its
+            // rendered output, which is what gets partitioned (tags
+            // stripped).
             let parser = Parser::default();
             let author = Author::parse_from_entry(
                 "pass:n[https://example.org/x[Ze *team*]]",

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -94,8 +94,8 @@ fn split_authors(data: &str) -> Vec<&str> {
             continue;
         }
 
-        // A semicolon is a separator only when followed by a space or the end of
-        // the line.
+        // A semicolon is a separator only when followed by a space or the end
+        // of the line.
         let is_separator = match bytes.get(index + 1) {
             Some(next) => *next == b' ',
             None => true,
@@ -147,10 +147,10 @@ mod tests {
     fn implicit_author_name_is_always_header_substituted() {
         // The header substitution group (special characters + attribute
         // references) is applied to the implicit author-line name consistently,
-        // whether or not the line contains an attribute reference. Previously the
-        // name was returned raw unless it happened to carry an attribute
-        // reference, which forced a downstream converter to guess whether the
-        // value was already substituted.
+        // whether or not the line contains an attribute reference. Previously
+        // the name was returned raw unless it happened to carry an
+        // attribute reference, which forced a downstream converter to
+        // guess whether the value was already substituted.
         let author_name = |src: &str| {
             let mut parser = Parser::default();
             let doc = parser.parse(src);
@@ -183,9 +183,10 @@ mod tests {
     #[test]
     fn attr_reference_value_is_inserted_verbatim() {
         // The header substitution group runs special characters *before*
-        // attribute references (Asciidoctor's `HEADER_SUBS = [:specialcharacters,
-        // :attributes]`), so an attribute reference's value is inserted verbatim
-        // rather than being escaped a second time. Here the literal text carries
+        // attribute references (Asciidoctor's `HEADER_SUBS =
+        // [:specialcharacters, :attributes]`), so an attribute
+        // reference's value is inserted verbatim rather than being
+        // escaped a second time. Here the literal text carries
         // no special characters, so the resolved value's `<`, `>`, and `&` are
         // left as they are.
         let mut parser = Parser::default().with_intrinsic_attribute(
@@ -350,10 +351,11 @@ mod tests {
 
     #[test]
     fn fallback_condenses_whitespace_and_keeps_underscores_literal() {
-        // A line that does not match the author pattern (here because of the comma)
-        // is stored verbatim as the author with runs of spaces condensed. Unlike the
-        // matching path, underscores are left literal rather than replaced with
-        // spaces (matching Asciidoctor's `tr_s ' ', ' '` fallback).
+        // A line that does not match the author pattern (here because of the
+        // comma) is stored verbatim as the author with runs of spaces
+        // condensed. Unlike the matching path, underscores are left
+        // literal rather than replaced with spaces (matching
+        // Asciidoctor's `tr_s ' ', ' '` fallback).
         let mut parser = Parser::default();
 
         let al =
@@ -583,10 +585,10 @@ mod tests {
             &mut parser,
         );
 
-        // Note: This test documents the current behavior where attribute substitution
-        // happens after parsing, which results in HTML encoding of the angle brackets.
-        // The underscore replacement should still work on the attribute-substituted
-        // values.
+        // Note: This test documents the current behavior where attribute
+        // substitution happens after parsing, which results in HTML
+        // encoding of the angle brackets. The underscore replacement
+        // should still work on the attribute-substituted values.
         assert_eq!(
             al,
             AuthorLine {
@@ -661,10 +663,11 @@ mod tests {
 
     #[test]
     fn attr_sub_applied_after_parsing() {
-        // This is to demonstrate compatibility with Ruby asciidoctor behavior. In that
-        // implementation, the attribute substitution is applied *after* parsing for
-        // individual authors, which results in the unexpected treatment that the entire
-        // list is one author with mangled results.
+        // This is to demonstrate compatibility with Ruby asciidoctor behavior.
+        // In that implementation, the attribute substitution is applied
+        // *after* parsing for individual authors, which results in the
+        // unexpected treatment that the entire list is one author with
+        // mangled results.
         let mut parser = Parser::default().with_intrinsic_attribute(
             "author-list",
             "Jane Smith <jane@example.com>; John Doe <john@example.com>",
@@ -1122,8 +1125,8 @@ mod tests {
 
     #[test]
     fn character_reference_followed_by_space_not_treated_as_separator() {
-        // The terminating `;` of a character reference must not split the author
-        // even when it is followed by a space.
+        // The terminating `;` of a character reference must not split the
+        // author even when it is followed by a space.
         let mut parser = Parser::default();
 
         let al = crate::document::AuthorLine::parse(
@@ -1207,7 +1210,8 @@ mod tests {
     #[test]
     fn comprehensive_author_attribute_test() {
         // This test verifies that all author attribute types work correctly for
-        // multiple authors, including edge cases like missing middle names and emails.
+        // multiple authors, including edge cases like missing middle names and
+        // emails.
 
         let mut parser = Parser::default();
         let doc = parser.parse("= Document Title\nFirst Second Last <first@example.com>; Only First; A B C <abc@example.com>; No Email Guy");

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -100,9 +100,9 @@ impl Docinfo {
             return Self::default();
         };
 
-        // The `docinfo` attribute selects which scopes/locations apply. An unset
-        // attribute means no docinfo; an empty value (a bare `:docinfo:`) is
-        // equivalent to `private`.
+        // The `docinfo` attribute selects which scopes/locations apply. An
+        // unset attribute means no docinfo; an empty value (a bare
+        // `:docinfo:`) is equivalent to `private`.
         //
         // When `docinfo` itself is unset, the legacy `docinfo1`/`docinfo2`
         // standalone boolean attributes are consulted as a fallback: `docinfo1`
@@ -167,8 +167,9 @@ impl Docinfo {
             _ => ".html".to_string(),
         };
 
-        // When `docinfodir` is set, files are searched only there; otherwise the
-        // document directory is searched (the handler owns path resolution).
+        // When `docinfodir` is set, files are searched only there; otherwise
+        // the document directory is searched (the handler owns path
+        // resolution).
         let docinfodir = match parser.attribute_value("docinfodir") {
             InterpretedValue::Value(v) => Some(v),
             _ => None,

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -102,9 +102,10 @@ impl<'src> Document<'src> {
             let header = mi.item.item;
             let mut warnings = mi.warnings;
 
-            // Derive the `iconsdir` default from `imagesdir` (`{imagesdir}/icons`)
-            // now that the header is fully parsed, unless the author set
-            // `iconsdir` explicitly in the header (in which case it wins).
+            // Derive the `iconsdir` default from `imagesdir`
+            // (`{imagesdir}/icons`) now that the header is fully
+            // parsed, unless the author set `iconsdir` explicitly
+            // in the header (in which case it wins).
             let iconsdir_set_in_header = header.attributes().any(|a| a.name().data() == "iconsdir");
             parser.apply_iconsdir_default(iconsdir_set_in_header);
 
@@ -126,10 +127,11 @@ impl<'src> Document<'src> {
             // the section-child boundary check only sees sections nested under
             // another section; flag the document-root case here.
             //
-            // Skipped for a title-less document or when `fragment` is set — both
-            // are treated as section fragments with no level-0 root to sequence
-            // against — and when `leveloffset` is in effect, since a shifted (or
-            // clamped) effective level no longer reflects the authored level
+            // Skipped for a title-less document or when `fragment` is set —
+            // both are treated as section fragments with no level-0
+            // root to sequence against — and when `leveloffset` is
+            // in effect, since a shifted (or clamped) effective
+            // level no longer reflects the authored level
             // relationship and any degenerate offset is reported on its own.
             if header.title_source().is_some()
                 && !parser.is_attribute_set("fragment")
@@ -143,8 +145,9 @@ impl<'src> Document<'src> {
             // Warnings recorded while replacing attribute references (e.g. a
             // reference to a missing attribute under `attribute-missing=warn`)
             // are collected on the parser, where only owned offsets — not
-            // borrowed spans — can live. Now that the document's owned source is
-            // available, turn each one back into a spanned `Warning`.
+            // borrowed spans — can live. Now that the document's owned source
+            // is available, turn each one back into a spanned
+            // `Warning`.
             let root = Span::new(owned_src);
 
             // Warnings raised during preprocessing (e.g. an unresolved include
@@ -169,7 +172,8 @@ impl<'src> Document<'src> {
             let mut preamble_split_index: Option<usize> = None;
 
             // Only look for preamble content if document has a title.
-            // Asciidoctor only creates a preamble when there's a document title.
+            // Asciidoctor only creates a preamble when there's a document
+            // title.
             if header.title().is_some() {
                 for (index, block) in blocks.iter().enumerate() {
                     match block {
@@ -218,11 +222,12 @@ impl<'src> Document<'src> {
                 }
             }
 
-            // Under `doctype: inline`, only the first eligible block is converted,
-            // as bare inline content, and everything after it is dropped (the
-            // rendering lives on the embed path). A compound or empty candidate
-            // has no inline content to emit, so warn here — matching
-            // Asciidoctor's `Document#convert` — and let the embed path render
+            // Under `doctype: inline`, only the first eligible block is
+            // converted, as bare inline content, and everything
+            // after it is dropped (the rendering lives on the embed
+            // path). A compound or empty candidate has no inline
+            // content to emit, so warn here — matching Asciidoctor'
+            // s `Document#convert` — and let the embed path render
             // nothing. This runs on the final block list (after any preamble
             // split) and uses the same candidate selection as the renderer, so
             // the two always agree on which block is the candidate.
@@ -257,19 +262,20 @@ impl<'src> Document<'src> {
             // `toc-class` document attributes from the resolved placement into
             // the snapshot (matching Asciidoctor), so they are queryable via
             // `attribute_value` without perturbing the parser's own attribute
-            // state — a reused parser must not carry this document's derived TOC
-            // values into the next parse, where they would change what
-            // `TocMode::from_parser` observes.
+            // state — a reused parser must not carry this document's derived
+            // TOC values into the next parse, where they would
+            // change what `TocMode::from_parser` observes.
             attributes.materialize_toc_attributes(toc.mode);
 
             // Resolve docinfo from the final attribute state and the parser's
             // configured docinfo file handler (empty when no handler is set).
             let docinfo = Docinfo::resolve(parser);
 
-            // Warnings are collected in assembly order (header, then blocks, then
-            // preprocessor, substitution, and post-parse checks), which is not
-            // source order. Put them into source order now so a host can rely on
-            // `warnings()` yielding line-ordered diagnostics. See
+            // Warnings are collected in assembly order (header, then blocks,
+            // then preprocessor, substitution, and post-parse
+            // checks), which is not source order. Put them into
+            // source order now so a host can rely on `warnings()`
+            // yielding line-ordered diagnostics. See
             // `sort_warnings` for the ordering and its determinism.
             sort_warnings(&mut warnings);
 
@@ -656,10 +662,11 @@ impl<'src> Document<'src> {
             let source = dependent.source;
             let mut warnings = ReferenceWarnings::default();
 
-            // The footnotes are moved out of the catalog so they can be resolved
-            // mutably while the `CatalogResolver` borrows the (footnote-free)
-            // catalog. Footnotes are never cross-reference *targets*, so their
-            // absence does not affect resolution.
+            // The footnotes are moved out of the catalog so they can be
+            // resolved mutably while the `CatalogResolver` borrows
+            // the (footnote-free) catalog. Footnotes are never
+            // cross-reference *targets*, so their absence does not
+            // affect resolution.
             let mut footnotes = dependent.catalog.take_footnotes();
 
             let resolver = CatalogResolver::new(&dependent.catalog);
@@ -1934,8 +1941,9 @@ mod tests {
         #[test]
         fn matches_parser_state_for_masked_docdir_and_docfile() {
             // Under `SafeMode::Server` the `Document` snapshot must report the
-            // same masked `docdir` / `docfile` the parser does, so the host path
-            // never leaks through the public `Document::attribute_value` (#735).
+            // same masked `docdir` / `docfile` the parser does, so the host
+            // path never leaks through the public
+            // `Document::attribute_value` (#735).
             let mut parser = Parser::default()
                 .with_safe_mode(SafeMode::Server)
                 .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -94,9 +94,10 @@ impl<'src> Header<'src> {
                 // Once a title has been seen, a `////` block comment delimiter
                 // opens a comment block within the header. Skip every line
                 // through the matching closing delimiter (or to the end of the
-                // input if the block is never closed), retaining the whole block
-                // as a single comment so it is not mistaken for the author or
-                // revision line. Blank lines inside the block do not terminate
+                // input if the block is never closed), retaining the whole
+                // block as a single comment so it is not
+                // mistaken for the author or revision line.
+                // Blank lines inside the block do not terminate
                 // the header.
                 //
                 // Before a title is seen there is no header author/revision
@@ -134,8 +135,8 @@ impl<'src> Header<'src> {
                         !matches!(attr.item.value(), InterpretedValue::Unset);
                 }
 
-                // Special handling for :author: attribute to populate individual author
-                // attributes.
+                // Special handling for :author: attribute to populate
+                // individual author attributes.
                 //
                 // When the value is a plain name, the partitioned name replaces
                 // the stored `author` value. This condenses repeated interior
@@ -143,15 +144,17 @@ impl<'src> Header<'src> {
                 // Asciidoctor.
                 //
                 // Asciidoctor runs an attribute-entry value through the
-                // substitution pipeline *before* partitioning it into name parts
-                // (`process_authors`, `names_only`). When that substitution
-                // produced inline HTML — for example a `pass:[…]` macro whose
-                // content resolves to a link and inline formatting — the rendered
-                // markup is stripped before partitioning so it does not leak into
+                // substitution pipeline *before* partitioning it into name
+                // parts (`process_authors`, `names_only`). When
+                // that substitution produced inline HTML — for
+                // example a `pass:[…]` macro whose
+                // content resolves to a link and inline formatting — the
+                // rendered markup is stripped before
+                // partitioning so it does not leak into
                 // `firstname`/`middlename`/`lastname`, while the `author` value
                 // keeps the rendered markup. A value that produced no markup
-                // keeps the original raw-value partitioning, so every other form
-                // is unchanged.
+                // keeps the original raw-value partitioning, so every other
+                // form is unchanged.
                 let mut author_name_override: Option<String> = None;
                 if attr.item.name().data().eq_ignore_ascii_case("author")
                     && let Some(raw_value) = attr.item.raw_value()
@@ -190,11 +193,12 @@ impl<'src> Header<'src> {
                     // reconstructed name (the rendered markup with name-joiner
                     // underscores turned to spaces) replaces the stored value.
                     // Otherwise the value is overridden only for a plain name
-                    // that was partitioned by the fallback whitespace split (four
-                    // or more parts, or punctuation such as a comma); a value that
+                    // that was partitioned by the fallback whitespace split
+                    // (four or more parts, or punctuation
+                    // such as a comma); a value that
                     // matches the pattern, carries an inline email (`<…>`), or
-                    // holds an attribute reference (`{…}`) keeps the substituted
-                    // entry value set below.
+                    // holds an attribute reference (`{…}`) keeps the
+                    // substituted entry value set below.
                     let raw = raw_value.data();
 
                     if is_attribute_entry_pass_macro(raw)
@@ -218,9 +222,10 @@ impl<'src> Header<'src> {
                     parser.set_attribute_by_value_from_header("author", author_name);
                 }
 
-                // A `:doctitle:` entry below the document title is a candidate to
-                // override the implicit section title (resolved after the header
-                // is fully parsed; see below).
+                // A `:doctitle:` entry below the document title is a candidate
+                // to override the implicit section title
+                // (resolved after the header is fully parsed;
+                // see below).
                 if title.is_some() && attr.item.name().data().eq_ignore_ascii_case("doctitle") {
                     doctitle_entry_after_title = true;
                 }
@@ -235,25 +240,30 @@ impl<'src> Header<'src> {
             {
                 warnings.extend(metadata_warnings);
 
-                // A block attribute line directly above the document title assigns
-                // metadata to the *document* — its `id`, `reftext`, `role`, and
-                // options — mirroring Asciidoctor's `parse_document_header`. Each
-                // recognized value folds into the document's attributes at this
-                // point in the header, so it follows document order alongside any
+                // A block attribute line directly above the document title
+                // assigns metadata to the *document* — its
+                // `id`, `reftext`, `role`, and
+                // options — mirroring Asciidoctor's `parse_document_header`.
+                // Each recognized value folds into the
+                // document's attributes at this point in the
+                // header, so it follows document order alongside any
                 // equivalent header attribute entry (e.g. `:reftext:`).
                 //
                 // A `separator` sets the subtitle separator; it behaves exactly
-                // like assigning the `title-separator` document attribute here, so
-                // both mechanisms share the same partitioning logic and the same
-                // modification-context lock check (an API-locked `title-separator`
-                // is not overwritten by this block attribute).
+                // like assigning the `title-separator` document attribute here,
+                // so both mechanisms share the same
+                // partitioning logic and the same
+                // modification-context lock check (an API-locked
+                // `title-separator` is not overwritten by this
+                // block attribute).
                 //
                 // The line is only intercepted when a document title eventually
-                // follows — possibly after further stacked block attribute lines,
-                // each folded on its own pass through this loop, mirroring
-                // Asciidoctor's `parse_block_metadata_lines`. Otherwise it is
-                // block metadata for the body (e.g. a table's `separator`) and is
-                // left for the block parser.
+                // follows — possibly after further stacked block attribute
+                // lines, each folded on its own pass through
+                // this loop, mirroring Asciidoctor's
+                // `parse_block_metadata_lines`. Otherwise it is
+                // block metadata for the body (e.g. a table's `separator`) and
+                // is left for the block parser.
                 if let Some(doc_id) = metadata.id {
                     id = Some(doc_id);
                 }
@@ -265,11 +275,13 @@ impl<'src> Header<'src> {
                 }
                 if !metadata.roles.is_empty() {
                     // Fold the role(s) into the `role` document attribute
-                    // (space-joined, as Asciidoctor stores `attributes['role']`)
-                    // and also retain them on the header so `Document::roles()`
+                    // (space-joined, as Asciidoctor stores
+                    // `attributes['role']`) and also retain
+                    // them on the header so `Document::roles()`
                     // agrees with the document attribute (see #820). Roles from
-                    // separate stacked block attribute lines accumulate, just as
-                    // multiple roles within a single line combine (see #821).
+                    // separate stacked block attribute lines accumulate, just
+                    // as multiple roles within a single
+                    // line combine (see #821).
                     roles.extend(metadata.roles);
                     parser.set_attribute_by_value_from_header("role", roles.join(" "));
                 }
@@ -282,9 +294,10 @@ impl<'src> Header<'src> {
                 && document_title_follows_block_metadata(source, parser.level_offset())
             {
                 // A block title (`.Title`) directly above the document title is
-                // not a title *of* the document — a document has no block title.
-                // Its presence demotes the following `= …` line: the document
-                // has no title, and `= …` is a level-0 section heading in the
+                // not a title *of* the document — a document has no block
+                // title. Its presence demotes the following `=
+                // …` line: the document has no title, and `= …`
+                // is a level-0 section heading in the
                 // body rather than the document title (matching Asciidoctor,
                 // which logs "level 0 sections can only be used when doctype is
                 // book").
@@ -301,9 +314,10 @@ impl<'src> Header<'src> {
                 //
                 // `source` is left pointing at the block-title line (it is not
                 // advanced), so the header span ends above it and the body
-                // begins there. `document_title_follows_block_metadata` confirms
-                // a `= …` title actually follows — possibly past further stacked
-                // block metadata lines — so an ordinary body block title (with
+                // begins there. `document_title_follows_block_metadata`
+                // confirms a `= …` title actually follows —
+                // possibly past further stacked block metadata
+                // lines — so an ordinary body block title (with
                 // no document title beneath it) is not caught here.
                 break;
             } else if title.is_none()
@@ -382,11 +396,12 @@ impl<'src> Header<'src> {
 
         // Finalize the document (section) title, mirroring Asciidoctor's
         // `parse_document_header` doctitle handling. The `doctitle` attribute
-        // retains the eager, at-title-line substitution; the section title below
-        // is (re)derived from the *final* attribute state so that:
+        // retains the eager, at-title-line substitution; the section title
+        // below is (re)derived from the *final* attribute state so
+        // that:
         //
-        //   - an implicit `= Title` referencing an attribute defined later in the
-        //     header still resolves ("lazy" resolution),
+        //   - an implicit `= Title` referencing an attribute defined later in
+        //     the header still resolves ("lazy" resolution),
         //   - a `:doctitle:` attribute entry (above or below the title, or in a
         //     document with no title line at all) can supply or override it.
         let final_doctitle_attr = match parser.attribute_value("doctitle") {
@@ -396,21 +411,24 @@ impl<'src> Header<'src> {
 
         title = if saw_implicit_title {
             // The base section title is normally the eager (at-title-line)
-            // substitution already held in `title`. It is re-resolved against the
-            // final attribute set only when that eager substitution left an
-            // unresolved attribute reference — an attribute defined later in the
-            // header — so that one-shot substitutions such as a `{counter:…}` in
-            // the title are not evaluated a second time. When the implicit title
-            // was overridden by a `doctitle` set above it, `title` already holds
-            // that (resolved) value and is not re-substituted.
+            // substitution already held in `title`. It is re-resolved against
+            // the final attribute set only when that eager
+            // substitution left an unresolved attribute reference —
+            // an attribute defined later in the header — so that
+            // one-shot substitutions such as a `{counter:…}` in the
+            // title are not evaluated a second time. When the implicit title
+            // was overridden by a `doctitle` set above it, `title` already
+            // holds that (resolved) value and is not
+            // re-substituted.
             //
             // Residual edge: a title that *mixes* a stateful, one-shot
             // substitution with a later-defined reference (e.g. `= {counter:n}
-            // {project-name}`) still contains a `{` after the eager pass, so the
-            // re-resolution runs that one-shot substitution a second time.
-            // Re-resolving is done from the raw title (not the eager result) so
-            // that escaped `\{…}` and specialchars stay correct; the duplicated
-            // side effect here is the price of that. Since the eager pass now
+            // {project-name}`) still contains a `{` after the eager pass, so
+            // the re-resolution runs that one-shot substitution a
+            // second time. Re-resolving is done from the raw title
+            // (not the eager result) so that escaped `\{…}` and
+            // specialchars stay correct; the duplicated side effect
+            // here is the price of that. Since the eager pass now
             // uses the `Title` group, this extends beyond a `{counter:…}`
             // advancing twice to any stateful macro sharing the title with a
             // later-defined reference — an anchor
@@ -447,15 +465,15 @@ impl<'src> Header<'src> {
                 base
             }
         } else {
-            // No `= Title` line: a `:doctitle:` attribute entry, if any, supplies
-            // the implicit document title.
+            // No `= Title` line: a `:doctitle:` attribute entry, if any,
+            // supplies the implicit document title.
             final_doctitle_attr
         };
 
-        // Partition the (fully substituted) document title into a main title and
-        // an optional subtitle. This happens after the header has been fully
-        // parsed so that a `title-separator` attribute takes effect even when it
-        // is defined below the document title line.
+        // Partition the (fully substituted) document title into a main title
+        // and an optional subtitle. This happens after the header has
+        // been fully parsed so that a `title-separator` attribute takes
+        // effect even when it is defined below the document title line.
         let (main_title, subtitle) = match &title {
             Some(title) => {
                 let (main_title, subtitle) = partition_title(title, parser);
@@ -464,9 +482,10 @@ impl<'src> Header<'src> {
             None => (None, None),
         };
 
-        // The value returned by `Document::doctitle()`: a `title` attribute entry
-        // overrides the section title (Asciidoctor's `Document#doctitle`), even
-        // when it is blank; otherwise the section title is the doctitle.
+        // The value returned by `Document::doctitle()`: a `title` attribute
+        // entry overrides the section title (Asciidoctor's
+        // `Document#doctitle`), even when it is blank; otherwise the
+        // section title is the doctitle.
         let doctitle = match parser.attribute_value("title") {
             InterpretedValue::Value(v) => Some(v),
             InterpretedValue::Set => Some(String::new()),
@@ -508,8 +527,8 @@ impl<'src> Header<'src> {
 
         // Asciidoctor exposes the number of resolved authors via the
         // `authorcount` document attribute. It defaults to `0` (a built-in
-        // default), so only a non-zero count is materialized here — this keeps an
-        // author-less parse from touching the attribute map at all.
+        // default), so only a non-zero count is materialized here — this keeps
+        // an author-less parse from touching the attribute map at all.
         if !authors.is_empty() {
             parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
         }
@@ -794,9 +813,10 @@ fn document_title_follows_block_metadata(source: Span<'_>, level_offset: i32) ->
             return !effective_style_is_discrete;
         }
 
-        // A block title (`.Title`) may appear anywhere in the metadata run above
-        // the document title; it carries no block style, so it leaves the
-        // running effective style unchanged and the scan continues.
+        // A block title (`.Title`) may appear anywhere in the metadata run
+        // above the document title; it carries no block style, so it
+        // leaves the running effective style unchanged and the scan
+        // continues.
         if block_title_text(line).is_some() {
             next = line_mi.after;
             continue;
@@ -883,9 +903,9 @@ fn is_document_metadata_line(line: Span<'_>) -> bool {
         return false;
     }
 
-    // A `[[anchor]]` block anchor is document metadata when it names a non-empty
-    // anchor; the empty `[[]]` form is not (`inner` would be the two-character
-    // `[]`).
+    // A `[[anchor]]` block anchor is document metadata when it names a
+    // non-empty anchor; the empty `[[]]` form is not (`inner` would be the
+    // two-character `[]`).
     if inner.starts_with('[') && inner.ends_with(']') {
         return inner.len() > 2;
     }
@@ -976,8 +996,9 @@ fn parse_document_metadata_anchor<'src>(
     parser: &Parser,
 ) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
     // Split an optional reftext off at the first comma (`id,reftext`). A comma
-    // in the final position leaves the whole span — trailing comma included — as
-    // the ID, which then fails XML-name validation, matching the block parser.
+    // in the final position leaves the whole span — trailing comma included —
+    // as the ID, which then fails XML-name validation, matching the block
+    // parser.
     let (id, reftext) = match anchor.position(|c| c == ',') {
         Some(comma) if comma < anchor.len() - 1 => (
             anchor.slice(0..comma),
@@ -1185,11 +1206,12 @@ fn resolve_authors(
         let author = author.with_email(attribute_string(parser, "email"));
 
         // Mirror Asciidoctor's `process_authors`, which sets the combined
-        // `authors` attribute to the single author's name. The remaining derived
-        // keys (`firstname`, `authorinitials`, …) were populated inline as the
-        // `:author:` entry was parsed — deliberately, so an explicit
-        // `:authorinitials:` override survives — but `authors` was still left
-        // unset there (see issue #1027).
+        // `authors` attribute to the single author's name. The remaining
+        // derived keys (`firstname`, `authorinitials`, …) were
+        // populated inline as the `:author:` entry was parsed —
+        // deliberately, so an explicit `:authorinitials:` override
+        // survives — but `authors` was still left unset there (see
+        // issue #1027).
         parser.set_attribute_by_value_from_header("authors", author.name());
 
         return vec![author];
@@ -1348,7 +1370,8 @@ mod tests {
         let doc = Parser::default().parse(":alpha: 1\n:bravo: 2\n:charlie: 3\n\nbody\n");
         let header = doc.header();
 
-        // Collect once to learn the order and length without hard-coding a count.
+        // Collect once to learn the order and length without hard-coding a
+        // count.
         let names: Vec<_> = header
             .attributes()
             .map(|a| a.name().data().to_string())
@@ -1818,7 +1841,8 @@ mod tests {
             InterpretedValue::Value("john@example.com")
         );
 
-        // Also verify the original author attribute is still set (with HTML encoding).
+        // Also verify the original author attribute is still set (with HTML
+        // encoding).
         assert_eq!(
             parser.attribute_value("author"),
             InterpretedValue::Value("John Q. Smith &lt;john@example.com&gt;")
@@ -1859,8 +1883,8 @@ mod tests {
     #[test]
     fn author_attribute_two_part_fallback_partitions_lastname() {
         // A two-part value that does not match the author pattern (here because
-        // of the comma attached to the first part) still partitions into a first
-        // and last name via the whitespace split.
+        // of the comma attached to the first part) still partitions into a
+        // first and last name via the whitespace split.
         let mut parser = Parser::default();
         let _doc = parser.parse(":author: Jane, Doe");
 
@@ -1884,8 +1908,8 @@ mod tests {
 
     #[test]
     fn author_attribute_single_part_fallback_is_firstname_only() {
-        // A single-token value that does not match the author pattern partitions
-        // to `firstname` alone, with no middle or last name.
+        // A single-token value that does not match the author pattern
+        // partitions to `firstname` alone, with no middle or last name.
         let mut parser = Parser::default();
         let _doc = parser.parse(":author: Jane,");
 
@@ -1906,9 +1930,9 @@ mod tests {
 
     #[test]
     fn author_attribute_four_or_more_parts_with_inline_email() {
-        // A four-plus-part fallback value that carries a trailing `<email>` must
-        // split the email off before partitioning, so it lands in `email` rather
-        // than being absorbed into `lastname`.
+        // A four-plus-part fallback value that carries a trailing `<email>`
+        // must split the email off before partitioning, so it lands in
+        // `email` rather than being absorbed into `lastname`.
         let mut parser = Parser::default();
         let _doc = parser.parse(":author: Leroy  Harold  Scherer,  Jr. <leroy@example.com>");
 
@@ -1936,9 +1960,10 @@ mod tests {
 
     #[test]
     fn author_attribute_reference_expands_and_partitions() {
-        // A `:author:` value given entirely as an attribute reference is expanded
-        // and then partitioned by the names-only rules, so it yields the same
-        // metadata as the equivalent literal four-plus-part name.
+        // A `:author:` value given entirely as an attribute reference is
+        // expanded and then partitioned by the names-only rules, so it
+        // yields the same metadata as the equivalent literal
+        // four-plus-part name.
         let mut parser = Parser::default();
         let _doc = parser.parse(":full-name: Leroy Harold Scherer, Jr.\n:author: {full-name}");
 
@@ -1963,8 +1988,8 @@ mod tests {
     #[test]
     fn author_attribute_reference_within_larger_value_expands_and_partitions() {
         // The same partitioning applies when the reference is only part of the
-        // value (so the single-attribute fast path is not taken) and the expanded
-        // result still fails the author pattern.
+        // value (so the single-attribute fast path is not taken) and the
+        // expanded result still fails the author pattern.
         let mut parser = Parser::default();
         let _doc = parser.parse(":rest: Harold Scherer, Jr.\n:author: Leroy {rest}");
 
@@ -1985,8 +2010,8 @@ mod tests {
     #[test]
     fn author_attribute_non_breaking_space_is_not_a_name_separator() {
         // Only ASCII whitespace separates name parts. A non-breaking space
-        // (U+00A0) joining two words keeps them as a single first name, matching
-        // Ruby's whitespace split.
+        // (U+00A0) joining two words keeps them as a single first name,
+        // matching Ruby's whitespace split.
         let mut parser = Parser::default();
         let _doc = parser.parse(":author: John\u{a0}Doe Scherer, Jr.");
 
@@ -2166,8 +2191,8 @@ mod tests {
             InterpretedValue::Value("DOC")
         );
 
-        // A second `:author:` entry after the explicit initials does not clobber
-        // them.
+        // A second `:author:` entry after the explicit initials does not
+        // clobber them.
         let doc = Parser::default()
             .parse(":author: Jane Roe\n:authorinitials: DOC\n:author: Doc Writer\n\nBody.");
 
@@ -2195,9 +2220,9 @@ mod tests {
 
     #[test]
     fn single_author_entry_sets_combined_authors_attribute() {
-        // A single `:author:` entry sets the combined `authors` attribute to the
-        // author's name, matching Asciidoctor (`{authors}` equals `{author}`),
-        // just as the implicit author line already does.
+        // A single `:author:` entry sets the combined `authors` attribute to
+        // the author's name, matching Asciidoctor (`{authors}` equals
+        // `{author}`), just as the implicit author line already does.
         let doc = Parser::default().parse(":author: Doc Writer\n\nBody.");
 
         assert_eq!(
@@ -2209,10 +2234,10 @@ mod tests {
             InterpretedValue::Value("Doc Writer")
         );
 
-        // The name is reconstructed the same way in the `authors` string, and an
-        // explicit `:authorinitials:` override is still preserved (the reason
-        // this path populates `authors` inline rather than via the shared
-        // metadata routine).
+        // The name is reconstructed the same way in the `authors` string, and
+        // an explicit `:authorinitials:` override is still preserved
+        // (the reason this path populates `authors` inline rather than
+        // via the shared metadata routine).
         let doc = Parser::default()
             .parse("= T\n:authorinitials: DOC\n:author: Kismet R. Chameleon\n\nBody.");
 
@@ -2291,8 +2316,8 @@ mod tests {
     #[test]
     fn authors_attribute_attaches_companion_emails_and_base_middlename() {
         // Companion `:email_N:` entries attach to each split author (`email_1`
-        // also fills the base `email`), and the first author's middle name lands
-        // on the unsuffixed `middlename`.
+        // also fills the base `email`), and the first author's middle name
+        // lands on the unsuffixed `middlename`.
         let doc = Parser::default().parse(
             ":authors: Jane Q. Doe; John Smith\n:email_1: jane@example.com\n:email_2: john@example.com\n\nBody.",
         );
@@ -2362,8 +2387,9 @@ mod tests {
 
     #[test]
     fn authors_attribute_with_only_empty_entries_yields_no_authors() {
-        // An `:authors:` value that splits into only empty entries resolves to no
-        // authors, so the derived attributes stay unset and `authorcount` is 0.
+        // An `:authors:` value that splits into only empty entries resolves to
+        // no authors, so the derived attributes stay unset and
+        // `authorcount` is 0.
         let doc = Parser::default().parse(":authors: ;\n\nBody.");
 
         assert!(doc.authors().is_empty());
@@ -2374,8 +2400,9 @@ mod tests {
         );
 
         // With no authors resolved, the raw `authors` value is left as written
-        // (never rewritten to a comma-joined list) — matching Asciidoctor, whose
-        // `process_authors` returns only `authorcount` for an all-empty value.
+        // (never rewritten to a comma-joined list) — matching Asciidoctor,
+        // whose `process_authors` returns only `authorcount` for an
+        // all-empty value.
         assert_eq!(doc.attribute_value("authors"), InterpretedValue::Value(";"));
     }
 
@@ -2407,20 +2434,22 @@ mod tests {
 
     #[test]
     fn authors_entry_replacing_a_longer_implicit_list_leaves_stale_attributes() {
-        // When a differing `:authors:` entry replaces a *longer* implicit author
-        // line, the reconciliation re-derives only the replacement authors'
-        // attributes. Attributes the implicit line set that the replacement does
-        // not are left in place: a trailing `author_N` (and its name parts)
-        // beyond the shorter list, and the base `email` / `middlename` when the
+        // When a differing `:authors:` entry replaces a *longer* implicit
+        // author line, the reconciliation re-derives only the
+        // replacement authors' attributes. Attributes the implicit line
+        // set that the replacement does not are left in place: a
+        // trailing `author_N` (and its name parts) beyond the shorter
+        // list, and the base `email` / `middlename` when the
         // replacement's first author omits them.
         //
         // This is not a gap in the port — it is exactly Asciidoctor's behavior.
         // Its `parse_header_metadata` reconciles with `doc_attrs.update
         // author_metadata`, a merge that overwrites the keys the replacement
-        // supplies and never deletes the ones it omits, so `{author_3}` (and the
-        // stale `email` / `middlename`) survive alongside an `authorcount` that
-        // reflects the shorter list. Verified byte-for-byte against Asciidoctor
-        // 2.0.26; there is no upstream test for this shrinking case, so this one
+        // supplies and never deletes the ones it omits, so `{author_3}` (and
+        // the stale `email` / `middlename`) survive alongside an
+        // `authorcount` that reflects the shorter list. Verified
+        // byte-for-byte against Asciidoctor 2.0.26; there is no
+        // upstream test for this shrinking case, so this one
         // pins the parity to guard against a future "cleanup" that would clear
         // the stale keys and diverge.
         let mut parser = Parser::default();
@@ -2453,9 +2482,9 @@ mod tests {
             InterpretedValue::Value("Dan Allen")
         );
 
-        // Stale attributes from the longer/richer implicit list survive, exactly
-        // as they do in Asciidoctor: the third author, the first implicit
-        // author's email, and its middle name.
+        // Stale attributes from the longer/richer implicit list survive,
+        // exactly as they do in Asciidoctor: the third author, the
+        // first implicit author's email, and its middle name.
         assert_eq!(
             parser.attribute_value("author_3"),
             InterpretedValue::Value("Third Author")
@@ -2549,8 +2578,8 @@ mod tests {
 
     #[test]
     fn subtitle_available_on_document() {
-        // The subtitle is reachable directly from `Document` as well as from its
-        // `Header`.
+        // The subtitle is reachable directly from `Document` as well as from
+        // its `Header`.
         let doc = Parser::default().parse("= Main Title: Subtitle");
 
         assert_eq!(doc.doctitle(), Some("Main Title: Subtitle"));
@@ -2690,8 +2719,8 @@ mod tests {
         assert_eq!(rendered_paragraphs(&doc), vec!["content"]);
 
         // The `[[id,reftext]]` form additionally folds its reference text into
-        // the document's `reftext` attribute, resolving attribute references the
-        // way a section/block anchor reftext does.
+        // the document's `reftext` attribute, resolving attribute references
+        // the way a section/block anchor reftext does.
         let doc = Parser::default()
             .parse(":product: Widgets\n[[guide,{product} Guide]]\n= User Guide\n\ncontent");
         let header = doc.header();
@@ -2706,9 +2735,9 @@ mod tests {
 
     #[test]
     fn bracket_anchor_above_title_requires_a_valid_name() {
-        // A `[[…]]` line whose anchor name is not a valid XML name is not folded
-        // as document metadata; the header terminates as it does for any other
-        // unrecognized line.
+        // A `[[…]]` line whose anchor name is not a valid XML name is not
+        // folded as document metadata; the header terminates as it does
+        // for any other unrecognized line.
         let doc = Parser::default().parse("[[bad name]]\n= Document Title\n\ncontent");
         let header = doc.header();
 
@@ -2829,10 +2858,11 @@ mod tests {
 
     #[test]
     fn role_block_attribute_above_title() {
-        // A `[role=…]` block attribute above the title folds into the document's
-        // `role` attribute; multiple roles are space-joined. The same role(s)
-        // are surfaced through the block API, so `Header::roles()` and
-        // `Document::roles()` agree with the document attribute (see #820).
+        // A `[role=…]` block attribute above the title folds into the
+        // document's `role` attribute; multiple roles are space-joined.
+        // The same role(s) are surfaced through the block API, so
+        // `Header::roles()` and `Document::roles()` agree with the
+        // document attribute (see #820).
         let doc = Parser::default().parse("[role=special]\n= Document Title\n\nBody.");
         let header = doc.header();
 
@@ -2856,8 +2886,8 @@ mod tests {
 
     #[test]
     fn roles_empty_without_block_attribute() {
-        // With no role assigned above the title, both the block accessor and the
-        // header accessor report no roles.
+        // With no role assigned above the title, both the block accessor and
+        // the header accessor report no roles.
         let doc = Parser::default().parse("= Document Title\n\nBody.");
 
         assert!(doc.header().roles().is_empty());
@@ -2881,10 +2911,10 @@ mod tests {
     #[test]
     fn bracketed_line_that_is_not_a_separator_attribute_list() {
         // A `[...]` line above the title that isn't a well-formed block
-        // attribute list carrying `separator` is not consumed as a separator. An
-        // empty block anchor (`[[]]`) and a leading-space form are both rejected,
-        // so the line terminates the header exactly as any other unrecognized
-        // line would.
+        // attribute list carrying `separator` is not consumed as a separator.
+        // An empty block anchor (`[[]]`) and a leading-space form are
+        // both rejected, so the line terminates the header exactly as
+        // any other unrecognized line would.
         let doc = Parser::default().parse("[[]]\n= Some Title: Subtitle");
         let header = doc.header();
 
@@ -2912,10 +2942,10 @@ mod tests {
     #[test]
     fn counter_does_not_shadow_title_separator() {
         // A counter that happens to be named `title-separator` must not be
-        // mistaken for the configured separator: partitioning reads the document
-        // attribute directly, ignoring the counter overlay. Here the title
-        // creates such a counter, but the default `:{sp}` separator still
-        // applies.
+        // mistaken for the configured separator: partitioning reads the
+        // document attribute directly, ignoring the counter overlay.
+        // Here the title creates such a counter, but the default
+        // `:{sp}` separator still applies.
         let doc = Parser::default().parse("= Main Title: Subtitle {counter:title-separator}");
         let header = doc.header();
 
@@ -2944,8 +2974,9 @@ mod tests {
 
     #[test]
     fn skips_block_comment_with_blank_lines() {
-        // Blank lines inside a header block comment do not terminate the header;
-        // the whole block is skipped and the author line is still recognized.
+        // Blank lines inside a header block comment do not terminate the
+        // header; the whole block is skipped and the author line is
+        // still recognized.
         let doc = Parser::default().parse("= Title\n////\n\nAsciidoctor\n\n////\nRyan Waldron");
         let header = doc.header();
 
@@ -3094,8 +3125,9 @@ mod tests {
 
         #[test]
         fn separator_block_attribute_above_title() {
-            // The `[separator=…]` line is only intercepted when a document title
-            // follows it; a `#` title qualifies just as an `=` title does.
+            // The `[separator=…]` line is only intercepted when a document
+            // title follows it; a `#` title qualifies just as an
+            // `=` title does.
             let doc = Parser::default().parse("[separator=::]\n# Main Title:: Subtitle");
             let header = doc.header();
 

--- a/parser/src/document/revision_line.rs
+++ b/parser/src/document/revision_line.rs
@@ -28,7 +28,8 @@ impl<'src> RevisionLine<'src> {
         };
 
         let (revnumber, revdate) = if let Some((rev, date)) = left_of_colon.split_once(',') {
-            // When there's a comma, we have a revision number followed by a date.
+            // When there's a comma, we have a revision number followed by a
+            // date.
             let rev_trimmed = rev.trim();
             let cleaned_rev = strip_non_numeric_prefix(rev_trimmed);
             (Some(cleaned_rev), date.trim().to_owned())
@@ -47,9 +48,9 @@ impl<'src> RevisionLine<'src> {
 
         // Resolve attribute references *before* recording the built-in
         // `revnumber`/`revdate`/`revremark` document attributes, so a revision
-        // component written as an attribute reference (e.g. `{project-version}`)
-        // is reflected in `doc.attr` with its value resolved rather than as the
-        // raw `{...}` text.
+        // component written as an attribute reference (e.g.
+        // `{project-version}`) is reflected in `doc.attr` with its
+        // value resolved rather than as the raw `{...}` text.
         let revnumber = revnumber.map(|s| {
             let resolved = apply_header_subs(&s, parser);
             parser.set_attribute_by_value_from_header("revnumber", &resolved);
@@ -145,11 +146,12 @@ static STANDALONE_REVISION: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static NON_NUMERIC_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
-    // Strip any leading run of characters that are neither a digit nor the start
-    // of an attribute reference (`{`). Stopping at `{` preserves a revision
-    // number written purely as an attribute reference (e.g. `v{project-version}`
-    // keeps `{project-version}` for later substitution) instead of dropping the
-    // whole value because it contains no literal digit.
+    // Strip any leading run of characters that are neither a digit nor the
+    // start of an attribute reference (`{`). Stopping at `{` preserves a
+    // revision number written purely as an attribute reference (e.g.
+    // `v{project-version}` keeps `{project-version}` for later
+    // substitution) instead of dropping the whole value because it contains
+    // no literal digit.
     #[allow(clippy::unwrap_used)]
     Regex::new(r"^[^0-9{]*(.*)$").unwrap()
 });
@@ -175,8 +177,8 @@ mod tests {
         let mut parser = Parser::default();
         let result = crate::document::RevisionLine::parse(Span::new("1.2.3"), &mut parser);
 
-        // According to Asciidoctor behavior, standalone numbers without "v" are not
-        // revision numbers.
+        // According to Asciidoctor behavior, standalone numbers without "v" are
+        // not revision numbers.
         assert_eq!(result.revnumber(), None);
         assert_eq!(result.revdate(), "1.2.3");
         assert_eq!(result.revremark(), None);
@@ -316,7 +318,8 @@ mod tests {
         let result =
             crate::document::RevisionLine::parse(Span::new("nodigits, 2023-01-01"), &mut parser);
 
-        // When there are no digits, the prefix stripping should leave empty string.
+        // When there are no digits, the prefix stripping should leave empty
+        // string.
         assert_eq!(result.revnumber(), Some(""));
         assert_eq!(result.revdate(), "2023-01-01");
         assert_eq!(result.revremark(), None);
@@ -328,7 +331,8 @@ mod tests {
         // prefix class is `[^\d{]*`: the leading run stops at `{`, so an
         // attribute reference survives prefix removal and is then resolved by
         // the header substitutions. With the referenced attribute undefined the
-        // reference is preserved verbatim (default `attribute-missing` skips it).
+        // reference is preserved verbatim (default `attribute-missing` skips
+        // it).
         let mut parser = Parser::default();
         let result =
             crate::document::RevisionLine::parse(Span::new("v{draft}, 2024-01-01"), &mut parser);

--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -79,10 +79,11 @@ impl TocMode {
     /// the resolved placement *after* this runs — see
     /// [`Parser::materialize_toc_attributes`](crate::Parser).
     pub(crate) fn from_parser(parser: &Parser) -> Self {
-        // Asciidoctor: `toc_val = (attrs.delete 'toc2') ? 'left' : attrs['toc']`.
-        // `toc2` is a legacy alias for a left side-column TOC: when set it
-        // overrides the `toc` value with `left`. (A soft-unset `toc2!` records an
-        // `Unset` tombstone, which does not enable it.)
+        // Asciidoctor: `toc_val = (attrs.delete 'toc2') ? 'left' :
+        // attrs['toc']`. `toc2` is a legacy alias for a left
+        // side-column TOC: when set it overrides the `toc` value with
+        // `left`. (A soft-unset `toc2!` records an `Unset` tombstone,
+        // which does not enable it.)
         let toc_val = if parser.attribute_value("toc2") != InterpretedValue::Unset {
             "left".to_string()
         } else {
@@ -93,24 +94,27 @@ impl TocMode {
                 return Self::Disabled;
             }
 
-            // `toc` carries a built-in `auto` default, so a bare `:toc:` reads as
-            // `Value("auto")` (never `Set`); any other value is taken as-is, and a
-            // set-but-empty value folds to empty.
+            // `toc` carries a built-in `auto` default, so a bare `:toc:` reads
+            // as `Value("auto")` (never `Set`); any other value is
+            // taken as-is, and a set-but-empty value folds to
+            // empty.
             toc.as_maybe_str().unwrap_or_default().to_string()
         };
 
-        // A bare `:toc:` carries this crate's built-in `auto` default; Asciidoctor
-        // treats a bare `toc` as an empty value, so fold `auto` back to empty to
-        // match its `toc_val.empty?` branches below.
+        // A bare `:toc:` carries this crate's built-in `auto` default;
+        // Asciidoctor treats a bare `toc` as an empty value, so fold
+        // `auto` back to empty to match its `toc_val.empty?` branches
+        // below.
         let toc_val = toc_val.trim();
         let toc_val = if toc_val == "auto" { "" } else { toc_val };
 
-        // `toc-placement` lets a document separate the *position* of the TOC from
-        // the *slot* it occupies. Asciidoctor fetches it with a `macro` fallback
-        // (`attrs.fetch 'toc-placement', 'macro'`) while its default attribute
-        // normally seeds `auto`; this crate seeds no such default, so a never-set
-        // `toc-placement` reads as `auto`, an explicit value is taken as-is, and a
-        // soft-unset tombstone — which Asciidoctor *deletes*, so its `fetch` yields
+        // `toc-placement` lets a document separate the *position* of the TOC
+        // from the *slot* it occupies. Asciidoctor fetches it with a
+        // `macro` fallback (`attrs.fetch 'toc-placement', 'macro'`)
+        // while its default attribute normally seeds `auto`; this crate
+        // seeds no such default, so a never-set `toc-placement` reads
+        // as `auto`, an explicit value is taken as-is, and a soft-unset
+        // tombstone — which Asciidoctor *deletes*, so its `fetch` yields
         // the `macro` fallback — reads as `macro`.
         let toc_placement_val = match parser.attribute_value("toc-placement") {
             InterpretedValue::Value(v) => v.trim().to_string(),
@@ -120,10 +124,11 @@ impl TocMode {
         };
 
         // Asciidoctor: `toc_placement_val && toc_placement_val != 'auto' ?
-        // toc_placement_val : attrs['toc-position']`. When `toc-placement` names
-        // anything other than `auto` it *is* the position (so `preamble`/`macro`,
-        // or a side keyword on `toc-placement`, override the `toc` value's own
-        // keyword); otherwise the separate `toc-position` attribute supplies it.
+        // toc_placement_val : attrs['toc-position']`. When `toc-placement`
+        // names anything other than `auto` it *is* the position (so
+        // `preamble`/`macro`, or a side keyword on `toc-placement`,
+        // override the `toc` value's own keyword); otherwise the
+        // separate `toc-position` attribute supplies it.
         let toc_position_val = if toc_placement_val != "auto" {
             toc_placement_val
         } else {
@@ -142,11 +147,11 @@ impl TocMode {
             return Self::Auto;
         }
 
-        // A resolved `toc-position` wins over the `toc` value; when `toc-position`
-        // is empty the empty/empty early return above guarantees a non-empty `toc`
-        // value, which then supplies the position. (Asciidoctor's
-        // `default_toc_position` fallback of `left` is likewise unreachable once
-        // that case has returned.)
+        // A resolved `toc-position` wins over the `toc` value; when
+        // `toc-position` is empty the empty/empty early return above
+        // guarantees a non-empty `toc` value, which then supplies the
+        // position. (Asciidoctor's `default_toc_position` fallback of
+        // `left` is likewise unreachable once that case has returned.)
         let position = if toc_position_val.is_empty() {
             toc_val
         } else {
@@ -154,11 +159,12 @@ impl TocMode {
         };
 
         // Map the resolved position to a placement, mirroring Asciidoctor's
-        // `case`. The direction shorthands arrive here already special-character
-        // substituted (`>` as `&gt;`, `<` as `&lt;`), so both spellings are
-        // matched; a literally typed `&gt;`/`&lt;` becomes `&amp;gt;`/`&amp;lt;`
-        // and correctly falls through to an automatic placement, as in
-        // Asciidoctor. An unrecognized position (including `content`, `auto`, or a
+        // `case`. The direction shorthands arrive here already
+        // special-character substituted (`>` as `&gt;`, `<` as `&lt;`),
+        // so both spellings are matched; a literally typed
+        // `&gt;`/`&lt;` becomes `&amp;gt;`/`&amp;lt;` and correctly
+        // falls through to an automatic placement, as in Asciidoctor.
+        // An unrecognized position (including `content`, `auto`, or a
         // bogus value) is an automatic placement.
         match position {
             "left" | "<" | "&lt;" => Self::Left,
@@ -387,10 +393,11 @@ mod tests {
 
     #[test]
     fn mode_resolves_direction_shorthands_and_keywords() {
-        // The `<`/`>`/`^`/`v` direction shorthands in the `toc` value resolve to
-        // the `left`/`right`/`top`/`bottom` positions, matching Asciidoctor. (The
-        // `<`/`>` shorthands reach resolution already special-character
-        // substituted to `&lt;`/`&gt;`, but resolve the same.)
+        // The `<`/`>`/`^`/`v` direction shorthands in the `toc` value resolve
+        // to the `left`/`right`/`top`/`bottom` positions, matching
+        // Asciidoctor. (The `<`/`>` shorthands reach resolution already
+        // special-character substituted to `&lt;`/`&gt;`, but resolve
+        // the same.)
         assert_eq!(doc_with(":toc: <").toc_mode(), TocMode::Left);
         assert_eq!(doc_with(":toc: >").toc_mode(), TocMode::Right);
         assert_eq!(doc_with(":toc: ^").toc_mode(), TocMode::Top);
@@ -409,9 +416,10 @@ mod tests {
 
     #[test]
     fn toc_position_attribute_selects_the_side() {
-        // The separate `toc-position` attribute selects the side of an otherwise
-        // automatic TOC. It also overrides the `left` implied by the legacy `toc2`
-        // alias, and a bare side keyword in the `toc` value.
+        // The separate `toc-position` attribute selects the side of an
+        // otherwise automatic TOC. It also overrides the `left` implied
+        // by the legacy `toc2` alias, and a bare side keyword in the
+        // `toc` value.
         assert_eq!(
             doc_with(":toc:\n:toc-position: right").toc_mode(),
             TocMode::Right
@@ -429,9 +437,10 @@ mod tests {
 
     #[test]
     fn toc_placement_side_resolves_the_position() {
-        // `toc-placement` is resolved into the position ahead of the `toc` value,
-        // so a `preamble`/`macro` placement (or a side keyword on `toc-placement`)
-        // wins over a conflicting keyword in the `toc` value.
+        // `toc-placement` is resolved into the position ahead of the `toc`
+        // value, so a `preamble`/`macro` placement (or a side keyword
+        // on `toc-placement`) wins over a conflicting keyword in the
+        // `toc` value.
         assert_eq!(
             doc_with(":toc: left\n:toc-placement: macro").toc_mode(),
             TocMode::Macro
@@ -448,8 +457,9 @@ mod tests {
             TocMode::Right
         );
 
-        // A bare `:toc-placement:` (set with no value) supplies an empty position,
-        // so an otherwise-bare `:toc:` stays an automatic top TOC.
+        // A bare `:toc-placement:` (set with no value) supplies an empty
+        // position, so an otherwise-bare `:toc:` stays an automatic top
+        // TOC.
         assert_eq!(doc_with(":toc:\n:toc-placement:").toc_mode(), TocMode::Auto);
     }
 
@@ -487,9 +497,9 @@ mod tests {
         );
 
         // A non-`auto` `toc-placement` supplies the position and wins over the
-        // `toc` value's own keyword (Asciidoctor resolves `toc-placement` into the
-        // position before consulting the `toc` value), so `toc-placement:
-        // preamble` overrides `toc: macro`.
+        // `toc` value's own keyword (Asciidoctor resolves `toc-placement` into
+        // the position before consulting the `toc` value), so
+        // `toc-placement: preamble` overrides `toc: macro`.
         assert_eq!(
             doc_with(":toc: macro\n:toc-placement: preamble").toc_mode(),
             TocMode::Preamble
@@ -505,8 +515,9 @@ mod tests {
     #[test]
     fn soft_unset_toc_placement_resolves_to_macro() {
         // With `toc` enabled, explicitly unsetting `toc-placement` defers the
-        // TOC to a `toc::[]` block macro (Asciidoctor's `macro` fetch fallback),
-        // whereas a `toc-placement` that was never set stays automatic.
+        // TOC to a `toc::[]` block macro (Asciidoctor's `macro` fetch
+        // fallback), whereas a `toc-placement` that was never set stays
+        // automatic.
         assert_eq!(doc_with(":toc:").toc_mode(), TocMode::Auto);
         assert_eq!(
             doc_with(":toc:\n:toc-placement!:").toc_mode(),
@@ -547,7 +558,8 @@ mod tests {
         // A `:toc-title:` set with no value yields an empty title.
         assert_eq!(doc_with(":toc:\n:toc-title:").toc_title(), "");
 
-        // An explicitly unset `:toc-title!:` falls back to the built-in default.
+        // An explicitly unset `:toc-title!:` falls back to the built-in
+        // default.
         assert_eq!(
             doc_with(":toc:\n:toc-title!:").toc_title(),
             "Table of Contents"
@@ -565,8 +577,9 @@ mod tests {
 
     #[test]
     fn class_defaults_to_toc2_for_side_column_placement() {
-        // A `left`/`right` side-column TOC switches the default class to `toc2`,
-        // matching Asciidoctor; every other placement keeps the plain `toc`.
+        // A `left`/`right` side-column TOC switches the default class to
+        // `toc2`, matching Asciidoctor; every other placement keeps the
+        // plain `toc`.
         assert_eq!(doc_with(":toc: left").toc_class(), "toc2");
         assert_eq!(doc_with(":toc: right").toc_class(), "toc2");
         assert_eq!(doc_with(":toc:\n:toc-placement: left").toc_class(), "toc2");
@@ -580,9 +593,10 @@ mod tests {
             "floaty"
         );
 
-        // An explicit but empty `:toc-class:` resolves to the built-in `toc-class`
-        // default (`toc`) at the attribute layer, so the placement-derived `toc2`
-        // default only applies when `toc-class` is left entirely unset.
+        // An explicit but empty `:toc-class:` resolves to the built-in
+        // `toc-class` default (`toc`) at the attribute layer, so the
+        // placement-derived `toc2` default only applies when
+        // `toc-class` is left entirely unset.
         assert_eq!(doc_with(":toc: left\n:toc-class:").toc_class(), "toc");
     }
 
@@ -605,7 +619,8 @@ mod tests {
             )
         };
 
-        // An automatic top TOC: position and class stay unset, placement `auto`.
+        // An automatic top TOC: position and class stay unset, placement
+        // `auto`.
         assert_eq!(derived(":toc:"), (Unset, Value("auto".into()), Unset));
 
         // An unrecognized `toc` value still resolves to an automatic placement.
@@ -699,15 +714,18 @@ mod tests {
         // A `>` direction shorthand derives a right side-column TOC.
         assert_eq!(derived(":toc: >"), right());
 
-        // `:toc:` + `:toc-position: right` derives a right side column and defaults
-        // the class to `toc2` (was previously left as the plain `toc`).
+        // `:toc:` + `:toc-position: right` derives a right side column and
+        // defaults the class to `toc2` (was previously left as the
+        // plain `toc`).
         assert_eq!(derived(":toc:\n:toc-position: right"), right());
 
-        // `:toc2:` + `:toc-position: right`: the explicit `toc-position` overrides
-        // the `left` implied by the `toc2` alias (was previously left).
+        // `:toc2:` + `:toc-position: right`: the explicit `toc-position`
+        // overrides the `left` implied by the `toc2` alias (was
+        // previously left).
         assert_eq!(derived(":toc2:\n:toc-position: right"), right());
 
-        // The `^` shorthand derives a top column, likewise defaulting to `toc2`.
+        // The `^` shorthand derives a top column, likewise defaulting to
+        // `toc2`.
         assert_eq!(
             derived(":toc: ^"),
             (
@@ -720,9 +738,10 @@ mod tests {
 
     #[test]
     fn automatic_toc_clears_unrecognized_toc_position() {
-        // An enabled automatic TOC drops an author `toc-position` that resolves to
-        // no side: Asciidoctor's normalization deletes it in its `else` arm, so a
-        // bogus (or `content`) value does not leak into the derived state.
+        // An enabled automatic TOC drops an author `toc-position` that resolves
+        // to no side: Asciidoctor's normalization deletes it in its
+        // `else` arm, so a bogus (or `content`) value does not leak
+        // into the derived state.
         let doc = doc_with(":toc:\n:toc-position: bogus");
         assert_eq!(doc.toc_mode(), TocMode::Auto);
         assert!(!doc.has_attribute("toc-position"));
@@ -759,9 +778,9 @@ mod tests {
         );
 
         // A second document that enables an automatic TOC must resolve `Auto` —
-        // if the first document's derived `toc-placement: macro` had leaked onto
-        // the parser, `TocMode::from_parser` would read it back and wrongly
-        // resolve `Macro` here.
+        // if the first document's derived `toc-placement: macro` had leaked
+        // onto the parser, `TocMode::from_parser` would read it back
+        // and wrongly resolve `Macro` here.
         let doc2 = parser.parse("= Two\n:toc:\n\n== S\n\nx");
         assert_eq!(doc2.toc_mode(), TocMode::Auto);
         assert_eq!(

--- a/parser/src/internal/base64.rs
+++ b/parser/src/internal/base64.rs
@@ -86,8 +86,8 @@ mod tests {
 
     #[test]
     fn encodes_full_byte_range() {
-        // A run of bytes spanning the high bit confirms the `+` and `/` alphabet
-        // slots and that no line breaks are emitted.
+        // A run of bytes spanning the high bit confirms the `+` and `/`
+        // alphabet slots and that no line breaks are emitted.
         let bytes: Vec<u8> = (0u8..=255).collect();
         let encoded = strict_encode(&bytes);
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -272,13 +272,13 @@ pub(crate) fn synthesized_attr(
     name: &str,
     overrides: &HashMap<String, AttributeValue>,
 ) -> Option<&'static AttributeValue> {
-    // The derived backend-family flags are all empty-valued and defined only for
-    // the *active* backend / basebackend / filetype / doctype. Rather than parse
-    // the queried name, compute the flag names that are currently active and
-    // compare — unambiguous even where the components overlap. An explicitly
-    // unset (or empty) `backend` / `doctype` contributes no flags, so the
-    // backend-dependent and doctype-dependent groups are each gated on a
-    // present, non-empty value.
+    // The derived backend-family flags are all empty-valued and defined only
+    // for the *active* backend / basebackend / filetype / doctype. Rather
+    // than parse the queried name, compute the flag names that are
+    // currently active and compare — unambiguous even where the components
+    // overlap. An explicitly unset (or empty) `backend` / `doctype`
+    // contributes no flags, so the backend-dependent and doctype-dependent
+    // groups are each gated on a present, non-empty value.
     if name.starts_with("backend-")
         || name.starts_with("basebackend-")
         || name.starts_with("filetype-")
@@ -339,8 +339,8 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     // non-visible characters, escapes for characters with special meaning in
     // AsciiDoc, and passthroughs for characters that get encoded by default.
     // See the reference page:
-    // `ref/asciidoc-lang/docs/modules/attributes/pages/character-replacement-ref.
-    // adoc`.
+    // `ref/asciidoc-lang/docs/modules/attributes/pages/
+    // character-replacement-ref. adoc`.
     //
     // The entries below are listed in the same order they appear on that
     // reference page. The replacement values match Ruby Asciidoctor's
@@ -414,10 +414,10 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         value,
     };
 
-    // Set by default to a concrete `default` value. The value is stored directly
-    // (not via [`build_built_in_default_values`]) so that setting the attribute
-    // with an empty value overrides it with an empty value, rather than
-    // re-applying the default.
+    // Set by default to a concrete `default` value. The value is stored
+    // directly (not via [`build_built_in_default_values`]) so that setting
+    // the attribute with an empty value overrides it with an empty value,
+    // rather than re-applying the default.
     let set = |ctx, default: &str| AttributeValue {
         allowable_value: AllowableValue::Any,
         modification_context: ctx,
@@ -477,24 +477,24 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     //
     // `authorcount` reflects the number of resolved authors and defaults to `0`
     // for a document with none. Registering the default here (rather than
-    // writing it during every header parse) lets an author-less document resolve
-    // `{authorcount}` to `0` without materializing the attribute — the header
-    // parser only writes `authorcount` when the count is non-zero (see
-    // [`Header::parse`](crate::document::Header)).
+    // writing it during every header parse) lets an author-less document
+    // resolve `{authorcount}` to `0` without materializing the attribute —
+    // the header parser only writes `authorcount` when the count is
+    // non-zero (see [`Header::parse`](crate::document::Header)).
     attrs.insert("authorcount".to_owned(), set(Anywhere, "0"));
 
     // ### General content and formatting attributes
     //
     // The active backend defaults to `html5` (the only backend this crate
-    // renders). It is a normal, unlocked attribute — settable in the header, the
-    // body, or via the API, matching Asciidoctor, where `{backend}` reflects the
-    // latest assignment — so its default context is `Anywhere`; an API caller
-    // that wants to pin it uses `ApiOnly`. Its derived family —
-    // `backend-{backend}`, `basebackend`, `basebackend-{basebackend}`,
-    // `filetype`, `filetype-{filetype}`, and the `*-doctype-{doctype}` flags —
-    // is synthesized on the fly from this value (see [`synthesized_attr`] and
-    // [`derived_backend_value`]), so it is never materialized or kept in sync
-    // when `backend` changes.
+    // renders). It is a normal, unlocked attribute — settable in the header,
+    // the body, or via the API, matching Asciidoctor, where `{backend}`
+    // reflects the latest assignment — so its default context is
+    // `Anywhere`; an API caller that wants to pin it uses `ApiOnly`. Its
+    // derived family — `backend-{backend}`, `basebackend`,
+    // `basebackend-{basebackend}`, `filetype`, `filetype-{filetype}`, and
+    // the `*-doctype-{doctype}` flags — is synthesized on the fly from this
+    // value (see [`synthesized_attr`] and [`derived_backend_value`]), so it
+    // is never materialized or kept in sync when `backend` changes.
     attrs.insert("backend".to_owned(), any(Anywhere, Value("html5".into())));
 
     // The document type defaults to `article` and may be set in the header or
@@ -558,8 +558,8 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     attrs.insert("max-block-nesting".to_owned(), set(ApiOnly, "32"));
 
     // NOTE: `max-attribute-value-size` is *not* registered here. Its `4096`
-    // default is only in effect under `SafeMode::Secure`, so it is resolved as a
-    // mode-aware synthesized attribute instead (see
+    // default is only in effect under `SafeMode::Secure`, so it is resolved as
+    // a mode-aware synthesized attribute instead (see
     // [`max_attribute_value_size_default`] and `Parser::effective_attribute`).
     // Keeping it out of this mode-agnostic table is what lets a caller-supplied
     // limit (which, being API-only, always lives in the per-parser map) survive
@@ -602,8 +602,9 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     // `Parser::with_safe_mode` overrides `safe-mode-level` and `safe-mode-name`
     // (via `apply_safe_mode_attributes`) when the caller chooses a different
     // mode. The active `safe-mode-<name>` flag is *not* stored here: it is
-    // synthesized on the fly from `safe-mode-name` (see [`synthesized_attr`]), so
-    // exactly one flag is ever defined and the inactive flags stay absent.
+    // synthesized on the fly from `safe-mode-name` (see [`synthesized_attr`]),
+    // so exactly one flag is ever defined and the inactive flags stay
+    // absent.
     attrs.insert(
         "safe-mode-level".to_owned(),
         any(ApiOnly, Value("20".into())),
@@ -615,11 +616,12 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
 
     // NOTE: The derived backend-family flags (`backend-{backend}`,
     // `basebackend-{basebackend}`, `filetype-{filetype}`, `doctype-{doctype}`,
-    // and the `*-doctype-*` combinations) are *not* registered here, nor are the
-    // derived `basebackend` / `filetype` values. They are synthesized on the fly
-    // for the active `backend` / `doctype` by `Parser::attribute_value` (via
-    // [`synthesized_attr`] and [`derived_backend_value`]), so they never need to
-    // be materialized or kept in sync when `backend` or `doctype` changes.
+    // and the `*-doctype-*` combinations) are *not* registered here, nor are
+    // the derived `basebackend` / `filetype` values. They are synthesized
+    // on the fly for the active `backend` / `doctype` by
+    // `Parser::attribute_value` (via [`synthesized_attr`] and
+    // [`derived_backend_value`]), so they never need to be materialized or
+    // kept in sync when `backend` or `doctype` changes.
 
     attrs
 }
@@ -632,11 +634,11 @@ fn build_built_in_default_values() -> HashMap<String, String> {
     // This map holds the defaults for attributes that are *not* set by default:
     // the reference page's "turn-on" attributes (`toc`, `sectnums`) and its
     // implied `(x)` / effective `_empty_[=x]` values. Because these attributes
-    // are absent from [`build_built_in_attrs`], they are treated as missing when
-    // referenced while unset; their default is applied only once they are
-    // explicitly set. Attributes that *are* set by default store their value
-    // directly in [`build_built_in_attrs`] and do not appear here, so setting
-    // one with an empty value overrides it with an empty value.
+    // are absent from [`build_built_in_attrs`], they are treated as missing
+    // when referenced while unset; their default is applied only once they
+    // are explicitly set. Attributes that *are* set by default store their
+    // value directly in [`build_built_in_attrs`] and do not appear here, so
+    // setting one with an empty value overrides it with an empty value.
     //
     // `docinfosubs` is intentionally omitted: its implied default of
     // `attributes` is handled where docinfo substitution is resolved (an unset

--- a/parser/src/parser/inline_renderer.rs
+++ b/parser/src/parser/inline_renderer.rs
@@ -694,10 +694,11 @@ impl InlineRenderer for HtmlInlineRenderer {
                 .map(|id| id.to_owned())
         }
 
-        // A quote-delimited first positional attribute (e.g. `['role']`) carries
-        // no shorthand role or block style, so the derivation above leaves it
-        // out. Asciidoctor treats such a value as a verbatim role — quotes
-        // included — so recover it here rather than dropping the role.
+        // A quote-delimited first positional attribute (e.g. `['role']`)
+        // carries no shorthand role or block style, so the derivation
+        // above leaves it out. Asciidoctor treats such a value as a
+        // verbatim role — quotes included — so recover it here rather
+        // than dropping the role.
         if roles.is_empty()
             && id.is_none()
             && let Some(role) = attrlist.quoted_text_fallback_role()
@@ -890,10 +891,11 @@ impl InlineRenderer for HtmlInlineRenderer {
             )
             .unwrap_or_else(|| format!(r#"<span class="alt">{alt}</span>"#, alt = alt))
         } else if svg_active && attrlist.has_option("interactive") {
-            // Render an interactive SVG as an `<object>` element so its embedded
-            // scripting and links remain live. A `fallback` image (or, failing
-            // that, the alt text) is nested inside for user agents that can't
-            // display the object.
+            // Render an interactive SVG as an `<object>` element so its
+            // embedded scripting and links remain live. A
+            // `fallback` image (or, failing that, the alt text) is
+            // nested inside for user agents that can't display the
+            // object.
             let fallback = if let Some(fallback) = attrlist.named_attribute("fallback") {
                 // A `fallback=` value restored from a masked construct
                 // resolves over its restored ranges masked, exactly as the
@@ -1094,10 +1096,10 @@ impl InlineRenderer for HtmlInlineRenderer {
             format!("[{alt}&#93;", alt = alt)
         };
 
-        // `src` is only a real image URI in the image-icon branch (icons enabled
-        // and not font-based); the font (`<i>`) and text (`[alt]`) branches have
-        // no `src`, so a `link=self` on them stays literal (see
-        // `render_icon_or_image`).
+        // `src` is only a real image URI in the image-icon branch (icons
+        // enabled and not font-based); the font (`<i>`) and text
+        // (`[alt]`) branches have no `src`, so a `link=self` on them
+        // stays literal (see `render_icon_or_image`).
         let link_self_href = if context.is_attribute_set("icons")
             && context.attribute_value("icons").as_maybe_str() != Some("font")
         {
@@ -1211,8 +1213,9 @@ impl InlineRenderer for HtmlInlineRenderer {
             (Some(resolved), _) => {
                 // Explicit link text always wins; otherwise use the target's
                 // reference text, optionally reformatted by the `xrefstyle`.
-                // Empty explicit text (`<<id,>>`) is treated as absent, matching
-                // Asciidoctor's fallback to the target's reference text.
+                // Empty explicit text (`<<id,>>`) is treated as absent,
+                // matching Asciidoctor's fallback to the
+                // target's reference text.
                 let text = match params.provided_text {
                     Some(provided) if !provided.is_empty() => provided.to_string(),
                     _ => {
@@ -1222,8 +1225,9 @@ impl InlineRenderer for HtmlInlineRenderer {
                         // carries a nested `<a>…</a>`; an anchor cannot legally
                         // nest inside another, so the inner anchor tags are
                         // dropped (keeping their text), mirroring Asciidoctor's
-                        // `DropAnchorRx`. The bracketed fallback (`[id]`) has no
-                        // anchors, so stripping only applies to a resolved
+                        // `DropAnchorRx`. The bracketed fallback (`[id]`) has
+                        // no anchors, so stripping only
+                        // applies to a resolved
                         // reftext.
                         let base = resolved
                             .text
@@ -1329,8 +1333,8 @@ impl InlineRenderer for HtmlInlineRenderer {
         } else {
             // The visual separator is always `+`, even when the source used a
             // comma delimiter (e.g. `kbd:[Ctrl,T]`). This matches Asciidoctor's
-            // HTML5 output, where the delimiter only selects how keys are split,
-            // not how the sequence is displayed.
+            // HTML5 output, where the delimiter only selects how keys are
+            // split, not how the sequence is displayed.
             dest.push_str(&format!(
                 r#"<span class="keyseq"><kbd>{keys}</kbd></span>"#,
                 keys = join_cow_strs(keys, "</kbd>+<kbd>")
@@ -1613,8 +1617,8 @@ pub(crate) fn has_dangerous_self_href(href: &str, from_uri_target: bool) -> bool
         return true;
     }
 
-    // A `data:image/*` source is exempt, except an author-supplied SVG data URI,
-    // whose script runs when the anchor is followed.
+    // A `data:image/*` source is exempt, except an author-supplied SVG data
+    // URI, whose script runs when the anchor is followed.
     from_uri_target && is_svg_data_uri(href)
 }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -707,11 +707,12 @@ impl Parser {
         // attributes. See `baseline_attribute_values`.
         self.attribute_values = Arc::clone(&self.baseline_attribute_values);
 
-        // The time-dependent document attributes (docdate, doctime, docdatetime,
-        // docyear, and their local* siblings) are resolved lazily from a
-        // reference instant captured the first time one is read (see
-        // `resolve_datetime_attribute`). Reset that capture so each parse sees a
-        // fresh "now"; a parse that never references one does no datetime work.
+        // The time-dependent document attributes (docdate, doctime,
+        // docdatetime, docyear, and their local* siblings) are resolved
+        // lazily from a reference instant captured the first time one
+        // is read (see `resolve_datetime_attribute`). Reset that
+        // capture so each parse sees a fresh "now"; a parse that never
+        // references one does no datetime work.
         *self.datetime_context.borrow_mut() = None;
 
         // Strip a leading UTF-8 byte-order mark (U+FEFF), which is valid but
@@ -733,15 +734,16 @@ impl Parser {
         let (preprocessed_source, source_map, preprocessor_warnings, includes) =
             preprocess(source, self);
 
-        // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
-        // parsing operation. Start each parse with a fresh catalog.
+        // NOTE: `Document::parse` will transfer the catalog to itself at the
+        // end of the parsing operation. Start each parse with a fresh
+        // catalog.
         *self.catalog.borrow_mut() = Catalog::new();
 
         // Seed the fresh catalog with the files the preprocessor just expanded,
         // so an inter-document cross reference to an included file can resolve
         // to an internal anchor while the document is parsed. Replaying each
-        // event lets the catalog resolve a file that was included both fully and
-        // partially to a full include.
+        // event lets the catalog resolve a file that was included both fully
+        // and partially to a full include.
         {
             let mut catalog = self.catalog.borrow_mut();
             for (key, full) in includes {
@@ -774,8 +776,8 @@ impl Parser {
         self.block_nesting_depth = 0;
 
         // Resolve the block-nesting cap once, now, so the guard on the hot
-        // `parse_blocks_until` path is a plain integer compare. The attribute is
-        // API-only and so cannot change mid-parse.
+        // `parse_blocks_until` path is a plain integer compare. The attribute
+        // is API-only and so cannot change mid-parse.
         self.block_nesting_limit = self.max_block_nesting();
 
         Document::parse(
@@ -984,8 +986,9 @@ impl Parser {
         }
 
         // `basebackend` / `filetype` are derived on the fly from the current
-        // `backend` (see [`derived_backend_value`]) rather than stored; they are
-        // read-only intrinsics, so no per-parser entry ever shadows this.
+        // `backend` (see [`derived_backend_value`]) rather than stored; they
+        // are read-only intrinsics, so no per-parser entry ever shadows
+        // this.
         if let Some(value) = derived_backend_value(name, &self.attribute_values) {
             return value;
         }
@@ -1043,10 +1046,11 @@ impl Parser {
         }
 
         // `max-attribute-value-size` carries its `4096` default only under
-        // Secure, so it is resolved as a mode-aware synthesized attribute rather
-        // than a fixed built-in. It is consulted here *after* the per-parser map
-        // so a caller-supplied value (always API-only, hence always in that map)
-        // wins regardless of builder-call order, and a `with_safe_mode` change
+        // Secure, so it is resolved as a mode-aware synthesized attribute
+        // rather than a fixed built-in. It is consulted here *after*
+        // the per-parser map so a caller-supplied value (always
+        // API-only, hence always in that map) wins regardless of
+        // builder-call order, and a `with_safe_mode` change
         // never rewrites it.
         if name == "max-attribute-value-size" {
             return Some(max_attribute_value_size_default(
@@ -1581,8 +1585,9 @@ impl Parser {
             // a request to force-hide (or force-show) that a later,
             // unlocked document entry for the partner cannot override (issue
             // #1143). So when the triggering write is `ApiOnly`, the plant
-            // always uses an unlocked ([`Anywhere`](ModificationContext::Anywhere))
-            // context instead of mirroring the trigger's own `ApiOnly`
+            // always uses an unlocked
+            // ([`Anywhere`](ModificationContext::Anywhere)) context
+            // instead of mirroring the trigger's own `ApiOnly`
             // context — letting a later document entry for the partner
             // resolve normally, exactly as if the API call had never
             // touched it.
@@ -1892,18 +1897,19 @@ impl Parser {
 
         // Footnotes are numbered consecutively throughout the document via the
         // `footnote-number` counter, which is seeded to `0` so the first
-        // footnote is numbered `1`. The counter is a document-wide attribute, so
-        // numbering continues across nested documents (AsciiDoc table cells)
-        // even though the footnote *list* does not. The counter honors any seed
-        // the document sets, so a non-integer seed yields a non-integer number
-        // (matching Asciidoctor); the value is therefore kept as a string.
+        // footnote is numbered `1`. The counter is a document-wide attribute,
+        // so numbering continues across nested documents (AsciiDoc
+        // table cells) even though the footnote *list* does not. The
+        // counter honors any seed the document sets, so a non-integer
+        // seed yields a non-integer number (matching Asciidoctor); the
+        // value is therefore kept as a string.
         let index = self.counter("footnote-number", None);
 
-        // Record the defining occurrence's location only when it is locatable in
-        // the document source. A footnote defined inside an owned sub-source
-        // indexes that private source, whose offset would misplace the warning,
-        // so it is left unrecorded (resolution then falls back to the
-        // whole-document span).
+        // Record the defining occurrence's location only when it is locatable
+        // in the document source. A footnote defined inside an owned
+        // sub-source indexes that private source, whose offset would
+        // misplace the warning, so it is left unrecorded (resolution
+        // then falls back to the whole-document span).
         let location = if self.owned_subsource_depth == 0 {
             Some((source.byte_offset(), source.data().len()))
         } else {
@@ -2808,8 +2814,8 @@ impl Parser {
             value,
         };
 
-        // An explicit assignment supersedes (and resets) any counter of the same
-        // name.
+        // An explicit assignment supersedes (and resets) any counter of the
+        // same name.
         Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(&attr_name);
 
         // The derived `backend-html5-doctype-*` attribute tracks `doctype`
@@ -3005,20 +3011,21 @@ impl Parser {
             value,
         };
 
-        // Inside an AsciiDoc table cell (a nested document) the leading attribute
-        // lines act as the cell's own header, so a `sectnumlevels` assignment
-        // there must refresh the cached depth that section numbering reads. The
-        // top-level document freezes that value at the end of its header (see
-        // [`Document::parse`](crate::Document)) and a cell has no separate header
-        // pass, so without this a cell that lowered `sectnumlevels` would still
-        // number its deeper sections at the inherited depth. The enclosing cell
-        // parse saves and restores the field, keeping the change scoped to the
-        // cell.
+        // Inside an AsciiDoc table cell (a nested document) the leading
+        // attribute lines act as the cell's own header, so a
+        // `sectnumlevels` assignment there must refresh the cached
+        // depth that section numbering reads. The top-level document
+        // freezes that value at the end of its header (see
+        // [`Document::parse`](crate::Document)) and a cell has no separate
+        // header pass, so without this a cell that lowered
+        // `sectnumlevels` would still number its deeper sections at the
+        // inherited depth. The enclosing cell parse saves and restores
+        // the field, keeping the change scoped to the cell.
         let refresh_cell_sectnumlevels =
             attr_name == "sectnumlevels" && self.nested_document_depth > 0;
 
-        // An explicit assignment supersedes (and resets) any counter of the same
-        // name. This is what lets `:!name:` reset a counter.
+        // An explicit assignment supersedes (and resets) any counter of the
+        // same name. This is what lets `:!name:` reset a counter.
         Arc::make_mut(&mut self.counter_values.borrow_mut()).remove(&attr_name);
 
         // The derived `backend-html5-doctype-*` attribute tracks `doctype`
@@ -3307,8 +3314,9 @@ fn string_succ(current: &str) -> String {
     for &c in chars.iter().rev() {
         if carrying && c.is_ascii_alphanumeric() {
             // Increment within the character's class, carrying on wrap-around.
-            // The arms are exhaustive over ASCII alphanumerics, so the catch-all
-            // can only be `Z` (the one value not matched above).
+            // The arms are exhaustive over ASCII alphanumerics, so the
+            // catch-all can only be `Z` (the one value not matched
+            // above).
             let (next, carry) = match c {
                 '0'..='8' | 'a'..='y' | 'A'..='Y' => ((c as u8 + 1) as char, false),
                 '9' => ('0', true),
@@ -3360,11 +3368,12 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
     //
     // The full Unicode case fold (Asciidoctor's `downcase`, not merely ASCII)
     // is what makes an attribute reference case-insensitive: an entry written
-    // `:He-Man:` is reachable as `{he-man}` or `{HE-MAN}`. A reference is folded
-    // through this same `to_lowercase()` before lookup (see `AttributeReplacer`
-    // in `content::substitution_step`), so definition and reference stay
-    // symmetric even when a fold expands a character (e.g. `İ` -> `i` + combining
-    // dot): both sides land on the identical key.
+    // `:He-Man:` is reachable as `{he-man}` or `{HE-MAN}`. A reference is
+    // folded through this same `to_lowercase()` before lookup (see
+    // `AttributeReplacer` in `content::substitution_step`), so definition
+    // and reference stay symmetric even when a fold expands a character
+    // (e.g. `İ` -> `i` + combining dot): both sides land on the identical
+    // key.
     let attr_name: String = INVALID_ATTR_NAME_CHARS
         .replace_all(raw_attr_name.as_ref(), "")
         .to_lowercase();
@@ -3615,7 +3624,8 @@ mod tests {
                 ModificationContext::Anywhere,
             );
 
-            // The first document overrides the API-configured value in its body.
+            // The first document overrides the API-configured value in its
+            // body.
             let _ = parser.parse(":site: dev\n\nText.\n");
             assert_eq!(
                 parser.attribute_value("site"),
@@ -3638,8 +3648,8 @@ mod tests {
             let _ = parser.parse("Text.\n");
             assert_eq!(parser.attribute_value("env"), InterpretedValue::Unset);
 
-            // A builder call between parses re-establishes the baseline for every
-            // subsequent parse.
+            // A builder call between parses re-establishes the baseline for
+            // every subsequent parse.
             parser = parser.with_intrinsic_attribute("env", "ci", ModificationContext::Anywhere);
 
             let _ = parser.parse("Text.\n");
@@ -3801,8 +3811,8 @@ mod tests {
     #[test]
     fn case_insensitive_attribute_reference_resolves_in_preprocessor() {
         // The preprocessor folds a `{name}` reference the same way the main
-        // substitution pass does, so a mismatched-case reference still drives an
-        // `ifeval` condition.
+        // substitution pass does, so a mismatched-case reference still drives
+        // an `ifeval` condition.
         let doc = Parser::default()
             .parse(":Answer: yes\n\nifeval::[\"{answer}\" == \"yes\"]\nShown.\nendif::[]");
         assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
@@ -3844,8 +3854,9 @@ mod tests {
             SourceLine(Some("inc.adoc".to_owned()), 3)
         );
 
-        // Publish a cell source map (output line 1 came from `cell.adoc` line 2,
-        // the way the preprocessor would record an include-expanded cell).
+        // Publish a cell source map (output line 1 came from `cell.adoc` line
+        // 2, the way the preprocessor would record an include-expanded
+        // cell).
         let mut sm = SourceMap::default();
         sm.append(1, Some("cell.adoc"), 2, crate::parser::Fidelity::Verbatim);
         p.push_owned_cell_source_map(Rc::new(sm));
@@ -3903,8 +3914,8 @@ mod tests {
 
     #[test]
     fn with_intrinsic_attribute_strips_soft_set_modifier() {
-        // A single trailing `@` on an API value is AsciiDoc's soft-set modifier:
-        // it is stripped from the stored value.
+        // A single trailing `@` on an API value is AsciiDoc's soft-set
+        // modifier: it is stripped from the stored value.
         let mut p = Parser::default().with_intrinsic_attribute(
             "myattr",
             "hello@",
@@ -3939,8 +3950,9 @@ mod tests {
 
     #[test]
     fn without_soft_set_modifier_api_value_is_locked() {
-        // The same value *without* the `@` keeps the caller's `ApiOnly` context,
-        // so the document assignment is rejected and the API value stands.
+        // The same value *without* the `@` keeps the caller's `ApiOnly`
+        // context, so the document assignment is rejected and the API
+        // value stands.
         let doc = Parser::default()
             .with_intrinsic_attribute("cash", "heroes", ModificationContext::ApiOnly)
             .parse(":cash: money");
@@ -4034,8 +4046,9 @@ mod tests {
 
     #[test]
     fn api_unset_flexible_attribute_stays_locked() {
-        // An API-*unset* `sectnums` (here via `numbered!`, i.e. the alias set to
-        // `false`) stays locked: a body `:sectnums:` cannot re-enable numbering.
+        // An API-*unset* `sectnums` (here via `numbered!`, i.e. the alias set
+        // to `false`) stays locked: a body `:sectnums:` cannot
+        // re-enable numbering.
         let mut p = Parser::default().with_intrinsic_attribute_bool(
             "numbered",
             false,
@@ -4059,7 +4072,8 @@ mod tests {
     // crate-specific edge cases not exercised by the single upstream test.
     #[test]
     fn masks_docdir_and_docfile_under_secure_mode() {
-        // Secure (the default) is stricter than Server, so masking also applies.
+        // Secure (the default) is stricter than Server, so masking also
+        // applies.
         let p = Parser::default()
             .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
             .with_intrinsic_attribute(
@@ -4155,8 +4169,9 @@ mod tests {
 
     #[test]
     fn unset_docdir_and_docfile_stay_missing_under_server_mode() {
-        // Masking never conjures a value for an attribute that was never set, so
-        // a reference to an unset `docdir` / `docfile` still resolves as missing.
+        // Masking never conjures a value for an attribute that was never set,
+        // so a reference to an unset `docdir` / `docfile` still
+        // resolves as missing.
         let p = Parser::default().with_safe_mode(SafeMode::Server);
         assert_eq!(p.attribute_value("docdir"), InterpretedValue::Unset);
         assert_eq!(p.attribute_value("docfile"), InterpretedValue::Unset);
@@ -4324,10 +4339,11 @@ mod tests {
     #[test]
     fn asciidoctor_flag_is_predefined() {
         // The crate predefines the always-set `asciidoctor` boolean flag, so a
-        // document guarding Asciidoctor-only content with `ifdef::asciidoctor[]`
-        // behaves the same here. A `////` comment block containing a directive
-        // that would corrupt it once the flag is defined must stay untouched
-        // (see issue #810).
+        // document guarding Asciidoctor-only content with
+        // `ifdef::asciidoctor[]` behaves the same here. A `////`
+        // comment block containing a directive that would corrupt it
+        // once the flag is defined must stay untouched (see issue
+        // #810).
         let mut parser = Parser::default();
 
         assert_eq!(parser.attribute_value("asciidoctor"), InterpretedValue::Set);
@@ -4393,9 +4409,9 @@ mod tests {
     #[test]
     fn silently_locked_intrinsic_rejects_header_and_body_without_warning() {
         // A silently-locked `ApiOnly` intrinsic (as a converter would seed a
-        // safe-mode-restricted attribute) rejects both a header assignment and a
-        // body assignment of the same name, leaving the value unchanged and
-        // recording no warning.
+        // safe-mode-restricted attribute) rejects both a header assignment and
+        // a body assignment of the same name, leaving the value
+        // unchanged and recording no warning.
         let mut parser = Parser::default().with_intrinsic_attribute_silent(
             "backend",
             "html5",
@@ -4946,9 +4962,10 @@ mod tests {
         #[test]
         fn turning_the_toggle_on_leaves_no_partner_tombstone() {
             // `:notitle:` removes `showtitle` outright rather than leaving an
-            // unset tombstone, so a `{showtitle}` reference stays literal (as it
-            // would with the attribute absent) instead of resolving to an empty
-            // string. This guards the interaction flagged in review.
+            // unset tombstone, so a `{showtitle}` reference stays literal (as
+            // it would with the attribute absent) instead of
+            // resolving to an empty string. This guards the
+            // interaction flagged in review.
             let parser = parse_header(":notitle:");
             assert!(!parser.has_attribute("showtitle"));
 
@@ -4963,8 +4980,8 @@ mod tests {
 
         #[test]
         fn unrelated_attributes_are_untouched() {
-            // A document that never assigns either spelling leaves both absent —
-            // the linkage is a no-op for every other attribute.
+            // A document that never assigns either spelling leaves both absent
+            // — the linkage is a no-op for every other attribute.
             let parser = parse_header(":sectnums:");
             assert!(!parser.has_attribute("notitle"));
             assert!(!parser.has_attribute("showtitle"));
@@ -5183,8 +5200,8 @@ mod tests {
         fn tracks_the_active_doctype() {
             let mut parser = Parser::default();
 
-            // The default doctype is `article`, so only its derived attribute is
-            // defined (to an empty value).
+            // The default doctype is `article`, so only its derived attribute
+            // is defined (to an empty value).
             assert_eq!(
                 parser.attribute_value("backend-html5-doctype-article"),
                 InterpretedValue::Value(String::new())
@@ -5239,9 +5256,10 @@ mod tests {
         #[test]
         fn document_header_cannot_assign_a_derived_doctype_flag() {
             // The `backend-html5-doctype-*` namespace is a read-only intrinsic,
-            // so a document header assignment to it is ignored: the flag for the
-            // (inactive) `book` doctype stays undefined rather than taking the
-            // assigned value, so it cannot later shadow the intrinsic.
+            // so a document header assignment to it is ignored: the flag for
+            // the (inactive) `book` doctype stays undefined rather
+            // than taking the assigned value, so it cannot later
+            // shadow the intrinsic.
             let mut parser = Parser::default();
             let _doc = parser.parse("= Title\n:backend-html5-doctype-book: custom\n\nbody");
 
@@ -5282,9 +5300,9 @@ mod tests {
         #[test]
         fn family_tracks_a_non_html_backend() {
             // Setting a different backend re-derives the whole family from it
-            // (basebackend strips the trailing digits, filetype maps through the
-            // Asciidoctor extension table), and the inactive `html5` flags fall
-            // away.
+            // (basebackend strips the trailing digits, filetype maps through
+            // the Asciidoctor extension table), and the inactive
+            // `html5` flags fall away.
             let doc = Parser::default().parse(":backend: docbook5\n\nbody");
 
             assert_eq!(
@@ -5317,8 +5335,8 @@ mod tests {
         #[test]
         fn derived_value_and_flag_attributes_are_read_only() {
             // `basebackend` / `filetype` and the derived flag namespace are
-            // read-only intrinsics; a document assignment is silently ignored and
-            // the synthesized value stands.
+            // read-only intrinsics; a document assignment is silently ignored
+            // and the synthesized value stands.
             let doc = Parser::default().parse(
                 ":basebackend: custom\n:filetype: custom\n:backend-html5: custom\n:doctype-article: custom\n\nbody",
             );
@@ -5392,7 +5410,8 @@ mod tests {
                 assert!(!doc.has_attribute(name), "unexpectedly present: {name:?}");
             }
 
-            // The doctype-only flag does not depend on `backend`, so it remains.
+            // The doctype-only flag does not depend on `backend`, so it
+            // remains.
             assert!(doc.has_attribute("doctype-article"));
         }
     }
@@ -5407,8 +5426,8 @@ mod tests {
 
         #[test]
         fn explicit_attribute_takes_precedence() {
-            // An explicitly-set `docname` attribute is the source of truth, even
-            // when no primary file name has been supplied.
+            // An explicitly-set `docname` attribute is the source of truth,
+            // even when no primary file name has been supplied.
             assert_eq!(
                 Parser::default()
                     .with_intrinsic_attribute("docname", "test", ModificationContext::ApiOnly)
@@ -5420,9 +5439,10 @@ mod tests {
 
         #[test]
         fn explicit_attribute_overrides_primary_file_name() {
-            // When both are present, the attribute wins and is returned verbatim
-            // (no directory/extension stripping), mirroring Asciidoctor's
-            // `doc.attributes['docname']` being the single source of truth.
+            // When both are present, the attribute wins and is returned
+            // verbatim (no directory/extension stripping),
+            // mirroring Asciidoctor's `doc.attributes['docname']`
+            // being the single source of truth.
             assert_eq!(
                 Parser::default()
                     .with_primary_file_name("mydoc.adoc")
@@ -5544,14 +5564,15 @@ mod tests {
 
         #[test]
         fn next_counter_value_trailing_non_alphanumeric() {
-            // The right-most alphanumeric is incremented; trailing punctuation is
-            // left in place.
+            // The right-most alphanumeric is incremented; trailing punctuation
+            // is left in place.
             assert_eq!(next_counter_value("a)"), "b)");
         }
 
         #[test]
         fn next_counter_value_no_alphanumeric() {
-            // With nothing alphanumeric to carry, the final code point advances.
+            // With nothing alphanumeric to carry, the final code point
+            // advances.
             assert_eq!(next_counter_value("{"), "|");
         }
 
@@ -5644,8 +5665,8 @@ mod tests {
 
         #[test]
         fn conditional_directive_sees_a_computed_date_attribute() {
-            // `ifdef` queries `is_attribute_set`, which must report the computed
-            // `docdate` as set.
+            // `ifdef` queries `is_attribute_set`, which must report the
+            // computed `docdate` as set.
             let doc = Parser::default()
                 .with_reference_time(ReferenceTime::from_unix_timestamp(1_420_106_400))
                 .parse("ifdef::docdate[present]");

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -90,8 +90,9 @@ impl PathResolver for DefaultPathResolver {
 
         let mut uri_prefix: Option<String> = None;
 
-        // Ruby treats a `nil` *or* empty `start` the same (`start.nil_or_empty?`):
-        // in both cases the target is used as-is, with no start path prepended.
+        // Ruby treats a `nil` *or* empty `start` the same
+        // (`start.nil_or_empty?`): in both cases the target is used
+        // as-is, with no start path prepended.
         let start_is_empty = start.as_deref().is_none_or(str::is_empty);
 
         if !(start_is_empty || self.is_web_root(&target)) {
@@ -166,9 +167,10 @@ impl DefaultPathResolver {
     fn partition_path(&self, path: &str, web: WebPath) -> (Vec<String>, Option<String>) {
         // Ruby memoizes partition results per (path, web) in a hash. That cache
         // exists to avoid Ruby's comparatively expensive string work; here the
-        // partitioning is cheap and the resolver takes `&self`, so caching would
-        // require interior mutability that the derived `Clone`/`Eq` would then
-        // have to skip. Deliberately not ported.
+        // partitioning is cheap and the resolver takes `&self`, so caching
+        // would require interior mutability that the derived
+        // `Clone`/`Eq` would then have to skip. Deliberately not
+        // ported.
         let posix_path = self.posixify(path);
 
         let root: Option<String> = if web.0 {
@@ -187,13 +189,15 @@ impl DefaultPathResolver {
                 // ex. /sample/path
                 Some("/".to_owned())
             } else if posix_path.starts_with(URI_CLASSLOADER) {
-                // ex. uri:classloader:sample/path (or uri:classloader:/sample/path)
+                // ex. uri:classloader:sample/path (or
+                // uri:classloader:/sample/path)
                 Some(URI_CLASSLOADER.to_owned())
             } else {
                 // ex. C:/sample/path (or file:///sample/path in browser
                 // environment). The root is everything up to and including the
-                // first slash. `is_root` guarantees a slash for the drive-letter
-                // case, so `None` here is unreachable in practice.
+                // first slash. `is_root` guarantees a slash for the
+                // drive-letter case, so `None` here is
+                // unreachable in practice.
                 posix_path
                     .find('/')
                     .map(|slash| posix_path[..=slash].to_owned())
@@ -219,10 +223,11 @@ impl DefaultPathResolver {
             .collect();
 
         // Ruby builds these segments with `posix_path.split SLASH`, and Ruby's
-        // `String#split` drops trailing empty fields (e.g. `'a/b/'.split '/'` is
-        // `['a', 'b']`, and `''.split '/'` is `[]`). Rust's `str::split` keeps
-        // them, so strip trailing empties to match — otherwise a trailing slash
-        // would survive as a spurious empty final segment.
+        // `String#split` drops trailing empty fields (e.g. `'a/b/'.split '/'`
+        // is `['a', 'b']`, and `''.split '/'` is `[]`). Rust's
+        // `str::split` keeps them, so strip trailing empties to match —
+        // otherwise a trailing slash would survive as a spurious empty
+        // final segment.
         while path_segments.last().is_some_and(|s| s.is_empty()) {
             path_segments.pop();
         }
@@ -542,8 +547,8 @@ mod tests {
             // `String#split('/')` drops *all* trailing empty fields, so
             // `partition_path` yields no segments and the rooted path collapses
             // to `/`. This guards the trailing-empty-segment stripping in
-            // `partition_path` against regressing to a one-shot pop (which would
-            // leave `//`, `///`, etc.).
+            // `partition_path` against regressing to a one-shot pop (which
+            // would leave `//`, `///`, etc.).
             let pr = DefaultPathResolver::default();
 
             assert_eq!(pr.web_path("/", None), "/");

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -311,9 +311,10 @@ impl<'p> PreprocessorState<'p> {
             }
 
             // The lines of a `[comment]` paragraph after its first are likewise
-            // raw, up to the blank line that ends the paragraph. (Its first line
-            // is still processed, matching Asciidoctor's one-line look-ahead: by
-            // the time a paragraph is recognized as a comment, the reader has
+            // raw, up to the blank line that ends the paragraph. (Its first
+            // line is still processed, matching Asciidoctor's
+            // one-line look-ahead: by the time a paragraph is
+            // recognized as a comment, the reader has
             // already visited that line.)
             if in_comment_paragraph {
                 if line.data().is_empty() {
@@ -330,9 +331,10 @@ impl<'p> PreprocessorState<'p> {
             }
 
             // Conditional preprocessor directives (`ifdef`, `ifndef`, `ifeval`,
-            // `endif`) are handled before anything else so they take effect even
-            // while a surrounding conditional is skipping (the nesting still has
-            // to be tracked to balance the stack).
+            // `endif`) are handled before anything else so they take effect
+            // even while a surrounding conditional is skipping (the
+            // nesting still has to be tracked to balance the
+            // stack).
             if has_conditional_prefix(line.data())
                 && let Some(caps) = CONDITIONAL_DIRECTIVE.captures(line.data())
             {
@@ -351,7 +353,8 @@ impl<'p> PreprocessorState<'p> {
                     // Escaped directive (e.g. `\ifdef::foo[]`): not processed.
                     // The leading backslash is stripped and the remainder is
                     // emitted literally, matching Asciidoctor — unless we're
-                    // skipping, in which case it's discarded like any other line.
+                    // skipping, in which case it's discarded like any other
+                    // line.
                     if !self.skipping() {
                         // The leading backslash is removed, so the emitted line
                         // no longer matches the origin column-for-column.
@@ -384,16 +387,16 @@ impl<'p> PreprocessorState<'p> {
                 continue;
             }
 
-            // A `////` line (four or more slashes, nothing else) opens a comment
-            // block. Its content is raw, so it is emitted verbatim and no
-            // directive within it is processed until the matching closing
-            // delimiter. See issue #810.
+            // A `////` line (four or more slashes, nothing else) opens a
+            // comment block. Its content is raw, so it is emitted
+            // verbatim and no directive within it is processed
+            // until the matching closing delimiter. See issue #810.
             if is_comment_block_delimiter(line.data()) {
                 comment_block_delimiter = Some(line.data().to_owned());
 
-                // A `////` block is self-identifying, so it consumes any pending
-                // `[comment]` style; clearing it keeps the block that follows
-                // this one independent.
+                // A `////` block is self-identifying, so it consumes any
+                // pending `[comment]` style; clearing it keeps
+                // the block that follows this one independent.
                 comment_style_pending = false;
                 self.emit_line(
                     line.data(),
@@ -406,11 +409,12 @@ impl<'p> PreprocessorState<'p> {
             }
 
             // With a `[comment]` block style pending, classify the block it
-            // introduces. An open block (`--`) is a comment block, raw up to the
-            // closing `--`; otherwise the block is a comment paragraph, whose
-            // lines after the first are raw (see above). Further block metadata
-            // (a title `.text`, an anchor or attribute list `[…]`) may sit
-            // between the `[comment]` line and the block it styles; the pending
+            // introduces. An open block (`--`) is a comment block, raw up to
+            // the closing `--`; otherwise the block is a comment
+            // paragraph, whose lines after the first are raw (see
+            // above). Further block metadata (a title `.text`, an
+            // anchor or attribute list `[…]`) may sit between the
+            // `[comment]` line and the block it styles; the pending
             // style holds across it until the block itself is reached.
             if comment_style_pending {
                 if line.data() == "--" {
@@ -434,8 +438,8 @@ impl<'p> PreprocessorState<'p> {
                     // content is preprocessed with fresh comment state, so a
                     // directive on its own subsequent lines is still evaluated.
                     // That case (an include on the very first line of a comment
-                    // paragraph) is an accepted limitation of preprocessing in a
-                    // separate pass.
+                    // paragraph) is an accepted limitation of preprocessing in
+                    // a separate pass.
                     if !line.data().is_empty() {
                         in_comment_paragraph = true;
                     }
@@ -444,10 +448,11 @@ impl<'p> PreprocessorState<'p> {
             }
 
             // A block attribute list sets or replaces the pending block style:
-            // `[comment]` marks the upcoming block a comment, another positional
-            // style (`[source]`, …) overrides it, and a bracketed line without a
-            // positional style (an anchor `[[id]]`, a shorthand- or named-only
-            // list) leaves the pending style unchanged.
+            // `[comment]` marks the upcoming block a comment, another
+            // positional style (`[source]`, …) overrides it, and a
+            // bracketed line without a positional style (an anchor
+            // `[[id]]`, a shorthand- or named-only list) leaves the
+            // pending style unchanged.
             if let Some(is_comment) = self.attrlist_block_style_is_comment(line.data()) {
                 comment_style_pending = is_comment;
             }
@@ -457,10 +462,11 @@ impl<'p> PreprocessorState<'p> {
                 && (line.ends_with(':') || line.contains(": "))
                 && let Some(attr) = Attribute::parse(original_source, self.parser)
             {
-                // Process attribute entries so they're available for include directives. NOTE:
-                // We ignore warnings here since this is a quick pass through the content.
-                // Later, `Block::parse` will see the same warnings, if they occur, and will
-                // actually record them.
+                // Process attribute entries so they're available for include
+                // directives. NOTE: We ignore warnings here
+                // since this is a quick pass through the content.
+                // Later, `Block::parse` will see the same warnings, if they
+                // occur, and will actually record them.
                 self.record_origin(
                     file_name,
                     source_line_number,
@@ -501,9 +507,10 @@ impl<'p> PreprocessorState<'p> {
                 // If none of the above apply, add the line to output.
                 //
                 // An escaped include directive (e.g. `\include::foo[]`) is not
-                // processed. The leading backslash is removed and the remainder is
-                // emitted literally, matching Asciidoctor. The backslash is only
-                // removed when what follows is actually an include directive; a
+                // processed. The leading backslash is removed and the remainder
+                // is emitted literally, matching Asciidoctor.
+                // The backslash is only removed when what
+                // follows is actually an include directive; a
                 // backslash followed by anything else is left untouched.
                 let escaped_include = line.starts_with("\\include::")
                     && INCLUDE_DIRECTIVE.is_match(&line.data()[1..]);
@@ -1102,13 +1109,14 @@ impl<'p> PreprocessorState<'p> {
                 let attr_name = &caps[2];
 
                 // A backslash immediately before the opening brace (`\{id}`) or
-                // before the closing brace (`{id\}`) — or both, as in `\{id\}` —
-                // escapes the reference: it is emitted literally with the
-                // escaping backslash(es) removed, whether or not the attribute is
-                // set. This mirrors the content-substitution path and
-                // Asciidoctor's `sub_attributes`, which returns `{#{name}}` when
-                // either its leading or trailing backslash capture is present
-                // (see issue #667).
+                // before the closing brace (`{id\}`) — or both, as in `\{id\}`
+                // — escapes the reference: it is emitted
+                // literally with the escaping backslash(es)
+                // removed, whether or not the attribute is set.
+                // This mirrors the content-substitution path and
+                // Asciidoctor's `sub_attributes`, which returns `{#{name}}`
+                // when either its leading or trailing backslash
+                // capture is present (see issue #667).
                 if caps.get(1).is_some() || caps.get(3).is_some() {
                     dest.push('{');
                     dest.push_str(attr_name);
@@ -1117,9 +1125,10 @@ impl<'p> PreprocessorState<'p> {
                 }
 
                 // Resolve case-insensitively: attribute names are stored
-                // lower-cased, so the lookup name is folded the same way (see the
-                // content-substitution path in `content::substitution_step` and
-                // Asciidoctor's `key = $2.downcase`).
+                // lower-cased, so the lookup name is folded the same way (see
+                // the content-substitution path in
+                // `content::substitution_step` and Asciidoctor'
+                // s `key = $2.downcase`).
                 let lookup_name = attribute_lookup_name(attr_name);
 
                 if !self.parser.has_attribute(&lookup_name) {
@@ -1368,8 +1377,8 @@ impl<'p> PreprocessorState<'p> {
 
         // `ifdef` / `ifndef`.
         if target.is_empty() {
-            // Malformed: a target (attribute name) is required. Dropped, with an
-            // error logged unless already skipping.
+            // Malformed: a target (attribute name) is required. Dropped, with
+            // an error logged unless already skipping.
             if !already_skipping {
                 self.emit_conditional_warning(
                     WarningType::MalformedConditionalDirective(
@@ -1395,8 +1404,8 @@ impl<'p> PreprocessorState<'p> {
                 source_line: source_line_number,
             });
         } else if !already_skipping && self.eval_ifdef(keyword, target) {
-            // Single-line form: the bracketed content is included in place (with
-            // no `endif`) when the condition holds.
+            // Single-line form: the bracketed content is included in place
+            // (with no `endif`) when the condition holds.
             self.process_single_line_content(
                 content,
                 file_name,
@@ -1505,10 +1514,11 @@ impl<'p> PreprocessorState<'p> {
         source_line_number: usize,
         has_reported_file: &mut bool,
     ) {
-        // A single-line conditional whose body is itself an include directive is
-        // re-fed through include processing rather than emitted literally,
-        // matching Asciidoctor: its reader restores the body as the next line and
-        // decrements the look-ahead so a line beginning `include::` is processed
+        // A single-line conditional whose body is itself an include directive
+        // is re-fed through include processing rather than emitted
+        // literally, matching Asciidoctor: its reader restores the body
+        // as the next line and decrements the look-ahead so a line
+        // beginning `include::` is processed
         // again (`replace_next_line`/`@look_ahead -= 1`). The body is right-
         // trimmed first (Asciidoctor's `replace_next_line text.rstrip`) so the
         // anchored include-directive pattern still matches.
@@ -1542,7 +1552,8 @@ impl<'p> PreprocessorState<'p> {
         }
 
         // The bracketed content is spliced in from within the directive line
-        // (`ifdef::name[content]`), so its columns do not align with the origin.
+        // (`ifdef::name[content]`), so its columns do not align with the
+        // origin.
         self.emit_line(
             content,
             file_name,
@@ -1551,11 +1562,12 @@ impl<'p> PreprocessorState<'p> {
             has_reported_file,
         );
 
-        // The main attribute-entry handler leaves `can_have_attribute` unchanged
-        // so that consecutive attribute entries are all applied by the
-        // preprocessor (and thus observed by later include targets); `emit_line`
-        // would instead clear it for this non-empty line. Restore the invariant
-        // when the single-line content was itself an attribute entry.
+        // The main attribute-entry handler leaves `can_have_attribute`
+        // unchanged so that consecutive attribute entries are all
+        // applied by the preprocessor (and thus observed by later
+        // include targets); `emit_line` would instead clear it for this
+        // non-empty line. Restore the invariant when the single-line
+        // content was itself an attribute entry.
         if applied_attribute {
             self.can_have_attribute = can_have_attribute;
         }
@@ -1627,7 +1639,8 @@ impl<'p> PreprocessorState<'p> {
     fn resolve_expr_val(&self, raw: &str) -> Value {
         let raw = raw.trim();
 
-        // A value wrapped in matching single or double quotes is always a string.
+        // A value wrapped in matching single or double quotes is always a
+        // string.
         let quoted_inner = raw
             .strip_prefix('"')
             .and_then(|s| s.strip_suffix('"'))
@@ -2094,9 +2107,10 @@ fn is_absolute_path(path: &str) -> bool {
 /// `includes` field of [`PreprocessorState`]), so the key is always relative to
 /// that document — the coordinate system an inter-document xref target uses.
 fn include_catalog_key(target: &str) -> &str {
-    // `target` names an AsciiDoc file, so its final `.`-delimited segment is the
-    // extension to strip; only the trailing extension is removed, so a path that
-    // contains a period elsewhere (`using-.net-web-services.adoc`) keeps it.
+    // `target` names an AsciiDoc file, so its final `.`-delimited segment is
+    // the extension to strip; only the trailing extension is removed, so a
+    // path that contains a period elsewhere
+    // (`using-.net-web-services.adoc`) keeps it.
     match target.rsplit_once('.') {
         Some((stem, _ext)) if !stem.is_empty() => stem,
         _ => target,
@@ -2227,12 +2241,14 @@ enum TagFilterDiagnostic {
 /// line; `from..to` is inclusive; an empty or negative end (`from..` or
 /// `from..-1`) extends to the end of the file.
 fn select_by_line_ranges(text: &str, spec: &str) -> String {
-    // Each range is `(from, Some(to))` or `(from, None)` for an open-ended range.
+    // Each range is `(from, Some(to))` or `(from, None)` for an open-ended
+    // range.
     let ranges: Vec<(usize, Option<usize>)> = split_delimited_value(spec)
         .map(|entry| {
             if let Some((from, to)) = entry.split_once("..") {
-                // A non-numeric start coerces to 0, matching Ruby `String#to_i`.
-                // Since line numbers are 1-based this behaves the same as a start
+                // A non-numeric start coerces to 0, matching Ruby
+                // `String#to_i`. Since line numbers are 1-based
+                // this behaves the same as a start
                 // of 1 (the range still begins at the first line).
                 let from = from.trim().parse().unwrap_or(0);
                 let to = to.trim();
@@ -2353,8 +2369,8 @@ fn select_by_tags(text: &str, spec: &str) -> (String, Vec<TagFilterDiagnostic>) 
     let mut select = base_select;
     let mut active_tag: Option<String> = None;
 
-    // Each entry records the tag name and the `select` state to restore when the
-    // region is closed.
+    // Each entry records the tag name and the `select` state to restore when
+    // the region is closed.
     let mut tag_stack: Vec<(String, bool)> = vec![];
 
     for line in text.lines() {
@@ -2373,12 +2389,14 @@ fn select_by_tags(text: &str, spec: &str) -> (String, Vec<TagFilterDiagnostic>) 
                         }
                     }
                 } else if let Some(idx) = tag_stack.iter().rposition(|(n, _)| n == name) {
-                    // The named region is open, but it is not the innermost one:
-                    // an inner region was left unclosed. Report the mismatch and
+                    // The named region is open, but it is not the innermost
+                    // one: an inner region was left
+                    // unclosed. Report the mismatch and
                     // close the named region (the still-open inner regions are
                     // reported as unclosed at end of file). This matches
-                    // Asciidoctor, which removes the matched entry from the stack
-                    // while leaving the active (innermost) region in effect.
+                    // Asciidoctor, which removes the matched entry from the
+                    // stack while leaving the active
+                    // (innermost) region in effect.
                     diagnostics.push(TagFilterDiagnostic::MismatchedEnd {
                         expected: active_tag.clone().unwrap_or_default(),
                         found: name.to_string(),
@@ -2400,8 +2418,9 @@ fn select_by_tags(text: &str, spec: &str) -> (String, Vec<TagFilterDiagnostic>) 
                 select = if let Some(named) = lookup(name) {
                     named
                 } else if let Some(wildcard) = wildcard {
-                    // An unnamed region uses the wildcard default, unless we are
-                    // already inside an unselected region (then it stays excluded).
+                    // An unnamed region uses the wildcard default, unless we
+                    // are already inside an unselected
+                    // region (then it stays excluded).
                     if active_tag.is_some() && !select {
                         false
                     } else {
@@ -2592,7 +2611,8 @@ fn adjust_indentation(lines: &mut [String], indent: usize) {
     };
 
     if offset == 0 {
-        // At least one line is flush left, so the `indent` attribute is ignored.
+        // At least one line is flush left, so the `indent` attribute is
+        // ignored.
         return;
     }
 
@@ -3199,7 +3219,8 @@ mod tests {
             "= Document Title\n\nUnresolved directive in main.adoc - include::missing.adoc[]\n\nMore content.\n"
         );
 
-        // With no handler at all, the include is likewise unresolved and warned.
+        // With no handler at all, the include is likewise unresolved and
+        // warned.
         assert_eq!(warnings.len(), 1);
         assert_eq!(
             warnings[0].warning,
@@ -3248,8 +3269,8 @@ mod tests {
 
     #[test]
     fn asciidoc_include_processes_nested_directives() {
-        // An included AsciiDoc file is run through the preprocessor, so a nested
-        // include within it is expanded.
+        // An included AsciiDoc file is run through the preprocessor, so a
+        // nested include within it is expanded.
         let source = "include::outer.adoc[]";
 
         let handler = InlineFileHandler::from_pairs([
@@ -3269,8 +3290,9 @@ mod tests {
 
     #[test]
     fn non_asciidoc_include_merged_verbatim() {
-        // A non-AsciiDoc file (here `.csv`) is merged verbatim: a nested include
-        // directive within it is left as literal text, not expanded.
+        // A non-AsciiDoc file (here `.csv`) is merged verbatim: a nested
+        // include directive within it is left as literal text, not
+        // expanded.
         let source = "include::data.csv[]";
 
         let handler = InlineFileHandler::from_pairs([
@@ -3301,9 +3323,10 @@ mod tests {
 
     #[test]
     fn non_asciidoc_include_in_body_tracks_header_state() {
-        // A non-AsciiDoc include placed in the document body (so the preprocessor
-        // is past the header) whose content includes a blank line exercises the
-        // verbatim path's header-state updates for both blank and non-blank lines.
+        // A non-AsciiDoc include placed in the document body (so the
+        // preprocessor is past the header) whose content includes a
+        // blank line exercises the verbatim path's header-state updates
+        // for both blank and non-blank lines.
         let source = "Body.\n\ninclude::data.csv[]";
 
         let handler = InlineFileHandler::from_pairs([("data.csv", "row one\n\nrow two")]);
@@ -3320,8 +3343,9 @@ mod tests {
 
     #[test]
     fn optional_include_dropped_silently() {
-        // `opts=optional` drops an unresolved include with no output text and no
-        // warning, while keeping the source map aligned for the lines that follow.
+        // `opts=optional` drops an unresolved include with no output text and
+        // no warning, while keeping the source map aligned for the
+        // lines that follow.
         let source = "Before.\n\ninclude::missing.adoc[opts=optional]\n\nAfter.";
 
         // Handler doesn't provide missing.adoc.
@@ -3334,7 +3358,8 @@ mod tests {
 
         let (processed_source, source_map, warnings, _includes) = preprocess(source, &parser);
 
-        // The directive line is gone; no "Unresolved directive" text is inserted.
+        // The directive line is gone; no "Unresolved directive" text is
+        // inserted.
         assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
         assert!(warnings.is_empty());
 
@@ -3386,10 +3411,10 @@ mod tests {
 
     #[test]
     fn include_target_with_missing_attribute_is_dropped_under_drop_line() {
-        // `attribute-missing=drop-line` drops the entire directive line: nothing
-        // is emitted in its place, no warning is recorded, and the include file
-        // handler is never consulted. The source map stays aligned for the lines
-        // that follow. See issue #776.
+        // `attribute-missing=drop-line` drops the entire directive line:
+        // nothing is emitted in its place, no warning is recorded, and
+        // the include file handler is never consulted. The source map
+        // stays aligned for the lines that follow. See issue #776.
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[]\n\nAfter.";
 
         let (processed_source, source_map, warnings, _includes) =
@@ -3434,8 +3459,9 @@ mod tests {
     fn include_target_with_missing_attribute_warns_under_warn() {
         // `attribute-missing=warn` leaves the "Unresolved directive" message in
         // place of the directive and records a warning naming the whole
-        // directive (Asciidoctor maps `warn` to `drop-line` when substituting an
-        // include target, so the target is emptied and never resolved).
+        // directive (Asciidoctor maps `warn` to `drop-line` when substituting
+        // an include target, so the target is emptied and never
+        // resolved).
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[]\n\nAfter.";
 
         let (processed_source, _source_map, warnings, _includes) =
@@ -3485,8 +3511,9 @@ mod tests {
 
     #[test]
     fn escaped_include_directive() {
-        // An escaped include directive is not processed. The leading backslash is
-        // stripped and the remainder is emitted literally (matching Asciidoctor).
+        // An escaped include directive is not processed. The leading backslash
+        // is stripped and the remainder is emitted literally (matching
+        // Asciidoctor).
         let source = "Before.\n\n\\include::partial.adoc[]\n\nAfter.";
 
         let handler = InlineFileHandler::from_pairs([("partial.adoc", "SHOULD NOT APPEAR")]);
@@ -3511,8 +3538,9 @@ mod tests {
 
     #[test]
     fn escaped_include_directive_without_primary_file() {
-        // The backslash is stripped even when there is no primary file name (and
-        // thus no include handler) so the escape behaves identically.
+        // The backslash is stripped even when there is no primary file name
+        // (and thus no include handler) so the escape behaves
+        // identically.
         let source = "\\include::partial.adoc[]";
         let parser = Parser::default();
         let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
@@ -3521,8 +3549,8 @@ mod tests {
 
     #[test]
     fn escaped_non_directive_is_unchanged() {
-        // A backslash followed by something that is not a valid include directive
-        // (here, no attribute brackets) is left untouched.
+        // A backslash followed by something that is not a valid include
+        // directive (here, no attribute brackets) is left untouched.
         let source = "\\include::partial.adoc";
         let parser = Parser::default().with_primary_file_name("main.adoc");
         let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
@@ -3758,9 +3786,9 @@ mod tests {
         // A backslash before the closing brace (`{missing\}`) — or both braces
         // (`\{missing\}`) — escapes the reference the same way a leading
         // backslash does: every escaping backslash is removed and the reference
-        // is left unexpanded, so the include target resolves against the literal
-        // `{missing}` form. This matches the content-substitution path and
-        // Asciidoctor.
+        // is left unexpanded, so the include target resolves against the
+        // literal `{missing}` form. This matches the
+        // content-substitution path and Asciidoctor.
         let source = "include::pre{missing\\}mid\\{missing\\}post.adoc[]";
 
         let handler = InlineFileHandler::from_pairs([(
@@ -3862,11 +3890,12 @@ mod tests {
     fn attribute_substitution_with_multiline_attribute() {
         let source = ":longpath: very/long/path/to/some/ \\\nsubdirectory\n:ext: adoc\n\ninclude::{longpath}/file.{ext}[]";
 
-        // A soft-wrap line continuation folds the ` \` marker, the newline, and any
-        // ensuing indentation into a single space (see the `wrap_values` spec test).
-        // So `{longpath}` correctly resolves to "very/long/path/to/some/ subdirectory"
-        // *with* the space, matching Asciidoctor. The space is inherent to soft
-        // wrapping, not a stray artifact.
+        // A soft-wrap line continuation folds the ` \` marker, the newline, and
+        // any ensuing indentation into a single space (see the
+        // `wrap_values` spec test). So `{longpath}` correctly resolves
+        // to "very/long/path/to/some/ subdirectory" *with* the space,
+        // matching Asciidoctor. The space is inherent to soft wrapping,
+        // not a stray artifact.
         let handler = InlineFileHandler::from_pairs([(
             "very/long/path/to/some/ subdirectory/file.adoc",
             "Multi-line attribute worked!",
@@ -3992,9 +4021,9 @@ mod tests {
 
     #[test]
     fn ifdef_single_line_include_in_brackets_honors_rstrip() {
-        // Asciidoctor right-trims the single-line body before re-reading it, so a
-        // trailing space inside the brackets still leaves an include directive
-        // the anchored pattern matches.
+        // Asciidoctor right-trims the single-line body before re-reading it, so
+        // a trailing space inside the brackets still leaves an include
+        // directive the anchored pattern matches.
         let handler = InlineFileHandler::from_pairs([("snippet.adoc", "snippet content\n")]);
 
         let parser = Parser::default()
@@ -4013,10 +4042,11 @@ mod tests {
         // An *escaped* include in a single-line conditional body is emitted
         // literally with its backslash intact, matching Asciidoctor. Its reader
         // decrements the look-ahead — forcing the body to be re-read as an
-        // include — only when the body starts with the unescaped `include::`, so
-        // `\include::…` is left as written rather than being unescaped the way a
-        // normal reader line is. A normal line `\include::…` does drop the
-        // backslash; the two paths legitimately differ.
+        // include — only when the body starts with the unescaped `include::`,
+        // so `\include::…` is left as written rather than being
+        // unescaped the way a normal reader line is. A normal line
+        // `\include::…` does drop the backslash; the two paths
+        // legitimately differ.
         let handler = InlineFileHandler::from_pairs([("snippet.adoc", "snippet content\n")]);
 
         let parser = Parser::default()
@@ -4032,9 +4062,10 @@ mod tests {
 
     #[test]
     fn ifdef_single_line_include_in_brackets_becomes_link_when_secure() {
-        // At `SafeMode::Secure` (the default) the include directive is disabled,
-        // so the single-line body is rewritten to a link to its target — the
-        // same rewrite a top-level include gets — rather than being resolved.
+        // At `SafeMode::Secure` (the default) the include directive is
+        // disabled, so the single-line body is rewritten to a link to
+        // its target — the same rewrite a top-level include gets —
+        // rather than being resolved.
         assert_eq!(
             conditional_output(":foo:\n\nifdef::foo[include::snippet.adoc[]]"),
             ":foo:\n\nlink:snippet.adoc[role=include]\n"
@@ -4080,8 +4111,8 @@ mod tests {
 
     #[test]
     fn comment_open_block_suppresses_conditional_directive() {
-        // A `[comment]`-styled open block (`--`) is a comment block: a directive
-        // within it is emitted verbatim.
+        // A `[comment]`-styled open block (`--`) is a comment block: a
+        // directive within it is emitted verbatim.
         assert_eq!(
             conditional_output("[comment]\n--\nfirst\nifdef::foo[dropped]\nlast\n--\n\ntail"),
             "[comment]\n--\nfirst\nifdef::foo[dropped]\nlast\n--\n\ntail\n"
@@ -4127,9 +4158,9 @@ mod tests {
 
     #[test]
     fn later_style_overrides_comment_style() {
-        // A positional style on a later attribute list (`[source]`) overrides an
-        // earlier `[comment]`, so the block is a real listing and an `include::`
-        // within it is processed rather than left raw.
+        // A positional style on a later attribute list (`[source]`) overrides
+        // an earlier `[comment]`, so the block is a real listing and an
+        // `include::` within it is processed rather than left raw.
         let source = "[comment]\n[source]\n----\ninclude::sub.adoc[]\n----\n";
         let handler = InlineFileHandler::from_pairs([("sub.adoc", "Included.")]);
         let parser = Parser::default()
@@ -4155,9 +4186,9 @@ mod tests {
 
     #[test]
     fn comment_style_carried_across_metadata_before_open_block() {
-        // The same carry-across applies before a `[comment]` open block: a title
-        // between `[comment]` and `--` must not stop the block from being
-        // recognized as a comment.
+        // The same carry-across applies before a `[comment]` open block: a
+        // title between `[comment]` and `--` must not stop the block
+        // from being recognized as a comment.
         assert_eq!(
             conditional_output("[comment]\n.title\n--\nifdef::foo[dropped]\n--\n\ntail"),
             "[comment]\n.title\n--\nifdef::foo[dropped]\n--\n\ntail\n"
@@ -4176,10 +4207,11 @@ mod tests {
 
     #[test]
     fn single_line_attribute_entry_preserves_attribute_context() {
-        // Emitting an attribute-entry line via a single-line conditional must not
-        // disable preprocessor attribute handling for the immediately following
-        // line (as the main attribute-entry handler leaves it enabled). Here the
-        // entry after the directive must still be applied so the include target
+        // Emitting an attribute-entry line via a single-line conditional must
+        // not disable preprocessor attribute handling for the
+        // immediately following line (as the main attribute-entry
+        // handler leaves it enabled). Here the entry after the
+        // directive must still be applied so the include target
         // that references it resolves.
         let source = ":flag:\n\nifdef::flag[:dir: sub]\n:file: {dir}/f\ninclude::{file}.adoc[]";
 
@@ -4347,8 +4379,8 @@ mod tests {
 
     #[test]
     fn ifdef_with_empty_target_is_malformed() {
-        // `ifdef`/`ifndef` require a target; an empty one is malformed and opens
-        // no conditional.
+        // `ifdef`/`ifndef` require a target; an empty one is malformed and
+        // opens no conditional.
         assert_eq!(conditional_output("ifdef::[]\nkept\nendif::[]"), "kept\n");
     }
 
@@ -4547,8 +4579,8 @@ mod tests {
 
     #[test]
     fn leveloffset_wraps_included_content() {
-        // The included content is surrounded by `:leveloffset:` attribute entries
-        // that apply and then reset the offset.
+        // The included content is surrounded by `:leveloffset:` attribute
+        // entries that apply and then reset the offset.
         assert_eq!(
             include_output("leveloffset=+1", "== Chapter\n\nBody."),
             ":leveloffset: +1\n\n== Chapter\n\nBody.\n\n:leveloffset!:\n"
@@ -4594,8 +4626,8 @@ mod tests {
 
     #[test]
     fn uri_include_resolved_with_allow_uri_read() {
-        // With `allow-uri-read` set (and safe mode below secure), the handler is
-        // consulted for the URI target.
+        // With `allow-uri-read` set (and safe mode below secure), the handler
+        // is consulted for the URI target.
         let source = "include::https://example.org/frag.adoc[]";
         let handler =
             InlineFileHandler::from_pairs([("https://example.org/frag.adoc", "Remote content.")]);
@@ -4631,8 +4663,8 @@ mod tests {
 
     #[test]
     fn non_utf8_encoding_warns_but_still_includes() {
-        // A non-UTF-8 `encoding` cannot be honored, so a warning is recorded; the
-        // content (as provided by the handler) is still merged.
+        // A non-UTF-8 `encoding` cannot be honored, so a warning is recorded;
+        // the content (as provided by the handler) is still merged.
         let source = "include::sample.adoc[encoding=iso-8859-1]";
         let handler = InlineFileHandler::from_pairs([("sample.adoc", "Résumé.")]);
         let parser = Parser::default()
@@ -4693,8 +4725,8 @@ mod tests {
 
     #[test]
     fn leveloffset_restores_previous_offset() {
-        // When a `:leveloffset:` is already in effect, the include restores it to
-        // that value (rather than unsetting it) afterward.
+        // When a `:leveloffset:` is already in effect, the include restores it
+        // to that value (rather than unsetting it) afterward.
         let source = ":leveloffset: 1\n\ninclude::sample.adoc[leveloffset=+1]";
         let handler = InlineFileHandler::from_pairs([("sample.adoc", "== Chapter")]);
         let parser = Parser::default()
@@ -4712,9 +4744,9 @@ mod tests {
 
     #[test]
     fn leveloffset_restore_ignores_offset_set_within_include() {
-        // A `:leveloffset:` set inside the included file must not affect the value
-        // restored after the include: the restore reflects the offset in effect
-        // *before* the include (here, unset).
+        // A `:leveloffset:` set inside the included file must not affect the
+        // value restored after the include: the restore reflects the
+        // offset in effect *before* the include (here, unset).
         let source = "include::sample.adoc[leveloffset=+1]";
         let handler =
             InlineFileHandler::from_pairs([("sample.adoc", ":leveloffset: 2\n\n== Chapter")]);
@@ -4751,7 +4783,8 @@ mod tests {
             "x\ny\n"
         );
 
-        // A negated double wildcard combined with an exclusion selects no lines.
+        // A negated double wildcard combined with an exclusion selects no
+        // lines.
         assert_eq!(
             include_output(
                 "tags=!**;!foo",
@@ -4767,8 +4800,8 @@ mod tests {
             "c\n"
         );
 
-        // A `tag::` that is not immediately followed by a space or end of line is
-        // not a directive, so the line is kept as content.
+        // A `tag::` that is not immediately followed by a space or end of line
+        // is not a directive, so the line is kept as content.
         assert_eq!(
             include_output("tag=x", "// tag::x[]\ntag::x[]y\n// end::x[]"),
             "tag::x[]y\n"
@@ -4796,8 +4829,9 @@ mod tests {
 
     #[test]
     fn indent_with_tabsize_and_untabbed_line() {
-        // With `tabsize` set, leading tabs are expanded even on a block that also
-        // contains a line with no tabs (which is passed through unchanged).
+        // With `tabsize` set, leading tabs are expanded even on a block that
+        // also contains a line with no tabs (which is passed through
+        // unchanged).
         let source = "----\ninclude::code.rb[indent=0]\n----";
         let handler = InlineFileHandler::from_pairs([("code.rb", "\ta\nno-tab\n\tb")]);
         let parser = Parser::default()
@@ -4808,8 +4842,9 @@ mod tests {
 
         let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
-        // Tabs expand to the tab stop; the common indent is zero (the middle line
-        // is flush left), so no further indentation change is made.
+        // Tabs expand to the tab stop; the common indent is zero (the middle
+        // line is flush left), so no further indentation change is
+        // made.
         assert_eq!(output, "----\n    a\nno-tab\n    b\n----\n");
     }
 
@@ -5038,8 +5073,9 @@ mod tests {
 
         #[test]
         fn lines_takes_precedence_over_a_whole_file_tag_selection() {
-            // A `lines` selection is partial even when `tags=**` is also present
-            // (`lines` wins, matching the selection the preprocessor applies).
+            // A `lines` selection is partial even when `tags=**` is also
+            // present (`lines` wins, matching the selection the
+            // preprocessor applies).
             assert!(!is_full("lines=1..2,tags=**"));
         }
     }

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -431,7 +431,8 @@ mod tests {
     #[test]
     fn new_builds_a_resolvable_context() {
         // The `new` constructor is the seam a downstream `ReferenceResolver`
-        // uses to build its own contexts, since the type is `#[non_exhaustive]`.
+        // uses to build its own contexts, since the type is
+        // `#[non_exhaustive]`.
         let catalog = catalog_with("later", Some("The Later Section"), RefType::Section);
         let resolver = CatalogResolver::new(&catalog);
 

--- a/parser/src/parser/reference_time.rs
+++ b/parser/src/parser/reference_time.rs
@@ -380,9 +380,9 @@ impl DatetimeContext {
 /// [reproducible builds specification]: https://reproducible-builds.org/specs/source-date-epoch/
 fn source_date_epoch_from_env() -> Option<ReferenceTime> {
     // An unset variable reads as empty, which `parse_source_date_epoch` rejects
-    // just like a set-but-empty value — so the (common) unset path exercises the
-    // same line as a set one, without the tests having to mutate the process
-    // environment.
+    // just like a set-but-empty value — so the (common) unset path exercises
+    // the same line as a set one, without the tests having to mutate the
+    // process environment.
     parse_source_date_epoch(&std::env::var("SOURCE_DATE_EPOCH").unwrap_or_default())
 }
 

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -108,8 +108,8 @@ impl std::hash::Hash for ResolvedAttributes {
         // with the derived, content-based `Eq` (equal snapshots hash equally),
         // while distinguishing snapshots whose tables differ in their keys or
         // values — not merely in their entry count (hashing the count alone
-        // would collide every cell in a document, since they typically share one
-        // `Arc`-backed, equal-length attribute table).
+        // would collide every cell in a document, since they typically share
+        // one `Arc`-backed, equal-length attribute table).
         hash_table(self.attribute_values.iter(), state);
         hash_table(self.default_attribute_values.iter(), state);
         hash_table(self.counter_values.iter(), state);
@@ -219,8 +219,9 @@ impl ResolvedAttributes {
             // An enabled automatic (top) TOC clears any author-supplied
             // `toc-position`: Asciidoctor's normalization falls into its `else`
             // arm and deletes the attribute, so an unrecognized author value
-            // (e.g. a bogus side) does not leak into the derived state. A disabled
-            // TOC returns early above and leaves the author value untouched.
+            // (e.g. a bogus side) does not leak into the derived state. A
+            // disabled TOC returns early above and leaves the
+            // author value untouched.
             attrs.remove("toc-position");
         }
         if let Some(class) = class {
@@ -737,9 +738,9 @@ mod tests {
 
     #[test]
     fn absent_docdir_and_docfile_stay_missing_under_server_safe_mode() {
-        // With no `docdir` / `docfile` stored, the masking finds nothing to mask
-        // (`raw_set_value` short-circuits on the absent attribute) and they stay
-        // missing — mirroring the parser.
+        // With no `docdir` / `docfile` stored, the masking finds nothing to
+        // mask (`raw_set_value` short-circuits on the absent attribute)
+        // and they stay missing — mirroring the parser.
         let attrs = ResolvedAttributes::new(
             Arc::new(HashMap::new()),
             Arc::new(HashMap::new()),

--- a/parser/src/parser/source_map.rs
+++ b/parser/src/parser/source_map.rs
@@ -189,8 +189,9 @@ impl SourceMap {
     /// same line number.
     fn resolve(&self, key: usize) -> (Option<u32>, usize, Fidelity) {
         // The exact match and the segment-before-`key` cases share one formula
-        // (`source_line + key - output_line`, which is `source_line` on an exact
-        // match). A `key` before the first segment has no governing segment.
+        // (`source_line + key - output_line`, which is `source_line` on an
+        // exact match). A `key` before the first segment has no
+        // governing segment.
         let segment = match self.segments.binary_search_by_key(&key, |s| s.output_line) {
             Ok(i) => self.segments.get(i),
             Err(0) => None,

--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -144,18 +144,20 @@ impl<'src> Span<'src> {
             loop {
                 let next = cursor.after.take_normalized_line();
 
-                // A blank line (or end of input) terminates the value and is not
-                // consumed.
+                // A blank line (or end of input) terminates the value and is
+                // not consumed.
                 if next.item.is_empty() {
                     break;
                 }
 
-                // Left- and right-trim the line before testing for the marker so
-                // this agrees exactly with `fold_continuation_value`, which trims
+                // Left- and right-trim the line before testing for the marker
+                // so this agrees exactly with
+                // `fold_continuation_value`, which trims
                 // each continuation line the same way. Without the left trim a
-                // line that is *only* the marker (e.g. a bare ` +`) would be kept
-                // open here but treated as a terminating line by the folder,
-                // causing the following line to be consumed from the stream yet
+                // line that is *only* the marker (e.g. a bare ` +`) would be
+                // kept open here but treated as a terminating
+                // line by the folder, causing the following
+                // line to be consumed from the stream yet
                 // silently dropped from the value.
                 let keep_open = next
                     .item
@@ -1431,10 +1433,10 @@ mod tests {
 
         #[test]
         fn bare_backslash_is_not_a_continuation() {
-            // A soft-wrap line continuation requires a *space* before the trailing
-            // backslash. A bare `\` (no preceding space) is a literal character and
-            // terminates the line; the next line is not folded in.
-            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
+            // A soft-wrap line continuation requires a *space* before the
+            // trailing backslash. A bare `\` (no preceding space)
+            // is a literal character and terminates the line; the
+            // next line is not folded in. See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
             let span = crate::Span::new("abc\\\ndef");
             let line = span.take_value_with_continuation();
 
@@ -1513,9 +1515,10 @@ mod tests {
 
         #[test]
         fn legacy_plus_continuation() {
-            // A legacy `+` continuation (a space followed by `+`) fuses lines just
-            // like the modern `\` marker. The raw item preserves the markers and
-            // interior newlines; folding happens later.
+            // A legacy `+` continuation (a space followed by `+`) fuses lines
+            // just like the modern `\` marker. The raw item
+            // preserves the markers and interior newlines; folding
+            // happens later.
             let span = crate::Span::new("abc +\ndef +\nghi");
             let line = span.take_value_with_continuation();
 
@@ -1542,8 +1545,9 @@ mod tests {
 
         #[test]
         fn legacy_plus_terminates_on_line_without_marker() {
-            // The continuation stops after the first line that no longer carries
-            // the legacy `+` marker (that line is still consumed).
+            // The continuation stops after the first line that no longer
+            // carries the legacy `+` marker (that line is still
+            // consumed).
             let span = crate::Span::new("abc +\ndef\nghi");
             let line = span.take_value_with_continuation();
 
@@ -1571,8 +1575,8 @@ mod tests {
         #[test]
         fn legacy_plus_marker_is_fixed_by_first_line() {
             // The marker is fixed by the first line. When the first line has no
-            // marker, a trailing `\` on a *later* line is not a continuation: the
-            // value is just the first line.
+            // marker, a trailing `\` on a *later* line is not a continuation:
+            // the value is just the first line.
             let span = crate::Span::new("abc\ndef \\\nghi");
             let line = span.take_value_with_continuation();
 
@@ -1599,9 +1603,10 @@ mod tests {
 
         #[test]
         fn bare_plus_is_not_a_continuation() {
-            // A legacy continuation requires a *space* before the trailing `+`. A
-            // bare `+` (no preceding space) is a literal character and terminates
-            // the line; the next line is not folded in.
+            // A legacy continuation requires a *space* before the trailing `+`.
+            // A bare `+` (no preceding space) is a literal
+            // character and terminates the line; the next line is
+            // not folded in.
             let span = crate::Span::new("abc+\ndef");
             let line = span.take_value_with_continuation();
 
@@ -1629,10 +1634,11 @@ mod tests {
         #[test]
         fn bare_marker_only_line_terminates_extent() {
             // A continuation line that is *only* the marker (a bare ` +` once
-            // left-trimmed) terminates the value. The extent must stop after that
-            // line so the following line stays in the stream; otherwise the folder
-            // (which left-trims and treats the bare marker as terminating) would
-            // drop it. Extent = `text +\n +`; `more` is left for the next block.
+            // left-trimmed) terminates the value. The extent must stop after
+            // that line so the following line stays in the stream;
+            // otherwise the folder (which left-trims and treats the
+            // bare marker as terminating) would drop it. Extent =
+            // `text +\n +`; `more` is left for the next block.
             let span = crate::Span::new("text +\n +\nmore");
             let line = span.take_value_with_continuation();
 

--- a/parser/src/span/primitives.rs
+++ b/parser/src/span/primitives.rs
@@ -1043,7 +1043,8 @@ mod tests {
 
         #[test]
         fn rem_too_long() {
-            // This is nonsense input, but we should at least not panic in this case.
+            // This is nonsense input, but we should at least not panic in this
+            // case.
 
             let source = advanced_span("abcdef", 6);
             let after = crate::Span::new("abcdef_bogus_bogus");

--- a/parser/src/span/slice.rs
+++ b/parser/src/span/slice.rs
@@ -240,9 +240,10 @@ mod tests {
     mod empty {
         use crate::tests::prelude::*;
 
-        // `empty()` is the release-build fallback that the slice functions reach
-        // for an out-of-bounds range (debug builds panic before reaching it). It
-        // returns a zero-length span anchored at the start of `self`.
+        // `empty()` is the release-build fallback that the slice functions
+        // reach for an out-of-bounds range (debug builds panic before
+        // reaching it). It returns a zero-length span anchored at the
+        // start of `self`.
         #[test]
         fn anchors_at_start_of_span() {
             let s = crate::Span::new("abcdef").slice_from(2..);

--- a/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
@@ -130,14 +130,15 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn only_contain_word_characters_and_hyphens() {
-        // The prose above describes what a *well-formed* user-defined name looks
-        // like. Like the lower-case normalization (see `may_contain_uppercase`),
-        // enforcement of this rule is deferred: rather than reject a name that
-        // contains other characters, the parser captures the raw name and it is
+        // The prose above describes what a *well-formed* user-defined name
+        // looks like. Like the lower-case normalization (see
+        // `may_contain_uppercase`), enforcement of this rule is
+        // deferred: rather than reject a name that contains other
+        // characters, the parser captures the raw name and it is
         // sanitized before being stored as an attribute key — every character
         // outside `[a-z0-9_-]` is dropped and the rest is lower-cased. This
-        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what lets
-        // `:Author Initials:` set `authorinitials`. See
+        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what
+        // lets `:Author Initials:` set `authorinitials`. See
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/761 and
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/726.
         let mi =

--- a/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
@@ -365,8 +365,8 @@ To force the use of UTC, set the `TZ=UTC` environment variable when invoking Asc
 /// configured [`SafeMode`], so their values are asserted directly here.
 #[test]
 fn safe_mode_attributes() {
-    // (safe mode, `safe-mode-level`, `safe-mode-name`, active `safe-mode-<name>`
-    // flag)
+    // (safe mode, `safe-mode-level`, `safe-mode-name`, active
+    // `safe-mode-<name>` flag)
     let cases = [
         (SafeMode::Unsafe, "0", "unsafe", "safe-mode-unsafe"),
         (SafeMode::Safe, "1", "safe", "safe-mode-safe"),
@@ -1387,9 +1387,10 @@ fn relfilesuffix_tracks_outfilesuffix_counter_overlay() {
     let mut parser = Parser::default();
     let _ = parser.parse("= Title\n\nSuffix is {counter:outfilesuffix}.\n");
 
-    // Resolving the counter overlays `outfilesuffix`: the counter increments its
-    // last character, so `.html` becomes `.htmm`. An unset `relfilesuffix` must
-    // read that overlaid value, not the raw `.html` attribute underneath it.
+    // Resolving the counter overlays `outfilesuffix`: the counter increments
+    // its last character, so `.html` becomes `.htmm`. An unset
+    // `relfilesuffix` must read that overlaid value, not the raw `.html`
+    // attribute underneath it.
     let outfilesuffix = parser.attribute_value("outfilesuffix");
     assert_eq!(outfilesuffix.as_maybe_str(), Some(".htmm"));
     assert_eq!(parser.attribute_value("relfilesuffix"), outfilesuffix);
@@ -1884,8 +1885,8 @@ Since attributes can reference attributes, it's possible to create an output doc
     assert_default("max-include-depth", "64");
 
     // `max-attribute-value-size` is only assigned its `4096` default in SECURE
-    // mode. `SafeMode::Secure` is the default mode, so a pristine parser resolves
-    // it to `4096`; a relaxed safe mode leaves it unset (see
+    // mode. `SafeMode::Secure` is the default mode, so a pristine parser
+    // resolves it to `4096`; a relaxed safe mode leaves it unset (see
     // `SafeMode`-relaxed coverage below).
     assert_default("max-attribute-value-size", "4096");
 
@@ -1942,7 +1943,8 @@ fn explicit_max_attribute_value_size_survives_safe_mode_change() {
     };
 
     // Explicit value set *before* the safe-mode change (the order the reviewer
-    // flagged) is preserved, whether the mode is relaxed or (redundantly) Secure.
+    // flagged) is preserved, whether the mode is relaxed or (redundantly)
+    // Secure.
     let set_then_relax = Parser::default()
         .with_intrinsic_attribute(
             "max-attribute-value-size",

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -189,10 +189,10 @@ If the text cannot be parsed, an error message will be emitted to the log.
             &mut parser,
         );
 
-        // `style` is a placeholder for a real style name in this doc example, not
-        // a style this parser recognizes, so it records a DEBUG-severity
-        // unknown-style diagnostic. That is incidental to the attribute-list
-        // parsing this test verifies.
+        // `style` is a placeholder for a real style name in this doc example,
+        // not a style this parser recognizes, so it records a
+        // DEBUG-severity unknown-style diagnostic. That is incidental
+        // to the attribute-list parsing this test verifies.
         assert_eq!(parsed.warnings.len(), 1);
         assert_eq!(parsed.warnings[0].severity, WarningSeverity::Debug);
         assert_eq!(
@@ -506,7 +506,8 @@ Specifically, it does not support named attributes, only the attribute shorthand
         );
     }
 
-    // Treated as non-normative because these requirements are covered elsewhere.
+    // Treated as non-normative because these requirements are covered
+    // elsewhere.
     non_normative!(
         r#"
 Attribute lists:

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -742,8 +742,8 @@ TIP: The order of ID and role values in the shorthand syntax does not matter.
         );
 
         // The role-then-id ordering from the example above (`.movie#roads`) and
-        // the reverse, id-then-role ordering (`#roads.movie`) assign the same ID
-        // and role: the shorthand is order-independent.
+        // the reverse, id-then-role ordering (`#roads.movie`) assign the same
+        // ID and role: the shorthand is order-independent.
         let mut parser = Parser::default();
         let role_then_id = crate::blocks::Block::parse(
             crate::Span::new("[quote.movie#roads]\n____\nRoads?\n____"),
@@ -1720,8 +1720,8 @@ include::example$id.adoc[tag=anchor-wrong]
         );
 
         // An anchor in front of a list marker does not produce a list item. The
-        // line is parsed as an ordinary paragraph: the inline anchor is rendered
-        // and registered, and the `*` is left as literal text.
+        // line is parsed as an ordinary paragraph: the inline anchor is
+        // rendered and registered, and the `*` is left as literal text.
         let doc = Parser::default().parse("[[anchor-point]]* list item with invalid anchor");
 
         let block = doc.child_blocks().next().unwrap();
@@ -1802,8 +1802,8 @@ The remaining anchors are auxiliary and are used for making deep links (i.e., ac
 "#
         );
 
-        // Each anchor is rendered as an invisible anchor point and registered so
-        // that it can be the target of a deep link.
+        // Each anchor is rendered as an invisible anchor point and registered
+        // so that it can be the target of a deep link.
         let doc = Parser::default().parse("* [[a1]][[a2]]Item");
 
         assert!(doc.catalog().contains_id("a1"));
@@ -1829,8 +1829,8 @@ You can assign an ID to a table cell by placing an inline anchor at the start of
 "#
         );
 
-        // The inline anchor at the start of the cell is registered as the cell's
-        // referenceable ID.
+        // The inline anchor at the start of the cell is registered as the
+        // cell's referenceable ID.
         let doc =
             Parser::default().parse("|===\n|[[my_cell]]The table cell I want to jump to.\n|===");
 
@@ -1855,8 +1855,9 @@ include::example$id.adoc[tag=inline-anchor-brackets]
 "#
         );
 
-        // The anchor adjacent to the inline image is rendered as an anchor point
-        // immediately before the image and registered as a referenceable ID.
+        // The anchor adjacent to the inline image is rendered as an anchor
+        // point immediately before the image and registered as a
+        // referenceable ID.
         let doc = Parser::default().parse("[[tiger-image]]image:tiger.png[Image of a tiger]");
 
         let block = doc.child_blocks().next().unwrap();

--- a/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
@@ -128,14 +128,15 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn only_contain_word_characters_and_hyphens() {
-        // The prose above describes what a *well-formed* user-defined name looks
-        // like. Like the lower-case normalization (see `may_contain_uppercase`),
-        // enforcement of this rule is deferred: rather than reject a name that
-        // contains other characters, the parser captures the raw name and it is
+        // The prose above describes what a *well-formed* user-defined name
+        // looks like. Like the lower-case normalization (see
+        // `may_contain_uppercase`), enforcement of this rule is
+        // deferred: rather than reject a name that contains other
+        // characters, the parser captures the raw name and it is
         // sanitized before being stored as an attribute key — every character
         // outside `[a-z0-9_-]` is dropped and the rest is lower-cased. This
-        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what lets
-        // `:Author Initials:` set `authorinitials`. See
+        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what
+        // lets `:Author Initials:` set `authorinitials`. See
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/761 and
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/726.
         let mi =
@@ -179,8 +180,8 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn may_contain_uppercase() {
-        // IMPORTANT: We've defined the lower-case normalization as out of scope for
-        // the parser crate for now.
+        // IMPORTANT: We've defined the lower-case normalization as out of scope
+        // for the parser crate for now.
         let mi =
             crate::document::Attribute::parse(crate::Span::new(":URL-REPO:"), &Parser::default())
                 .unwrap();

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -1162,7 +1162,8 @@ In these rules, `name` consists of a word character (letter or numeral) followed
 
     #[test]
     fn attrlist_cant_start_with_space() {
-        // NOTE: The requirement about parsing an attribute is covered elsewhere.
+        // NOTE: The requirement about parsing an attribute is covered
+        // elsewhere.
         verifies!(
             r#"
 * Parsing an attribute proceeds from the beginning of the attribute list string or after a previously identified delimiter (`,`).

--- a/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
@@ -427,11 +427,11 @@ If the syntax that follows the backslash does not match an attribute reference, 
         );
 
         // The braces here enclose spaces, which is not a valid attribute name,
-        // so this does not look like an attribute reference at all. The escaping
-        // backslash is therefore left in place, unlike an escaped *valid*
-        // reference such as `\{id}` (see `prefix_with_backslash`), whose
-        // backslash is always removed regardless of whether the attribute is
-        // set.
+        // so this does not look like an attribute reference at all. The
+        // escaping backslash is therefore left in place, unlike an
+        // escaped *valid* reference such as `\{id}` (see
+        // `prefix_with_backslash`), whose backslash is always removed
+        // regardless of whether the attribute is set.
         let mut parser = Parser::default();
 
         let doc = parser.parse("In the path /items/\\{not a name}, this is preserved.");

--- a/parser/src/tests/asciidoc_lang/blocks/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/add_title.rs
@@ -591,8 +591,8 @@ ifdef::prev-example-number[:example-number: {prev-example-number}]
     );
 
     // On a pristine parser `example-number` is unset, so both conditionals are
-    // false: the save and restore are no-ops, the counter is reset to 0, and the
-    // example is numbered 1 and displayed with its caption.
+    // false: the save and restore are no-ops, the counter is reset to 0, and
+    // the example is numbered 1 and displayed with its caption.
     let doc = Parser::default().parse(
         ":example-caption: Example\nifdef::example-number[:prev-example-number: {example-number}]\n:example-number: 0\n\n.Block that supports captioned title\n====\nBlock content\n====\n\n:!example-caption:\nifdef::prev-example-number[:example-number: {prev-example-number}]\n:!prev-example-number:",
     );
@@ -609,7 +609,8 @@ ifdef::prev-example-number[:example-number: {prev-example-number}]
     );
     let mut examples = doc.child_blocks().filter(|b| b.title().is_some());
     // The first conditional fired (`example-number` was set), saving 7 into
-    // `prev-example-number`; the counter was then reset to 0, so this example is 1.
+    // `prev-example-number`; the counter was then reset to 0, so this example
+    // is 1.
     let saved = examples.next().unwrap();
     assert_eq!(saved.number(), Some(1));
     // The second conditional fired (`prev-example-number` was set), restoring
@@ -695,8 +696,8 @@ Block content
     assert_eq!(block.title(), Some("Block Title"));
 
     // The custom caption replaces the entire caption verbatim (the counter
-    // reference is resolved), including the trailing space, and the block is not
-    // auto-numbered.
+    // reference is resolved), including the trailing space, and the block is
+    // not auto-numbered.
     assert_eq!(block.caption(), Some("Example A: "));
     assert_eq!(block.number(), None);
 }

--- a/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
@@ -329,8 +329,8 @@ It's possible to use Unicode glyphs as admonition icons.
     );
 
     // The character reference is assigned with substitutions disabled (via the
-    // `pass` macro), so it reaches the label as written; the rendered HTML shows
-    // the referenced glyph.
+    // `pass` macro), so it reaches the label as written; the rendered HTML
+    // shows the referenced glyph.
     let doc = Parser::default().parse(
         ":tip-caption: pass:[&#128161;]\n\n[TIP]\nIt's possible to use Unicode glyphs as admonition icons.",
     );

--- a/parser/src/tests/asciidoc_lang/blocks/block_name_table.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/block_name_table.rs
@@ -294,8 +294,8 @@ Will be colorized by the source highlighter if enabled on the document and a lan
 "#
     );
 
-    // A `[source]` style over a listing (`----`) delimited block resolves to the
-    // `listing` context, specialized by the `source` style.
+    // A `[source]` style over a listing (`----`) delimited block resolves to
+    // the `listing` context, specialized by the `source` style.
     let (resolved, model, style) = facts("[source]\n----\ncode\n----");
     assert_eq!(resolved, "listing");
     assert_eq!(model, ContentModel::Verbatim);

--- a/parser/src/tests/asciidoc_lang/blocks/blockquotes.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/blockquotes.rs
@@ -56,8 +56,8 @@ These positional attributes are all optional.
         1,
     );
 
-    // The attribution and citation are both optional: a bare `quote` style still
-    // produces a quote block, with no attribution.
+    // The attribution and citation are both optional: a bare `quote` style
+    // still produces a quote block, with no attribution.
     let doc = Parser::default().parse("[quote]\n____\nA quote with no attribution.\n____");
 
     assert_css(&doc, ".quoteblock", 1);
@@ -180,8 +180,8 @@ If the quote or excerpt is more than one paragraph, place the text between delim
 "#
     );
 
-    // A quote delimited block contains multiple paragraphs, each rendered inside
-    // the blockquote.
+    // A quote delimited block contains multiple paragraphs, each rendered
+    // inside the blockquote.
     let doc = Parser::default()
         .parse("[quote,Monty Python]\n____\nDennis: Help! I'm being repressed!\n\nKing Arthur: Bloody peasant!\n____");
 
@@ -314,8 +314,8 @@ The exceptation is that this role makes the quote block appear with the quote de
 "#
     );
 
-    // The `excerpt` role is carried through to the rendered block as a CSS class
-    // on the quote block.
+    // The `excerpt` role is carried through to the rendered block as a CSS
+    // class on the quote block.
     let doc = Parser::default().parse("[.excerpt]\n____\nThis text is an excerpt.\n____");
 
     assert_css(&doc, ".quoteblock.excerpt", 1);
@@ -452,8 +452,8 @@ If you need to put a description list inside a blockquote, you should use the As
 "#
     );
 
-    // A `>`-prefixed line that is also a valid description-list term is parsed as
-    // a description list, not a Markdown-style blockquote.
+    // A `>`-prefixed line that is also a valid description-list term is parsed
+    // as a description list, not a Markdown-style blockquote.
     let doc = Parser::default().parse("> term:: definition");
 
     assert_css(&doc, ".dlist", 1);

--- a/parser/src/tests/asciidoc_lang/blocks/collapsible.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/collapsible.rs
@@ -124,8 +124,8 @@ include::example$collapsible.adoc[tag=paragraph]
         1,
     );
 
-    // A collapsible paragraph's content sits directly in `<div class="content">`,
-    // without a wrapping paragraph.
+    // A collapsible paragraph's content sits directly in `<div
+    // class="content">`, without a wrapping paragraph.
     assert_xpath(
         &doc,
         "//details/div[@class=\"content\"][normalize-space(text())=\"This content is only revealed when the user clicks the block title.\"]",
@@ -141,9 +141,9 @@ include::example$collapsible.adoc[tag=paragraph]
         1,
     );
 
-    // The example paragraph style is required: a bare `[%collapsible]` paragraph
-    // (with no `example` style) is not collapsible; it remains an ordinary
-    // paragraph.
+    // The example paragraph style is required: a bare `[%collapsible]`
+    // paragraph (with no `example` style) is not collapsible; it remains an
+    // ordinary paragraph.
     let doc = Parser::default().parse(
         "[%collapsible]\nThis content is only revealed when the user clicks the block title.",
     );

--- a/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
@@ -539,10 +539,11 @@ Then each dialog will appear on its own line.
     );
 
     // No hard line break is generated here, matching Asciidoctor. The spaced em
-    // dash replacement for the ` -- ` at the start of the second line matches (and
-    // consumes) the preceding newline, so both source lines render on one output
-    // line. Because the newline is gone, the trailing ` +` is no longer at the end
-    // of a line and is left literal rather than becoming a `<br>`.
+    // dash replacement for the ` -- ` at the start of the second line matches
+    // (and consumes) the preceding newline, so both source lines render on
+    // one output line. Because the newline is gone, the trailing ` +` is no
+    // longer at the end of a line and is left literal rather than becoming
+    // a `<br>`.
     let doc =
         Parser::default().parse("-- Come here! -- I said. +\n-- What is it? -- replied Lance.");
 

--- a/parser/src/tests/asciidoc_lang/blocks/index.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/index.rs
@@ -125,10 +125,11 @@ We'll cover that modifier shortly.
         todo!("Redundant: Covered by block_style test below.");
     }
 
-    // Block extensions are out of scope for the 1.0 release, so the block name →
-    // context mapping described here — an arbitrary block name mapped to one or
-    // more contexts by an extension's process method — has no corresponding
-    // parser behavior to verify. Treated as non-normative for now.
+    // Block extensions are out of scope for the 1.0 release, so the block name
+    // → context mapping described here — an arbitrary block name mapped to
+    // one or more contexts by an extension's process method — has no
+    // corresponding parser behavior to verify. Treated as non-normative for
+    // now.
     non_normative!(
         r#"
 For blocks, the context is sometimes referred to as the block name.
@@ -487,8 +488,8 @@ Additional contexts may be introduced through the use of the block, block macro,
 "#
         );
 
-        // Test a few context names that are not built-in contexts as a spot-check
-        // against false positives.
+        // Test a few context names that are not built-in contexts as a
+        // spot-check against false positives.
         assert!(!is_built_in_context("documentx"));
         assert!(!is_built_in_context("sentence"));
         assert!(!is_built_in_context(""));
@@ -627,8 +628,9 @@ One of the five admonition styles (e.g., `[TIP]`) above an example block transfo
 "#
         );
 
-        // A `[TIP]` block style above an example structural container transforms
-        // the example block into an admonition block whose label is `Tip`.
+        // A `[TIP]` block style above an example structural container
+        // transforms the example block into an admonition block whose
+        // label is `Tip`.
         let doc = Parser::default().parse("[TIP]\n====\nPay attention.\n====");
         let block = doc.child_blocks().next().expect("expected a block");
 
@@ -658,8 +660,8 @@ A block style (e.g., `[circle]` or `[loweralpha]`) above an unordered or ordered
 "#
         );
 
-        // A `[circle]` block style above an unordered list declares the `circle`
-        // style on the list.
+        // A `[circle]` block style above an unordered list declares the
+        // `circle` style on the list.
         let doc = Parser::default().parse("[circle]\n* one\n* two");
         let block = doc.child_blocks().next().expect("expected a block");
         assert_eq!(block.raw_context().as_ref(), "list");
@@ -729,9 +731,9 @@ To learn more about how to change the context of a block using the declared bloc
 
         // The `[listing]` block style above the literal (`....`) delimiters
         // changes the context of the block: the raw (default) context is
-        // `literal`, but the declared block style matches the `listing` context,
-        // so the resolved context becomes `listing` and the resolved block style
-        // is left unset.
+        // `literal`, but the declared block style matches the `listing`
+        // context, so the resolved context becomes `listing` and the
+        // resolved block style is left unset.
         let doc = Parser::default().parse("[listing]\n....\na > b\n....");
         let block = doc.child_blocks().next().expect("expected a block");
 
@@ -810,8 +812,8 @@ To workaround this interpretation of the source, you need to move the trailing `
         // A first line that begins with `[` and ends with `]` is consumed as a
         // block attribute line rather than as content, regardless of the text
         // between the brackets. Here it is interpreted as the block's attribute
-        // list (declaring the `sidebar` style) rather than as a description list
-        // term/definition.
+        // list (declaring the `sidebar` style) rather than as a description
+        // list term/definition.
         let doc = Parser::default().parse("[sidebar]\nAn aside.");
         let block = doc.child_blocks().next().expect("expected a block");
 

--- a/parser/src/tests/asciidoc_lang/blocks/masquerading.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/masquerading.rs
@@ -46,8 +46,8 @@ When masquerading the context of a structural container, only contexts that pres
     );
 
     // The declared block style modifies the context of a paragraph: `[sidebar]`
-    // on a paragraph changes its context to `sidebar`, and the block retains the
-    // simple content model.
+    // on a paragraph changes its context to `sidebar`, and the block retains
+    // the simple content model.
     let (_, resolved, model, _) = facts("[sidebar]\nA short aside.");
     assert_eq!(resolved, "sidebar");
     assert_eq!(model, ContentModel::Simple);
@@ -124,9 +124,10 @@ The resolved block style of the block remains unset.
 "#
     );
 
-    // The `....` delimiters mark a literal structural container; the `[listing]`
-    // block style changes its context to `listing`. The default (raw) context
-    // remains `literal`, and the resolved context is `listing`.
+    // The `....` delimiters mark a literal structural container; the
+    // `[listing]` block style changes its context to `listing`. The default
+    // (raw) context remains `literal`, and the resolved context is
+    // `listing`.
     let (raw, resolved, _, _) = facts("[listing]\n....\na > b\n....");
     assert_eq!(raw, "literal");
     assert_eq!(resolved, "listing");
@@ -159,8 +160,8 @@ This sidebar is short, so a styled paragraph will do.
 "#
     );
 
-    // A `[sidebar]` style on a contiguous paragraph turns it into a sidebar that
-    // still retains the simple content model.
+    // A `[sidebar]` style on a contiguous paragraph turns it into a sidebar
+    // that still retains the simple content model.
     let (_, resolved, model, _) =
         facts("[sidebar]\nThis sidebar is short, so a styled paragraph will do.");
     assert_eq!(resolved, "sidebar");
@@ -189,9 +190,10 @@ Remember the milk.
 "#
     );
 
-    // The `NOTE` block style on a `====` example container transforms it into an
-    // admonition block (context `admonition`). Because the example container has
-    // the compound content model, the resulting admonition is also compound.
+    // The `NOTE` block style on a `====` example container transforms it into
+    // an admonition block (context `admonition`). Because the example
+    // container has the compound content model, the resulting admonition is
+    // also compound.
     let (raw, _, model, _) = facts("[NOTE]\n====\nRemember the milk.\n====");
     assert_eq!(raw, "admonition");
     assert_eq!(model, ContentModel::Compound);
@@ -381,9 +383,9 @@ fn permutations_table() {
     assert_eq!(model, ContentModel::Simple);
 
     // The `abstract`, `comment`, and `partintro` masquerades over an open block
-    // are doctype- and converter-specific (e.g. `partintro` is valid only inside
-    // a book part); the parser preserves the declared style for a downstream
-    // converter to act on.
+    // are doctype- and converter-specific (e.g. `partintro` is valid only
+    // inside a book part); the parser preserves the declared style for a
+    // downstream converter to act on.
     for style in ["abstract", "comment", "partintro"] {
         let (_, _, _, declared) = facts(&format!("[{style}]\n--\nx\n--"));
         assert_eq!(declared.as_deref(), Some(style));
@@ -433,10 +435,10 @@ A paragraph also access the `normal` style, which can be applied to revert a lit
     assert_eq!(raw, "verse");
     assert_eq!(model, ContentModel::Simple);
 
-    // The `normal` style reverts an (indentation-induced) literal paragraph back
-    // to a normal paragraph: the content model stays simple, the context is
-    // `paragraph`, and the block is parsed with the paragraph (not literal)
-    // style.
+    // The `normal` style reverts an (indentation-induced) literal paragraph
+    // back to a normal paragraph: the content model stays simple, the
+    // context is `paragraph`, and the block is parsed with the paragraph
+    // (not literal) style.
     let doc =
         Parser::default().parse("[normal]\n  This would be a literal paragraph without the style.");
     let normal = doc.child_blocks().next().expect("expected a block");
@@ -448,7 +450,8 @@ A paragraph also access the `normal` style, which can be applied to revert a lit
         panic!("expected a simple block, got {normal:?}");
     }
 
-    // Without the `normal` style, the same indented text is a literal paragraph.
+    // Without the `normal` style, the same indented text is a literal
+    // paragraph.
     let doc = Parser::default().parse("  This is a literal paragraph.");
     let literal = doc.child_blocks().next().expect("expected a block");
     if let crate::blocks::Block::Simple(simple) = literal {

--- a/parser/src/tests/asciidoc_lang/blocks/open_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/open_blocks.rs
@@ -22,7 +22,8 @@ The only notable limitation is that an open block cannot be nested inside of ano
     );
 
     // An open block is a generic structural container: the `--` delimiters wrap
-    // their content in `div.openblock > div.content`, adding no other semantics.
+    // their content in `div.openblock > div.content`, adding no other
+    // semantics.
     let doc = Parser::default().parse("--\nGeneric content.\n--");
     assert_css(&doc, "div.openblock > div.content", 1);
     assert_css(&doc, "div.openblock > div.content > div.paragraph", 1);
@@ -219,15 +220,15 @@ fn open_block_masquerading_as_a_listing_or_literal_block() {
 
 #[test]
 fn open_block_masquerading_as_a_quote_or_verse_block() {
-    // A `[quote]` style on an open block makes it act as a quote block: the body
-    // is a compound (nested-block) content model rendered inside a
+    // A `[quote]` style on an open block makes it act as a quote block: the
+    // body is a compound (nested-block) content model rendered inside a
     // `div.quoteblock > blockquote`, with the attribution surfaced.
     let doc = Parser::default().parse("[quote,Author]\n--\nQuoted open block.\n--");
     assert_css(&doc, ".openblock", 0);
     assert_css(&doc, "div.quoteblock > blockquote", 1);
 
-    // A `[verse]` style on an open block makes it act as a verse block, with the
-    // body preserved verbatim inside `pre.content`.
+    // A `[verse]` style on an open block makes it act as a verse block, with
+    // the body preserved verbatim inside `pre.content`.
     let doc = Parser::default().parse("[verse]\n--\nverse line\n--");
     assert_css(&doc, ".openblock", 0);
     assert_css(&doc, "div.verseblock > pre.content", 1);
@@ -235,9 +236,10 @@ fn open_block_masquerading_as_a_quote_or_verse_block() {
 
 #[test]
 fn masquerade_style_only_applies_to_an_open_block() {
-    // A masquerade style replaces the context only on an open block. On any other
-    // delimited block the delimiter's own context wins and the style is ignored:
-    // a `[quote]` style on an example block (`====`) stays an example block.
+    // A masquerade style replaces the context only on an open block. On any
+    // other delimited block the delimiter's own context wins and the style
+    // is ignored: a `[quote]` style on an example block (`====`) stays an
+    // example block.
     let doc = Parser::default().parse("[quote]\n====\nx\n====");
     assert_css(&doc, "div.exampleblock", 1);
     assert_css(&doc, "div.quoteblock", 0);

--- a/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
@@ -292,10 +292,10 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
         }
     );
 
-    // Writing the bracketed text as an indented (literal) paragraph and applying
-    // the explicit `[normal]` style attaches `normal` as the block's attribute
-    // list, so the bracketed line is treated as paragraph content rather than as
-    // block metadata, again with no warnings.
+    // Writing the bracketed text as an indented (literal) paragraph and
+    // applying the explicit `[normal]` style attaches `normal` as the
+    // block's attribute list, so the bracketed line is treated as paragraph
+    // content rather than as block metadata, again with no warnings.
     assert_eq!(
         Parser::default().parse("[normal]\n [.rolename]*main text*footnote:[The footnote.]"),
         Document {

--- a/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
@@ -147,9 +147,9 @@ const { expect, expectCalledWith, heredoc } = require('../test/test-utils')
 "#
     );
 
-    // A pair of four consecutive asterisks delimits a sidebar block; no `sidebar`
-    // style is needed. The block can contain any type of content (here: a title,
-    // a paragraph, a TIP admonition, and a source block).
+    // A pair of four consecutive asterisks delimits a sidebar block; no
+    // `sidebar` style is needed. The block can contain any type of content
+    // (here: a title, a paragraph, a TIP admonition, and a source block).
     let doc = Parser::default().parse(
         ".Optional Title\n****\nSidebars are used to visually separate auxiliary bits of content\nthat supplement the main text.\n\nTIP: They can contain any type of content.\n\n.Source code block in a sidebar\n[source,js]\n----\nconst { expect, expectCalledWith, heredoc } = require('../test/test-utils')\n----\n****",
     );

--- a/parser/src/tests/asciidoc_lang/blocks/thematic_breaks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/thematic_breaks.rs
@@ -76,8 +76,8 @@ As with Markdown, spaces between the characters is optional.
         );
     }
 
-    // Only 3 repeating characters are recognized: a run of four or more is not a
-    // thematic break (four dashes is a listing delimiter instead).
+    // Only 3 repeating characters are recognized: a run of four or more is not
+    // a thematic break (four dashes is a listing delimiter instead).
     let doc = Parser::default().parse("----");
     let block = doc.child_blocks().next().expect("expected a block");
     assert_eq!(block.resolved_context().as_ref(), "listing");

--- a/parser/src/tests/asciidoc_lang/blocks/verses.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/verses.rs
@@ -40,7 +40,8 @@ Verses are defined by setting `verse` on a paragraph or an excerpt block delimit
         "Roses are red,\n  violets are blue."
     );
 
-    // A verse can also be set on an excerpt block delimited by four underscores.
+    // A verse can also be set on an excerpt block delimited by four
+    // underscores.
     let doc = Parser::default().parse("[verse]\n____\nRoses are red,\n\nviolets are blue.\n____");
     let block = doc.child_blocks().next().unwrap();
     let quote = as_quote(block);

--- a/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
@@ -178,22 +178,23 @@ The two combinators cannot be combined in the same expression.
 "#
     );
 
-    // The spec forbids mixing the `,` (or) and `+` (and) combinators in a single
-    // expression, but the parser (like Asciidoctor) neither rejects nor warns
-    // about a mixed expression. Instead, whichever combinator appears *first*
-    // governs the whole expression, and the target is split on that delimiter
-    // alone — so the other delimiter becomes part of a single literal attribute
-    // name. Since no attribute is ever named (for example) `b+c`, such a segment
-    // can never match.
+    // The spec forbids mixing the `,` (or) and `+` (and) combinators in a
+    // single expression, but the parser (like Asciidoctor) neither rejects
+    // nor warns about a mixed expression. Instead, whichever combinator
+    // appears *first* governs the whole expression, and the target is split
+    // on that delimiter alone — so the other delimiter becomes part of a
+    // single literal attribute name. Since no attribute is ever named (for
+    // example) `b+c`, such a segment can never match.
 
     // `,` appears first, so this is an "`or`": the `a` segment is set, so the
     // content is included (the `b+c` segment is never consulted).
     let doc = Parser::default().parse(":a:\n:b:\n:c:\n\nifdef::a,b+c[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 
-    // Still an "`or`" (`,` first): with `a` unset, the `b+c` segment is a single
-    // never-set attribute name — the `+` is not honored as an "`and`" — so the
-    // content is excluded even though both `b` and `c` are set.
+    // Still an "`or`" (`,` first): with `a` unset, the `b+c` segment is a
+    // single never-set attribute name — the `+` is not honored as an
+    // "`and`" — so the content is excluded even though both `b` and `c` are
+    // set.
     let doc = Parser::default().parse(":b:\n:c:\n\nifdef::a,b+c[Shown.]\n\nTail.");
     assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
 
@@ -234,8 +235,8 @@ Otherwise, the content is not included.
 "#
     );
 
-    // OR (comma): the default backend is `html5`, so the derived `backend-html5`
-    // flag is set and the content is included.
+    // OR (comma): the default backend is `html5`, so the derived
+    // `backend-html5` flag is set and the content is included.
     let doc = Parser::default().parse("ifdef::backend-html5,backend-docbook5[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 
@@ -292,22 +293,26 @@ Otherwise, the content is included.
 "#
     );
 
-    // "Unless any" (comma): neither attribute is set, so the content is included.
+    // "Unless any" (comma): neither attribute is set, so the content is
+    // included.
     let doc = Parser::default().parse("ifndef::profile-production,env-site[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 
-    // "Unless any" (comma): one attribute is set, so the content is not included.
+    // "Unless any" (comma): one attribute is set, so the content is not
+    // included.
     let doc = Parser::default()
         .parse(":env-site:\n\nifndef::profile-production,env-site[Shown.]\n\nTail.");
     assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
 
-    // "Unless all" (plus): all attributes are set, so the content is not included.
+    // "Unless all" (plus): all attributes are set, so the content is not
+    // included.
     let doc = Parser::default().parse(
         ":profile-staging:\n:env-site:\n\nifndef::profile-staging+env-site[Shown.]\n\nTail.",
     );
     assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
 
-    // "Unless all" (plus): only one attribute is set, so the content is included.
+    // "Unless all" (plus): only one attribute is set, so the content is
+    // included.
     let doc = Parser::default().parse(":env-site:\n\nifndef::profile-staging+env-site[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 }

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -94,8 +94,9 @@ An include directive must be placed on a line by itself with the following synta
 "#
     );
 
-    // Because an include directive must be on a line by itself, a directive with
-    // trailing content on the same line is not processed as an include.
+    // Because an include directive must be on a line by itself, a directive
+    // with trailing content on the same line is not processed as an
+    // include.
     let handler =
         InlineFileHandler::from_pairs([("part1.adoc", "First"), ("part2.adoc", "Second")]);
 
@@ -389,9 +390,9 @@ If you don't want the include directive to be processed, you must escape it usin
 "#
     );
 
-    // An escaped include directive is not processed: its target is not resolved.
-    // Matching Asciidoctor, the leading backslash is stripped and the remainder
-    // is emitted literally.
+    // An escaped include directive is not processed: its target is not
+    // resolved. Matching Asciidoctor, the leading backslash is stripped and
+    // the remainder is emitted literally.
     let handler = InlineFileHandler::from_pairs([("just-an-example.ext", "SHOULD NOT APPEAR")]);
 
     let doc = Parser::default()
@@ -461,8 +462,8 @@ Escaping the directive is necessary _even if it appears in a verbatim block_ sin
 "#
     );
 
-    // An unescaped include is processed even inside a verbatim block, so escaping
-    // is required there to prevent it from being expanded.
+    // An unescaped include is processed even inside a verbatim block, so
+    // escaping is required there to prevent it from being expanded.
     let handler = InlineFileHandler::from_pairs([("ex.adoc", "IMPORTED")]);
 
     let doc = Parser::default()
@@ -510,8 +511,8 @@ The following message will also be inserted into the output:
 "#
     );
 
-    // When the target cannot be resolved, the directive is replaced in the output
-    // with an "Unresolved directive" message.
+    // When the target cannot be resolved, the directive is replaced in the
+    // output with an "Unresolved directive" message.
     let handler = InlineFileHandler::from_pairs([("other.adoc", "unused")]);
 
     let doc = Parser::default()
@@ -561,8 +562,8 @@ If you don't want the AsciiDoc processor to emit a warning, but rather drop the 
     );
 
     // The handler does not provide content.adoc, but `opts=optional` means the
-    // unresolved directive is dropped silently: no "Unresolved directive" text is
-    // inserted and no warning is emitted.
+    // unresolved directive is dropped silently: no "Unresolved directive" text
+    // is inserted and no warning is emitted.
     let handler = InlineFileHandler::from_pairs([("other.adoc", "unused")]);
 
     let doc = Parser::default()
@@ -600,8 +601,8 @@ A common pattern to help here is to define the paths in attributes defined in th
 "#
     );
 
-    // An attribute reference in the include target is resolved before the target
-    // is looked up.
+    // An attribute reference in the include target is resolved before the
+    // target is looked up.
     let handler = InlineFileHandler::from_pairs([("_includes/fragment1.adoc", "Fragment one.")]);
 
     let doc = Parser::default()
@@ -637,9 +638,9 @@ The content of all included content goes through some form of normalization.
 "#
     );
 
-    // The directive merges any text file's content, not just AsciiDoc: here a CSV
-    // fragment is included verbatim. The content is normalized as it is merged —
-    // the CRLF line ending becomes a Unix line feed.
+    // The directive merges any text file's content, not just AsciiDoc: here a
+    // CSV fragment is included verbatim. The content is normalized as it is
+    // merged — the CRLF line ending becomes a Unix line feed.
     let handler = InlineFileHandler::from_pairs([("results.csv", "Year,Total\r\n2016,1234")]);
 
     let doc = Parser::default()
@@ -674,8 +675,8 @@ If the file is recognized as an AsciiDoc file (i.e., it has one of the following
     );
 
     // An include whose target is recognized as AsciiDoc (by its `.adoc`
-    // extension) is run through the preprocessor, so an include directive nested
-    // within it is itself expanded.
+    // extension) is run through the preprocessor, so an include directive
+    // nested within it is itself expanded.
     let handler = InlineFileHandler::from_pairs([
         ("chapter.adoc", "Chapter intro.\n\ninclude::fragment.adoc[]"),
         ("fragment.adoc", "Fragment body."),
@@ -737,8 +738,8 @@ Running the preprocessor on the included content allows includes to be nested, t
 "#
     );
 
-    // The preprocessor runs on included content, so an include inside an included
-    // file is itself resolved (nested includes).
+    // The preprocessor runs on included content, so an include inside an
+    // included file is itself resolved (nested includes).
     let handler = InlineFileHandler::from_pairs([
         ("outer.adoc", "Outer top.\n\ninclude::inner.adoc[]"),
         ("inner.adoc", "Inner content."),
@@ -779,8 +780,9 @@ The content is inserted as is (after being normalized).
 "#
     );
 
-    // A non-AsciiDoc include (here a `.csv` file) is merged verbatim: an include
-    // directive nested within it is left as literal text, never expanded.
+    // A non-AsciiDoc include (here a `.csv` file) is merged verbatim: an
+    // include directive nested within it is left as literal text, never
+    // expanded.
     let handler = InlineFileHandler::from_pairs([
         ("results.csv", "year,total\ninclude::fragment.adoc[]"),
         ("fragment.adoc", "SHOULD NOT APPEAR"),

--- a/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
@@ -381,10 +381,10 @@ The single quotes around the variable name in the assignment are required to for
     );
 
     // Verify line number mapping.
-    // This verifies that the source map correctly tracks the original file and line
-    // numbers for included content. Each line in the preprocessed document should
-    // map back to either the main document (None) or the included file
-    // (Some(filename)).
+    // This verifies that the source map correctly tracks the original file and
+    // line numbers for included content. Each line in the preprocessed
+    // document should map back to either the main document (None) or the
+    // included file (Some(filename)).
     let source_map = doc.source_map();
 
     // Main document lines.

--- a/parser/src/tests/asciidoc_lang/directives/include_tagged_regions.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_tagged_regions.rs
@@ -383,7 +383,8 @@ A leading inclusion implicitly starts by selecting no lines.
 "#
     );
 
-    // A leading exclusion (`!foo`) implies a `**` base: untagged lines are kept.
+    // A leading exclusion (`!foo`) implies a `**` base: untagged lines are
+    // kept.
     assert_eq!(tag_select(FOOBAR, "tags=!foo"), "before\nafter");
     // A leading inclusion (`foo`) implies a `!**` base: untagged lines dropped.
     assert_eq!(tag_select(FOOBAR, "tags=foo"), "foo1\nbar1\nfoo2");

--- a/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
@@ -95,8 +95,8 @@ If the `tabsize` attribute is set on the block or the document, tabs are also re
         "----\ndef names\n  @name\nend\n----"
     );
 
-    // With no `indent` attribute, tabs are still expanded to spaces (tab stop of
-    // 4), but the block indentation is left untouched.
+    // With no `indent` attribute, tabs are still expanded to spaces (tab stop
+    // of 4), but the block indentation is left untouched.
     assert_eq!(
         listing_include_with_tabsize("", "\tdef names\n\t  @name\n\tend"),
         "----\n    def names\n      @name\n    end\n----"

--- a/parser/src/tests/asciidoc_lang/directives/include_with_leveloffset.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_with_leveloffset.rs
@@ -85,9 +85,9 @@ This allows you to publish each chapter as a standalone document (complete with 
     );
 
     // Without the offset the level-0 document title of the included file is not
-    // shifted, so it stays at level 0: a body-level `= Chapter Title` modeled as
-    // a level-0 section (Asciidoctor's `sect0`) that contains the level-1
-    // `== A Section`.
+    // shifted, so it stays at level 0: a body-level `= Chapter Title` modeled
+    // as a level-0 section (Asciidoctor's `sect0`) that contains the
+    // level-1 `== A Section`.
     let handler = InlineFileHandler::from_pairs([(
         "chapter01.adoc",
         "= Chapter Title\n\nChapter intro.\n\n== A Section\n\nSection body.",
@@ -262,8 +262,8 @@ fn absolute_offset_set_in_header_shifts_body_headings() {
     // The spec's "Alternatively, you could use absolute levels" note applies an
     // absolute `:leveloffset:` (here in the document header) rather than a
     // relative one. An absolute offset is stored verbatim and applied to every
-    // following heading: `= Chapter One` (level 0) becomes a level-1 section and
-    // its `== A Section` (level 1) becomes level 2.
+    // following heading: `= Chapter One` (level 0) becomes a level-1 section
+    // and its `== A Section` (level 1) becomes level 2.
     let doc = Parser::default().parse(concat!(
         "= My Book\n",
         ":leveloffset: 1\n",
@@ -282,8 +282,9 @@ fn absolute_offset_set_in_header_shifts_body_headings() {
 #[test]
 fn malformed_relative_offset_is_ignored() {
     // A `leveloffset` whose relative form has no valid integer (`+x`) cannot be
-    // resolved, so it is left as-is and read back as a zero offset: headings are
-    // not shifted. `== Real Section` (level 1) therefore stays at level 1.
+    // resolved, so it is left as-is and read back as a zero offset: headings
+    // are not shifted. `== Real Section` (level 1) therefore stays at level
+    // 1.
     let doc = Parser::default().parse(concat!(
         "= My Book\n",
         "\n",
@@ -297,11 +298,11 @@ fn malformed_relative_offset_is_ignored() {
 
 #[test]
 fn absolute_offset_near_i32_max_does_not_overflow() {
-    // A hostile absolute `:leveloffset:` at `i32::MAX` must not overflow when it
-    // is folded into a heading's syntactic level (here 5, from `======`). The
-    // effective level saturates instead of panicking (debug) or wrapping
-    // (release), then clamps into the supported 1-5 range: the heading is still
-    // a section, at level 5.
+    // A hostile absolute `:leveloffset:` at `i32::MAX` must not overflow when
+    // it is folded into a heading's syntactic level (here 5, from
+    // `======`). The effective level saturates instead of panicking (debug)
+    // or wrapping (release), then clamps into the supported 1-5 range: the
+    // heading is still a section, at level 5.
     let src = format!(
         "= My Book\n:leveloffset: {}\n\n====== Deep Heading",
         i32::MAX
@@ -326,8 +327,8 @@ fn absolute_offset_near_i32_max_does_not_overflow() {
 fn relative_offset_accumulation_near_i32_max_does_not_overflow() {
     // Accumulating a relative `+1` on top of an offset already at `i32::MAX`
     // must not overflow while resolving the assignment. The offset saturates at
-    // `i32::MAX`, so the following heading is still parsed as a section, clamped
-    // to level 5.
+    // `i32::MAX`, so the following heading is still parsed as a section,
+    // clamped to level 5.
     let src = format!(
         "= My Book\n:leveloffset: {}\n\n:leveloffset: +1\n\n====== Deep Heading",
         i32::MAX

--- a/parser/src/tests/asciidoc_lang/document/header.rs
+++ b/parser/src/tests/asciidoc_lang/document/header.rs
@@ -187,8 +187,8 @@ These implicit content lines are used to assign xref:author-information.adoc[] a
         );
     }
 
-    // Treating as non-normative because these conditions are well-verified in the
-    // test suite for header parsing.
+    // Treating as non-normative because these conditions are well-verified in
+    // the test suite for header parsing.
     non_normative!(
         r#"
 The header may contain the following elements as long as there aren't any empty lines between them:

--- a/parser/src/tests/asciidoc_lang/document/title.rs
+++ b/parser/src/tests/asciidoc_lang/document/title.rs
@@ -106,10 +106,10 @@ image::document-title.png[Title of document]
     }
 
     // Out of scope (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
-    // multiple level-0 headings are only valid for the `book` doctype, where the
-    // additional level-0 titles are interpreted as parts of a multi-part book. We
-    // don't support the `book` doctype's parts, so this is treated as
-    // non-normative.
+    // multiple level-0 headings are only valid for the `book` doctype, where
+    // the additional level-0 titles are interpreted as parts of a
+    // multi-part book. We don't support the `book` doctype's parts, so this
+    // is treated as non-normative.
     non_normative!(
         r#"
 === Doctypes and titles
@@ -259,8 +259,9 @@ If neither a level 0 section title or `doctitle` is specified in the header, but
     );
 
     // With no level 0 section title (`= …`) and no `doctitle` attribute in the
-    // header, a `title` attribute entry supplies the document title: there is no
-    // section title, and the effective doctitle falls back to the `title` value.
+    // header, a `title` attribute entry supplies the document title: there is
+    // no section title, and the effective doctitle falls back to the
+    // `title` value.
     let doc = Parser::default().parse(":title: The Intrepid Chronicles\n\nA frigid morning.");
 
     assert_eq!(doc.header().title(), None);

--- a/parser/src/tests/asciidoc_lang/lists/checklist.rs
+++ b/parser/src/tests/asciidoc_lang/lists/checklist.rs
@@ -125,8 +125,8 @@ include::example$checklist.adoc[tag=check-int]
     assert!(checklist.has_option("interactive"));
 
     // Each checklist item renders an interactive `<input type="checkbox">`. The
-    // `data-item-complete` attribute is 1 (with `checked`) for checked items and
-    // 0 for unchecked ones; no checkbox is disabled.
+    // `data-item-complete` attribute is 1 (with `checked`) for checked items
+    // and 0 for unchecked ones; no checkbox is disabled.
     assert_css(&doc, ".ulist.checklist", 1);
     assert_css(&doc, ".ulist.checklist li input[type=\"checkbox\"]", 3);
     assert_css(

--- a/parser/src/tests/asciidoc_lang/lists/continuation.rs
+++ b/parser/src/tests/asciidoc_lang/lists/continuation.rs
@@ -2106,9 +2106,9 @@ include::example$complex.adoc[tag=complex-only]
 
         // The principal-text node is dropped from each item's child blocks (the
         // listing block is the only child, so it lines up with the marker), but
-        // each item records that it had an empty principal text. A renderer uses
-        // this to emit the empty principal paragraph ahead of the attached
-        // listing block, matching Asciidoctor.
+        // each item records that it had an empty principal text. A renderer
+        // uses this to emit the empty principal paragraph ahead of the
+        // attached listing block, matching Asciidoctor.
         let Some(crate::blocks::Block::List(list)) = doc.child_blocks().next() else {
             panic!("expected a list block");
         };

--- a/parser/src/tests/asciidoc_lang/lists/description.rs
+++ b/parser/src/tests/asciidoc_lang/lists/description.rs
@@ -43,8 +43,8 @@ If a term has an anchor, the anchor must be defined at the start of the same lin
     let items: Vec<&crate::blocks::Block<'_>> = list.child_blocks().collect();
     assert_eq!(items.len(), 1);
 
-    // The `::` term is still recognized even though the term line begins with an
-    // anchor, and the anchor becomes part of the rendered term.
+    // The `::` term is still recognized even though the term line begins with
+    // an anchor, and the anchor becomes part of the rendered term.
     assert_eq!(term_delimiter(items[0]), "::");
     assert_eq!(term_rendered(items[0]), "<a id=\"cpu\"></a>CPU");
 
@@ -110,8 +110,8 @@ The available term delimiters you can use for this purpose are as follows:
     let list = top_list(&doc);
     assert_eq!(list.type_(), ListType::Description);
 
-    // Changing the delimiter means the second term is not a sibling; it begins a
-    // new description list nested inside the first item.
+    // Changing the delimiter means the second term is not a sibling; it begins
+    // a new description list nested inside the first item.
     let outer: Vec<&crate::blocks::Block<'_>> = list.child_blocks().collect();
     assert_eq!(outer.len(), 1);
     assert_eq!(term_delimiter(outer[0]), "::");
@@ -2414,7 +2414,8 @@ fn ordered_list_nests_under_second_level_term() {
     assert_eq!(outer_items.len(), 1);
     assert_eq!(term_delimiter(outer_items[0]), "::");
 
-    // The `OS` term nests a `:::` description list whose single term is `Linux`.
+    // The `OS` term nests a `:::` description list whose single term is
+    // `Linux`.
     let inner = nested_list(outer_items[0]);
     let inner_items: Vec<_> = inner.child_blocks().collect();
     assert_eq!(inner_items.len(), 1);

--- a/parser/src/tests/asciidoc_lang/macros/audio_and_video.rs
+++ b/parser/src/tests/asciidoc_lang/macros/audio_and_video.rs
@@ -609,10 +609,11 @@ include::example$video.adoc[tag=vimeo]
 "#
         );
 
-        // The video ID is the macro target and the hosting service name (`vimeo`)
-        // is the first positional attribute. How the target ID and service name
-        // are assembled into an embed URL is the converter's responsibility, not
-        // the parser's, so the parser simply preserves both verbatim.
+        // The video ID is the macro target and the hosting service name
+        // (`vimeo`) is the first positional attribute. How the target
+        // ID and service name are assembled into an embed URL is the
+        // converter's responsibility, not the parser's, so the parser
+        // simply preserves both verbatim.
         //
         // example$video.adoc[tag=vimeo]
         let doc = Parser::default().parse("video::67480300[vimeo]");
@@ -671,9 +672,9 @@ include::example$video.adoc[tag=youtube-with-list]
 "#
         );
 
-        // The `list` named attribute carries the playlist ID. The parser exposes
-        // it as a plain named attribute; mapping it onto the embed URL is the
-        // converter's job.
+        // The `list` named attribute carries the playlist ID. The parser
+        // exposes it as a plain named attribute; mapping it onto the
+        // embed URL is the converter's job.
         //
         // example$video.adoc[tag=youtube-with-list]
         let doc = Parser::default()
@@ -709,9 +710,9 @@ include::example$video.adoc[tag=youtube-with-list-in-target]
         );
 
         // The playlist ID follows the video ID in the target, separated by a
-        // slash. The parser keeps the whole target verbatim (it does not split on
-        // the slash); the converter is responsible for separating the video ID
-        // from the playlist ID.
+        // slash. The parser keeps the whole target verbatim (it does not split
+        // on the slash); the converter is responsible for separating
+        // the video ID from the playlist ID.
         //
         // example$video.adoc[tag=youtube-with-list-in-target]
         let doc = Parser::default()
@@ -746,8 +747,8 @@ include::example$video.adoc[tag=youtube-with-playlist]
         );
 
         // The `playlist` named attribute holds a comma-separated list of video
-        // IDs. Because the value contains commas, it is enclosed in double quotes
-        // so the attribute parser keeps it as a single value.
+        // IDs. Because the value contains commas, it is enclosed in double
+        // quotes so the attribute parser keeps it as a single value.
         //
         // example$video.adoc[tag=youtube-with-playlist]
         let doc = Parser::default()
@@ -783,9 +784,9 @@ include::example$video.adoc[tag=youtube-with-playlist-in-target]
         );
 
         // The additional video IDs follow the first video ID in the target,
-        // separated by commas. The parser keeps the entire comma-separated target
-        // verbatim; splitting it into the lead video ID and the playlist members
-        // is the converter's job.
+        // separated by commas. The parser keeps the entire comma-separated
+        // target verbatim; splitting it into the lead video ID and the
+        // playlist members is the converter's job.
         //
         // example$video.adoc[tag=youtube-with-playlist-in-target]
         let doc = Parser::default().parse("video::RvRhUHTV_8k,_SvwdK_HibQ,SGqg_ZzThDU[youtube]");

--- a/parser/src/tests/asciidoc_lang/macros/autolinks.rs
+++ b/parser/src/tests/asciidoc_lang/macros/autolinks.rs
@@ -869,9 +869,9 @@ mod pr498 {
         // fires capture group 6 with group 2 unset. Previously this panicked on
         // the direct `&caps[7]` / `&caps[8]` indexing in InlineLinkReplacer.
         //
-        // Expected output matches Ruby Asciidoctor 2.0.23, which treats the stray
-        // `&gt;` as part of a bare link (keeping `&gt` in the URL) and leaves the
-        // trailing `;` outside the link.
+        // Expected output matches Ruby Asciidoctor 2.0.23, which treats the
+        // stray `&gt;` as part of a bare link (keeping `&gt` in the
+        // URL) and leaves the trailing `;` outside the link.
         let doc = Parser::default().parse("See https://example.org> for details.");
 
         let rendered = doc
@@ -889,8 +889,9 @@ mod pr498 {
 
     #[test]
     fn multiple_bare_urls_with_trailing_gt() {
-        // Two group-6 matches in a row also exercised the skip/retry path; verify
-        // both URLs render and no panic occurs. Output matches Ruby Asciidoctor.
+        // Two group-6 matches in a row also exercised the skip/retry path;
+        // verify both URLs render and no panic occurs. Output matches
+        // Ruby Asciidoctor.
         let doc = Parser::default().parse("a https://example.org> b https://example.com> c");
 
         let rendered = doc

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -277,13 +277,13 @@ That means the text formatting in the footnote text will already be applied when
 
 #[test]
 fn footnotes_in_headings_are_numbered_in_document_order() {
-    // The crate deliberately diverges from Asciidoctor here (see the note on the
-    // "Footnotes in headings" section below and issue #594). Rather than
-    // converting section titles eagerly and out of document order, it applies a
-    // title's substitutions before parsing the section body. A footnote in a
-    // heading is therefore numbered in straightforward document order: the
-    // heading's footnote follows footnotes in preceding content and precedes
-    // footnotes in the heading's own section body.
+    // The crate deliberately diverges from Asciidoctor here (see the note on
+    // the "Footnotes in headings" section below and issue #594). Rather
+    // than converting section titles eagerly and out of document order, it
+    // applies a title's substitutions before parsing the section body. A
+    // footnote in a heading is therefore numbered in straightforward
+    // document order: the heading's footnote follows footnotes in preceding
+    // content and precedes footnotes in the heading's own section body.
     let doc = Parser::default().parse(concat!(
         "== Section 1\n",
         "\n",

--- a/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
@@ -136,11 +136,12 @@ Here's how the HTML converter converts an icon macro when the `icons` attribute 
 
         // The spec's "not set or empty" wording is loose: with the `icons`
         // attribute genuinely unset the icon renders as bracketed fallback text
-        // (see `how_the_icon_is_resolved` below); the image `<img>` output shown
-        // here is produced when `icons` is *empty* (i.e. image mode). This crate
-        // renders only the inline fragment, so the `<span class="icon">` wrapper
-        // appears without the enclosing `<div class="paragraph"><p>` block markup
-        // shown above. It also uses `class="icon"` (matching Asciidoctor's actual
+        // (see `how_the_icon_is_resolved` below); the image `<img>` output
+        // shown here is produced when `icons` is *empty* (i.e. image
+        // mode). This crate renders only the inline fragment, so the
+        // `<span class="icon">` wrapper appears without the enclosing
+        // `<div class="paragraph"><p>` block markup shown above. It
+        // also uses `class="icon"` (matching Asciidoctor's actual
         // output) rather than the `class="image"` printed in this spec example.
         let doc = Parser::default().parse(":icons:\n\nicon:tags[] ruby, asciidoctor");
 
@@ -152,8 +153,8 @@ Here's how the HTML converter converts an icon macro when the `icons` attribute 
 
     // The DocBook converter is not implemented by this crate, so the
     // `<inlinemediaobject>` rendering below is not verified here. Likewise, the
-    // fallback behavior when an icon image can't be located requires file-system
-    // access this crate leaves to the caller.
+    // fallback behavior when an icon image can't be located requires
+    // file-system access this crate leaves to the caller.
     non_normative!(
         r#"
 Here's how the DocBook converter converts an icon macro.
@@ -223,8 +224,9 @@ WARNING: If you include a file extension in the image target, the icon macro wil
             r#"<span class="icon"><i class="fa fa-heart"></i></span>"#
         );
 
-        // WARNING: a file extension in the target breaks font icon mode, because
-        // the extension is carried into the glyph class (`fa-heart.png`).
+        // WARNING: a file extension in the target breaks font icon mode,
+        // because the extension is carried into the glyph class
+        // (`fa-heart.png`).
         let doc = Parser::default().parse(":icons: font\n\nicon:heart.png[]");
         assert_eq!(
             rendered_paragraphs(&doc).join("\n"),
@@ -285,7 +287,8 @@ icon:tags[role=blue] ruby, asciidoctor
 "#
         );
 
-        // The role is appended to the class of the `<span>` surrounding the icon.
+        // The role is appended to the class of the `<span>` surrounding the
+        // icon.
         let doc =
             Parser::default().parse(":icons: image\n\nicon:tags[role=blue] ruby, asciidoctor");
         assert_eq!(
@@ -368,11 +371,12 @@ icon:tags[Tags,width=16] ruby, asciidoctor
         );
 
         // NOTE: The icon macro's sole positional attribute is `size` (see the
-        // font-mode section below), so in `icon:tags[Tags,width=16]` the leading
-        // `Tags` is parsed as `size`, not `alt`. Because `size` has no effect in
-        // image mode, the alt text falls back to the target-derived default
-        // (`tags`) while `width=16` applies. To set the alt text explicitly, use
-        // the named `alt` attribute as shown above.
+        // font-mode section below), so in `icon:tags[Tags,width=16]` the
+        // leading `Tags` is parsed as `size`, not `alt`. Because `size`
+        // has no effect in image mode, the alt text falls back to the
+        // target-derived default (`tags`) while `width=16` applies. To
+        // set the alt text explicitly, use the named `alt` attribute as
+        // shown above.
         let doc =
             Parser::default().parse(":icons: image\n\nicon:tags[Tags,width=16] ruby, asciidoctor");
         assert_eq!(

--- a/parser/src/tests/asciidoc_lang/macros/icons_image.rs
+++ b/parser/src/tests/asciidoc_lang/macros/icons_image.rs
@@ -62,9 +62,10 @@ Instead, it will look for icons that have the _.png_ file extension.
 "#
     );
 
-    // With neither `iconsdir` nor `imagesdir` configured, an icon resolves under
-    // the default `./images/icons` directory with the `.png` extension (the "if
-    // you have not configured either attribute" outcome).
+    // With neither `iconsdir` nor `imagesdir` configured, an icon resolves
+    // under the default `./images/icons` directory with the `.png`
+    // extension (the "if you have not configured either attribute"
+    // outcome).
     let doc = Parser::default().parse(":icons: image\n\nicon:note[]");
     assert_eq!(
         rendered_paragraphs(&doc).join("\n"),

--- a/parser/src/tests/asciidoc_lang/macros/image_position.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_position.rs
@@ -516,9 +516,9 @@ This role isn't technically required, but it gives the image semantic meaning.
 
 mod control_the_float {
     // This section describes the browser layout behavior of the `float-group`
-    // role, which the parser records as an ordinary role on the enclosing block.
-    // No parser-specific behavior is normative here (block images are not
-    // rendered to HTML by this crate), so the section is covered as
+    // role, which the parser records as an ordinary role on the enclosing
+    // block. No parser-specific behavior is normative here (block images
+    // are not rendered to HTML by this crate), so the section is covered as
     // non-normative.
     use crate::tests::prelude::*;
 

--- a/parser/src/tests/asciidoc_lang/macros/image_ref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_ref.rs
@@ -125,7 +125,8 @@ fn fallback() {
 
     // The `fallback` image is nested inside the interactive SVG `<object>` for
     // user agents that cannot render the object. (Interactive SVG handling is
-    // security sensitive, so it only takes effect below the `Secure` safe mode.)
+    // security sensitive, so it only takes effect below the `Secure` safe
+    // mode.)
     let doc = Parser::default()
         .with_safe_mode(SafeMode::Server)
         .parse("image:tiger.svg[Tiger,fallback=tiger.png,opts=interactive]");

--- a/parser/src/tests/asciidoc_lang/macros/image_svg.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_svg.rs
@@ -114,8 +114,9 @@ How these options values work and when each should be used is described below:
 "#
         );
 
-        // With no option (and in the default `Secure` safe mode) an SVG image is
-        // referenced with a plain `<img>` element, exactly like any other image.
+        // With no option (and in the default `Secure` safe mode) an SVG image
+        // is referenced with a plain `<img>` element, exactly like any
+        // other image.
         let doc = Parser::default().parse("image:sample.svg[Static,300]");
 
         assert_eq!(
@@ -136,10 +137,11 @@ How these options values work and when each should be used is described below:
 "#
         );
 
-        // The `interactive` option references the SVG with an `<object>` element
-        // so its embedded scripting and links stay live. It is security
-        // sensitive, so it only takes effect below the `Secure` safe mode; the
-        // alt text becomes the object's fallback content.
+        // The `interactive` option references the SVG with an `<object>`
+        // element so its embedded scripting and links stay live. It is
+        // security sensitive, so it only takes effect below the
+        // `Secure` safe mode; the alt text becomes the object's
+        // fallback content.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Server)
             .parse("image:sample.svg[Interactive,300,opts=interactive]");
@@ -152,11 +154,12 @@ How these options values work and when each should be used is described below:
 
     #[test]
     fn interactive_is_ignored_in_secure_mode() {
-        // Because the `interactive` option is security sensitive, in the default
-        // `Secure` safe mode it is ignored and the SVG is referenced with a plain
-        // `<img>`, exactly as Ruby Asciidoctor does. (The page itself does not
-        // discuss safe mode, so this is behavior coverage rather than a
-        // `verifies!` of normative page text.)
+        // Because the `interactive` option is security sensitive, in the
+        // default `Secure` safe mode it is ignored and the SVG is
+        // referenced with a plain `<img>`, exactly as Ruby Asciidoctor
+        // does. (The page itself does not discuss safe mode, so this is
+        // behavior coverage rather than a `verifies!` of normative page
+        // text.)
         let doc = Parser::default().parse("image:sample.svg[Interactive,300,opts=interactive]");
 
         assert_eq!(
@@ -205,8 +208,9 @@ To allow SVG content reachable by JavaScript in the main DOM or to inherit style
     #[test]
     fn inline_is_ignored_in_secure_mode() {
         // Like `interactive`, the `inline` option is disabled in the default
-        // `Secure` safe mode: the registered `SvgFileHandler` is never consulted
-        // and a plain `<img>` is emitted instead of the embedded `<svg>`.
+        // `Secure` safe mode: the registered `SvgFileHandler` is never
+        // consulted and a plain `<img>` is emitted instead of the
+        // embedded `<svg>`.
         let doc = Parser::default()
             .with_svg_file_handler(SvgFileHandlerFixture::from_pairs([(
                 "sample.svg",
@@ -232,8 +236,8 @@ If the value of the fallback attribute is a relative path, it will be prefixed w
         );
 
         // The `fallback` image nests inside the `<object>` as an `<img>`. Its
-        // relative path (`fallback.png`) is prefixed with `imagesdir` (`images`),
-        // just like the object's own `data` target.
+        // relative path (`fallback.png`) is prefixed with `imagesdir`
+        // (`images`), just like the object's own `data` target.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Server)
             .with_intrinsic_attribute("imagesdir", "images", ModificationContext::Anywhere)
@@ -262,18 +266,19 @@ When using the `inline` option, if you specify a width or height on the image ma
         );
 
         // The fixture's opening `<svg>` tag carries `width`, `height`, and
-        // `style` attributes. Supplying a width (and here a height) on the image
-        // macro removes all three from the tag and appends the requested
-        // dimensions instead; the required `viewBox` is preserved.
+        // `style` attributes. Supplying a width (and here a height) on the
+        // image macro removes all three from the tag and appends the
+        // requested dimensions instead; the required `viewBox` is
+        // preserved.
         //
         // This test exercises only the attribute-stripping clause of the spec
         // line above. The trailing "cannot have a namespace" clause is an
         // authoring constraint on the SVG *source* — its element names must not
-        // be namespace-prefixed (e.g. `<svg:svg>`/`<svg:circle>`) — not a parser
-        // behavior: the parser embeds the SVG verbatim and never rewrites element
-        // names. The preserved `xmlns="…"` here is a default-namespace
-        // *declaration*, which is unrelated to (and not prohibited by) that
-        // clause; Asciidoctor keeps it as well.
+        // be namespace-prefixed (e.g. `<svg:svg>`/`<svg:circle>`) — not a
+        // parser behavior: the parser embeds the SVG verbatim and never
+        // rewrites element names. The preserved `xmlns="…"` here is a
+        // default-namespace *declaration*, which is unrelated to (and
+        // not prohibited by) that clause; Asciidoctor keeps it as well.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Server)
             .with_svg_file_handler(SvgFileHandlerFixture::from_pairs([(

--- a/parser/src/tests/asciidoc_lang/macros/image_url.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_url.rs
@@ -237,8 +237,8 @@ This time, `imagesdir` is used since the image target is not a URL (the value of
             r#"<span class="image"><img src="https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg" alt="Tux" width="250" height="350"></span>"#
         );
 
-        // Per the NOTE above, the `imagesdir` base is ignored when the target is
-        // itself a URL: the absolute target is used verbatim.
+        // Per the NOTE above, the `imagesdir` base is ignored when the target
+        // is itself a URL: the absolute target is used verbatim.
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "imagesdir",

--- a/parser/src/tests/asciidoc_lang/macros/images.rs
+++ b/parser/src/tests/asciidoc_lang/macros/images.rs
@@ -514,7 +514,8 @@ To turn off figure caption labels and numbers, unset the `figure-caption` attrib
 "#
         );
 
-        // By default a titled block image is captioned "Figure N." and numbered.
+        // By default a titled block image is captioned "Figure N." and
+        // numbered.
         let doc = Parser::default().parse(".A mountain sunset\nimage::sunset.jpg[Sunset]");
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(block.title(), Some("A mountain sunset"));

--- a/parser/src/tests/asciidoc_lang/macros/inter_document_xref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/inter_document_xref.rs
@@ -91,8 +91,8 @@ Now you can create inter-document cross references without the headache.
     // `document-b.adoc` is included into this document in full, so its
     // `section-b` anchor is now part of this document and the inter-document
     // reference to it collapses to a same-document one (issue #808). The Ruby
-    // suite reads the included file from disk; here an include handler serves it
-    // inline.
+    // suite reads the included file from disk; here an include handler serves
+    // it inline.
     let doc = Parser::default()
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(inline_file_handler::InlineFileHandler::from_pairs([(

--- a/parser/src/tests/asciidoc_lang/macros/keyboard_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/keyboard_macro.rs
@@ -100,8 +100,8 @@ You can find example of these cases in the example below.
         // A trailing backslash key must be followed by a space so it is not
         // mistaken for an escape...
         assert_eq!(render("kbd:[\\ ]"), "<kbd>\\</kbd>");
-        // ...and a closing square bracket key must be escaped with a backslash so
-        // the macro does not end prematurely.
+        // ...and a closing square bracket key must be escaped with a backslash
+        // so the macro does not end prematurely.
         assert_eq!(
             render("kbd:[Ctrl+\\]]"),
             r#"<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>]</kbd></span>"#
@@ -125,11 +125,13 @@ include::example$ui.adoc[tag=key]
 "#
         );
 
-        // The example above pulls in `example$ui.adoc[tag=key]`. The spec-coverage
-        // tool can't follow includes, so the included table is reproduced here and
-        // parsed directly (with `experimental` set, as the UI macros require). Each
-        // `Shortcut` cell exercises a documented case: a lone key, key sequences,
-        // the backslash-plus-space escape, and the escaped closing bracket.
+        // The example above pulls in `example$ui.adoc[tag=key]`. The
+        // spec-coverage tool can't follow includes, so the included
+        // table is reproduced here and parsed directly (with
+        // `experimental` set, as the UI macros require). Each
+        // `Shortcut` cell exercises a documented case: a lone key, key
+        // sequences, the backslash-plus-space escape, and the escaped
+        // closing bracket.
         let input = format!(
             ":experimental:\n\n{}",
             r#"|===

--- a/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
@@ -410,9 +410,10 @@ Strictly speaking, the enclosure is only required when the text preceding the eq
         );
 
         // The text preceding the `=` here is `Read this`, which is not a valid
-        // attribute name (it contains a space), so the whole unquoted attrlist is
-        // taken as the first positional attribute (the link text) even though it
-        // contains an equals sign. No double-quote enclosure is required.
+        // attribute name (it contains a space), so the whole unquoted attrlist
+        // is taken as the first positional attribute (the link text)
+        // even though it contains an equals sign. No double-quote
+        // enclosure is required.
         let doc = Parser::default().parse("https://example.org[Read this=important document]");
 
         assert_eq!(

--- a/parser/src/tests/asciidoc_lang/macros/ui_macros.rs
+++ b/parser/src/tests/asciidoc_lang/macros/ui_macros.rs
@@ -116,12 +116,12 @@ include::example$ui.adoc[tag=menu]
         );
     }
 
-    // The material below describes the *shorthand* menu syntax (`"File > Save"`).
-    // This crate does not implement it and does not plan to: per the AsciiDoc
-    // language documentation the shorthand is not on a standards track (see the
-    // "No planned support" section of the crate README). These lines are
-    // therefore kept non-normative — covered for completeness, but no behavior is
-    // asserted.
+    // The material below describes the *shorthand* menu syntax (`"File >
+    // Save"`). This crate does not implement it and does not plan to: per
+    // the AsciiDoc language documentation the shorthand is not on a
+    // standards track (see the "No planned support" section of the crate
+    // README). These lines are therefore kept non-normative — covered for
+    // completeness, but no behavior is asserted.
     non_normative!(
         r#"
 If the menu has more than one item, it can be expressed using a shorthand.
@@ -164,8 +164,9 @@ For example, to make a menu item that starts with vertical ellipsis, you must us
             render("menu:&#8942;[More Tools, Extensions]"),
             r#"<span class="menuseq"><b class="menu">&#8942;</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">More Tools</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Extensions</b></span>"#
         );
-        // A menu name that begins with a non-word, non-ampersand character is not
-        // recognized as a menu macro, so it is emitted as literal text.
+        // A menu name that begins with a non-word, non-ampersand character is
+        // not recognized as a menu macro, so it is emitted as literal
+        // text.
         assert_eq!(render("menu:.hidden[Item]"), "menu:.hidden[Item]");
     }
 

--- a/parser/src/tests/asciidoc_lang/macros/xref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref.rs
@@ -212,7 +212,8 @@ If the intention is to link to an ID within the same document, the target must b
         &[r##"See <a href="#the-id">Custom Text</a>."##]
     );
 
-    // A `#`-prefixed target is an explicit reference to an ID in the same document.
+    // A `#`-prefixed target is an explicit reference to an ID in the same
+    // document.
     let doc = Parser::default().parse("See xref:#the-id[].\n\n[#the-id]\n== Some Section\n");
 
     assert_eq!(

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -195,8 +195,8 @@ Additionally, no AsciiDoc syntax within the delimited lines is interpreted, not 
     );
 
     // The content of a comment block is raw: neither inline markup nor an
-    // attribute reference is interpreted, and an inner `//` line (a preprocessor
-    // line comment) is retained verbatim rather than stripped.
+    // attribute reference is interpreted, and an inner `//` line (a
+    // preprocessor line comment) is retained verbatim rather than stripped.
     let doc = Parser::default().parse("////\n*bold* {attr}\n// inner\n////");
     let block = doc.child_blocks().next().expect("expected a block");
     assert_eq!(
@@ -232,10 +232,10 @@ A comment block can also be written as an open block with the comment style:
 "#
     );
 
-    // An open block (`--`) carrying the `comment` style is the alternate form of
-    // a comment block: same `comment` context, raw (uninterpreted) content —
-    // inner `//` lines retained, and a `subs` override ignored — matching the
-    // `////` form exactly.
+    // An open block (`--`) carrying the `comment` style is the alternate form
+    // of a comment block: same `comment` context, raw (uninterpreted)
+    // content — inner `//` lines retained, and a `subs` override ignored —
+    // matching the `////` form exactly.
     let doc = Parser::default().parse("[comment]\n--\n*bold* {attr}\n// inner\n--");
     let block = doc.child_blocks().next().expect("expected a block");
     assert_eq!(block.resolved_context().as_ref(), "comment");

--- a/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
+++ b/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
@@ -409,7 +409,8 @@ include::document:example$header.adoc[tag=qr-attributes]
     let doc = Parser::default().parse("= Title\nv2.0, 2019-03-22");
     assert!(doc.header().revision_line().is_none());
 
-    // With an author line present, the third line is parsed as the revision line.
+    // With an author line present, the third line is parsed as the revision
+    // line.
     let doc = Parser::default().parse("= Title\nAuthor Name <author@email.org>\nv2.0, 2019-03-22");
     assert!(doc.header().author_line().is_some());
     assert!(doc.header().revision_line().is_some());
@@ -625,7 +626,8 @@ Assuming the safe mode is less than SECURE, you must also set the `allow-uri-rea
             .any(|p| p.contains("Remote content."))
     );
 
-    // In SECURE mode the read is forcefully disabled even with `allow-uri-read`.
+    // In SECURE mode the read is forcefully disabled even with
+    // `allow-uri-read`.
     let handler = InlineFileHandler::from_pairs([(URI, "SECRET CONTENT")]);
     let doc = Parser::default()
         .with_safe_mode(SafeMode::Secure)
@@ -791,8 +793,8 @@ include::lists:example$complex.adoc[tag=b-complex]
         2
     );
 
-    // The unordered list marker can be changed with a list style (e.g. `square`),
-    // which the parser captures as the list's declared style.
+    // The unordered list marker can be changed with a list style (e.g.
+    // `square`), which the parser captures as the list's declared style.
     let doc = Parser::default().parse("[square]\n* one\n* two");
     let Some(Block::List(list)) = doc.child_blocks().next() else {
         panic!("expected a list");
@@ -831,7 +833,8 @@ include::lists:example$complex.adoc[tag=b-complex]
     };
     assert_eq!(list.type_(), ListType::Description);
 
-    // Question-and-answer lists are description lists carrying the `qanda` style.
+    // Question-and-answer lists are description lists carrying the `qanda`
+    // style.
     let doc = Parser::default().parse("[qanda]\nWhat is the answer?::\nThis is the answer.");
     let Some(Block::List(list)) = doc.child_blocks().next() else {
         panic!("expected a list");
@@ -943,7 +946,8 @@ You can also pass it as a command line argument using `-a data-uri`.
     };
     assert_eq!(m.type_(), MediaType::Image);
 
-    // ... whereas `image:` (one colon) is an inline image within a line of text.
+    // ... whereas `image:` (one colon) is an inline image within a line of
+    // text.
     let doc = Parser::default().parse("Click image:play.png[] to start.");
     assert!(rendered_paragraphs(&doc)[0].contains(r#"<span class="image">"#));
 }
@@ -1303,7 +1307,8 @@ include::verbatim:example$source.adoc[tag=src-para]
         .parse("[source,ruby]\n----\nputs 'hi' # <1>\n----\n<1> Prints a greeting.\n");
     assert_output_contains(&doc, r#"<b class="conum">(1)</b>"#);
 
-    // A `[source,ruby]` paragraph (no delimiters) is a Source-styled simple block.
+    // A `[source,ruby]` paragraph (no delimiters) is a Source-styled simple
+    // block.
     let doc = Parser::default().parse("[source,ruby]\nputs 'hi'");
     let Some(Block::Simple(sb)) = doc.child_blocks().next() else {
         panic!("expected a simple block");
@@ -2004,8 +2009,8 @@ Any named, numeric or hexadecimal {url-char-xml}[XML character reference^] is su
 "#
     );
 
-    // Named, numeric, and hexadecimal XML character references are all preserved
-    // in the output.
+    // Named, numeric, and hexadecimal XML character references are all
+    // preserved in the output.
     let doc = Parser::default().parse("Named &sect;, decimal &#167;, hex &#xA9; stay.");
     assert_eq!(
         rendered_paragraphs(&doc)[0],

--- a/parser/src/tests/asciidoc_lang/sections/appendix.rs
+++ b/parser/src/tests/asciidoc_lang/sections/appendix.rs
@@ -37,10 +37,10 @@ include::example$appendix.adoc[tag=appx-article-out]
 
     // NOTE: Removed the `:appendix-caption: Exhibit` and `:toc:` header
     // attributes from the example. The `appendix-caption` attribute is now
-    // honored (it defaults to "`Appendix`", so the appendix sections below carry
-    // "Appendix A: " / "Appendix B: " captions), but `toc` rendering is still not
-    // supported. A custom `appendix-caption` value is exercised separately in
-    // `appendix_label` below.
+    // honored (it defaults to "`Appendix`", so the appendix sections below
+    // carry "Appendix A: " / "Appendix B: " captions), but `toc` rendering
+    // is still not supported. A custom `appendix-caption` value is
+    // exercised separately in `appendix_label` below.
     let doc = Parser::default().parse("= Article Title\n:sectnums:\n\n== Section\n\n=== Subsection\n\n[appendix]\n== First Appendix\n\n=== First Subsection\n\n=== Second Subsection\n\n[appendix]\n== Second Appendix");
 
     assert_eq!(
@@ -470,7 +470,8 @@ Unset the attribute to remove the prefix.
     );
 
     // Unsetting `appendix-caption` removes the label, but the appendix is still
-    // lettered: the prefix collapses to "<letter>. " (matching Ruby Asciidoctor).
+    // lettered: the prefix collapses to "<letter>. " (matching Ruby
+    // Asciidoctor).
     let doc = Parser::default().parse(
         ":appendix-caption!:\n\n[appendix]\n== Data Access Matrix\n\n[appendix]\n== Error Codes",
     );

--- a/parser/src/tests/asciidoc_lang/sections/bibliography.rs
+++ b/parser/src/tests/asciidoc_lang/sections/bibliography.rs
@@ -117,9 +117,10 @@ include::example$bibliography.adoc[tag=base]
 "#
     );
 
-    // The `base` example included above, with the `include::` directive expanded
-    // by inlining the example's `base` tag: two entries in a bibliography
-    // section, each cross-referenced from the introductory paragraph.
+    // The `base` example included above, with the `include::` directive
+    // expanded by inlining the example's `base` tag: two entries in a
+    // bibliography section, each cross-referenced from the introductory
+    // paragraph.
     let doc = Parser::default().parse(
         "_The Pragmatic Programmer_ <<pp>> should be required reading for all developers.\nTo learn all about design patterns, refer to the book by the \"`Gang of Four`\" <<gof>>.\n\n[bibliography]\n== References\n\n* [[[pp]]] Andy Hunt & Dave Thomas. The Pragmatic Programmer:\nFrom Journeyman to Master. Addison-Wesley. 1999.\n* [[[gof,gang]]] Erich Gamma, Richard Helm, Ralph Johnson & John Vlissides.\nDesign Patterns: Elements of Reusable Object-Oriented Software. Addison-Wesley. 1994.\n",
     );
@@ -142,9 +143,9 @@ Using this label, you can then reference the entry from anywhere above the bibli
 "#
     );
 
-    // A bibliography entry can be cross-referenced from anywhere above it, using
-    // the normal cross-reference syntax. The reference renders the bracketed
-    // label.
+    // A bibliography entry can be cross-referenced from anywhere above it,
+    // using the normal cross-reference syntax. The reference renders the
+    // bracketed label.
     let doc = Parser::default().parse(
         "Refer to <<pp>>.\n\n[bibliography]\n== References\n\n* [[[pp]]] Andy Hunt & Dave Thomas. 1999.\n",
     );
@@ -178,8 +179,8 @@ This prevents the anchor from being matched as a bibliography anchor or a normal
 "#
     );
 
-    // The escape syntax `[\[[word]]]` leaves the triple brackets untouched: it is
-    // matched neither as a bibliography anchor nor as a normal anchor.
+    // The escape syntax `[\[[word]]]` leaves the triple brackets untouched: it
+    // is matched neither as a bibliography anchor nor as a normal anchor.
     let doc =
         Parser::default().parse("[bibliography]\n== References\n\n* [\\[[word]]] Not an anchor.\n");
 
@@ -195,9 +196,10 @@ If you specify xreftext on the bibliography anchor (e.g., `+[[[label,xreftext]]]
 "#
     );
 
-    // By default the anchor and any reference are converted to `[<label>]`. When
-    // an xreftext is supplied (`[[[label,xreftext]]]`), `[<xreftext>]` is used
-    // instead, both at the entry and at every cross-reference to it.
+    // By default the anchor and any reference are converted to `[<label>]`.
+    // When an xreftext is supplied (`[[[label,xreftext]]]`), `[<xreftext>]`
+    // is used instead, both at the entry and at every cross-reference to
+    // it.
     let doc = Parser::default().parse(
         "See <<pp>> and <<gof>>.\n\n[bibliography]\n== References\n\n* [[[pp]]] Andy Hunt.\n* [[[gof,gang]]] Erich Gamma.\n",
     );

--- a/parser/src/tests/asciidoc_lang/sections/glossary.rs
+++ b/parser/src/tests/asciidoc_lang/sections/glossary.rs
@@ -113,10 +113,11 @@ rain::
 "#
     );
 
-    // Setting `glossary` on both the section and the description list within it:
-    // the section carries the `glossary` style, and the description list renders
-    // with the `glossary` style class. Per the spec, the section style is not
-    // implicitly propagated to the list; the list must declare it explicitly.
+    // Setting `glossary` on both the section and the description list within
+    // it: the section carries the `glossary` style, and the description
+    // list renders with the `glossary` style class. Per the spec, the
+    // section style is not implicitly propagated to the list; the list must
+    // declare it explicitly.
     let doc = Parser::default().parse(
         "[glossary]\n== Glossary\n\n[glossary]\nmud:: wet, cold dirt\nrain::\n\twater falling from the sky\n",
     );

--- a/parser/src/tests/asciidoc_lang/sections/user_index.rs
+++ b/parser/src/tests/asciidoc_lang/sections/user_index.rs
@@ -40,8 +40,8 @@ To create an index, define a level 1 section (`==`) marked with the style `index
     );
 
     // A level 1 section marked with the `index` style carries that style, which
-    // a converter that generates an index uses as the seed section. (The level 0
-    // multipart-book form is not modeled by this single-document crate.)
+    // a converter that generates an index uses as the seed section. (The level
+    // 0 multipart-book form is not modeled by this single-document crate.)
     let doc = Parser::default().parse("[index]\n== Index\n");
     let section = doc.child_blocks().next().unwrap();
     assert_eq!(section.declared_style(), Some("index"));
@@ -139,9 +139,10 @@ indexterm:[knight, Knight of the Round Table, Lancelot] <.>
 "#
     );
 
-    // The callout markers (`<.>`) above are annotations on the listing, not part
-    // of the marked-up content. Parsing the equivalent content, the visible
-    // (flow) terms remain inline while the concealed terms disappear.
+    // The callout markers (`<.>`) above are annotations on the listing, not
+    // part of the marked-up content. Parsing the equivalent content, the
+    // visible (flow) terms remain inline while the concealed terms
+    // disappear.
     let doc = Parser::default().parse(
         "signifying by divine providence that I, ((Arthur)),\nwas to carry Excalibur(((Sword, Broadsword, Excalibur))).",
     );
@@ -192,7 +193,8 @@ indexterm:[knight, "Arthur, King"]
     );
 
     // A comma inside a double-quoted term segment is treated as content, so the
-    // concealed term parses cleanly and contributes nothing to the flow of text.
+    // concealed term parses cleanly and contributes nothing to the flow of
+    // text.
     let doc = Parser::default().parse("I, King Arthur.\nindexterm:[knight, \"Arthur, King\"]");
     assert_eq!(rendered_paragraphs(&doc), &["I, King Arthur.\n"]);
 
@@ -274,8 +276,8 @@ To create a new git repository,
     );
 
     // An empty line between the terms and the paragraph splits them into two
-    // blocks: an (empty) paragraph holding only the now-invisible terms, and the
-    // real paragraph.
+    // blocks: an (empty) paragraph holding only the now-invisible terms, and
+    // the real paragraph.
     let doc = Parser::default().parse(
         "=== Create a new Git repository\n\n(((Repository, create)))\n(((Create Git repository)))\n\nTo create a new git repository,\n",
     );

--- a/parser/src/tests/asciidoc_lang/stem/index.rs
+++ b/parser/src/tests/asciidoc_lang/stem/index.rs
@@ -366,9 +366,10 @@ include::example$stem.adoc[tag=multi-a-render]
 "#
         );
 
-        // Inline `latexmath` macro (`example$stem.adoc[tag=multi-l]`): naming the
-        // macro after the notation surrounds the expression with LaTeX inline
-        // delimiters regardless of the document's default `stem` notation.
+        // Inline `latexmath` macro (`example$stem.adoc[tag=multi-l]`): naming
+        // the macro after the notation surrounds the expression with
+        // LaTeX inline delimiters regardless of the document's default
+        // `stem` notation.
         let doc = Parser::default().parse(r"latexmath:[C = \alpha + \beta Y^{\gamma} + \epsilon]");
 
         let block = doc.child_blocks().next().unwrap();

--- a/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
@@ -609,9 +609,9 @@ include::example$subs.adoc[tag=subs-sub]
 
         use inline_file_handler::InlineFileHandler;
 
-        // Preload the `subs-sub` example (an illegal XML tag) via the debug-only
-        // include handler. The tagged region is selected by the `tag=subs-sub`
-        // attribute on the include directive.
+        // Preload the `subs-sub` example (an illegal XML tag) via the
+        // debug-only include handler. The tagged region is selected by
+        // the `tag=subs-sub` attribute on the include directive.
         let handler = InlineFileHandler::from_pairs([(
             "example$subs.adoc",
             "// tag::subs-sub[]\n[source,xml,subs=\"-callouts\"]\n.An illegal XML tag\n----\n<1>\n  content inside \"1\" tag\n</1>\n----\n// end::subs-sub[]",
@@ -656,8 +656,8 @@ In the above example, the `attributes` substitution step is added to the beginni
         use inline_file_handler::InlineFileHandler;
 
         // Preload the `subs-multi` example via the debug-only include handler.
-        // The tagged region is selected by the `tag=subs-multi` attribute on the
-        // include directive.
+        // The tagged region is selected by the `tag=subs-multi` attribute on
+        // the include directive.
         let handler = InlineFileHandler::from_pairs([(
             "example$subs.adoc",
             "// tag::subs-multi[]\n[source,xml,subs=\"attributes+,+replacements,-callouts\"]\n----\n<version>{version}</version>\n<copyright>(C) ACME</copyright>\n<1>\n  content inside \"1\" tag\n</1>\n----\n// end::subs-multi[]",

--- a/parser/src/tests/asciidoc_lang/subs/attributes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/attributes.rs
@@ -91,7 +91,8 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -199,7 +200,8 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -269,7 +271,8 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -296,7 +299,8 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {

--- a/parser/src/tests/asciidoc_lang/subs/index.rs
+++ b/parser/src/tests/asciidoc_lang/subs/index.rs
@@ -95,10 +95,11 @@ The normal substitution group (`normal`) is applied to the majority of the Ascii
 
     // Unlike the other substitution groups in this section, the `header` group
     // applies to document-header metadata lines (author/revision) and to
-    // attribute-entry values rather than to a parsed block. There's no block that
-    // exposes a `header` substitution group to assert against — the way the normal
-    // and verbatim groups are checked below — so this paragraph is out of scope
-    // for verification and is treated as non-normative.
+    // attribute-entry values rather than to a parsed block. There's no block
+    // that exposes a `header` substitution group to assert against — the
+    // way the normal and verbatim groups are checked below — so this
+    // paragraph is out of scope for verification and is treated as
+    // non-normative.
     non_normative!(
         r#"
 [#header-group]

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -95,7 +95,8 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -167,10 +168,11 @@ mod default_macros_substitution {
         );
 
         // Can one macro contain another? Yes. The macros substitution step is
-        // applied to the *positional text* of a macro, so a macro nested in that
-        // text is itself processed. The canonical example is an inline image in
-        // the text of a link: the link text `image:logo.png[Logo]` is
-        // substituted into an image span, which then becomes the link's content.
+        // applied to the *positional text* of a macro, so a macro nested in
+        // that text is itself processed. The canonical example is an
+        // inline image in the text of a link: the link text
+        // `image:logo.png[Logo]` is substituted into an image span,
+        // which then becomes the link's content.
         let doc = Parser::default().parse("https://example.org[image:logo.png[Logo]]");
 
         let block1 = doc.child_blocks().next().unwrap();
@@ -234,7 +236,8 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -307,7 +310,8 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -337,7 +341,8 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -62,8 +62,9 @@ mod default_post_replacements_substitution {
         );
 
         // The post replacements step is _not_ applied when an attribute entry
-        // value is parsed. A xref:attributes:wrap-values.adoc#hard[hard-wrapped]
-        // attribute value therefore stores the line-break marker (` +`)
+        // value is parsed. A
+        // xref:attributes:wrap-values.adoc#hard[hard-wrapped] attribute
+        // value therefore stores the line-break marker (` +`)
         // verbatim rather than converting it to a `<br>`. The marker is only
         // interpreted as a line break later, if and when the value is used in a
         // block whose substitutions include post_replacements.
@@ -144,7 +145,8 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -268,7 +270,8 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -349,7 +352,8 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -376,7 +380,8 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {

--- a/parser/src/tests/asciidoc_lang/subs/quotes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/quotes.rs
@@ -303,7 +303,8 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -399,7 +400,8 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -472,7 +474,8 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -502,7 +505,8 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -340,7 +340,8 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -462,7 +463,8 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -532,7 +534,8 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -559,7 +562,8 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -578,8 +582,8 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
 "#
         );
 
-        // The replacements substitution applies to default table cells but not to
-        // literal (`l`) cells, hence "Varies".
+        // The replacements substitution applies to default table cells but not
+        // to literal (`l`) cells, hence "Varies".
         let doc = Parser::default().parse("|===\n|(C)\nl|(C)\n|===");
 
         let Some(Block::Table(table)) = doc.child_blocks().next() else {

--- a/parser/src/tests/asciidoc_lang/subs/special_characters.rs
+++ b/parser/src/tests/asciidoc_lang/subs/special_characters.rs
@@ -159,7 +159,8 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -267,7 +268,8 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -337,7 +339,8 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -364,7 +367,8 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        // Dig an extra level deeper to get the simple block that has the content.
+        // Dig an extra level deeper to get the simple block that has the
+        // content.
         let block1 = block1.child_blocks().next().unwrap();
 
         let Block::Simple(block1) = block1 else {
@@ -384,8 +388,8 @@ mod default_special_characters_substitution {
         );
 
         // Special character substitution always applies to table cell content,
-        // including literal (`l`) cells, where most other substitution steps are
-        // skipped.
+        // including literal (`l`) cells, where most other substitution steps
+        // are skipped.
         let doc = Parser::default().parse("|===\n|a > b\nl|c > d\n|===");
 
         let Some(Block::Table(table)) = doc.child_blocks().next() else {

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -43,8 +43,8 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
     );
 
     // A space (or tab) followed by a `|`, or a `|` at the start of a line, ends
-    // the previous cell and begins a new one. The three cells declared here flow
-    // into a single row because the table has three columns.
+    // the previous cell and begins a new one. The three cells declared here
+    // flow into a single row because the table has three columns.
     let doc = Parser::default().parse(
         "[cols=\"3,2,3\"]\n|===\n|This content is placed in the first cell of column 1\n|This line starts with a vertical bar so this content is placed in a new cell in column 2 |When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell\n|===",
     );
@@ -166,10 +166,10 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
     );
 
     // Cell specifiers introduce per-cell spans, duplication, alignment, and
-    // style operators, each specified in detail on a dedicated page (span-cells,
-    // duplicate-cells, align-by-cell, format-cell-content). The span,
-    // duplication, alignment, and style operators (and the override behavior)
-    // are all implemented and verified here.
+    // style operators, each specified in detail on a dedicated page
+    // (span-cells, duplicate-cells, align-by-cell, format-cell-content).
+    // The span, duplication, alignment, and style operators (and the
+    // override behavior) are all implemented and verified here.
     verifies!(
         r#"
 [#specifiers]
@@ -217,9 +217,10 @@ Also, the operator in a cell specifier will override the operator in a xref:add-
     assert_eq!(row.cells()[1].style(), ColumnStyle::Default);
 
     // A cell specifier operator overrides the column specifier operator for the
-    // same property: the column is centered and monospace (`^m`), but the cell's
-    // own `>` and `s` operators win, while a property the cell leaves unset (here
-    // vertical alignment) still falls back to the column.
+    // same property: the column is centered and monospace (`^m`), but the
+    // cell's own `>` and `s` operators win, while a property the cell
+    // leaves unset (here vertical alignment) still falls back to the
+    // column.
     let table = specifier_table("[cols=\"^.^m\"]\n|===\n>s|overridden\n|===");
     let cell = &table.body_rows()[0].cells()[0];
     assert_eq!(cell.h_align(), HorizontalAlignment::Right);

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -152,9 +152,9 @@ In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
 "#
     );
 
-    // Shorthand `%header%footer` entered before `cols` is honored: the first row
-    // is the header and the last row is the footer (this is the `ex-short`
-    // example from the page).
+    // Shorthand `%header%footer` entered before `cols` is honored: the first
+    // row is the header and the last row is the footer (this is the
+    // `ex-short` example from the page).
     let before = parse_table(
         "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
     );
@@ -226,8 +226,8 @@ include::example$row.adoc[tag=opt-f]
 "#
     );
 
-    // The `ex-formal` example sets the `options` attribute to `footer` using the
-    // formal syntax, promoting the last row to the footer.
+    // The `ex-formal` example sets the `options` attribute to `footer` using
+    // the formal syntax, promoting the last row to the footer.
     let ex_formal =
         parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
     assert!(ex_formal.footer_row().is_some());

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -118,9 +118,10 @@ TIP: The header row ignores any style operators assigned via column and cell spe
     // every cell (header or body), copying the column's `halign`/`valign` onto
     // the cell; the header-specific handling only skips
     // `cell_style = column.style`, so the header ignores the column *style*,
-    // not its alignment. Because the SDD coverage tool matches whole spec lines,
-    // the honored and contradicted rules cannot be split, so the line is marked
-    // non-normative rather than falsely reporting rule (1) as verified.
+    // not its alignment. Because the SDD coverage tool matches whole spec
+    // lines, the honored and contradicted rules cannot be split, so the
+    // line is marked non-normative rather than falsely reporting rule (1)
+    // as verified.
     non_normative!(
         r#"
 It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.
@@ -265,8 +266,8 @@ In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options
 "#
     );
 
-    // The `ex-short` example assigns `header` using the `%` shorthand syntax, so
-    // the first row is promoted to the header. (The callout `<.>` on the
+    // The `ex-short` example assigns `header` using the `%` shorthand syntax,
+    // so the first row is promoted to the header. (The callout `<.>` on the
     // attribute line is doc-authoring markup, not part of the table source.)
     let ex_short = parse_table(
         "[%header,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
@@ -364,7 +365,8 @@ include::example$row.adoc[tag=opt-h]
 "#
     );
 
-    // The rendered result of <<ex-formal>>: the first row renders as the header.
+    // The rendered result of <<ex-formal>>: the first row renders as the
+    // header.
     let ex_formal_result = parse_table(
         "[cols=\"2*\",options=\"header\"]\n|===\n|Column 1, header row\n|Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
     );
@@ -422,8 +424,9 @@ include::example$row.adoc[tag=impl-h]
 "#
     );
 
-    // The `ex-implicit` example (`impl-h` from row.adoc) relies on layout alone:
-    // a non-empty first line followed by a blank line promotes the first row.
+    // The `ex-implicit` example (`impl-h` from row.adoc) relies on layout
+    // alone: a non-empty first line followed by a blank line promotes the
+    // first row.
     let ex_implicit = parse_table(
         "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
     );
@@ -439,7 +442,8 @@ include::example$row.adoc[tag=impl-h]
 "#
     );
 
-    // The rendered result of <<ex-implicit>>: the first row renders as the header.
+    // The rendered result of <<ex-implicit>>: the first row renders as the
+    // header.
     let ex_implicit_result = parse_table(
         "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
     );
@@ -479,8 +483,8 @@ In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
         parse_table("[options=\"noheader\"]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
     assert!(table.header_row().is_none());
 
-    // `noheader` only suppresses the *implicit* assignment; an explicit `header`
-    // still wins when both options are present.
+    // `noheader` only suppresses the *implicit* assignment; an explicit
+    // `header` still wins when both options are present.
     let table = parse_table("[%header%noheader]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
     assert!(table.header_row().is_some());
 
@@ -500,8 +504,9 @@ In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
 "#
     );
 
-    // The `ex-noheader` example suppresses the implicit header via the `%noheader`
-    // shorthand, so the first row stays in the body rather than being promoted.
+    // The `ex-noheader` example suppresses the implicit header via the
+    // `%noheader` shorthand, so the first row stays in the body rather than
+    // being promoted.
     let ex_noheader = parse_table(
         "[%noheader]\n|===\n|Cell in column 1, row 1 |Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -146,9 +146,9 @@ include::example$align-cell.adoc[tag=factor]
 
     // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
     // placed directly after the span (`2+`) and duplication (`2*`) operators;
-    // both cells are centered. The `2+` span fills the two-column row on its own,
-    // so it lands in its own row; the `2*^` duplication clones its centered
-    // content into the two cells of the next row.
+    // both cells are centered. The `2+` span fills the two-column row on its
+    // own, so it lands in its own row; the `2*^` duplication clones its
+    // centered content into the two cells of the next row.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
     );
@@ -193,8 +193,8 @@ include::example$align-cell.adoc[tag=right]
     );
 
     // Expansion of `example$align-cell.adoc[tag=right]`. The `>` operator
-    // right-aligns the first cell and the spanned cell (`2+>`); the cell with no
-    // operator falls back to the default (left).
+    // right-aligns the first cell and the spanned cell (`2+>`); the cell with
+    // no operator falls back to the default (left).
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n>|This content is aligned to the right side of the cell because the cell specifier includes the `>` operator.\n|There isn't a horizontal alignment operator on this cell specifier, so the cell falls back to the default horizontal alignment.\nContent is aligned to the left side of the cell by default.\n\n2+>|This cell spans two columns.\n\nIts content is aligned to the right because the cell specifier includes the `>` operator.\nThe `>` operator must be placed directly after the span operator (`+`).\n|===",
     );
@@ -316,8 +316,8 @@ include::example$align-cell.adoc[tag=vspan]
     // Expansion of `example$align-cell.adoc[tag=vspan]`. The `.>` is placed
     // after the row-span operator (`.2+`); that cell is bottom-aligned, while
     // the cells with no vertical alignment operator stay top-aligned. The `.2+`
-    // cell spans two rows, so it carries its column down into the next row, which
-    // then needs only the one remaining cell.
+    // cell spans two rows, so it carries its column down into the next row,
+    // which then needs only the one remaining cell.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n|There isn't a vertical alignment operator on this cell specifier, so the content is aligned to the top of the cell by default.\n\n.2+.>|This cell spans two rows, and its content is aligned to the bottom because the cell specifier includes the `.>` operator.\n\n|This content is aligned to the top of the cell by default.\n|===",
     );
@@ -410,7 +410,8 @@ include::example$align-cell.adoc[tag=combine]
     // operators falls back to the default alignments (left, top). The `3*.>`
     // duplication clones its bottom-aligned content into three cells: the first
     // fills the row alongside the `2.3+` block span, and the next two each land
-    // in a row of their own (alongside the columns the block span carries down).
+    // in a row of their own (alongside the columns the block span carries
+    // down).
     let table = parse_table(
         "|===\n|Column 1 |Column 2 |Column 3\n\n^.>|The specifier for this cell is `^.>`.\nThe content is centered horizontally and aligned to the bottom of the cell.\n|There aren't any alignment operators on this cell's specifier, so the cell falls back to the default alignments.\nThe default horizontal alignment is the left side of the cell.\nThe default vertical alignment is the top of the cell.\n>.^|The specifier for this cell is `>.^`.\nThe content is aligned to the right side of the cell and centered vertically.\n\n2.3+^.^|The specifier for this cell is `pass:[2.3+^.^]`.\nIt spans two columns and three rows.\n\nIts content is centered horizontally and vertically.\n3*.>|The specifier for this cell is `3*.>`.\nThe cell is duplicated in three consecutive rows in the same column.\nIt's content is aligned to the bottom of the cell.\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -90,8 +90,8 @@ If the number of columns is assigned using a multiplier (`+<n>*+`), the horizont
         ]
     );
 
-    // A horizontal alignment operator is placed in front of a vertical alignment
-    // operator.
+    // A horizontal alignment operator is placed in front of a vertical
+    // alignment operator.
     let table = parse_table("[cols=\">.^1,2\"]\n|===\n|a |b\n|===");
     assert_eq!(
         column_alignments(&table),
@@ -376,7 +376,8 @@ Then it's placed after the horizontal alignment operator, (e.g., `[cols="3*^pass
     );
 
     // When a column width doesn't need to be specified, a vertical alignment
-    // operator can represent both the column and the column content's alignment.
+    // operator can represent both the column and the column content's
+    // alignment.
     let table = parse_table("[cols=\".^,.>\"]\n|===\n|a |b\n|===");
     assert_eq!(
         column_alignments(&table),
@@ -386,8 +387,8 @@ Then it's placed after the horizontal alignment operator, (e.g., `[cols="3*^pass
         ]
     );
 
-    // The vertical alignment operator is placed directly after a multiplier when
-    // there is no horizontal alignment operator.
+    // The vertical alignment operator is placed directly after a multiplier
+    // when there is no horizontal alignment operator.
     let table = parse_table("[cols=\"3*.>\"]\n|===\n|a |b |c\n|===");
     assert_eq!(
         column_alignments(&table),
@@ -641,9 +642,9 @@ IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's
 "#
     );
 
-    // The column is centered horizontally and aligned to the bottom (`^.>`), but
-    // the cell's own specifier (`>.^`) overrides both: the cell is right-aligned
-    // and centered vertically.
+    // The column is centered horizontally and aligned to the bottom (`^.>`),
+    // but the cell's own specifier (`>.^`) overrides both: the cell is
+    // right-aligned and centered vertically.
     let table = parse_table("[cols=\"^.>\"]\n|===\n>.^|overridden\n|===");
     assert_eq!(
         column_alignments(&table),

--- a/parser/src/tests/asciidoc_lang/tables/borders.rs
+++ b/parser/src/tests/asciidoc_lang/tables/borders.rs
@@ -134,8 +134,9 @@ include::example$row.adoc[tag=base-h]
 "#
     );
 
-    // <<ex-ends>>: the standard three-column table framed on its ends. The frame
-    // is the only thing that changes; the header and body rows are unaffected.
+    // <<ex-ends>>: the standard three-column table framed on its ends. The
+    // frame is the only thing that changes; the header and body rows are
+    // unaffected.
     let src = format!("[frame=ends]\n{BASE_H}");
     let table = parse_table(&src);
     assert_eq!(table.frame(), Frame::Ends);

--- a/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
@@ -114,10 +114,10 @@ Therefore, the third table is assigned the label _Data Set 2._
 "#
     );
 
-    // The three tables share a document whose `table-caption` is "Data Set". The
-    // two titled tables are labeled "Data Set 1." and "Data Set 2."; the untitled
-    // middle table is neither labeled nor counted, so the third table is numbered
-    // 2 rather than 3.
+    // The three tables share a document whose `table-caption` is "Data Set".
+    // The two titled tables are labeled "Data Set 1." and "Data Set 2.";
+    // the untitled middle table is neither labeled nor counted, so the
+    // third table is numbered 2 rather than 3.
     let doc = Parser::default().parse(
         "= Document Title\n:table-caption: Data Set\n\n.A table with a title\n[cols=\"2,1\"]\n|===\n|Lots and lots of data |A little data\n\n|834,734 |3\n|3,999,271.5601 |5\n|===\n\n|===\n|Group |Climate |Example\n\n|A\n|Tropical\n|Suva, Fiji\n\n|B\n|Arid\n|Lima, Peru\n|===\n\n.Another table with a title\n|===\n|Value |Result |Notes\n\n|Null |A mystery |See Appendix R\n|===",
     );
@@ -187,11 +187,11 @@ The table from <<ex-caption>> is displayed below.
 "#
     );
 
-    // The explicit `caption` attribute (on its own attribute-list line above the
-    // title, with the `cols` specifier on a second line below it) sets the label
-    // verbatim — including its trailing space — with no automatically inserted
-    // number. The label and title render together inside the table's
-    // `<caption class="title">`.
+    // The explicit `caption` attribute (on its own attribute-list line above
+    // the title, with the `cols` specifier on a second line below it) sets
+    // the label verbatim — including its trailing space — with no
+    // automatically inserted number. The label and title render together
+    // inside the table's `<caption class="title">`.
     let doc = Parser::default().parse(
         "[caption=\"Table A. \"]\n.A table with a custom label\n[cols=\"3*\"]\n|===\n|Null\n|A mystery\n|See Appendix R\n|===",
     );
@@ -236,13 +236,13 @@ include::example$table.adoc[tag=b-col-h]
 "#
     );
 
-    // This alternate form disables the caption *label* (`caption=` clears it) and
-    // instead supplies the whole caption line through the block's `title`
-    // attribute. The `title` value resolves `{table-caption}` to its default
-    // ("Table") and `{counter:table-number}` to the table's number, yielding
-    // "Table 1"; with the label suppressed, the rendered `<caption>` is just the
-    // title. (`example$table.adoc[tag=b-col-h]` is inlined here to avoid
-    // depending on include resolution.)
+    // This alternate form disables the caption *label* (`caption=` clears it)
+    // and instead supplies the whole caption line through the block's
+    // `title` attribute. The `title` value resolves `{table-caption}` to
+    // its default ("Table") and `{counter:table-number}` to the table's
+    // number, yielding "Table 1"; with the label suppressed, the rendered
+    // `<caption>` is just the title. (`example$table.adoc[tag=b-col-h]` is
+    // inlined here to avoid depending on include resolution.)
     let doc = Parser::default().parse(
         "[caption=,title=\"{table-caption} {counter:table-number}\"]\n[%header,cols=2*]\n|===\n|Name of Column 1\n|Name of Column 2\n\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -96,7 +96,8 @@ AsciiDoc also supports comma-separated values (CSV), tab-separated values (TSV),
         DataFormat::Psv
     );
 
-    // CSV, TSV, and DSV are also supported, selected with the `format` attribute.
+    // CSV, TSV, and DSV are also supported, selected with the `format`
+    // attribute.
     assert_eq!(
         parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
         DataFormat::Csv
@@ -151,8 +152,8 @@ This table will render as follows:
 "#
     );
 
-    // The backslash-escaped separator (`\|`) is unescaped to a bare `|`, and the
-    // leading backslash is removed from the rendered cell.
+    // The backslash-escaped separator (`\|`) is unescaped to a bare `|`, and
+    // the leading backslash is removed from the rendered cell.
     let table = parse_table(
         "[cols=2*]\n|===\n|The default separator in PSV tables is the \\| character.\n|The \\| character is often referred to as a \"`pipe`\".\n|===",
     );
@@ -230,8 +231,8 @@ To address these cases, AsciiDoc allows you to override the cell separator.
 "#
     );
 
-    // The `{vbar}` attribute reference renders as a bare `|`, producing the same
-    // result as the backslash escape.
+    // The `{vbar}` attribute reference renders as a bare `|`, producing the
+    // same result as the backslash escape.
     let table = parse_table(
         "[cols=2*]\n|===\n|The default separator in PSV tables is the {vbar} character.\n|The {vbar} character is often referred to as a \"`pipe`\".\n|===",
     );
@@ -258,8 +259,8 @@ A good candidate is the broken bar, or `¦`.
 "#
     );
 
-    // With the separator overridden to the broken bar (`¦`), the vertical bar in
-    // the cell content is ordinary text rather than a cell boundary.
+    // With the separator overridden to the broken bar (`¦`), the vertical bar
+    // in the cell content is ordinary text rather than a cell boundary.
     let table = parse_table(
         "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
     );
@@ -296,8 +297,8 @@ You can safely use the original cell separator in the cell content and not worry
 "#
     );
 
-    // With the separator overridden to the broken bar (`¦`), the vertical bars in
-    // the cell content are ordinary text and need no escaping.
+    // With the separator overridden to the broken bar (`¦`), the vertical bars
+    // in the cell content are ordinary text and need no escaping.
     let table = parse_table(
         "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
     );
@@ -333,8 +334,9 @@ How the table data gets interpreted is controlled by the `format` and `separator
     assert_eq!(table.columns().len(), 3);
     assert_eq!(all_texts(&table), ["a", "b", "c"]);
 
-    // A data cell does not accept a cell formatting spec: what would be a colspan
-    // operator in PSV (`2+`) is taken literally as the cell's value.
+    // A data cell does not accept a cell formatting spec: what would be a
+    // colspan operator in PSV (`2+`) is taken literally as the cell's
+    // value.
     let table = parse_table("[format=csv]\n|===\n2+,b,c\n|===");
     assert_eq!(table.columns().len(), 3);
     assert_eq!(table.body_rows()[0].cells()[0].colspan(), 1);
@@ -634,8 +636,8 @@ Table data in DSV format is parsed according to the following rules:
 "#
     );
 
-    // The default delimiter for DSV is a colon, empty lines are skipped, and the
-    // whitespace surrounding each value is stripped.
+    // The default delimiter for DSV is a colon, empty lines are skipped, and
+    // the whitespace surrounding each value is stripped.
     let table = parse_table("[format=dsv]\n|===\na : b :c\nd:e:f\n|===");
     assert!(table.header_row().is_none());
     assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
@@ -699,7 +701,8 @@ d;e;f
 "#
     );
 
-    // The DSV example with a custom `;` separator parses into two three-cell rows.
+    // The DSV example with a custom `;` separator parses into two three-cell
+    // rows.
     let table = parse_table("[format=dsv,separator=;]\n|===\na;b;c\nd;e;f\n|===");
     assert_eq!(table.data_format(), DataFormat::Dsv);
     assert_eq!(table.columns().len(), 3);
@@ -736,9 +739,9 @@ If you set `format=dsv` and `separator=,`, the data will be processed using the 
 "#
     );
 
-    // The same separator is processed by whichever format's rules are in effect.
-    // Under DSV a double quote is not an enclosing character, so it stays in the
-    // value and the separator still splits around it.
+    // The same separator is processed by whichever format's rules are in
+    // effect. Under DSV a double quote is not an enclosing character, so it
+    // stays in the value and the separator still splits around it.
     let table = parse_table("[format=dsv,separator=;]\n|===\n\"a;b\";c\n|===");
     assert_eq!(table.data_format(), DataFormat::Dsv);
     assert_eq!(table.columns().len(), 3);
@@ -794,7 +797,8 @@ include::example$data.adoc[tag=s-csv]
 "#
     );
 
-    // `include::example$data.adoc[tag=s-csv]` expands to this shorthand CSV table.
+    // `include::example$data.adoc[tag=s-csv]` expands to this shorthand CSV
+    // table.
     let table = parse_table(",===\nArtist,Track,Genre\n\nBaauer,Harlem Shake,Hip Hop\n,===");
     assert_eq!(table.data_format(), DataFormat::Csv);
     assert!(table.header_row().is_some());
@@ -843,7 +847,8 @@ include::example$data.adoc[tag=s-dsv]
 "#
     );
 
-    // `include::example$data.adoc[tag=s-dsv]` expands to this shorthand DSV table.
+    // `include::example$data.adoc[tag=s-dsv]` expands to this shorthand DSV
+    // table.
     let table = parse_table(":===\nArtist:Track:Genre\n\nRobyn:Indestructible:Dance\n:===");
     assert_eq!(table.data_format(), DataFormat::Dsv);
     assert!(table.header_row().is_some());
@@ -891,11 +896,13 @@ There is no special delimited block notation for a TSV table.
 "#
     );
 
-    // TSV is selected with `format=tsv`; there is no shorthand delimiter for it.
+    // TSV is selected with `format=tsv`; there is no shorthand delimiter for
+    // it.
     let table = parse_table("[format=tsv]\n|===\na\tb\tc\n|===");
     assert_eq!(table.data_format(), DataFormat::Tsv);
 
-    // Either `|===` or `,===` may be used as the block delimiter for a TSV table.
+    // Either `|===` or `,===` may be used as the block delimiter for a TSV
+    // table.
     let table = parse_table("[format=tsv]\n,===\na\tb\tc\n,===");
     assert_eq!(table.data_format(), DataFormat::Tsv);
     assert_eq!(all_texts(&table), ["a", "b", "c"]);
@@ -918,9 +925,9 @@ Instead, you can apply cell formatting to all cells in a given column using the 
 "#
     );
 
-    // The delimited formats carry no per-cell spec, so cell formatting is applied
-    // per column with the `cols` spec: here column 1 is a header column and
-    // column 2 is an AsciiDoc column.
+    // The delimited formats carry no per-cell spec, so cell formatting is
+    // applied per column with the `cols` spec: here column 1 is a header
+    // column and column 2 is an AsciiDoc column.
     let table = parse_table(
         "[format=csv,cols=\"1h,1a\"]\n|===\nSky,image::sky.jpg[]\nForest,image::forest.jpg[]\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
@@ -84,10 +84,10 @@ The duplication operator tells the converter to interpret the duplication factor
     );
 
     // The duplication factor is a single integer (`<n>`): a `<n>*` specifier
-    // clones the cell's content into `<n>` consecutive cells. Here `2*` produces
-    // two identical cells, leaving the trailing `|c` cell to complete the row.
-    // (The implicit column count is three, because each clone is counted as a
-    // separate column slot.)
+    // clones the cell's content into `<n>` consecutive cells. Here `2*`
+    // produces two identical cells, leaving the trailing `|c` cell to
+    // complete the row. (The implicit column count is three, because each
+    // clone is counted as a separate column slot.)
     let table = parse_table("|===\n2*|dup |c\n|===");
     assert_eq!(table.columns().len(), 3);
     assert_eq!(
@@ -95,10 +95,10 @@ The duplication operator tells the converter to interpret the duplication factor
         vec![vec!["dup".to_string(), "dup".to_string(), "c".to_string()]]
     );
 
-    // The duplication factor is interpreted as a duplication, not a span, so each
-    // clone is an independent single-column cell (colspan 1) rather than one cell
-    // stretched across two columns. Contrast the span operator (`+`), which makes
-    // a single cell span the columns.
+    // The duplication factor is interpreted as a duplication, not a span, so
+    // each clone is an independent single-column cell (colspan 1) rather
+    // than one cell stretched across two columns. Contrast the span
+    // operator (`+`), which makes a single cell span the columns.
     let dup = parse_table("|===\n2*|x\n|===");
     assert_eq!(dup.body_rows()[0].cells().len(), 2);
     assert_eq!(dup.body_rows()[0].cells()[0].colspan(), 1);
@@ -108,10 +108,10 @@ The duplication operator tells the converter to interpret the duplication factor
     assert_eq!(span.body_rows()[0].cells().len(), 1);
     assert_eq!(span.body_rows()[0].cells()[0].colspan(), 2);
 
-    // A duplication is the first operator in the cell specifier: the duplication
-    // factor and operator come before any alignment or style operator. Here `3*e`
-    // is the duplication `3*` followed by the style operator `e`, so all three
-    // clones are emphasized.
+    // A duplication is the first operator in the cell specifier: the
+    // duplication factor and operator come before any alignment or style
+    // operator. Here `3*e` is the duplication `3*` followed by the style
+    // operator `e`, so all three clones are emphasized.
     let table = parse_table("|===\n3*e|x\n|===");
     assert_eq!(
         body_styles(&table),
@@ -151,11 +151,11 @@ include::example$cell.adoc[tag=clone]
     );
 
     // Expansion of `example$cell.adoc[tag=clone]`. The `2*` cell clones its
-    // content into the first two columns of row 2, leaving the trailing `|Cell in
-    // column 3, row 2` cell to finish that row. The `3*e` cell clones its
-    // emphasized content into three cells: the first finishes row 3 (after the
-    // two plain cells) and the next two open row 4, which is then completed by the
-    // trailing `|Cell in column 3, row 4` cell.
+    // content into the first two columns of row 2, leaving the trailing `|Cell
+    // in column 3, row 2` cell to finish that row. The `3*e` cell clones
+    // its emphasized content into three cells: the first finishes row 3
+    // (after the two plain cells) and the next two open row 4, which is
+    // then completed by the trailing `|Cell in column 3, row 4` cell.
     let table = parse_table(
         "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n2*|This cell is duplicated in columns 1 and 2 because its specifier contains a duplication of `2*`\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n3*e|This cell specifier contains the duplication `3*` and style operator `e`.\n\nThe cell's text is italicized and duplicated in column 3, row 3 and columns 1 and 2 on row 4.\n\n|Cell in column 3, row 4\n|===",
     );
@@ -189,8 +189,8 @@ include::example$cell.adoc[tag=clone]
     );
 
     // The duplication clones the cell's properties as well as its content: the
-    // `3*e` style operator emphasizes every clone, while the cells with no style
-    // operator keep the default style.
+    // `3*e` style operator emphasizes every clone, while the cells with no
+    // style operator keep the default style.
     assert_eq!(
         body_styles(&table),
         vec![

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -110,9 +110,9 @@ When a style operator isn't explicitly assigned to a cell specifier (or xref:for
     let table = parse_table("|===\n|h\n\n|plain\n|===");
     assert_eq!(body_styles(&table), vec![vec![ColumnStyle::Default]]);
 
-    // The explicit `d` operator only matters when the column carries a style: it
-    // reverts that one cell to the default while its siblings keep the column's
-    // style.
+    // The explicit `d` operator only matters when the column carries a style:
+    // it reverts that one cell to the default while its siblings keep the
+    // column's style.
     let table = parse_table("[cols=\"m,m\"]\n|===\n|h1 |h2\n\nd|reverted |still monospace\n|===");
     assert_eq!(
         body_styles(&table),
@@ -143,10 +143,10 @@ Don't insert any spaces between the `|` and the operator.
 
     // The style operator occupies the last position of the specifier, after any
     // span/duplication operator and the horizontal and vertical alignment
-    // operators: `2*>m` (duplication, right, monospace) and `.3+^.>s` (row span,
-    // center, bottom, strong). The `2*` duplication clones its cell, so the first
-    // two cells both carry the right-aligned monospace specifier; the `.3+^.>s`
-    // cell follows.
+    // operators: `2*>m` (duplication, right, monospace) and `.3+^.>s` (row
+    // span, center, bottom, strong). The `2*` duplication clones its cell,
+    // so the first two cells both carry the right-aligned monospace
+    // specifier; the `.3+^.>s` cell follows.
     let table =
         parse_table("|===\n|h\n\n2*>m|dup right mono\n.3+^.>s|span center bottom strong\n|===");
     let cells: Vec<&crate::blocks::TableCell<'_>> =
@@ -270,8 +270,8 @@ d|This content is rendered as regular paragraph text because the `d` operator in
         "[cols=\"m,m\"]\n|===\n|Column 1, header row |Column 2, header row\n\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n\ns|This content is rendered as bold paragraph text because the `s` operator in the cell's specifier overrides the style operator in the column specifier.\n|*This content is rendered using a monospace font because the column's specifier includes the `m` operator.\nIt's also bold because it's marked up with the inline syntax for bold formatting.*\n\nd|This content is rendered as regular paragraph text because the `d` operator in the cell's specifier overrides the style operator in the column specifier.\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n|===",
     );
 
-    // A cell style operator overrides the column's style; a cell with no operator
-    // inherits it.
+    // A cell style operator overrides the column's style; a cell with no
+    // operator inherits it.
     assert_eq!(
         body_styles(&table),
         vec![
@@ -281,17 +281,18 @@ d|This content is rendered as regular paragraph text because the `d` operator in
         ]
     );
 
-    // The header row overrides (ignores) style operators: both header cells stay
-    // the default style even though their column carries the `m` operator.
+    // The header row overrides (ignores) style operators: both header cells
+    // stay the default style even though their column carries the `m`
+    // operator.
     let header = table.header_row().unwrap();
     assert_eq!(
         header.cells().iter().map(|c| c.style()).collect::<Vec<_>>(),
         vec![ColumnStyle::Default, ColumnStyle::Default]
     );
 
-    // Inline formatting markup is applied in addition to the style operator: the
-    // monospace cell whose content is wrapped in `*...*` still renders a strong
-    // span.
+    // Inline formatting markup is applied in addition to the style operator:
+    // the monospace cell whose content is wrapped in `*...*` still renders
+    // a strong span.
     let bold_in_mono = &table.body_rows()[1].cells()[1];
     assert_eq!(bold_in_mono.style(), ColumnStyle::Monospace);
     assert!(simple_text(bold_in_mono).contains("<strong>"));
@@ -317,8 +318,8 @@ The `a` can also be specified on the column in the `cols` attribute on the table
     );
 
     // A cell prefixed with the `a` operator parses its content as a nested
-    // sequence of blocks; a cell with no operator keeps the same markup as inline
-    // text.
+    // sequence of blocks; a cell with no operator keeps the same markup as
+    // inline text.
     let table = parse_table("|===\n|Normal |AsciiDoc\n\n|* not a list\na|* a list\n|===");
     let row = &table.body_rows()[0];
     assert!(matches!(
@@ -334,8 +335,8 @@ The `a` can also be specified on the column in the `cols` attribute on the table
         other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
     }
 
-    // The `a` operator can equally be set on the column via the `cols` attribute,
-    // which makes every cell in that column an AsciiDoc cell.
+    // The `a` operator can equally be set on the column via the `cols`
+    // attribute, which makes every cell in that column an AsciiDoc cell.
     let table = parse_table("[cols=\"a,d\"]\n|===\n|h1 |h2\n\n|* a list\n|* not a list\n|===");
     let row = &table.body_rows()[0];
     assert!(matches!(
@@ -363,9 +364,10 @@ include::example$cell.adoc[tag=adoc]
 "#
     );
 
-    // Expansion of `example$cell.adoc[tag=adoc]`. In each row the first cell has
-    // no operator (its list / listing markup stays inline text), while the second
-    // cell's `a` operator parses the same markup as nested AsciiDoc blocks.
+    // Expansion of `example$cell.adoc[tag=adoc]`. In each row the first cell
+    // has no operator (its list / listing markup stays inline text), while
+    // the second cell's `a` operator parses the same markup as nested
+    // AsciiDoc blocks.
     let table = parse_table(
         "|===\n|Normal Style |AsciiDoc Style\n\n|This cell isn't prefixed with an `a`, so the processor doesn't interpret the following lines as an AsciiDoc list.\n\n* List item 1\n* List item 2\n* List item 3\n\na|This cell is prefixed with an `a`, so the processor interprets the following lines as an AsciiDoc list.\n\n* List item 1\n* List item 2\n* List item 3\n\n|This cell isn't prefixed with an `a`, so the processor doesn't interpret the listing block delimiters or the `source` style.\n\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n\na|This cell is prefixed with an `a`, so the listing block is processed and rendered according to the `source` style rules.\n\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n\n|===",
     );
@@ -390,8 +392,8 @@ include::example$cell.adoc[tag=adoc]
     }
 
     // Second row: the source listing. The plain cell keeps it inline; the `a`
-    // cell parses its leading sentence as a paragraph and the delimited block as
-    // a listing block.
+    // cell parses its leading sentence as a paragraph and the delimited block
+    // as a listing block.
     let row = &table.body_rows()[1];
     assert!(matches!(
         row.cells()[0].content(),
@@ -457,8 +459,8 @@ There are a handful of exceptions to this rule, which includes doctype, toc, not
         .parse(":locked: parent\n\n|===\n|h\n\na|\n:locked: child\n\nvalue is {locked}\n|===");
     assert_eq!(asciidoc_cell_text(&doc), "value is parent");
 
-    // One of the carved-out exceptions (here `compat-mode`) may still be modified
-    // inside the cell even though the parent set it.
+    // One of the carved-out exceptions (here `compat-mode`) may still be
+    // modified inside the cell even though the parent set it.
     let mut parser = Parser::default();
     let doc = parser
         .parse(":compat-mode: parent\n\n|===\n|h\n\na|\n:compat-mode: child\n\nmode is {compat-mode}\n|===");
@@ -492,11 +494,11 @@ By starting the contents of the AsciiDoc table cell on the line after the cell s
 "#
     );
 
-    // A preprocessor conditional that opens on the cell-separator line is limited
-    // to that single line: the `ifdef::[]` is retained as literal cell text
-    // rather than opening a multiline conditional, so the guarded body is neither
-    // included nor excluded by the attribute test. The `endif::[]` on a later
-    // line is then left unmatched.
+    // A preprocessor conditional that opens on the cell-separator line is
+    // limited to that single line: the `ifdef::[]` is retained as literal
+    // cell text rather than opening a multiline conditional, so the guarded
+    // body is neither included nor excluded by the attribute test. The
+    // `endif::[]` on a later line is then left unmatched.
     let doc = Parser::default().parse("|===\na|ifdef::showit[]\nvisible\nendif::[]\n|===");
     assert_eq!(asciidoc_cell_text(&doc), "ifdef::showit[]\nvisible");
     assert!(doc.warnings().any(|w| matches!(
@@ -506,8 +508,8 @@ By starting the contents of the AsciiDoc table cell on the line after the cell s
 
     // By contrast, starting the cell contents on the line after the cell
     // separator lets the directive act as a normal multiline conditional: with
-    // `showit` unset the guarded body is excluded, leaving the cell empty, and no
-    // unmatched-directive warning is raised.
+    // `showit` unset the guarded body is excluded, leaving the cell empty, and
+    // no unmatched-directive warning is raised.
     let doc = Parser::default().parse("|===\na|\nifdef::showit[]\nvisible\nendif::[]\n|===");
     assert_eq!(asciidoc_cell_text(&doc), "");
     assert!(doc.warnings().next().is_none());

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -171,8 +171,8 @@ A style operator is always placed in the last position on a column's specifier o
     assert_eq!(columns[1].width(), 3);
     assert_eq!(columns[1].style(), ColumnStyle::Strong);
 
-    // When a column width isn't specified, the style operator can represent both
-    // the column and its content style.
+    // When a column width isn't specified, the style operator can represent
+    // both the column and its content style.
     let table = parse_table("[cols=\"h,e\"]\n|===\n|a |b\n|===");
     let columns = table.columns();
     assert_eq!(

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -100,8 +100,8 @@ To distinguish the inner table from the enclosing one, you need to use `!===` as
 
     // The inner table is delimited by `!===` and separates its cells with `!`,
     // which differs from the outer table's `|`. Because the separators differ,
-    // the outer table's `|` scan does not break the inner table apart: the inner
-    // `!`-separated cells are parsed as a complete two-column table.
+    // the outer table's `|` scan does not break the inner table apart: the
+    // inner `!`-separated cells are parsed as a complete two-column table.
     let inner = nested_table(last_cell);
     assert_eq!(inner.header_row().unwrap().cells().len(), 2);
     assert_eq!(inner.body_rows().len(), 1);
@@ -152,8 +152,8 @@ The default cell separator for a nested table is `!`, though you can choose anot
     assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "one");
     assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "two");
 
-    // The `separator` attribute applies to an outer table as well, replacing the
-    // default `|` with the chosen character.
+    // The `separator` attribute applies to an outer table as well, replacing
+    // the default `|` with the chosen character.
     let outer = parse_table("[separator=;]\n|===\n;one ;two\n|===");
     assert_eq!(outer.body_rows()[0].cells().len(), 2);
     assert_eq!(simple_text(&outer.body_rows()[0].cells()[0]), "one");
@@ -186,8 +186,8 @@ include::example$table.adoc[tag=nested]
     );
 
     // Expansion of `example$table.adoc[tag=nested]`, which is identical to
-    // `NESTED_EXAMPLE`: a two-column outer table whose AsciiDoc-styled (`a`) last
-    // cell carries a nested table.
+    // `NESTED_EXAMPLE`: a two-column outer table whose AsciiDoc-styled (`a`)
+    // last cell carries a nested table.
     let outer = parse_table(NESTED_EXAMPLE);
     assert_eq!(outer.columns().len(), 2);
     assert_eq!(outer.body_rows().len(), 2);

--- a/parser/src/tests/asciidoc_lang/tables/span_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/span_cells.rs
@@ -74,8 +74,8 @@ A span is the first operator in a xref:add-cells-and-rows.adoc#specifiers[cell s
 "#
     );
 
-    // A column span factor (`<n>`) followed by the span operator (`+`) makes the
-    // cell span `<n>` consecutive columns (and a single row).
+    // A column span factor (`<n>`) followed by the span operator (`+`) makes
+    // the cell span `<n>` consecutive columns (and a single row).
     let table = parse_table("|===\n3+|x\n|===");
     assert_eq!(body_spans(&table), vec![vec![(3, 1)]]);
 
@@ -162,9 +162,9 @@ include::example$cell.adoc[tag=span-rows]
 "#
     );
 
-    // Expansion of `example$cell.adoc[tag=span-rows]`. The `.2+` cell spans rows
-    // 2 and 3 in the first column, so it carries that column down into row 3,
-    // which then needs only its single remaining cell.
+    // Expansion of `example$cell.adoc[tag=span-rows]`. The `.2+` cell spans
+    // rows 2 and 3 in the first column, so it carries that column down into
+    // row 3, which then needs only its single remaining cell.
     let table = parse_table(
         "|===\n|Column 1, header row |Column 2, header row\n\n.2+|This cell spans rows 2 and 3 because its specifier contains a span of `.2+`\n|Cell in column 2, row 2\n\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/striping.rs
+++ b/parser/src/tests/asciidoc_lang/tables/striping.rs
@@ -58,8 +58,8 @@ When this feature is enabled, the specified rows are shaded using a background c
     // With no `stripes` attribute, a table is not striped.
     assert_eq!(parse_table(BASE).stripes(), Stripes::None);
 
-    // The note below describes a rendering concern (CSS and the stylesheet), not
-    // anything this parser models.
+    // The note below describes a rendering concern (CSS and the stylesheet),
+    // not anything this parser models.
     non_normative!(
         r#"
 NOTE: In the HTML output, table striping is done using CSS and thus depends on the stylesheet to supply the necessary styles.
@@ -94,8 +94,8 @@ You can override the default value by setting the stripes attribute on the table
     let src = format!("[stripes=none]\n{BASE}");
     assert_eq!(parse_table(&src).stripes(), Stripes::None);
 
-    // The `table-stripes` document attribute changes the default for tables that
-    // don't set their own `stripes`.
+    // The `table-stripes` document attribute changes the default for tables
+    // that don't set their own `stripes`.
     let src = format!(":table-stripes: odd\n\n{BASE}");
     let doc = Parser::default().parse(&src);
     assert_eq!(first_table(&doc).stripes(), Stripes::Odd);

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -97,11 +97,11 @@ d|specifiers
 "#
     );
 
-    // A comma-separated list of column specifiers sets the number of columns, the
-    // per-column distribution ratio, and the default formatting for each column.
-    // The page's own spec, `1m,2,1m,2,2`, declares five columns: the first and
-    // third are width 1 with the monospace style, the rest are width 2 with the
-    // default style.
+    // A comma-separated list of column specifiers sets the number of columns,
+    // the per-column distribution ratio, and the default formatting for
+    // each column. The page's own spec, `1m,2,1m,2,2`, declares five
+    // columns: the first and third are width 1 with the monospace style,
+    // the rest are width 2 with the default style.
     let table = parse_table("[cols=\"1m,2,1m,2,2\"]\n|===\n|a |b |c |d |e\n|===");
     assert_eq!(table.columns().len(), 5);
 
@@ -139,9 +139,9 @@ fn format_attribute() {
 "#
     );
 
-    // The `format` attribute selects the data format. PSV is the default, and its
-    // cells are delimited by the `separator` (default `|`), placed in front of
-    // each cell.
+    // The `format` attribute selects the data format. PSV is the default, and
+    // its cells are delimited by the `separator` (default `|`), placed in
+    // front of each cell.
     assert_eq!(
         parse_table("|===\n|a |b\n|===").data_format(),
         DataFormat::Psv
@@ -201,11 +201,11 @@ _Ideally a character not found in the cell content._
     assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "y");
 
     // A user-defined separator can be any single character (here `%`), after
-    // which the original cell separator (`|`) is ordinary text within a cell. As
-    // in Asciidoctor's PSV, the separator only begins a new cell when it follows
-    // whitespace, so that boundary whitespace is necessarily trimmed from the
-    // preceding cell; the explicit assertion messages make a trimming regression
-    // fail loudly rather than silently.
+    // which the original cell separator (`|`) is ordinary text within a cell.
+    // As in Asciidoctor's PSV, the separator only begins a new cell when it
+    // follows whitespace, so that boundary whitespace is necessarily
+    // trimmed from the preceding cell; the explicit assertion messages make
+    // a trimming regression fail loudly rather than silently.
     let table = parse_table("[separator=%]\n|===\n%a | b %c\n|===");
     assert_eq!(table.body_rows()[0].cells().len(), 2);
     assert_eq!(
@@ -242,9 +242,9 @@ fn frame_attribute() {
 "#
     );
 
-    // The `frame` attribute draws a border around the table. `all` (the default)
-    // borders every side; `ends` borders the top and bottom; `none` removes the
-    // border; `sides` borders the left and right.
+    // The `frame` attribute draws a border around the table. `all` (the
+    // default) borders every side; `ends` borders the top and bottom;
+    // `none` removes the border; `sides` borders the left and right.
     assert_eq!(parse_table("|===\n|a\n|===").frame(), Frame::All);
     assert_eq!(
         parse_table("[frame=all]\n|===\n|a\n|===").frame(),
@@ -286,9 +286,9 @@ fn grid_attribute() {
 "#
     );
 
-    // The `grid` attribute draws boundary lines between cells. `all` (the default)
-    // borders every cell; `cols` borders between columns; `rows` borders between
-    // rows; `none` removes the boundary lines.
+    // The `grid` attribute draws boundary lines between cells. `all` (the
+    // default) borders every cell; `cols` borders between columns; `rows`
+    // borders between rows; `none` removes the boundary lines.
     assert_eq!(parse_table("|===\n|a\n|===").grid(), Grid::All);
     assert_eq!(parse_table("[grid=all]\n|===\n|a\n|===").grid(), Grid::All);
     assert_eq!(
@@ -330,9 +330,10 @@ fn stripes_attribute() {
 "#
     );
 
-    // The `stripes` attribute controls which rows are shaded. `none` (the default)
-    // shades nothing; `even` and `odd` shade alternating rows; `hover` shades the
-    // row under the mouse cursor; `all` shades every row.
+    // The `stripes` attribute controls which rows are shaded. `none` (the
+    // default) shades nothing; `even` and `odd` shade alternating rows;
+    // `hover` shades the row under the mouse cursor; `all` shades every
+    // row.
     assert_eq!(parse_table("|===\n|a\n|===").stripes(), Stripes::None);
     assert_eq!(
         parse_table("[stripes=none]\n|===\n|a\n|===").stripes(),
@@ -378,11 +379,11 @@ Alignment roles and the `float` attributes are mutually exclusive.
 "#
     );
 
-    // `align` is not recognized by Asciidoctor, and this crate matches that: the
-    // attribute is accepted but given no special meaning. Whatever value it is
-    // set to, the table's structure is unchanged and its columns keep their
-    // default left alignment (alignment is expressed instead with a role or with
-    // column/cell specifiers).
+    // `align` is not recognized by Asciidoctor, and this crate matches that:
+    // the attribute is accepted but given no special meaning. Whatever
+    // value it is set to, the table's structure is unchanged and its
+    // columns keep their default left alignment (alignment is expressed
+    // instead with a role or with column/cell specifiers).
     for value in ["left", "right", "center"] {
         let src = format!("[align={value}]\n|===\n|a |b\n|===");
         let table = parse_table(&src);
@@ -410,8 +411,9 @@ The `float` and `align` attributes are mutually exclusive.
 "#
     );
 
-    // `float` only floats the table in HTML output; this crate does no rendering,
-    // so the attribute is accepted but leaves the parsed table unchanged.
+    // `float` only floats the table in HTML output; this crate does no
+    // rendering, so the attribute is accepted but leaves the parsed table
+    // unchanged.
     for value in ["left", "right"] {
         let src = format!("[float={value},width=50%]\n|===\n|a |b\n|===");
         let table = parse_table(&src);
@@ -472,8 +474,8 @@ Define instead using column or cell specifiers (e.g., `3*.>`), which take preced
     );
 
     // `valign` is not recognized by Asciidoctor, and this crate matches that:
-    // whatever value it is set to, the columns retain their default top alignment
-    // (a column or cell specifier must be used instead).
+    // whatever value it is set to, the columns retain their default top
+    // alignment (a column or cell specifier must be used instead).
     for value in ["top", "bottom", "middle"] {
         let src = format!("[valign={value}]\n|===\n|a |b\n|===");
         let table = parse_table(&src);
@@ -497,8 +499,8 @@ DocBook only.
     );
 
     // `orientation` only rotates the table in the DocBook backend (it sets
-    // `orient="land"`); this crate does no rendering, so the attribute is accepted
-    // but leaves the parsed table unchanged.
+    // `orient="land"`); this crate does no rendering, so the attribute is
+    // accepted but leaves the parsed table unchanged.
     let table = parse_table("[orientation=landscape]\n|===\n|a |b\n|===");
     assert_eq!(table.columns().len(), 2);
 }
@@ -520,7 +522,8 @@ fn options_attribute() {
     );
 
     // Header and footer rows are omitted by default: a table whose rows run
-    // together (no blank line that would implicitly promote a header) has neither.
+    // together (no blank line that would implicitly promote a header) has
+    // neither.
     let plain = parse_table("|===\n|a |b\n|c |d\n|===");
     assert!(plain.header_row().is_none());
     assert!(plain.footer_row().is_none());
@@ -546,9 +549,9 @@ DocBook only (specifically for generating PDF output).
 "#
     );
 
-    // The `breakable`/`unbreakable` options only control page splitting in DocBook
-    // PDF output; this crate does no rendering, so either option is accepted but
-    // leaves the parsed table unchanged.
+    // The `breakable`/`unbreakable` options only control page splitting in
+    // DocBook PDF output; this crate does no rendering, so either option is
+    // accepted but leaves the parsed table unchanged.
     for option in ["breakable", "unbreakable"] {
         let src = format!("[%{option}]\n|===\n|a |b\n|===");
         let table = parse_table(&src);
@@ -585,7 +588,8 @@ DocBook only.
 
     // The `rotate` option only prints the table in landscape in the DocBook
     // backend (equivalent to `orientation=landscape`); this crate does no
-    // rendering, so the option is accepted but leaves the parsed table unchanged.
+    // rendering, so the option is accepted but leaves the parsed table
+    // unchanged.
     let table = parse_table("[%rotate]\n|===\n|a |b\n|===");
     assert_eq!(table.columns().len(), 2);
 }
@@ -641,8 +645,8 @@ d|user defined value
 "#
     );
 
-    // The `width` attribute sets the table width as a user-defined percentage of
-    // the available page width. The trailing `%` is optional.
+    // The `width` attribute sets the table width as a user-defined percentage
+    // of the available page width. The trailing `%` is optional.
     assert_eq!(parse_table("[width=50%]\n|===\n|a\n|===").width(), Some(50));
     assert_eq!(parse_table("[width=75]\n|===\n|a\n|===").width(), Some(75));
     assert_eq!(

--- a/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
@@ -52,7 +52,8 @@ When `table-caption` is unset, table titles aren't preceded by a label and label
 
     // Unsetting `table-caption` in the document header suppresses the label for
     // every titled table: the title still renders inside the table's
-    // `<caption class="title">`, but with no "Table <n>." prefix in front of it.
+    // `<caption class="title">`, but with no "Table <n>." prefix in front of
+    // it.
     let doc = Parser::default().parse(
         "= Title of Document\n:table-caption!:\n\n.A table with a title but no label\n|===\n|Value |Result |Notes\n\n|Null |A mystery |See Appendix R\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
+++ b/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
@@ -445,8 +445,9 @@ The mix of constrained and unconstrained formatting marks in the line is ambiguo
             panic!("Unexpected block type: {block2:?}");
         };
 
-        // NOTE: this is the **one golden output the inline-AST cutover changes**
-        // (design §5.2 Phase 4, step 6), and it changes for the better.
+        // NOTE: this is the **one golden output the inline-AST cutover
+        // changes** (design §5.2 Phase 4, step 6), and it changes for
+        // the better.
         //
         // The string pipeline ran its quoted-text subs as passes over one flat
         // string, so the `#`-delimited highlight pass matched across the markup

--- a/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
@@ -54,8 +54,9 @@ The sections that follow detail these features.
     // one item per callout number.
     assert_css(&doc, ".colist ol li", 2);
 
-    // The `subs=-callouts` modifier used in the syntax examples above suppresses
-    // callout processing, so the callout numbers are shown literally.
+    // The `subs=-callouts` modifier used in the syntax examples above
+    // suppresses callout processing, so the callout numbers are shown
+    // literally.
     let raw = Parser::default().parse("[source,subs=-callouts]\n----\nrequire 'x' # <1>\n----\n");
     refute_output_contains(&raw, "conum");
     assert_output_contains(&raw, "# &lt;1&gt;");
@@ -124,8 +125,9 @@ The risk of this approach is that you have to keep track of which numbers are be
     );
 
     // The automatic numbering is not aware of the explicit `<1>`: the `<.>`
-    // markers are numbered 1 and 2 in sequence, while the explicit `<1>` repeats
-    // callout number 1. Asserted at the substitution level for an exact match.
+    // markers are numbered 1 and 2 in sequence, while the explicit `<1>`
+    // repeats callout number 1. Asserted at the substitution level for an
+    // exact match.
     let mut content = crate::content::Content::from(crate::Span::new(
         "first &lt;.&gt;\nsecond &lt;.&gt;\nrepeat &lt;1&gt;",
     ));
@@ -294,7 +296,8 @@ Now both you and the reader can copy and paste XML source code containing callou
     );
 
     // An XML callout places the angle brackets around the XML comment and
-    // number; the rendered output keeps the comment delimiters around the conum.
+    // number; the rendered output keeps the comment delimiters around the
+    // conum.
     let doc = Parser::default().parse(
         "[source,xml]\n----\n<section>\n  <title>Section Title</title> <!--1-->\n</section>\n----\n<1> The title is required.\n",
     );

--- a/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
@@ -258,8 +258,9 @@ include::example$source.adoc[tag=src-inc]
         .parse("[,ruby]\n----\ninclude::app.rb[]\n----");
 
     // The structure is asserted at the block level (rather than via a full
-    // `Document` fixture) because the unresolved-include warning below carries an
-    // owned target string, which the `&'static` warnings fixture can't express.
+    // `Document` fixture) because the unresolved-include warning below carries
+    // an owned target string, which the `&'static` warnings fixture can't
+    // express.
     assert_eq!(doc.child_blocks().count(), 1);
 
     let block = doc.child_blocks().next().unwrap();

--- a/parser/src/tests/asciidoctor_rb/attribute_list_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attribute_list_test.rs
@@ -281,10 +281,10 @@ fn collect_isolated_single_quote_positional_attribute() {
 "#
     );
 
-    // A lone single quote has no terminator, so it is a literal positional value
-    // (`'`), not a quoted string. `asciidoc-parser` additionally emits a lenient
-    // "missing terminating quote" warning, which these value-focused tests
-    // disregard.
+    // A lone single quote has no terminator, so it is a literal positional
+    // value (`'`), not a quoted string. `asciidoc-parser` additionally
+    // emits a lenient "missing terminating quote" warning, which these
+    // value-focused tests disregard.
     let a = parse_attrlist("'");
     assert_eq!(a.nth(1), Some("'"));
     assert!(a.named.is_empty());
@@ -353,10 +353,10 @@ fn collect_unnamed_attribute_single_quoted_containing_escaped_quote() {
     );
 
     // A genuinely single-quoted value has the normal substitution group applied
-    // in a block context — exactly Asciidoctor's behavior when a block is present
-    // (`single_quoted && @block`). So the unescaped `ba'zaar` becomes
-    // `ba&#8217;zaar` (typographic apostrophe), where the Ruby unit test, which
-    // stubs `apply_subs`, sees the literal `ba'zaar`.
+    // in a block context — exactly Asciidoctor's behavior when a block is
+    // present (`single_quoted && @block`). So the unescaped `ba'zaar`
+    // becomes `ba&#8217;zaar` (typographic apostrophe), where the Ruby unit
+    // test, which stubs `apply_subs`, sees the literal `ba'zaar`.
     let a = parse_attrlist("'ba\\'zaar'");
     assert_eq!(a.nth(1), Some("ba&#8217;zaar"));
     assert!(a.named.is_empty());

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -183,10 +183,11 @@ mod assignment {
 "#
         );
 
-        // A name ending with a colon isn't a valid attribute entry; `:foo:: bar`
-        // is instead a description list (`foo` is the term, `bar` the
-        // description). This crate models a description list as a `list` block
-        // whose type is `Description`, the equivalent of Asciidoctor's `:dlist`.
+        // A name ending with a colon isn't a valid attribute entry; `:foo::
+        // bar` is instead a description list (`foo` is the term, `bar`
+        // the description). This crate models a description list as a
+        // `list` block whose type is `Description`, the equivalent of
+        // Asciidoctor's `:dlist`.
         let doc = Parser::default().parse(":foo:: bar");
         assert!(!doc.has_attribute("foo:"));
 
@@ -535,12 +536,13 @@ mod assignment {
 "#
         );
 
-        // The legacy `+` continuation fuses the `{version}` line into the header
-        // value (`Asciidoctor {version}`); the unresolved `{version}` reference
-        // then drops the line under `attribute-missing=drop-line`, leaving the
-        // empty string and recording the drop as a
-        // `SkippingReferenceToMissingAttribute` warning naming `version`
-        // (the crate's analogue of Asciidoctor's INFO log).
+        // The legacy `+` continuation fuses the `{version}` line into the
+        // header value (`Asciidoctor {version}`); the unresolved
+        // `{version}` reference then drops the line under
+        // `attribute-missing=drop-line`, leaving the empty string and
+        // recording the drop as a `SkippingReferenceToMissingAttribute`
+        // warning naming `version` (the crate's analogue of
+        // Asciidoctor's INFO log).
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "attribute-missing",
@@ -701,9 +703,9 @@ mod assignment {
 "#
         );
 
-        // The limit of 8 falls in the middle of the third (3-byte) character, so
-        // that character is dropped whole rather than split: the truncated value
-        // is 6 bytes, not 8.
+        // The limit of 8 falls in the middle of the third (3-byte) character,
+        // so that character is dropped whole rather than split: the
+        // truncated value is 6 bytes, not 8.
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "max-attribute-value-size",
@@ -737,10 +739,10 @@ mod assignment {
 "#
         );
 
-        // Asciidoctor disables the limit with a `nil` value; this crate models a
-        // disabled limit as a non-positive value (Ruby's `String#to_i` coerces
-        // `nil`/empty to `0`), so `0` turns it off and the full 5000-byte value
-        // is preserved.
+        // Asciidoctor disables the limit with a `nil` value; this crate models
+        // a disabled limit as a non-positive value (Ruby's
+        // `String#to_i` coerces `nil`/empty to `0`), so `0` turns it
+        // off and the full 5000-byte value is preserved.
         let input = format!(":name: {}\n\n{{name}}", "a".repeat(5000));
         let doc = Parser::default()
             .with_intrinsic_attribute(
@@ -812,9 +814,9 @@ mod assignment {
 "#
         );
 
-        // At `SafeMode::Server` (and above, including the default `Secure`), the
-        // real home path is masked and `user-home` resolves to `.`, so the
-        // reference expands to a relative path.
+        // At `SafeMode::Server` (and above, including the default `Secure`),
+        // the real home path is masked and `user-home` resolves to `.`,
+        // so the reference expands to a relative path.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Server)
             .parse(":imagesdir: {user-home}/etc/images\n\n{imagesdir}");
@@ -1034,8 +1036,8 @@ mod assignment {
 "#
         );
 
-        // The Ruby `@` modifier (soft set) maps to a value that the document may
-        // override anywhere, i.e. `ModificationContext::Anywhere`.
+        // The Ruby `@` modifier (soft set) maps to a value that the document
+        // may override anywhere, i.e. `ModificationContext::Anywhere`.
         let doc = Parser::default()
             .with_intrinsic_attribute("cash", "heroes", ModificationContext::Anywhere)
             .parse(":cash: money");
@@ -1126,8 +1128,9 @@ mod assignment {
 "#
         );
 
-        // The three Ruby forms (`cash!`, `!cash`, `cash => nil`) all mean "unset
-        // via API, locked", which maps to a single locked boolean-false intrinsic.
+        // The three Ruby forms (`cash!`, `!cash`, `cash => nil`) all mean
+        // "unset via API, locked", which maps to a single locked
+        // boolean-false intrinsic.
         let doc = Parser::default()
             .with_intrinsic_attribute_bool("cash", false, ModificationContext::ApiOnly)
             .parse(":cash: money");
@@ -1154,8 +1157,9 @@ mod assignment {
 "#
         );
 
-        // All five Ruby forms are a soft unset (unset via API, overridable by the
-        // document), which maps to a boolean-false intrinsic modifiable anywhere.
+        // All five Ruby forms are a soft unset (unset via API, overridable by
+        // the document), which maps to a boolean-false intrinsic
+        // modifiable anywhere.
         let doc = Parser::default()
             .with_intrinsic_attribute_bool("cash", false, ModificationContext::Anywhere)
             .parse(":cash: money");
@@ -1246,8 +1250,8 @@ mod assignment {
 
         // The derived backend / basebackend / filetype / doctype family is
         // materialized as queryable document attributes. A `''` Ruby value maps
-        // to an empty [`InterpretedValue::Value`] here; each key must be present
-        // (`has_attribute`) and resolve to the expected value.
+        // to an empty [`InterpretedValue::Value`] here; each key must be
+        // present (`has_attribute`) and resolve to the expected value.
         let doc = Parser::default().parse("= Document Title\nAuthor Name\n\ncontent");
         for (key, value) in [
             ("backend", "html5"),
@@ -1365,10 +1369,10 @@ mod assignment {
 "#
         );
 
-        // The API-set `backend` value (locked, `ApiOnly`) wins over the document
-        // `:backend: docbook5` assignment, and the derived `backend-html5` /
-        // `basebackend` / `basebackend-html` attributes are synthesized from the
-        // winning value.
+        // The API-set `backend` value (locked, `ApiOnly`) wins over the
+        // document `:backend: docbook5` assignment, and the derived
+        // `backend-html5` / `basebackend` / `basebackend-html`
+        // attributes are synthesized from the winning value.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Safe)
             .with_intrinsic_attribute("backend", "html5", ModificationContext::ApiOnly)
@@ -1399,8 +1403,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr should not retrieve attribute from document if not set on block' do
@@ -1412,8 +1416,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr looks for attribute on document if fallback name is true' do
@@ -1425,8 +1429,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr uses fallback name when looking for attribute on document' do
@@ -1438,8 +1442,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr? should not check for attribute on document if not set on block' do
@@ -1451,8 +1455,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr? checks for attribute on document if fallback name is true' do
@@ -1464,8 +1468,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's node `attr?` document-fallback API, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'attr? checks for fallback name when looking for attribute on document' do
@@ -1477,8 +1481,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'set_attr should set value to empty string if no value is specified' do
@@ -1504,8 +1508,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'set_attr should not overwrite existing key if overwrite is false' do
@@ -1518,8 +1522,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable node `set_attr` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'set_attr should overwrite existing key by default' do
@@ -1552,8 +1556,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API, which
-    // this crate does not expose.
+    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API,
+    // which this crate does not expose.
     non_normative!(
         r#"
     test 'set_attribute should set attribute if key is not locked' do
@@ -1567,8 +1571,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API, which
-    // this crate does not expose.
+    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API,
+    // which this crate does not expose.
     non_normative!(
         r#"
     test 'set_attribute should not set key if key is locked' do
@@ -1582,8 +1586,8 @@ mod assignment {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API, which
-    // this crate does not expose.
+    // Out of scope: exercises Ruby's mutable `Document#set_attribute` API,
+    // which this crate does not expose.
     non_normative!(
         r#"
     test 'set_attribute should update backend attributes' do
@@ -1648,15 +1652,16 @@ mod assignment {
         // `toc-placement` / `toc-position`, and materializes it even for the
         // legacy `toc2` alias. This crate instead keeps the author's raw `toc`
         // value (and never materializes `toc` for the `toc2` alias), exposing
-        // the placement through `toc_mode()`. Every row enables a TOC — what the
-        // matrix's `toc` column asserts — so that column is checked here via the
-        // resolved `toc_mode()`.
+        // the placement through `toc_mode()`. Every row enables a TOC — what
+        // the matrix's `toc` column asserts — so that column is checked
+        // here via the resolved `toc_mode()`.
         use crate::document::TocMode;
 
-        // (spec, toc-position, toc-placement, toc-class, toc_mode). Each spec is
-        // parsed the way Ruby parses the vendored matrix: space-separated
-        // entries, `name=value`, or `name!` for a soft unset. A `None` column is
-        // an attribute Asciidoctor leaves unset (its `nil`).
+        // (spec, toc-position, toc-placement, toc-class, toc_mode). Each spec
+        // is parsed the way Ruby parses the vendored matrix:
+        // space-separated entries, `name=value`, or `name!` for a soft
+        // unset. A `None` column is an attribute Asciidoctor leaves
+        // unset (its `nil`).
         type Row = (
             &'static str,
             Option<&'static str>,
@@ -1820,8 +1825,8 @@ mod interpolation {
 
         // An attribute-entry name and an API-supplied attribute name are both
         // stored lower-cased; a reference is folded the same way before lookup,
-        // so `{He-Man}` resolves the `:He-Man:` entry and `{She-Ra}` resolves the
-        // API attribute stored as `she-ra`.
+        // so `{He-Man}` resolves the `:He-Man:` entry and `{She-Ra}` resolves
+        // the API attribute stored as `she-ra`.
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "She-Ra",
@@ -2025,9 +2030,9 @@ mod interpolation {
 "#
         );
 
-        // Intentional divergence: this crate does not implement the `{set:…}` attribute
-        // assignment/unassignment reference, so `{set:a!}` is left literal and
-        // its line is not dropped.
+        // Intentional divergence: this crate does not implement the `{set:…}`
+        // attribute assignment/unassignment reference, so `{set:a!}` is
+        // left literal and its line is not dropped.
         let doc = Parser::default().parse(
             ":a:\n\nLine 1: This line should appear in the output.\nLine 2: {set:a!}This line should not appear in the output.",
         );
@@ -2057,8 +2062,8 @@ mod interpolation {
 "#
         );
 
-        // Intentional divergence: `{set:…}` is not implemented, so `{set:a!}` remains
-        // literal in the output rather than being consumed.
+        // Intentional divergence: `{set:…}` is not implemented, so `{set:a!}`
+        // remains literal in the output rather than being consumed.
         let doc = Parser::default().parse(
             ":attribute-undefined: drop\n:a:\n\nLine 1: This line should appear in the output.\nLine 2: {set:a!}This line should appear in the output.",
         );
@@ -2085,8 +2090,8 @@ mod interpolation {
 "#
         );
 
-        // Intentional divergence: `{set:…}` is not implemented, so the `{set:a}` line
-        // is kept literally instead of being dropped.
+        // Intentional divergence: `{set:…}` is not implemented, so the
+        // `{set:a}` line is kept literally instead of being dropped.
         let doc = Parser::default().parse("Line 1\n{set:a}\nLine 2");
         assert_xpath(&doc, "//p[text()=\"Line 1\n{set:a}\nLine 2\"]", 1);
     }
@@ -2358,11 +2363,12 @@ mod interpolation {
         // A block title is exposed via the `title()` accessor (rendered with
         // inline substitutions applied) rather than as a queryable DOM node.
         //
-        // The modern backtick form (`` `{gem_name}` ``) substitutes and wraps in
-        // `<code>` as Asciidoctor does. The compat-mode `+…+` monospace form is
-        // an intentional divergence — compat mode is not supported, so the `+…+`
-        // markers are dropped and the attribute reference is left unsubstituted;
-        // that first case is recorded as the crate's actual output.
+        // The modern backtick form (`` `{gem_name}` ``) substitutes and wraps
+        // in `<code>` as Asciidoctor does. The compat-mode `+…+`
+        // monospace form is an intentional divergence — compat mode is
+        // not supported, so the `+…+` markers are dropped and the
+        // attribute reference is left unsubstituted; that first case is
+        // recorded as the crate's actual output.
         let doc = Parser::default()
             .with_intrinsic_attribute("compat-mode", "", ModificationContext::Anywhere)
             .parse(
@@ -2447,9 +2453,9 @@ mod interpolation {
                 ":foo: bar\n\n[[paragraph-a]]\n`{foo}`\n\n:compat-mode!:\n\n[[paragraph-b]]\n`{foo}`\n\n:compat-mode:\n\n[[paragraph-c]]\n`{foo}`",
             );
         // Intentional divergence: this crate does not change backtick/monospace
-        // attribute substitution based on compat-mode, so `{foo}` resolves to `bar` in
-        // all three paragraphs (Asciidoctor keeps it literal where compat-mode
-        // is on, i.e. paragraphs a and c).
+        // attribute substitution based on compat-mode, so `{foo}` resolves to
+        // `bar` in all three paragraphs (Asciidoctor keeps it literal
+        // where compat-mode is on, i.e. paragraphs a and c).
         assert_xpath(&doc, "//*[@id=\"paragraph-a\"]//code[text()=\"bar\"]", 1);
         assert_xpath(&doc, "//*[@id=\"paragraph-b\"]//code[text()=\"bar\"]", 1);
         assert_xpath(&doc, "//*[@id=\"paragraph-c\"]//code[text()=\"bar\"]", 1);
@@ -2626,9 +2632,10 @@ mod interpolation {
 "#
         );
 
-        // Intentional divergence: this crate does not implement the `{set:…}` attribute
-        // assignment reference, so it stays literal and `{foo}` is never
-        // assigned (it remains an unresolved reference).
+        // Intentional divergence: this crate does not implement the `{set:…}`
+        // attribute assignment reference, so it stays literal and
+        // `{foo}` is never assigned (it remains an unresolved
+        // reference).
         let doc = Parser::default().parse("{set:foo:bar}{foo}");
         assert_xpath(&doc, "//p", 1);
         assert_xpath(&doc, "//p[text()=\"{set:foo:bar}{foo}\"]", 1);
@@ -2696,9 +2703,9 @@ mod interpolation {
 "#
         );
 
-        // Intentional divergence: `{set:foo!}` unassignment is not implemented; it
-        // stays literal, and because `foo` is still set (to empty) `{foo}`
-        // resolves to nothing, so no line is dropped.
+        // Intentional divergence: `{set:foo!}` unassignment is not implemented;
+        // it stays literal, and because `foo` is still set (to empty)
+        // `{foo}` resolves to nothing, so no line is dropped.
         let doc =
             Parser::default().parse(":attribute-missing: drop-line\n:foo:\n\n{set:foo!}\n{foo}yes");
         assert_eq!(
@@ -2741,8 +2748,8 @@ mod intrinsic_attributes {
 
 "#
     );
-    // Out of scope: iterates Ruby's `Asciidoctor::INTRINSIC_ATTRIBUTES` constant,
-    // which this crate does not expose as an enumerable set.
+    // Out of scope: iterates Ruby's `Asciidoctor::INTRINSIC_ATTRIBUTES`
+    // constant, which this crate does not expose as an enumerable set.
     non_normative!(
         r#"
     test "substitute intrinsics" do
@@ -3252,9 +3259,9 @@ mod intrinsic_attributes {
         // This crate exposes a block's caption/number via the `caption()` /
         // `number()` accessors rather than as a `<div class="title">` DOM node,
         // so the shared-counter behavior is verified through those accessors.
-        // The figure counter is shared with the nested table-cell documents: the
-        // two top-level images are numbered 1 and 4, leaving 2 and 3 for the
-        // images inside the table cells.
+        // The figure counter is shared with the nested table-cell documents:
+        // the two top-level images are numbered 1 and 4, leaving 2 and
+        // 3 for the images inside the table cells.
         let blocks: Vec<_> = doc.child_blocks().collect();
         assert_eq!(blocks[0].title(), Some("Title for Foo"));
         assert_eq!(blocks[0].caption(), Some("Figure 1. "));
@@ -3279,8 +3286,8 @@ mod intrinsic_attributes {
         );
 
         // A counter reads and increments the current value (`bar` → `bas`) for
-        // display, but the API-locked `foo` is not overwritten, so `{foo}` still
-        // reads `bar`.
+        // display, but the API-locked `foo` is not overwritten, so `{foo}`
+        // still reads `bar`.
         let doc = Parser::default()
             .with_intrinsic_attribute("foo", "bar", ModificationContext::ApiOnly)
             .parse("{counter:foo:ignored} is not {foo}");
@@ -3329,9 +3336,10 @@ mod intrinsic_attributes {
 "#
         );
 
-        // The counter reads and increments the locked built-in `max-include-depth`
-        // (64 → 65) for display — its seed `128` is ignored while a current value
-        // exists — but the stored value is not overwritten, so it stays 64.
+        // The counter reads and increments the locked built-in
+        // `max-include-depth` (64 → 65) for display — its seed `128` is
+        // ignored while a current value exists — but the stored value
+        // is not overwritten, so it stays 64.
         let doc = Parser::default()
             .parse("{counter:max-include-depth:128} is one more than {max-include-depth}");
         assert_xpath(&doc, "//p[text()=\"65 is one more than 64\"]", 1);
@@ -3549,9 +3557,10 @@ mod block_attributes {
 "#
         );
 
-        // The block title is exposed via the `title()` accessor rather than as a
-        // `<div class="title">` DOM node; the single-quoted title has normal
-        // substitutions applied once (`*title*` → `<strong>title</strong>`).
+        // The block title is exposed via the `title()` accessor rather than as
+        // a `<div class="title">` DOM node; the single-quoted title has
+        // normal substitutions applied once (`*title*` →
+        // `<strong>title</strong>`).
         let doc = Parser::default().parse("[title='*title*']\ncontent");
         assert_eq!(first_block(&doc).title(), Some("<strong>title</strong>"));
     }
@@ -3672,8 +3681,8 @@ mod block_attributes {
 "#
         );
 
-        // As with the double-quoted form, a single-quoted style token produces a
-        // quote block whose `declared_style()` is `None`.
+        // As with the double-quoted form, a single-quoted style token produces
+        // a quote block whose `declared_style()` is `None`.
         let doc = Parser::default()
             .parse("['quote', 'author', 'source', role='famous']\n____\nA famous quote.\n____");
         let qb = first_quote(&doc);
@@ -3892,8 +3901,8 @@ mod block_attributes {
         assert!(first_block(&doc).roles().is_empty());
     }
 
-    // Out of scope: exercises Ruby's mutable `role=` setter on a node, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's mutable `role=` setter on a node, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'roles= sets the role attribute on the node' do
@@ -3906,8 +3915,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `role=` setter on a node, which this
-    // crate does not expose.
+    // Out of scope: exercises Ruby's mutable `role=` setter on a node, which
+    // this crate does not expose.
     non_normative!(
         r#"
     test 'roles= coerces array value to a space-separated string' do
@@ -4143,8 +4152,8 @@ mod block_attributes {
         assert_eq!(p.roles(), vec!["role"]);
     }
 
-    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate does
-    // not expose.
+    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate
+    // does not expose.
     non_normative!(
         r#"
     test 'a role can be added using add_role when the node has no roles' do
@@ -4160,8 +4169,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate does
-    // not expose.
+    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate
+    // does not expose.
     non_normative!(
         r#"
     test 'a role can be added using add_role when the node already has a role' do
@@ -4181,8 +4190,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate does
-    // not expose.
+    // Out of scope: exercises Ruby's mutable `add_role` API, which this crate
+    // does not expose.
     non_normative!(
         r#"
     test 'a role is not added using add_role if the node already has that role' do
@@ -4201,8 +4210,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `remove_role` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable `remove_role` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'an existing role can be removed using remove_role' do
@@ -4222,8 +4231,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `remove_role` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable `remove_role` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'roles are removed when last role is removed using remove_role' do
@@ -4243,8 +4252,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `remove_role` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable `remove_role` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'roles are not changed when a non-existent role is removed using remove_role' do
@@ -4264,8 +4273,8 @@ mod block_attributes {
 "#
     );
 
-    // Out of scope: exercises Ruby's mutable `remove_role` API, which this crate
-    // does not expose.
+    // Out of scope: exercises Ruby's mutable `remove_role` API, which this
+    // crate does not expose.
     non_normative!(
         r#"
     test 'roles are not changed when using remove_role if the node has no roles' do
@@ -4406,9 +4415,9 @@ mod block_attributes {
         );
 
         // Of consecutive block anchors the last wins (`[[bar]]` / `[[foo]]`
-        // resolves to `foo`), and an `[id=…]` attribute list following a `[[id]]`
-        // anchor likewise wins (`[[baz]]` / `[id='coolio']` resolves to
-        // `coolio`).
+        // resolves to `foo`), and an `[id=…]` attribute list following a
+        // `[[id]]` anchor likewise wins (`[[baz]]` / `[id='coolio']`
+        // resolves to `coolio`).
         let doc = Parser::default().parse(
             "[[bar]]\n[[foo]]\n== Section\n\nparagraph\n\n[[baz]]\n[id='coolio']\n=== Section",
         );

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -1267,8 +1267,8 @@ mod quote_and_verse_blocks {
         assert_css(&doc, ".quoteblock > blockquote", 1);
         assert_css(&doc, ".quoteblock > blockquote > *", 0);
         assert_css(&doc, ".quoteblock > .attribution", 1);
-        // The xpath engine does not implement `contains(text(), ..)`; assert the
-        // attribution text via the rendered output instead.
+        // The xpath engine does not implement `contains(text(), ..)`; assert
+        // the attribution text via the rendered output instead.
         assert_rendered_contains(&doc, "Anonymous");
     }
 
@@ -1825,10 +1825,11 @@ mod example_blocks {
         let doc = Parser::default().parse(
             ":example-number: @\n\n.Writing Docs with AsciiDoc\n====\nHere's how you write AsciiDoc.\n\nYou just write.\n====\n\n.Writing Docs with DocBook\n====\nHere's how you write DocBook.\n\nYou futz with XML.\n====\n",
         );
-        // NOTE: divergence from Asciidoctor: Ruby's `numeral`/`number` carry the
-        // character sequence ('A', 'B'); this crate's `number()` is a `usize` and
-        // returns `None` for character captions. The character caption itself is
-        // rendered in the title and reflected in the `example-number` attribute.
+        // NOTE: divergence from Asciidoctor: Ruby's `numeral`/`number` carry
+        // the character sequence ('A', 'B'); this crate's `number()` is
+        // a `usize` and returns `None` for character captions. The
+        // character caption itself is rendered in the title and
+        // reflected in the `example-number` attribute.
         let blocks = example_blocks(&doc);
         assert_eq!(blocks[0].number(), None);
         assert_eq!(blocks[1].number(), None);
@@ -2494,8 +2495,9 @@ mod preformatted_blocks {
 
         let doc = Parser::default().parse("outside\n\n----\ninside\n\nstill inside\n\neof\n");
         assert_xpath(&doc, "/*[@class=\"listingblock\"]", 1);
-        // This crate emits a single generic `UnterminatedDelimitedBlock` warning
-        // rather than Asciidoctor's block-type-specific message text.
+        // This crate emits a single generic `UnterminatedDelimitedBlock`
+        // warning rather than Asciidoctor's block-type-specific message
+        // text.
         let warnings: Vec<_> = doc
             .warnings()
             .filter(|w| w.warning == WarningType::UnterminatedDelimitedBlock)
@@ -3186,7 +3188,8 @@ mod preformatted_blocks {
     // NOTE: divergence from Asciidoctor. This crate does not treat a block
     // title whose first character is a period (`..gitignore`) as a title;
     // Asciidoctor renders the title ".gitignore". Kept `#[ignore]`d.
-    // TODO: allow a leading period in a block title when not followed by a space.
+    // TODO: allow a leading period in a block title when not followed by a
+    // space.
     #[ignore]
     #[test]
     fn first_character_of_block_title_may_be_a_period_if_not_followed_by_space() {
@@ -4685,10 +4688,11 @@ mod custom_blocks {
 
         let doc = Parser::default().parse("[foo]\n--\nbar\n--\n");
 
-        // Asciidoctor asserts no messages at its *default* (WARN) severity. This
-        // crate surfaces the unknown style as a `WarningSeverity::Debug`
-        // diagnostic (see the debug-level test below), which a host suppresses
-        // by default. The default-severity view — warnings at WARN or above — is
+        // Asciidoctor asserts no messages at its *default* (WARN) severity.
+        // This crate surfaces the unknown style as a
+        // `WarningSeverity::Debug` diagnostic (see the debug-level test
+        // below), which a host suppresses by default. The
+        // default-severity view — warnings at WARN or above — is
         // therefore empty, mirroring Asciidoctor.
         assert_eq!(
             doc.warnings()
@@ -4719,9 +4723,10 @@ mod custom_blocks {
         );
 
         // Asciidoctor logs this only at DEBUG severity (below its default WARN
-        // threshold). This crate records it as a single `WarningSeverity::Debug`
-        // warning, observable via `Document::warnings()`. The block keeps its
-        // default `open` context; the style `foo` is retained but otherwise
+        // threshold). This crate records it as a single
+        // `WarningSeverity::Debug` warning, observable via
+        // `Document::warnings()`. The block keeps its default `open`
+        // context; the style `foo` is retained but otherwise
         // ignored. The warning anchors at the block's delimiter line (the `--`,
         // line 2) — not the `[foo]` style line above it — matching the `line 2`
         // Asciidoctor reports, and naming the offending style directly.
@@ -4791,16 +4796,17 @@ mod metadata {
         assert_xpath(&doc, "//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]", 1);
     }
 
-    // NOTE: the DOM-framing assertions are out of scope. Both tests below demote
-    // a body-level document title (`= Title`) to a level-0 section: a block title
-    // directly above a `= …` line means the line is *not* the document title, so
-    // the header is empty and `= …` is a level-0 section heading in the body.
-    // This crate now honors the demotion *and* models the `= …` line as a
-    // level-0 section (Asciidoctor's `sect0`) that a renderer emits as an `<h1>`
-    // heading, with the block title forwarded into that section's first block —
-    // matching Asciidoctor's structure. What the crate does not reproduce is the
-    // converter's page framing (`#header` / `#content` / `#preamble` wrappers)
-    // nor the exact `h1.sect0` class placement (the test virtual DOM carries the
+    // NOTE: the DOM-framing assertions are out of scope. Both tests below
+    // demote a body-level document title (`= Title`) to a level-0 section:
+    // a block title directly above a `= …` line means the line is *not* the
+    // document title, so the header is empty and `= …` is a level-0 section
+    // heading in the body. This crate now honors the demotion *and* models
+    // the `= …` line as a level-0 section (Asciidoctor's `sect0`) that a
+    // renderer emits as an `<h1>` heading, with the block title forwarded
+    // into that section's first block — matching Asciidoctor's structure.
+    // What the crate does not reproduce is the converter's page framing
+    // (`#header` / `#content` / `#preamble` wrappers) nor the exact
+    // `h1.sect0` class placement (the test virtual DOM carries the
     // `sect0` class on the section's container, not the `<h1>`), so the Ruby
     // tests stay `non_normative!` for those framing assertions.
     //
@@ -4854,9 +4860,9 @@ mod metadata {
     // section heading in the body. Asciidoctor renders that heading as
     // `<h1 class="sect0">`; this crate models it as a level-0 section (rendered
     // as an `<h1>` inside a `sect0` container), raising
-    // `Level0SectionHeadingNotSupported` under the default (non-`book`) doctype.
-    // The block title is forwarded into that section's first block — the
-    // `section paragraph` — exactly as Asciidoctor forwards it.
+    // `Level0SectionHeadingNotSupported` under the default (non-`book`)
+    // doctype. The block title is forwarded into that section's first block
+    // — the `section paragraph` — exactly as Asciidoctor forwards it.
     #[test]
     fn block_title_above_document_title_demotes_it() {
         let doc = Parser::default().parse(".Block title\n= Section Title\n\nsection paragraph\n");
@@ -4875,7 +4881,8 @@ mod metadata {
         assert_eq!(warnings[0].source.line(), 2);
 
         // `= Section Title` is modeled as a level-0 section, rendered as an
-        // `<h1>` heading inside a `sect0` container — not as a literal paragraph.
+        // `<h1>` heading inside a `sect0` container — not as a literal
+        // paragraph.
         assert_xpath(&doc, "//*[@class=\"sect0\"]", 1);
         assert_xpath(
             &doc,
@@ -4904,8 +4911,8 @@ mod metadata {
     // *part*, so — unlike the default-doctype case — no
     // `Level0SectionHeadingNotSupported` warning is raised. The part has no
     // direct content before `== First Section`, so the forwarded block title
-    // travels through the empty part onto the first block of that first section,
-    // matching Asciidoctor.
+    // travels through the empty part onto the first block of that first
+    // section, matching Asciidoctor.
     #[test]
     fn block_title_above_document_title_demotes_it_in_book_doctype() {
         let doc = Parser::default().parse(
@@ -5330,7 +5337,8 @@ mod images {
     // whose target has a leading or trailing space and renders it as an image
     // block; Asciidoctor does not treat such a line as a block image. Kept
     // `#[ignore]`d with the Ruby-intended assertion (no `<img>`).
-    // TODO: reject a block image macro whose target has leading/trailing spaces.
+    // TODO: reject a block image macro whose target has leading/trailing
+    // spaces.
     #[ignore]
     #[test]
     fn should_not_recognize_block_image_if_target_has_leading_or_trailing_spaces() {
@@ -5496,9 +5504,10 @@ mod images {
         );
 
         // This crate does not apply a `style` named attribute as the block
-        // style (`declared_style()` is `None`), matching `assert_nil img.style`.
-        // NOTE: divergence — Asciidoctor also removes the `style` key from the
-        // block's attributes; this crate retains it as a plain named attribute.
+        // style (`declared_style()` is `None`), matching `assert_nil
+        // img.style`. NOTE: divergence — Asciidoctor also removes the
+        // `style` key from the block's attributes; this crate retains
+        // it as a plain named attribute.
         let doc = Parser::default().parse("[style=value]\nimage::images/tiger.png[Tiger]\n");
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(block.declared_style(), None);
@@ -6295,8 +6304,8 @@ mod images {
         );
     }
 
-    // Safe-mode jail / ancestor-directory cleaning during data-uri file reads is
-    // out of scope.
+    // Safe-mode jail / ancestor-directory cleaning during data-uri file reads
+    // is out of scope.
     non_normative!(
         r#"
     test 'cleans reference to ancestor directories in imagesdir before reading image if safe mode level is at least SAFE' do
@@ -6587,10 +6596,11 @@ mod media {
     }
 
     // The vimeo/youtube service video tests below require rendering a custom
-    // `<iframe>` embed (with a service-specific URL and query string) instead of
-    // a `<video>` element. This crate does not model service video embedding, so
-    // they are kept `#[ignore]`d with the Ruby-intended assertions.
-    // TODO: render vimeo/youtube service videos as `<iframe>` embeds.
+    // `<iframe>` embed (with a service-specific URL and query string) instead
+    // of a `<video>` element. This crate does not model service video
+    // embedding, so they are kept `#[ignore]`d with the Ruby-intended
+    // assertions. TODO: render vimeo/youtube service videos as `<iframe>`
+    // embeds.
     #[ignore]
     #[test]
     fn video_macro_should_output_custom_html_with_iframe_for_vimeo_service() {
@@ -6982,7 +6992,8 @@ mod admonition_icons {
         );
     }
 
-    // TODO: render image-based admonition icons (custom icon, icontype variations).
+    // TODO: render image-based admonition icons (custom icon, icontype
+    // variations).
     #[ignore]
     #[test]
     fn should_allow_icontype_to_be_specified_when_using_custom_admonition_icon() {
@@ -7088,8 +7099,8 @@ mod admonition_icons {
         );
     }
 
-    // Safe-mode ancestor-directory cleaning during icon data-uri reads is out of
-    // scope.
+    // Safe-mode ancestor-directory cleaning during icon data-uri reads is out
+    // of scope.
     non_normative!(
         r#"
     test 'cleans reference to ancestor directories before reading icon if safe mode level is at least SAFE' do
@@ -7280,10 +7291,10 @@ mod source_code {
 "#
     );
 
-    // NOTE: divergence from Asciidoctor. A fenced code block with no language is
-    // not given the `source` style by this crate (its `declared_style()` is
-    // `None`), so no `<code>` element is rendered. Kept `#[ignore]`d with the
-    // Ruby-intended assertions.
+    // NOTE: divergence from Asciidoctor. A fenced code block with no language
+    // is not given the `source` style by this crate (its `declared_style()`
+    // is `None`), so no `<code>` element is rendered. Kept `#[ignore]`d
+    // with the Ruby-intended assertions.
     // TODO: assign the `source` style to a language-less fenced code block.
     #[ignore]
     #[test]

--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -758,9 +758,9 @@ mod structure {
             Parser::default().parse(":doctitle: Document Title\n\npreamble\n\n== First Section");
 
         // A `:doctitle:` attribute entry, with no `= Title` line, supplies the
-        // implicit document title. (Ruby's `header.title` and `first_section.title`
-        // both read the section title verified here; asciidoc-parser has no
-        // `has_header?` accessor.)
+        // implicit document title. (Ruby's `header.title` and
+        // `first_section.title` both read the section title verified
+        // here; asciidoc-parser has no `has_header?` accessor.)
         assert_eq!(doc.doctitle(), Some("Document Title"));
         assert_eq!(doc.header().title(), Some("Document Title"));
     }
@@ -790,8 +790,9 @@ mod structure {
         let doc =
             Parser::default().parse(":doctitle: Document Title\n\n.Block title\nBlock content");
 
-        // The `:doctitle:` entry supplies the document title; the `.Block title`
-        // that follows is a block title on the paragraph, not a second doctitle.
+        // The `:doctitle:` entry supplies the document title; the `.Block
+        // title` that follows is a block title on the paragraph, not a
+        // second doctitle.
         assert_eq!(doc.doctitle(), Some("Document Title"));
 
         let blocks = top_blocks(&doc);
@@ -865,8 +866,9 @@ mod structure {
         let doc =
             Parser::default().parse("= Document Title\n:title:\n\n{doctitle}\n\n== First Section");
 
-        // A blank `:title:` entry still overrides the doctitle, which becomes the
-        // empty string; the section title and `doctitle` attribute are untouched.
+        // A blank `:title:` entry still overrides the doctitle, which becomes
+        // the empty string; the section title and `doctitle` attribute
+        // are untouched.
         assert_eq!(doc.doctitle(), Some(""));
         assert_eq!(doc.header().title(), Some("Document Title"));
         assert_eq!(rendered_paragraphs(&doc), ["Document Title"]);
@@ -935,8 +937,9 @@ mod structure {
 
         // A `:title:` entry wins over a `:doctitle:` entry for the `doctitle`
         // accessor, while the `:doctitle:` entry still overrides the section
-        // title. `{snapshot}` captured the implicit doctitle in force when it was
-        // defined; `{doctitle}` in the body resolves to the `:doctitle:` entry.
+        // title. `{snapshot}` captured the implicit doctitle in force when it
+        // was defined; `{doctitle}` in the body resolves to the
+        // `:doctitle:` entry.
         assert_eq!(doc.doctitle(), Some("Override"));
         assert_eq!(doc.header().title(), Some("doctitle"));
         assert_eq!(
@@ -1378,10 +1381,10 @@ mod structure {
         assert_eq!(doc.header().title(), None);
     }
 
-    // Out of scope: most of the remaining structure suite converts to standalone
-    // HTML or DocBook (author/revision bylines, copyright, header/footer,
-    // footnotes-in-footer) or uses the embedded-vs-standalone conversion toggles
-    // and `parse_header_only`.
+    // Out of scope: most of the remaining structure suite converts to
+    // standalone HTML or DocBook (author/revision bylines, copyright,
+    // header/footer, footnotes-in-footer) or uses the
+    // embedded-vs-standalone conversion toggles and `parse_header_only`.
     non_normative!(
         r##"
 
@@ -1694,8 +1697,8 @@ mod structure {
 "##
         );
 
-        // An explicit `:authorinitials:` entry preceding `:author:` is preserved
-        // rather than re-derived from the author name.
+        // An explicit `:authorinitials:` entry preceding `:author:` is
+        // preserved rather than re-derived from the author name.
         let doc = Parser::default().parse(
             ":authorinitials: DOC\n:author: Doc Writer\n\n{lastname}, {firstname} ({authorinitials})",
         );
@@ -1746,8 +1749,8 @@ mod structure {
 "##
         );
 
-        // A semicolon-separated `:authors:` entry splits into individual authors,
-        // populating the base and per-author `_N` attributes.
+        // A semicolon-separated `:authors:` entry splits into individual
+        // authors, populating the base and per-author `_N` attributes.
         let doc = Parser::default().parse(
             ":authors: Doc Writer; Other Author\n\n{lastname}, {firstname} ({authorinitials})",
         );

--- a/parser/src/tests/asciidoctor_rb/helpers_test.rs
+++ b/parser/src/tests/asciidoctor_rb/helpers_test.rs
@@ -167,8 +167,8 @@ fn extname_should_return_whether_path_contains_an_extname() {
         block.content().rendered_html().to_string()
     }
 
-    // `assert Asciidoctor::Helpers.extname?('document.adoc')`: has an extension,
-    // so the name is used verbatim (no `.png` appended).
+    // `assert Asciidoctor::Helpers.extname?('document.adoc')`: has an
+    // extension, so the name is used verbatim (no `.png` appended).
     assert_eq!(
         icon_src("document.adoc"),
         r#"<span class="icon"><img src="./images/icons/document.adoc" alt="document"></span>"#
@@ -188,9 +188,9 @@ fn extname_should_return_whether_path_contains_an_extname() {
         r#"<span class="icon"><img src="./images/icons/basename.png" alt="basename"></span>"#
     );
 
-    // `refute Asciidoctor::Helpers.extname?('include.d/basename')`: the only dot
-    // is in a non-final segment, so the final segment has no extension and
-    // `png` is appended.
+    // `refute Asciidoctor::Helpers.extname?('include.d/basename')`: the only
+    // dot is in a non-final segment, so the final segment has no extension
+    // and `png` is appended.
     assert_eq!(
         icon_src("include.d/basename"),
         r#"<span class="icon"><img src="./images/icons/include.d/basename.png" alt="basename"></span>"#

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -1908,8 +1908,8 @@ fn does_not_match_bibliography_anchor_in_prose_when_scanning_for_inline_anchor()
 
     // A bibliography-style anchor (`[[[label]]]`) in ordinary prose (not as the
     // prefix of a bibliography list item) is rendered like Asciidoctor — the
-    // inner `[[label]]` becomes an empty anchor, leaving a literal `[]` — but the
-    // id is *not* registered in the catalog. See #769.
+    // inner `[[label]]` becomes an empty anchor, leaving a literal `[]` — but
+    // the id is *not* registered in the catalog. See #769.
     let doc = Parser::default().parse(
         "Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.",
     );
@@ -3734,9 +3734,9 @@ fn internal_anchor_for_inter_document_xref_to_file_outside_base_directory() {
 "###
     );
 
-    // A file included from outside the base directory registers under the target
-    // as written (`../section-a`), and the reference to it collapses just the
-    // same.
+    // A file included from outside the base directory registers under the
+    // target as written (`../section-a`), and the reference to it collapses
+    // just the same.
     let doc = doc_with_includes(
         "= Document Title\n\nSee <<../section-a.adoc#section-a>>.\n\ninclude::../section-a.adoc[]\n",
         [("../section-a.adoc", "[#section-a]\n== Section A\n")],
@@ -3958,8 +3958,8 @@ fn should_drop_nested_anchor_in_xreftext() {
 
     // `a`'s title cross-references `b`, whose reference text is its own title:
     // `Consult <a href="https://google.com">Google</a>`. Splicing that in as the
-    // link text of `a`'s cross-reference would nest an anchor inside another, so
-    // the inner link's tags are dropped, leaving `Consult Google`.
+    // link text of `a`'s cross-reference would nest an anchor inside another,
+    // so the inner link's tags are dropped, leaving `Consult Google`.
     assert_eq!(
         sections[0].section_title(),
         r##"See <a href="#b">Consult Google</a>"##

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -530,12 +530,14 @@ mod bulleted_lists {
             assert_css(&doc, "ul", 1);
             assert_css(&doc, "ul li", 2);
 
-            // Asciidoctor test on which this is based comes with the following comment:
-            // > NOTE: for some reason, we're getting an extra line after the indented line.
+            // Asciidoctor test on which this is based comes with the following
+            // comment:
+            // > NOTE: for some reason, we're getting an extra line after the
+            // > indented line.
             //
-            // Looks like we're not having that problem in the Rust port. Use this detailed
-            // comparison to ensure that remains true. todo!("xmlnodes_at_xpath
-            // check for 3 lines");
+            // Looks like we're not having that problem in the Rust port. Use
+            // this detailed comparison to ensure that remains true.
+            // todo!("xmlnodes_at_xpath check for 3 lines");
 
             assert_eq!(
                 doc,
@@ -1073,9 +1075,10 @@ mod bulleted_lists {
             let doc = Parser::default().parse("* complex list item\n+\n[source,xml]\n----\n<name>value</name> <!--1-->\n----\n<1> a configuration value\n");
 
             // The callout list attached to the list item must not inherit the
-            // `[source,xml]` attributes from the preceding listing block. Mirror
-            // the Ruby test's `refute important_message.attributes.key?
-            // 'language'` by checking the list item's last block (the callout
+            // `[source,xml]` attributes from the preceding listing block.
+            // Mirror the Ruby test's `refute
+            // important_message.attributes.key? 'language'` by
+            // checking the list item's last block (the callout
             // list) carries no attrlist of its own.
             let list = doc.child_blocks().next().unwrap();
             let item = list.child_blocks().next().unwrap().as_list_item().unwrap();
@@ -1956,7 +1959,8 @@ mod bulleted_lists {
 
             let doc = Parser::default().parse("The highest peak in the Front Range is <<grays-peak>>, which tops <<mount-evans>> by just a few feet.\n\n* [[mount-evans,Mount Evans]]At 14,271 feet, Mount Evans is the highest summit of the Chicago Peaks in the Front Range of the Rocky Mountains.\n* [[grays-peak,Grays Peak]]\nGrays Peak rises to 14,278 feet, making it the highest summit in the Front Range of the Rocky Mountains.\n* Longs Peak is a 14,259-foot high, prominent mountain summit in the northern Front Range of the Rocky Mountains.\n* Pikes Peak is the highest summit of the southern Front Range of the Rocky Mountains at 14,115 feet.\n");
 
-            // The inline anchors at the start of the list items were registered.
+            // The inline anchors at the start of the list items were
+            // registered.
             assert!(doc.catalog().contains_id("mount-evans"));
             assert!(doc.catalog().contains_id("grays-peak"));
 
@@ -2324,8 +2328,8 @@ mod bulleted_lists {
             assert_css(&doc, "li", 26);
         }
 
-        // Ruby `List#level` model API: this crate's `ListBlock` exposes no `level`
-        // accessor.
+        // Ruby `List#level` model API: this crate's `ListBlock` exposes no
+        // `level` accessor.
         non_normative!(
             r#"
     test 'level of unordered list should match section level' do
@@ -2461,8 +2465,8 @@ mod bulleted_lists {
             assert_css(&doc, "li", 26);
         }
 
-        // Ruby `List#level` model API: this crate's `ListBlock` exposes no `level`
-        // accessor.
+        // Ruby `List#level` model API: this crate's `ListBlock` exposes no
+        // `level` accessor.
         non_normative!(
             r#"
     test 'level of ordered list should match section level' do
@@ -4066,11 +4070,12 @@ mod bulleted_lists {
 "#
             );
 
-            // The Ruby asciidoctor implementation on which this is based comes with the
-            // following comment:
+            // The Ruby asciidoctor implementation on which this is based comes
+            // with the following comment:
 
-            // NOTE: This is not consistent w/ AsciiDoc.py, but this is some screwy input
-            // anyway. FIXME: one list continuation is left behind.
+            // NOTE: This is not consistent w/ AsciiDoc.py, but this is some
+            // screwy input anyway. FIXME: one list continuation is
+            // left behind.
 
             let doc = Parser::default().parse("== Lists\n\n* Item one, paragraph one\n+\n+\nItem one, paragraph two\n+\n+\n* Item two\n+\n+\n");
 
@@ -4685,8 +4690,9 @@ mod ordered_lists {
             assert_xpath(&doc, "(//li)[2]/p[text()=\"b\u{2028}b\"]", 1);
         }
 
-        // The following tests extend the Ruby coverage with crate-specific cases
-        // (chiefly the `start` attribute) and so carry no `verifies!` block.
+        // The following tests extend the Ruby coverage with crate-specific
+        // cases (chiefly the `start` attribute) and so carry no
+        // `verifies!` block.
 
         #[test]
         fn should_honor_start_attribute_on_ordered_list() {
@@ -5737,8 +5743,8 @@ mod description_lists_dlist {
 "#
             );
 
-            // NOTE: blank line following literal paragraph is required or else it will
-            // gobble up the second term.
+            // NOTE: blank line following literal paragraph is required or else
+            // it will gobble up the second term.
             let doc = Parser::default().parse("term1::\ndef1\n\n  literal\n\nterm2::\n  def2\n");
 
             assert_xpath(&doc, "//dl", 1);
@@ -7667,7 +7673,8 @@ mod description_lists_dlist {
 "#
         );
 
-        // DocBook backend / horizontal list layout are out of scope for this crate.
+        // DocBook backend / horizontal list layout are out of scope for this
+        // crate.
         non_normative!(
             r#"
     test 'should set col widths of item and label in docbook if specified' do
@@ -7898,9 +7905,10 @@ mod description_lists_dlist {
             assert_css(&doc, ".ulist.bibliography ul li", 2);
             assert_css(&doc, ".ulist.bibliography ul li p", 2);
             // Asciidoctor scopes this to the first item with `li:nth-child(1)`;
-            // the test CSS engine can't evaluate `:nth-child` across a descendant
-            // combinator, so the first-item specificity is instead checked against
-            // the rendered paragraph below.
+            // the test CSS engine can't evaluate `:nth-child` across a
+            // descendant combinator, so the first-item specificity
+            // is instead checked against the rendered paragraph
+            // below.
             assert_css(&doc, ".ulist.bibliography ul li p a#taoup", 1);
 
             // The bibliography anchor renders as an empty `<a id>` (it has no
@@ -7909,8 +7917,8 @@ mod description_lists_dlist {
 
             // The crate produces inline content at parse time rather than
             // rendering whole blocks, so the anchor-then-`[taoup] ` sequence
-            // (asserted via `following-sibling::text()` in Asciidoctor) is checked
-            // against the rendered paragraph directly.
+            // (asserted via `following-sibling::text()` in Asciidoctor) is
+            // checked against the rendered paragraph directly.
             let paragraphs = rendered_paragraphs(&doc);
             assert!(paragraphs[0].starts_with("<a id=\"taoup\"></a>[taoup] "));
             assert!(paragraphs[1].starts_with("<a id=\"walsh-muellner\"></a>[walsh-muellner] "));
@@ -8013,10 +8021,11 @@ mod description_lists_dlist {
 
             let doc = Parser::default().parse("[bibliography]\n== Bibliography\n\n.Books\n* [[[taoup]]] Eric Steven Raymond. _The Art of Unix\n  Programming_. Addison-Wesley. ISBN 0-13-142901-9.\n* [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.\n  _DocBook - The Definitive Guide_. O'Reilly & Associates. 1999.\n  ISBN 1-56592-580-7.\n\n.Periodicals\n* [[[doc-writer]]] Doc Writer. _Documentation As Code_. Static Times, 54. August 2016.\n");
 
-            // Both top-level unordered lists in the bibliography section inherit
-            // the `bibliography` style, even though neither carries an explicit
-            // `[bibliography]` attribute. This mirrors the Ruby assertions
-            // `ulists[0].style == 'bibliography'` and `ulists[1].style ==
+            // Both top-level unordered lists in the bibliography section
+            // inherit the `bibliography` style, even though neither
+            // carries an explicit `[bibliography]` attribute. This
+            // mirrors the Ruby assertions `ulists[0].style ==
+            // 'bibliography'` and `ulists[1].style ==
             // 'bibliography'`: the crate surfaces the resolved style through
             // `resolved_style()`.
             let ulists: Vec<_> = doc
@@ -8064,7 +8073,8 @@ mod description_lists_dlist {
             );
 
             // A label that begins with a digit is not a bibliography anchor, so
-            // the triple brackets are left untouched and no anchor is generated.
+            // the triple brackets are left untouched and no anchor is
+            // generated.
             let paragraphs = rendered_paragraphs(&doc);
             assert!(paragraphs[0].starts_with("[[[1984]]] "));
             assert_xpath(&doc, "//a[@id=\"1984\"]", 0);
@@ -8184,12 +8194,14 @@ mod description_lists_dlist {
 
             let paragraphs = rendered_paragraphs(&doc);
 
-            // The cross-references use each entry's reftext: the plain label for
-            // `TMMM`, and the explicit xreftext `1` for `Fowler_1997`.
+            // The cross-references use each entry's reftext: the plain label
+            // for `TMMM`, and the explicit xreftext `1` for
+            // `Fowler_1997`.
             assert!(paragraphs[0].contains("<a href=\"#TMMM\">[TMMM]</a>"));
             assert!(paragraphs[0].contains("<a href=\"#Fowler_1997\">[1]</a>"));
 
-            // The bibliography entries themselves render the same bracketed text.
+            // The bibliography entries themselves render the same bracketed
+            // text.
             assert!(paragraphs[1].starts_with("<a id=\"TMMM\"></a>[TMMM] "));
             assert!(paragraphs[2].starts_with("<a id=\"Fowler_1997\"></a>[1] "));
         }
@@ -9564,7 +9576,8 @@ mod description_lists_redux {
             );
 
             // Comment ported from Ruby Asciidoctor tests:
-            // FIXME: this is a negative test; the behavior should be the other way around.
+            // FIXME: this is a negative test; the behavior should be the other
+            // way around.
             let doc =
                 Parser::default().parse("term1:: def\n+\nmore description\nnot a term:: def\n");
 
@@ -11469,8 +11482,8 @@ mod callout_lists {
 
         let doc = Parser::default().parse("foo::\n  bar <1>\n\n<1> Not pointing to a callout\n");
 
-        // The `<1>` in the indented description-list paragraph is not a callout;
-        // it is rendered literally and produces no conum.
+        // The `<1>` in the indented description-list paragraph is not a
+        // callout; it is rendered literally and produces no conum.
         assert_xpath(&doc, "//dl//b", 0);
         assert_output_contains(&doc, "bar &lt;1&gt;");
 
@@ -11561,8 +11574,8 @@ mod callout_lists {
 
         // The verbatim block defines only callout 1, so the second item (whose
         // marker is `<3>`) is both out of sequence and has no matching callout.
-        // Asciidoctor logs these via its memory logger; this crate surfaces them
-        // as document warnings.
+        // Asciidoctor logs these via its memory logger; this crate surfaces
+        // them as document warnings.
         let warnings: Vec<_> = doc.warnings().map(|w| &w.warning).collect();
         assert_eq!(
             warnings,
@@ -12247,8 +12260,8 @@ mod checklists {
         let checklist = first_list(&doc);
         assert!(checklist.is_checklist());
 
-        // First item: principal paragraph carries the check-mark marker, and the
-        // continuation paragraph is wrapped in div.paragraph.
+        // First item: principal paragraph carries the check-mark marker, and
+        // the continuation paragraph is wrapped in div.paragraph.
         assert_xpath(
             &doc,
             "(/*[@class=\"ulist checklist\"]/ul/li)[1]/p[text()=\"\u{2713} done\"]",
@@ -12674,7 +12687,8 @@ mod lists_model {
 "#
     );
 
-    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate equivalent.
+    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate
+    // equivalent.
     non_normative!(
         r#"
   test 'simple? should return true for list item with no nested blocks' do
@@ -12693,7 +12707,8 @@ mod lists_model {
 "#
     );
 
-    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate equivalent.
+    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate
+    // equivalent.
     non_normative!(
         r#"
   test 'simple? should return true for list item with nested outline list' do
@@ -12715,7 +12730,8 @@ mod lists_model {
 "#
     );
 
-    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate equivalent.
+    // Ruby `ListItem#simple?`/`compound?` model predicates: no crate
+    // equivalent.
     non_normative!(
         r#"
   test 'simple? should return false for list item with block content' do
@@ -12738,7 +12754,8 @@ mod lists_model {
 "#
     );
 
-    // Mutable model API (`ListItem#text=`): this crate's parsed AST is read-only.
+    // Mutable model API (`ListItem#text=`): this crate's parsed AST is
+    // read-only.
     non_normative!(
         r#"
   test 'should allow text of ListItem to be assigned' do
@@ -12759,8 +12776,8 @@ mod lists_model {
 "#
     );
 
-    // Mutable model API (`id=`/`add_role`) plus re-conversion: this crate's parsed
-    // AST is read-only.
+    // Mutable model API (`id=`/`add_role`) plus re-conversion: this crate's
+    // parsed AST is read-only.
     non_normative!(
         r#"
   test 'id and role assigned to ulist item in model are transmitted to output' do
@@ -12781,8 +12798,8 @@ mod lists_model {
 "#
     );
 
-    // Mutable model API (`id=`/`add_role`) plus re-conversion: this crate's parsed
-    // AST is read-only.
+    // Mutable model API (`id=`/`add_role`) plus re-conversion: this crate's
+    // parsed AST is read-only.
     non_normative!(
         r#"
   test 'id and role assigned to olist item in model are transmitted to output' do
@@ -12803,7 +12820,8 @@ mod lists_model {
 "#
     );
 
-    // Runtime substitution model API (`remove_sub`/`subs`): no crate equivalent.
+    // Runtime substitution model API (`remove_sub`/`subs`): no crate
+    // equivalent.
     non_normative!(
         r#"
   test 'should allow API control over substitutions applied to ListItem text' do

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -1313,8 +1313,8 @@ mod normal {
         );
     }
 
-    // No planned support for DocBook output, so these tests were not ported from
-    // asciidoctor_rb:
+    // No planned support for DocBook output, so these tests were not ported
+    // from asciidoctor_rb:
     //
     // * test 'automatically promotes index terms in DocBook output if
     //   indexterm-promotion-option is set'
@@ -3274,8 +3274,8 @@ mod special {
 "#
     );
 
-    // An `[open]` styled paragraph renders as an open block whose inline content
-    // sits directly in the content wrapper, with no wrapping `<p>`.
+    // An `[open]` styled paragraph renders as an open block whose inline
+    // content sits directly in the content wrapper, with no wrapping `<p>`.
     #[test]
     fn should_convert_open_paragraph_to_open_block() {
         verifies!(
@@ -3309,9 +3309,9 @@ mod special {
         );
     }
 
-    // Backend-specific test omitted: DocBook `simpara` wrapping of titled styled
-    // paragraphs. (This block also closes the Ruby `Styled Paragraphs` context
-    // and opens `Inline doctype`.)
+    // Backend-specific test omitted: DocBook `simpara` wrapping of titled
+    // styled paragraphs. (This block also closes the Ruby `Styled
+    // Paragraphs` context and opens `Inline doctype`.)
     non_normative!(
         r#"
       test 'should wrap text in simpara for styled paragraphs with title when converted to DocBook' do
@@ -3478,16 +3478,16 @@ mod special {
         }
 
         // A document title followed by a paragraph and a section wraps the
-        // paragraph in a compound preamble, which is the first block. A compound
-        // candidate has no inline content, so the parse-time warning and the
-        // (empty) rendered output stay in agreement — the preamble never masks a
-        // silently-dropped candidate.
+        // paragraph in a compound preamble, which is the first block. A
+        // compound candidate has no inline content, so the parse-time
+        // warning and the (empty) rendered output stay in agreement —
+        // the preamble never masks a silently-dropped candidate.
         //
         // This matches Asciidoctor 2.0.26 exactly: `= Title\n\nfirst
         // paragraph\n\n== Section` under `-d inline` logs `no inline candidate`
-        // and emits nothing (the preamble is `@blocks[0]`, and its content model
-        // is compound). Rendering the inner paragraph instead would diverge from
-        // Asciidoctor.
+        // and emits nothing (the preamble is `@blocks[0]`, and its content
+        // model is compound). Rendering the inner paragraph instead
+        // would diverge from Asciidoctor.
         #[test]
         fn preamble_is_a_compound_candidate() {
             let doc = Parser::default()
@@ -3503,11 +3503,12 @@ mod special {
         }
 
         // A title with a paragraph but *no* section creates no preamble (this
-        // crate, like Asciidoctor, only wraps a preamble when a section follows),
-        // so the paragraph is itself the first block and is rendered as inline
-        // content with no warning. Asciidoctor 2.0.26 emits `first paragraph`
-        // for `= Title\n\nfirst paragraph` under `-d inline`. This is the
-        // boundary that distinguishes the candidate from the compound-preamble
+        // crate, like Asciidoctor, only wraps a preamble when a section
+        // follows), so the paragraph is itself the first block and is
+        // rendered as inline content with no warning. Asciidoctor
+        // 2.0.26 emits `first paragraph` for `= Title\n\nfirst
+        // paragraph` under `-d inline`. This is the boundary that
+        // distinguishes the candidate from the compound-preamble
         // case above.
         #[test]
         fn titled_paragraph_without_section_is_rendered_html() {
@@ -3563,10 +3564,11 @@ mod custom {
         assert_eq!(block.declared_style(), Some("foo"));
         assert_eq!(block.rendered_html_content(), Some("bar"));
 
-        // Asciidoctor asserts no messages at its *default* (WARN) severity. This
-        // crate surfaces the unknown style as a `WarningSeverity::Debug`
-        // diagnostic (see the debug-level test below), which a host suppresses
-        // by default, so the default-severity view is empty.
+        // Asciidoctor asserts no messages at its *default* (WARN) severity.
+        // This crate surfaces the unknown style as a
+        // `WarningSeverity::Debug` diagnostic (see the debug-level test
+        // below), which a host suppresses by default, so the
+        // default-severity view is empty.
         assert_eq!(
             doc.warnings()
                 .filter(|w| w.severity >= WarningSeverity::Warning)
@@ -3593,9 +3595,10 @@ mod custom {
         );
 
         // Asciidoctor logs this only at DEBUG severity (below its default WARN
-        // threshold). This crate records it as a single `WarningSeverity::Debug`
-        // warning, observable via `Document::warnings()`. The paragraph keeps
-        // its default context; the style `foo` is retained but otherwise
+        // threshold). This crate records it as a single
+        // `WarningSeverity::Debug` warning, observable via
+        // `Document::warnings()`. The paragraph keeps its default
+        // context; the style `foo` is retained but otherwise
         // ignored. The warning anchors at the paragraph's first content line
         // (`bar`, line 2) — not the `[foo]` style line above it — matching the
         // `line 2` Asciidoctor reports.

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -282,8 +282,8 @@ fn store_attribute_with_value() {
     );
 
     // Constructing the parser with the attribute makes it active for a parsed
-    // document: `foo` is present on the resulting `Document` and resolves when a
-    // `{foo}` reference is substituted.
+    // document: `foo` is present on the resulting `Document` and resolves when
+    // a `{foo}` reference is substituted.
     let mut parser =
         Parser::default().with_intrinsic_attribute("foo", "bar", ModificationContext::Anywhere);
     let doc = parser.parse("{foo}");
@@ -1004,9 +1004,10 @@ fn parse_author_condenses_whitespace() {
 "#
     );
 
-    // This crate does not derive the `authors` or `authorcount` attributes, so we
-    // assert on the parsed author directly. The interior whitespace between the
-    // names is condensed to a single space (matching `metadata['author']`).
+    // This crate does not derive the `authors` or `authorcount` attributes, so
+    // we assert on the parsed author directly. The interior whitespace
+    // between the names is condensed to a single space (matching
+    // `metadata['author']`).
     let a = parse_authors("Stuart       Rackham     <founder@asciidoc.org>");
     assert_eq!(a.len(), 1);
     assert_eq!(a[0].name, "Stuart Rackham");
@@ -1034,17 +1035,17 @@ fn parse_invalid_author_line_becomes_author() {
     );
 
     // The author line doesn't match the author pattern (because of the embedded
-    // comma), so Asciidoctor condenses the interior whitespace and stores the whole
-    // line as the author.
+    // comma), so Asciidoctor condenses the interior whitespace and stores the
+    // whole line as the author.
     //
-    // The Ruby assertions above check `metadata['author']`, the *raw* value that
-    // `parse_header_metadata` returns before substitution. This crate's
-    // `Author::name()` instead represents the value that populates the `author`
-    // document attribute — the one `{author}` and the converter consume — to which
-    // Asciidoctor applies the header substitution group via `apply_header_subs`
-    // (`doc.attributes['author'] = apply_header_subs val`). Applying the header
-    // subs escapes the literal angle brackets, so they appear as `&lt;`/`&gt;`
-    // here.
+    // The Ruby assertions above check `metadata['author']`, the *raw* value
+    // that `parse_header_metadata` returns before substitution. This
+    // crate's `Author::name()` instead represents the value that populates
+    // the `author` document attribute — the one `{author}` and the
+    // converter consume — to which Asciidoctor applies the header
+    // substitution group via `apply_header_subs` (`doc.attributes['author']
+    // = apply_header_subs val`). Applying the header subs escapes the
+    // literal angle brackets, so they appear as `&lt;`/`&gt;` here.
     let a = parse_authors("   Stuart       Rackham, founder of AsciiDoc   <founder@asciidoc.org>");
     assert_eq!(a.len(), 1);
     assert_eq!(
@@ -1148,10 +1149,11 @@ fn skips_blank_author_entries_in_implicit_author_line() {
 "#
     );
 
-    // This crate splits the implicit author line on a semicolon that is followed
-    // by a space or the end of the line (see issue #757), then drops any blank
-    // entry. So the empty middle entry and the trailing bare `;` are both
-    // dropped, and the trailing `;` no longer clings to the final author's name.
+    // This crate splits the implicit author line on a semicolon that is
+    // followed by a space or the end of the line (see issue #757), then
+    // drops any blank entry. So the empty middle entry and the trailing
+    // bare `;` are both dropped, and the trailing `;` no longer clings to
+    // the final author's name.
     let a = parse_authors("Doc Writer; ; John Smith <john.smith@asciidoc.org>;");
     assert_eq!(a.len(), 2);
     assert_eq!(a[0].name, "Doc Writer");
@@ -1160,7 +1162,8 @@ fn skips_blank_author_entries_in_implicit_author_line() {
 
     // The two surviving authors are counted and numbered `author_1` /
     // `author_2`, matching Asciidoctor. A synthetic document title is prepended
-    // because this crate only recognizes an author line when a title is present.
+    // because this crate only recognizes an author line when a title is
+    // present.
     let mut parser = Parser::default();
     let _doc =
         parser.parse("= Document Title\nDoc Writer; ; John Smith <john.smith@asciidoc.org>;");
@@ -1516,8 +1519,8 @@ fn allows_authors_to_be_overridden_using_explicit_author_attributes() {
     // implicit author line. The first author is now exposed both unsuffixed
     // (`author`) and as `author_1`. The override is reconciled back into the
     // combined `authors` string and the resolved author list, so `{authors}`,
-    // `Document::authors()`, and `authorcount` all reflect `Danger Mouse` rather
-    // than the implicit `Johnny Bravo`.
+    // `Document::authors()`, and `authorcount` all reflect `Danger Mouse`
+    // rather than the implicit `Johnny Bravo`.
     let mut parser = Parser::default();
     let doc = parser.parse(
         "= Document Title\nKismet Chameleon; Johnny Bravo; Lazarus het_Draeke\n:author_2: Danger Mouse",
@@ -1721,9 +1724,9 @@ fn parse_rev_number_date_and_remark_as_attribute_references() {
 
     // With none of the referenced attributes defined, the references survive
     // verbatim: the `v` prefix is stripped from the revision number, but
-    // `{project-version}` is preserved rather than dropped for lack of a literal
-    // digit. (This crate does not surface the full header-metadata hash, so the
-    // `metadata.size` assertion is not modeled.)
+    // `{project-version}` is preserved rather than dropped for lack of a
+    // literal digit. (This crate does not surface the full header-metadata
+    // hash, so the `metadata.size` assertion is not modeled.)
     let (revnumber, revdate, revremark) =
         header_rev("Author Name\nv{project-version}, {release-date}: {release-summary}");
     assert_eq!(revnumber.as_deref(), Some("{project-version}"));

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -947,9 +947,9 @@ fn should_not_skip_front_matter_by_default() {
     );
 
     // With `skip-front-matter` unset, the leading `---` keeps its ordinary
-    // meaning: nothing is stripped, no `front-matter` attribute is recorded, and
-    // the `= Document Title` line — no longer the first line — is not read as the
-    // document title.
+    // meaning: nothing is stripped, no `front-matter` attribute is recorded,
+    // and the `= Document Title` line — no longer the first line — is not
+    // read as the document title.
     let doc = Parser::default().parse(
         "---\nlayout: post\ntitle: Document Title\nauthor: username\ntags: [ first, second ]\n---\n= Document Title\nAuthor Name\n\npreamble\n",
     );
@@ -1029,9 +1029,9 @@ fn should_skip_front_matter_if_specified_by_skip_front_matter_attribute() {
 
     // `skip-front-matter` is set and the block is well-formed: its content
     // (delimiters excluded, lines joined by LF) is captured in the
-    // `front-matter` attribute, and parsing resumes at `= Document Title`, which
-    // — thanks to the blank lines left in place of the removed block — is still
-    // reported at its original line 7.
+    // `front-matter` attribute, and parsing resumes at `= Document Title`,
+    // which — thanks to the blank lines left in place of the removed block
+    // — is still reported at its original line 7.
     let doc = Parser::default()
         .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
         .parse(
@@ -4274,7 +4274,8 @@ fn line_is_skipped_by_default_if_target_of_include_directive_resolves_to_empty()
         output,
         "Unresolved directive in (root file) - include::{blank}[]\n"
     );
-    // The blank target was still handed to the handler (as the empty string) ...
+    // The blank target was still handed to the handler (as the empty string)
+    // ...
     assert_eq!(probe.calls(), vec![(None, "".to_owned(), None)]);
     // ... which reported no such file, yielding the not-found warning.
     assert_eq!(warnings.len(), 1);

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -498,8 +498,8 @@ mod ids {
 "##
         );
 
-        // The embedded anchor is consumed to set the section ID and removed from
-        // the rendered title.
+        // The embedded anchor is consumed to set the section ID and removed
+        // from the rendered title.
         let doc = Parser::default().parse("== Section One [[one]] ==");
         let sec = first_section(&doc);
         assert_eq!(sec.id(), Some("one"));
@@ -644,8 +644,8 @@ mod ids {
 "##
         );
 
-        // The escaped anchor is unescaped to literal `[[one]]` but not processed,
-        // so the ID is not `one`.
+        // The escaped anchor is unescaped to literal `[[one]]` but not
+        // processed, so the ID is not `one`.
         let doc = Parser::default().parse(r#"== Section One \[[one]] =="#);
         let sec = first_section(&doc);
         assert_ne!(sec.id(), Some("one"));
@@ -981,7 +981,8 @@ mod ids {
         let reff = doc.catalog().get_ref("install").unwrap();
         assert_eq!(reff.reftext.as_deref(), Some("install on Linux"));
 
-        // The resolved reftext is what a natural cross reference matches against.
+        // The resolved reftext is what a natural cross reference matches
+        // against.
         assert_eq!(
             doc.catalog().resolve_id("install on Linux"),
             Some("install".to_string())
@@ -1026,10 +1027,11 @@ mod ids {
             "[#install]\n== First Install\n\ncontent\n\n[#install]\n== Second Install\n\ncontent\n",
         );
         // The normative behavior — the duplicate ID does not overwrite the
-        // existing entry, and a warning is emitted — holds. Two representational
-        // differences from Ruby: the crate stores the section title as the
-        // entry's fallback reftext (Ruby leaves `ref.reftext` nil and keeps the
-        // title separately in `ref.title`), and the `DuplicateId` warning does
+        // existing entry, and a warning is emitted — holds. Two
+        // representational differences from Ruby: the crate stores the
+        // section title as the entry's fallback reftext (Ruby leaves
+        // `ref.reftext` nil and keeps the title separately in
+        // `ref.title`), and the `DuplicateId` warning does
         // not distinguish "section" from "block" in its wording.
         let reff = doc.catalog().get_ref("install");
         assert!(reff.is_some());
@@ -1084,8 +1086,9 @@ mod ids {
             "== Do Not Repeat Yourself\n\ncontent\n\n[#_do_not_repeat_yourself]\n== Do Not Repeat Yourself\n\ncontent\n",
         );
         // As above, the entry stores the title as its fallback reftext. The
-        // explicit ID that collides with the auto-generated one is reported as a
-        // `DuplicateId` warning, and both headings render with the shared ID.
+        // explicit ID that collides with the auto-generated one is reported as
+        // a `DuplicateId` warning, and both headings render with the
+        // shared ID.
         let reff = doc.catalog().get_ref("_do_not_repeat_yourself");
         assert!(reff.is_some());
         assert_eq!(
@@ -1253,9 +1256,10 @@ mod levels {
 "##
         );
 
-        // The crate's virtual DOM models *embedded* output, which does not frame
-        // the document title in an `<h1>` by default; the parsed document title
-        // is verified through [`Document::doctitle`] instead.
+        // The crate's virtual DOM models *embedded* output, which does not
+        // frame the document title in an `<h1>` by default; the parsed
+        // document title is verified through [`Document::doctitle`]
+        // instead.
         #[test]
         fn document_title_with_atx_syntax() {
             verifies!(
@@ -1289,9 +1293,9 @@ mod levels {
         // A `:leveloffset:` shift that drives a heading to effective level 0
         // coerces it to the document title, exactly as a bare `=` would. The
         // crate models embedded output, which does not frame the doctitle in an
-        // `<h1>`, so the promotion is verified through [`Document::doctitle`]; a
-        // doctitle carries no `id`, matching the `not(@id)` in the Ruby
-        // assertions.
+        // `<h1>`, so the promotion is verified through [`Document::doctitle`];
+        // a doctitle carries no `id`, matching the `not(@id)` in the
+        // Ruby assertions.
         #[test]
         fn document_title_created_from_leveloffset_shift_defined_in_document() {
             verifies!(
@@ -1320,10 +1324,11 @@ mod levels {
 "##
             );
 
-            // The Ruby `'-1@'` value carries the trailing `@` soft-set modifier:
-            // the effective offset is `-1`, and the attribute becomes overridable
-            // by the document. `with_intrinsic_attribute` strips the `@` and
-            // relaxes the modification context to
+            // The Ruby `'-1@'` value carries the trailing `@` soft-set
+            // modifier: the effective offset is `-1`, and the
+            // attribute becomes overridable by the document.
+            // `with_intrinsic_attribute` strips the `@` and relaxes
+            // the modification context to
             // [`ModificationContext::Anywhere`] on its own, so the raw `-1@`
             // value can be passed through verbatim.
             let doc = Parser::default()
@@ -1334,12 +1339,13 @@ mod levels {
             assert!(doc.warnings().next().is_none());
         }
 
-        // A tab (not just a space) may separate the marker run from the title, so
-        // a tab-delimited heading shifted to effective level 0 is coerced to the
-        // document title exactly as its space-delimited form is — matching the
-        // section parser's `[ \t]+` whitespace handling. This edge is not covered
-        // by a Ruby test, but guards against the header recognizer and the body
-        // section parser disagreeing on what counts as a heading.
+        // A tab (not just a space) may separate the marker run from the title,
+        // so a tab-delimited heading shifted to effective level 0 is
+        // coerced to the document title exactly as its space-delimited
+        // form is — matching the section parser's `[ \t]+` whitespace
+        // handling. This edge is not covered by a Ruby test, but guards
+        // against the header recognizer and the body section parser
+        // disagreeing on what counts as a heading.
         #[test]
         fn document_title_from_leveloffset_shift_allows_a_tab_after_the_marker() {
             let doc = Parser::default().parse(":leveloffset: -1\n==\tDocument Title");
@@ -1393,11 +1399,11 @@ mod levels {
         );
 
         // The crate recognizes a document ID from a `[[id]]` block anchor above
-        // the document title, folding it into the header the same way the `[#id]`
-        // shorthand is. `doc.id` and any accompanying attribute entry are exposed
-        // through the header/document accessors; only the
-        // `assert_css 'body#reference'` (which needs a standalone `<body>`) is
-        // out of scope.
+        // the document title, folding it into the header the same way the
+        // `[#id]` shorthand is. `doc.id` and any accompanying attribute
+        // entry are exposed through the header/document accessors; only
+        // the `assert_css 'body#reference'` (which needs a standalone
+        // `<body>`) is out of scope.
         #[test]
         fn block_id_above_document_title_sets_id_on_document() {
             verifies!(
@@ -1480,10 +1486,10 @@ mod levels {
         // A cross-reference to a document title carrying an explicit shorthand
         // ID (`[#id]`) resolves to the title's reference text. The crate
         // registers the document title in the catalog under its ID (as a
-        // [`Section`](crate::document::RefType::Section) whose reference text is
-        // the doctitle), so an `<<id>>` to it renders the title rather than the
-        // bracketed `[id]` fallback — matching a cross-reference to an ordinary
-        // section.
+        // [`Section`](crate::document::RefType::Section) whose reference text
+        // is the doctitle), so an `<<id>>` to it renders the title
+        // rather than the bracketed `[id]` fallback — matching a
+        // cross-reference to an ordinary section.
         #[test]
         fn should_compute_xreftext_to_document_title() {
             verifies!(
@@ -1704,7 +1710,8 @@ mod levels {
 "##
             );
 
-            // A non-matching trailing run is part of the title (nothing to strip).
+            // A non-matching trailing run is part of the title (nothing to
+            // strip).
             let doc = Parser::default().parse("== My Title ===");
             let sec = first_section(&doc);
             assert_eq!(sec.level(), 1);
@@ -1713,9 +1720,9 @@ mod levels {
         }
 
         // The symmetric close must be separated by an ASCII blank (space or
-        // tab), matching Asciidoctor's `CG_BLANK`; a non-breaking space (U+00A0)
-        // before the close is not a valid separator, so the `==` stays part of
-        // the title. (No Ruby counterpart.)
+        // tab), matching Asciidoctor's `CG_BLANK`; a non-breaking space
+        // (U+00A0) before the close is not a valid separator, so the
+        // `==` stays part of the title. (No Ruby counterpart.)
         #[test]
         fn symmetric_close_requires_ascii_blank_not_unicode_whitespace() {
             let doc = Parser::default().parse("== My Title\u{a0}==");
@@ -1740,8 +1747,9 @@ mod levels {
             );
 
             // The straight apostrophe becomes a typographic right single quote,
-            // which the crate emits as the numeric character reference `&#8217;`
-            // in the rendered title (Ruby's test decodes it to `’`).
+            // which the crate emits as the numeric character reference
+            // `&#8217;` in the rendered title (Ruby's test decodes
+            // it to `’`).
             let doc = Parser::default().parse("== What's new?");
 
             let sec = first_section(&doc);
@@ -2096,9 +2104,9 @@ mod substitutions {
         assert_css(&doc, "h2", 1);
         // The heading's inline content is rendered to an HTML string on the
         // `h2` node (not parsed into child elements), so the link and trademark
-        // sign are verified in the rendered title: attribute references resolve,
-        // the macro becomes a link, and `{tm}` → `(TM)` → the trademark sign
-        // (emitted as `&#8482;`).
+        // sign are verified in the rendered title: attribute references
+        // resolve, the macro becomes a link, and `{tm}` → `(TM)` → the
+        // trademark sign (emitted as `&#8482;`).
         assert_eq!(
             first_section(&doc).section_title(),
             r#"<a href="https://acme.com">ACME</a>&#8482;"#
@@ -2164,11 +2172,11 @@ mod nesting {
         assert_eq!(nested.level(), 3);
     }
 
-    // NOTE: The crate now warns generically when a top-level section skips level
-    // 1 (`SectionHeadingLevelSkipped(0, 2)` here; see #754 and the regression
-    // test below), but the exact "expected levels 0 or 1" wording is
-    // book-specific — a level-0 part or level-1 chapter — and the book doctype
-    // is unsupported, so this test remains out of scope.
+    // NOTE: The crate now warns generically when a top-level section skips
+    // level 1 (`SectionHeadingLevelSkipped(0, 2)` here; see #754 and the
+    // regression test below), but the exact "expected levels 0 or 1"
+    // wording is book-specific — a level-0 part or level-1 chapter — and
+    // the book doctype is unsupported, so this test remains out of scope.
     non_normative!(
         r##"
     test 'should warn if chapter title is out of sequence' do
@@ -2226,9 +2234,9 @@ mod nesting {
     // Regression test for #754 — the contrapositive of the `fragment` test
     // above, and the article counterpart of the book-specific `should warn if
     // chapter title is out of sequence` test (which stays out of scope). It has
-    // no direct Ruby test in this suite. Without `fragment`, a top-level section
-    // that skips level 1 directly under the document title is reported as out of
-    // sequence.
+    // no direct Ruby test in this suite. Without `fragment`, a top-level
+    // section that skips level 1 directly under the document title is
+    // reported as out of sequence.
     #[test]
     fn top_level_section_out_of_sequence_warns_without_fragment() {
         let doc = Parser::default().parse("= Document Title\n\n=== First Section\n\ncontent\n");
@@ -2241,8 +2249,9 @@ mod nesting {
     }
 
     // A discrete (`[float]`) heading is not part of the section sequence, so a
-    // discrete heading at the document root does not trigger the out-of-sequence
-    // check even when its level skips ahead. (Also no Ruby counterpart.)
+    // discrete heading at the document root does not trigger the
+    // out-of-sequence check even when its level skips ahead. (Also no Ruby
+    // counterpart.)
     #[test]
     fn discrete_heading_at_document_root_is_not_out_of_sequence() {
         let doc = Parser::default().parse("= Document Title\n\n[float]\n=== Float Heading\n");
@@ -2343,9 +2352,9 @@ mod nesting {
         );
 
         // A `glossary` and a `bibliography` section do not support nested
-        // sections, so each subsection found directly within one is reported, in
-        // document order. An `appendix` section — and an ordinary section —
-        // support subsections and raise no such error.
+        // sections, so each subsection found directly within one is reported,
+        // in document order. An `appendix` section — and an ordinary
+        // section — support subsections and raise no such error.
         let warnings: Vec<_> = doc.warnings().collect();
 
         let special_warnings: Vec<&str> = warnings
@@ -2388,12 +2397,13 @@ mod nesting {
     }
 
     // NOTE: The book variant relies on the `book` doctype and its level-0 (`=`)
-    // special sections (colophon, dedication, glossary, bibliography). The crate
-    // now models a body-level `=` heading as a level-0 section, but it does not
-    // apply the special-section styles or their no-nested-sections rule at level
-    // 0 (that rule is recognized only for level-1 special sections), so this
-    // book variant can't be exercised. It stays out of scope until the book
-    // doctype's parts and special sections are supported.
+    // special sections (colophon, dedication, glossary, bibliography). The
+    // crate now models a body-level `=` heading as a level-0 section, but
+    // it does not apply the special-section styles or their
+    // no-nested-sections rule at level 0 (that rule is recognized only for
+    // level-1 special sections), so this book variant can't be exercised.
+    // It stays out of scope until the book doctype's parts and special
+    // sections are supported.
     non_normative!(
         r##"
     test 'should log error if subsections are found in special sections in book that do not support subsections' do
@@ -2585,7 +2595,8 @@ mod markdown_style_headings {
         );
 
         let doc = Parser::default().parse("=#= My Title");
-        // Not a heading: no sections are produced and the line stays a paragraph.
+        // Not a heading: no sections are produced and the line stays a
+        // paragraph.
         assert!(all_sections(&doc).is_empty());
         assert_eq!(rendered_paragraphs(&doc), vec!["=#= My Title"]);
     }
@@ -2602,11 +2613,12 @@ mod discrete_heading {
     use crate::tests::prelude::*;
 
     // A `[float]`/`[discrete]` style on a level-0 (`=`) heading suppresses the
-    // doctitle promotion and yields a level-0 discrete (floating-title) heading,
-    // just as `==`+ discrete headings do at their own level. As with
-    // the `==`+ cases below, the crate models the heading as a
+    // doctitle promotion and yields a level-0 discrete (floating-title)
+    // heading, just as `==`+ discrete headings do at their own level. As
+    // with the `==`+ cases below, the crate models the heading as a
     // `SectionType::Discrete` block and checks the normative facts against the
-    // AST rather than reproducing the Ruby `class`/following-sibling HTML shape.
+    // AST rather than reproducing the Ruby `class`/following-sibling HTML
+    // shape.
     #[test]
     fn should_create_discrete_heading_instead_of_section_if_style_is_float() {
         verifies!(
@@ -2633,7 +2645,8 @@ mod discrete_heading {
 
         let doc = Parser::default().parse("[float]\n= Independent Heading!\n\nnot in section\n");
 
-        // The level-0 heading must not have been promoted to the document title.
+        // The level-0 heading must not have been promoted to the document
+        // title.
         assert!(doc.header().title().is_none());
         assert_eq!(doc.doctitle(), None);
 
@@ -2647,11 +2660,11 @@ mod discrete_heading {
     }
 
     // The crate marks a discrete heading with `SectionType::Discrete` (verified
-    // via the AST); its virtual DOM renders it like a normal section rather than
-    // a bare `<hN class="discrete">`, so the `class`/following-sibling shape of
-    // the Ruby assertions is not reproduced. The normative facts — a discrete
-    // heading is created (not a section body), with the expected ID and title,
-    // holding no nested content — are checked directly.
+    // via the AST); its virtual DOM renders it like a normal section rather
+    // than a bare `<hN class="discrete">`, so the `class`/following-sibling
+    // shape of the Ruby assertions is not reproduced. The normative facts —
+    // a discrete heading is created (not a section body), with the expected
+    // ID and title, holding no nested content — are checked directly.
     #[test]
     fn should_create_discrete_heading_instead_of_section_if_style_is_discrete() {
         verifies!(
@@ -2717,10 +2730,11 @@ mod discrete_heading {
     }
 
     // Level-0 discrete headings using the shorthand attribute form
-    // (`[float.role#id]` / `[discrete.role#id]`): the `#id` supplies the heading
-    // ID, the `.role` adds a role, and the level-0 doctitle promotion is still
-    // suppressed. As above, the normative facts are checked against
-    // the AST rather than the Ruby `class`/following-sibling HTML shape.
+    // (`[float.role#id]` / `[discrete.role#id]`): the `#id` supplies the
+    // heading ID, the `.role` adds a role, and the level-0 doctitle
+    // promotion is still suppressed. As above, the normative facts are
+    // checked against the AST rather than the Ruby
+    // `class`/following-sibling HTML shape.
     #[test]
     fn should_create_discrete_heading_if_style_is_float_with_shorthand_role_and_id() {
         verifies!(
@@ -2960,9 +2974,9 @@ mod discrete_heading {
         assert_eq!(sec.id(), Some("free"));
     }
 
-    // NOTE: The `float`/role class rendering on discrete headings is not modeled
-    // (the crate renders a discrete heading like a normal section), so the
-    // `class="float isolated"` assertion is out of scope.
+    // NOTE: The `float`/role class rendering on discrete headings is not
+    // modeled (the crate renders a discrete heading like a normal section),
+    // so the `class="float isolated"` assertion is out of scope.
     non_normative!(
         r##"
     test 'should add role to class attribute on discrete heading' do
@@ -2984,8 +2998,8 @@ mod discrete_heading {
 
     // NOTE: The crate does not drop a `title` attribute on a discrete heading;
     // it exposes it as the block title (distinct from the heading text), so
-    // Ruby's `heading.title == 'Independent Heading!'` and the removed-attribute
-    // check do not hold. Out of scope.
+    // Ruby's `heading.title == 'Independent Heading!'` and the
+    // removed-attribute check do not hold. Out of scope.
     non_normative!(
         r##"
     test 'should ignore title attribute on discrete heading' do
@@ -3115,8 +3129,8 @@ mod level_offset {
     // `= Standalone Document` line is not recognized as a section here: the
     // `//`-comment line above it and the `:author:` line below it (no blank
     // lines between) are absorbed with it into a single paragraph, so there is
-    // no level-0 heading to flag. (A cleanly separated body level-0 heading does
-    // now raise `Level0SectionHeadingNotSupported`; see
+    // no level-0 heading to flag. (A cleanly separated body level-0 heading
+    // does now raise `Level0SectionHeadingNotSupported`; see
     // `should_print_error_if_level_0_section_comes_after_nested_section_and_doctype_is_not_book`.)
     // Out of scope.
     non_normative!(
@@ -3197,8 +3211,8 @@ mod level_offset {
         // attribute entry (`:author:`). A comment line (`// begin simulated
         // include::[]`) precedes the heading, which previously caused the
         // heading to be swallowed into a comment-led paragraph and the section
-        // to be dropped under the active `:leveloffset: 1` (see #746). It is now
-        // promoted to a level-1 section like its `==` sibling.
+        // to be dropped under the active `:leveloffset: 1` (see #746). It is
+        // now promoted to a level-1 section like its `==` sibling.
         let doc = Parser::default().parse(
             "= Main Document\nDoc Writer\n\nMain document written by {author}.\n\n:leveloffset: 1\n\n// begin simulated include::[]\n= Standalone Document\n:author: Junior Writer\n\nStandalone document written by {author}.\n\n== Section in Standalone\n\nStandalone section text.\n// end simulated include::[]\n\n:leveloffset!:\n\n== Section in Main\n\nMain section text.\n",
         );
@@ -3479,9 +3493,9 @@ mod section_numbering {
 "##
         );
 
-        // The crate models section numbers on the AST (rather than rendering the
-        // "N. " prefix into the heading text), so the numbers are verified via
-        // `section_number()`.
+        // The crate models section numbers on the AST (rather than rendering
+        // the "N. " prefix into the heading text), so the numbers are
+        // verified via `section_number()`.
         let doc = Parser::default().parse(
             "= Title\n:sectnums:\n\n== Section_1\n\ntext\n\n=== Section_1_1\n\ntext\n\n==== Section_1_1_1\n\ntext\n\n== Section_2\n\ntext\n\n=== Section_2_1\n\ntext\n\n=== Section_2_2\n\ntext\n",
         );
@@ -3768,8 +3782,8 @@ mod section_numbering {
         );
 
         // The crate carries the level on section blocks; it is verified here on
-        // the sections (the per-paragraph level Ruby also asserts is not modeled
-        // as a distinct property).
+        // the sections (the per-paragraph level Ruby also asserts is not
+        // modeled as a distinct property).
         let doc = Parser::default().parse(
             "= Title\n\npreamble\n\n== Section 1\n\nparagraph\n\n=== Section 1.1\n\nparagraph\n",
         );
@@ -3824,8 +3838,8 @@ mod section_numbering {
         );
 
         // Verified on the AST via `section_number()`: sections in the
-        // `:numbered!:` region are unnumbered, and numbering resumes (continuing
-        // the sequence) after `:numbered:`.
+        // `:numbered!:` region are unnumbered, and numbering resumes
+        // (continuing the sequence) after `:numbered:`.
         let doc = Parser::default().parse(
             "= Document Title\n:numbered:\n\n:numbered!:\n\n== Colophon Section\n\n== Another Colophon Section\n\n== Final Colophon Section\n\n:numbered:\n\n== Section One\n\n=== Section One Subsection\n\n== Section Two\n\n== Section Three\n",
         );
@@ -3890,11 +3904,11 @@ mod section_numbering {
 
         // An API-*enabled* `numbered` (`attributes: { 'numbered' => '' }`,
         // modeled here as an `ApiOnly` `with_intrinsic_attribute` on the raw
-        // `numbered` alias) seeds `sectnums` *set*, but a flexible attribute set
-        // through the API is unlocked once the header is parsed — so the body's
-        // `:numbered!:` / `:numbered:` toggles still take effect. The colophon
-        // sections are unnumbered and numbering restarts at `1` after
-        // `:numbered:`.
+        // `numbered` alias) seeds `sectnums` *set*, but a flexible attribute
+        // set through the API is unlocked once the header is parsed —
+        // so the body's `:numbered!:` / `:numbered:` toggles still take
+        // effect. The colophon sections are unnumbered and numbering
+        // restarts at `1` after `:numbered:`.
         let doc = Parser::default()
             .with_intrinsic_attribute("numbered", "", ModificationContext::ApiOnly)
             .parse(
@@ -4410,9 +4424,9 @@ mod special_sections {
 
     // The caption prefix is verified via `caption()` (see the note above about
     // captions being computed on the AST). `decode_char 946` is β (U+03B2) and
-    // `decode_char 947` is γ (U+03B3): the `appendix-number` value is the letter
-    // *before* the first appendix, so `:appendix-number: α` letters the
-    // appendices β and γ.
+    // `decode_char 947` is γ (U+03B3): the `appendix-number` value is the
+    // letter *before* the first appendix, so `:appendix-number: α` letters
+    // the appendices β and γ.
     #[test]
     fn should_allow_appendix_number_to_be_controlled_using_appendix_number_attribute() {
         verifies!(
@@ -4602,9 +4616,9 @@ mod special_sections {
     // (this crate models section numbers on the AST, not as rendered `N.`
     // prefixes) and on behaviors this crate does not model: appendix
     // *subsection* numbering (A.1, …), `sectnumlevels`-limited numbering, book
-    // parts and non-appendix special sections (preface / glossary / bibliography
-    // / dedication / colophon / abstract / index / partintro), table-of-contents
-    // rendering, and the DocBook backend. Out of scope.
+    // parts and non-appendix special sections (preface / glossary /
+    // bibliography / dedication / colophon / abstract / index / partintro),
+    // table-of-contents rendering, and the DocBook backend. Out of scope.
     non_normative!(
         r##"
     test 'should continue numbering after appendix' do
@@ -5295,8 +5309,9 @@ mod heading_patterns_in_blocks {
         );
 
         // A section heading (`== …`) inside a delimited block is literal block
-        // content, not a section: the interior line stays a paragraph inside the
-        // example block, so no `<h2>` is emitted anywhere in the document.
+        // content, not a section: the interior line stays a paragraph inside
+        // the example block, so no `<h2>` is emitted anywhere in the
+        // document.
         let doc = Parser::default().parse("====\n\n== not a heading\n\n====\n");
 
         assert_xpath(&doc, "//h2", 0);
@@ -5743,9 +5758,10 @@ mod table_of_contents {
     }
 
     // NOTE: The remaining tests depend on standalone `#header` framing, the
-    // `toc::[]` macro placement family, `toc-class`/`toc-title` rendered via the
-    // macro, book parts, and exact inner-HTML of TOC entries (icons / inline
-    // formatting) — not modeled by the embedded virtual DOM here. Out of scope.
+    // `toc::[]` macro placement family, `toc-class`/`toc-title` rendered via
+    // the macro, book parts, and exact inner-HTML of TOC entries (icons /
+    // inline formatting) — not modeled by the embedded virtual DOM here.
+    // Out of scope.
     non_normative!(
         r##"
     test 'should output table of contents at location of toc macro' do
@@ -6215,10 +6231,10 @@ mod book_doctype {
         ) && w.source.line() == 7));
     }
 
-    // NOTE: The remaining book-doctype tests all rely on book parts, `partintro`
-    // handling, DocBook output, or Ruby-internal `Block` accessors
-    // (`sectname` / `find_by` / `content_model` / `lines` / `subs`), none of
-    // which this crate models. Out of scope.
+    // NOTE: The remaining book-doctype tests all rely on book parts,
+    // `partintro` handling, DocBook output, or Ruby-internal `Block`
+    // accessors (`sectname` / `find_by` / `content_model` / `lines` /
+    // `subs`), none of which this crate models. Out of scope.
     non_normative!(
         r##"
     test 'should add class matching role to part' do

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -142,8 +142,9 @@ mod dispatcher {
         );
 
         // The crate models `apply_subs` as immutable substitution: the block's
-        // `original` span is preserved while `rendered` holds the result, so the
-        // upstream "source string is not mutated" guarantee holds by construction.
+        // `original` span is preserved while `rendered` holds the result, so
+        // the upstream "source string is not mutated" guarantee holds
+        // by construction.
         let mut p = Parser::default();
 
         let maw =
@@ -183,10 +184,10 @@ mod dispatcher {
 
     // Not ported to this crate:
     // - 'should not drop trailing blank lines when performing substitutions':
-    //   para.lines trailing-blank round-trip: no crate API to inject trailing blank
-    //   lines.
-    // - 'should expand subs passed to expand_subs': expand_subs Ruby API; sub-list
-    //   resolution is covered by content::substitution_group tests.
+    //   para.lines trailing-blank round-trip: no crate API to inject trailing
+    //   blank lines.
+    // - 'should expand subs passed to expand_subs': expand_subs Ruby API;
+    //   sub-list resolution is covered by content::substitution_group tests.
     non_normative!(
         r#"
     test 'should not drop trailing blank lines when performing substitutions' do
@@ -224,8 +225,8 @@ mod dispatcher {
         );
 
         // Upstream passes an explicit `nil` subs list; this crate resolves a
-        // `[pass]` block to no substitutions at parse time, so its raw content is
-        // emitted verbatim.
+        // `[pass]` block to no substitutions at parse time, so its raw content
+        // is emitted verbatim.
         let doc = Parser::default().parse("[pass]\n*raw*");
         assert_eq!(rendered_paragraphs(&doc), &["*raw*"]);
     }
@@ -2612,8 +2613,8 @@ mod quotes {
 
         let p = Parser::default();
         SubstitutionGroup::Custom(vec![SubstitutionStep::Quotes]).apply(&mut content, &p, None);
-        // ^^^ TO DO: This needs to be the full substitution group, not just the Quotes
-        // substition.
+        // ^^^ TO DO: This needs to be the full substitution group, not just the
+        // Quotes substition.
 
         assert!(!content.is_empty());
 
@@ -4544,8 +4545,8 @@ mod macros {
                 .parse("image:circle.svg[Tiger,100,opts=inline,link=self]");
 
             // The `link` value is used verbatim: `self` is not resolved to the
-            // image's own URI (which would be meaningless for an inline SVG), so
-            // the anchor's `href` is the literal string `self`.
+            // image's own URI (which would be meaningless for an inline SVG),
+            // so the anchor's `href` is the literal string `self`.
             assert_eq!(
                 rendered(&doc),
                 concat!(
@@ -4623,9 +4624,9 @@ mod macros {
         #[test]
         fn an_inline_svg_image_should_render_as_a_plain_img_when_safe_mode_is_secure() {
             // Like `interactive`, the `inline` option is disabled in `Secure`
-            // mode (the default), so the SVG contents are never read and a plain
-            // `<img>` is emitted. The registered handler is intentionally
-            // ignored.
+            // mode (the default), so the SVG contents are never read and a
+            // plain `<img>` is emitted. The registered handler is
+            // intentionally ignored.
             let doc = Parser::default()
                 .with_intrinsic_attribute("imagesdir", "fixtures", ModificationContext::Anywhere)
                 .with_svg_file_handler(SvgFileHandlerFixture::from_pairs([(
@@ -4643,8 +4644,8 @@ mod macros {
         #[test]
         fn an_inline_svg_image_appends_both_width_and_height_to_the_opening_tag() {
             // When both a width and a height are supplied, both are appended to
-            // the opening `<svg>` tag (after the original width/height/style are
-            // stripped).
+            // the opening `<svg>` tag (after the original width/height/style
+            // are stripped).
             let doc = Parser::default()
                 .with_safe_mode(SafeMode::Server)
                 .with_intrinsic_attribute("imagesdir", "fixtures", ModificationContext::Anywhere)
@@ -4665,8 +4666,9 @@ mod macros {
 
         #[test]
         fn an_inline_svg_image_without_dimensions_keeps_the_original_opening_tag() {
-            // With neither a width nor a height supplied, the opening `<svg>` tag
-            // is left untouched; only the XML preamble is stripped.
+            // With neither a width nor a height supplied, the opening `<svg>`
+            // tag is left untouched; only the XML preamble is
+            // stripped.
             let doc = Parser::default()
                 .with_safe_mode(SafeMode::Server)
                 .with_intrinsic_attribute("imagesdir", "fixtures", ModificationContext::Anywhere)
@@ -4861,11 +4863,12 @@ mod macros {
     }
 
     // Not ported to this crate:
-    // - 'a single-line image macro with text and dimensions should be interpreted
-    //   as an image with alt text and dimensions in docbook': DocBook backend not
-    //   supported (grouped Rust stub covers all four DocBook image tests).
-    // - 'a single-line image macro with scaledwidth attribute should be supported
-    //   in docbook': DocBook backend not supported.
+    // - 'a single-line image macro with text and dimensions should be
+    //   interpreted as an image with alt text and dimensions in docbook':
+    //   DocBook backend not supported (grouped Rust stub covers all four
+    //   DocBook image tests).
+    // - 'a single-line image macro with scaledwidth attribute should be
+    //   supported in docbook': DocBook backend not supported.
     // - 'a single-line image macro with scaled attribute should be supported in
     //   docbook': DocBook backend not supported.
     // - 'should pass through role on image macro to DocBook output': DocBook
@@ -5053,7 +5056,8 @@ mod macros {
             "<circle cx=\"250\" cy=\"250\" r=\"200\"/></svg>",
         );
 
-        // Base64 (strict, `pack 'm0'`) of `CIRCLE_SVG`, the `data:` URI payload.
+        // Base64 (strict, `pack 'm0'`) of `CIRCLE_SVG`, the `data:` URI
+        // payload.
         const CIRCLE_SVG_BASE64: &str = concat!(
             "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0",
             "cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBzdHls",
@@ -5091,8 +5095,8 @@ mod macros {
     }
 
     // Not ported to this crate:
-    // - 'an inline image macro with link should be interpreted as a linked image in
-    //   docbook': DocBook backend not supported.
+    // - 'an inline image macro with link should be interpreted as a linked
+    //   image in docbook': DocBook backend not supported.
     non_normative!(
         r#"
     test 'an inline image macro with link should be interpreted as a linked image in docbook' do
@@ -5875,10 +5879,11 @@ mod macros {
 "#
         );
 
-        // With `catalog_assets` enabled, the `image:` macro in the section title
-        // records its target in the document catalog. The `{iconsdir}` reference
-        // in the target is resolved (to `fixtures`) by the attribute-references
-        // step, which runs before the macros step, so the catalog records the
+        // With `catalog_assets` enabled, the `image:` macro in the section
+        // title records its target in the document catalog. The
+        // `{iconsdir}` reference in the target is resolved (to
+        // `fixtures`) by the attribute-references step, which runs
+        // before the macros step, so the catalog records the
         // resolved `fixtures/dot.gif`. `imagesdir` is unset here, so the
         // reference carries no `imagesdir`.
         let doc = Parser::default()
@@ -6902,7 +6907,8 @@ mod macros {
             assert_eq!(doc.catalog().footnotes().len(), 1);
             // Every occurrence links to the single footnote definition.
             assert_css(&doc, r##"a[href="#_footnotedef_1"]"##, 3);
-            // Setting compat mode suppresses the footnoteref deprecation warning.
+            // Setting compat mode suppresses the footnoteref deprecation
+            // warning.
             assert_eq!(doc.warnings().count(), 0);
         }
 
@@ -7103,10 +7109,11 @@ mod macros {
         // Intentional divergence (https://github.com/asciidoc-rs/asciidoc-parser/issues/594):
         // Asciidoctor converts section titles eagerly and out of document order
         // (to generate IDs and cross-reference text), so footnotes in headings
-        // are numbered out of sequence — this test asserts that quirk. The crate
-        // instead applies a title's substitutions before parsing its section
-        // body, numbering heading footnotes in straightforward document order.
-        // That in-order behavior is covered by
+        // are numbered out of sequence — this test asserts that quirk. The
+        // crate instead applies a title's substitutions before parsing
+        // its section body, numbering heading footnotes in
+        // straightforward document order. That in-order behavior is
+        // covered by
         // `asciidoc_lang::macros::footnote::footnotes_in_headings_are_numbered_in_document_order`,
         // so this Asciidoctor-fidelity test stays ignored.
         fn footnotes_in_headings_are_numbered_out_of_sequence() {
@@ -7264,7 +7271,8 @@ mod macros {
 "##
             );
 
-            // 'a single-line index term macro with primary and secondary terms ...'
+            // 'a single-line index term macro with primary and secondary terms
+            // ...'
             for macro_ in ["indexterm:[Big cats, Tigers]", "(((Big cats, Tigers)))"] {
                 let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
                 assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
@@ -7320,7 +7328,8 @@ mod macros {
 "##
             );
 
-            // 'a multi-line index term macro should be compacted and registered ...'
+            // 'a multi-line index term macro should be compacted and registered
+            // ...'
             for macro_ in ["indexterm:[Panthera\ntigris]", "(((Panthera\ntigris)))"] {
                 let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
                 assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
@@ -7412,8 +7421,9 @@ mod macros {
             );
 
             // 'should not split index terms on commas inside of quoted terms'
-            // The quoted comma keeps the term intact; the concealed term renders
-            // nothing, so only the leading sentence remains.
+            // The quoted comma keeps the term intact; the concealed term
+            // renders nothing, so only the leading sentence
+            // remains.
             let macro_form =
                 "Tigers are big, scary cats.\nindexterm:[Tigers, \"[Big\\],\nscary cats\"]";
             let shorthand = "Tigers are big, scary cats.\n(((Tigers, \"[Big],\nscary cats\")))";
@@ -7446,7 +7456,8 @@ mod macros {
             );
 
             // 'normal substitutions are performed on an index term macro'
-            // The concealed term renders nothing regardless of inner formatting.
+            // The concealed term renders nothing regardless of inner
+            // formatting.
             for macro_ in ["indexterm:[*Tigers*]", "(((*Tigers*)))"] {
                 let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
                 assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
@@ -7576,8 +7587,8 @@ mod macros {
 "##
             );
 
-            // 'an index term macro with square bracket syntax may contain square
-            // brackets in term'
+            // 'an index term macro with square bracket syntax may contain
+            // square brackets in term'
             let doc = Parser::default().parse(&format!(
                 "{SENTENCE}\nindexterm:[Tiger [Panthera tigris\\]]"
             ));
@@ -7633,8 +7644,8 @@ mod macros {
 "#
             );
 
-            // 'a multi-line index term 2 macro should be compacted ... and retain
-            // term inline'
+            // 'a multi-line index term 2 macro should be compacted ... and
+            // retain term inline'
             let expected = "The panthera tigris is the largest cat species.";
             for input in [
                 "The indexterm2:[ panthera\ntigris ] is the largest cat species.",
@@ -7775,8 +7786,9 @@ mod macros {
 
             // The DocBook-only `see`/`see-also` structure is not modeled, but
             // Asciidoctor strips the `see` (` >> `) and `see-also` (` &> `)
-            // clauses from a *visible* term's inline text regardless of backend,
-            // leaving only the primary term in the flow of text.
+            // clauses from a *visible* term's inline text regardless of
+            // backend, leaving only the primary term in the flow of
+            // text.
             let doc =
                 Parser::default().parse("((Flash >> HTML 5)) and ((HTML 5 &> CSS 3 &> SVG)) done.");
             assert_eq!(rendered_paragraphs(&doc), &["Flash and HTML 5 done."]);
@@ -7784,8 +7796,8 @@ mod macros {
 
         // Not ported to this crate:
         // - 'should parse concealed shorthand index term with see and seealso':
-        //   DocBook-only see/seealso structure; concealed shorthand form has no HTML5
-        //   analogue (concealed term renders nothing).
+        //   DocBook-only see/seealso structure; concealed shorthand form has no
+        //   HTML5 analogue (concealed term renders nothing).
         non_normative!(
             r#"
     test 'should parse concealed shorthand index term with see and seealso' do
@@ -7887,9 +7899,9 @@ mod macros {
     // - 'should parse concealed index term macro with see and seealso':
     //   DocBook-only see/seealso structure; concealed macro form has no HTML5
     //   analogue (concealed term renders nothing).
-    // - 'should honor secondary and tertiary index terms when primary index term is
-    //   quoted and contains equals sign': DocBook backend not supported; asserts
-    //   <indexterm> primary/secondary/tertiary markup.
+    // - 'should honor secondary and tertiary index terms when primary index
+    //   term is quoted and contains equals sign': DocBook backend not
+    //   supported; asserts <indexterm> primary/secondary/tertiary markup.
     non_normative!(
         r#"
     test 'should parse concealed index term macro with see and seealso' do
@@ -8094,8 +8106,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'kbd macro with key combination, docbook backend': DocBook backend not
-        //   supported.
+        // - 'kbd macro with key combination, docbook backend': DocBook backend
+        //   not supported.
         non_normative!(
             r#"
       test 'kbd macro with key combination, docbook backend' do
@@ -8175,7 +8187,8 @@ mod macros {
 "#
             );
 
-            // 'kbd macro with key combination delimited by plus containing a comma key'
+            // 'kbd macro with key combination delimited by plus containing a
+            // comma key'
             assert_eq!(
                 render("kbd:[Ctrl+,]"),
                 r#"<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>,</kbd></span>"#
@@ -8194,7 +8207,8 @@ mod macros {
 "#
             );
 
-            // 'kbd macro with key combination delimited by commas containing a plus key'
+            // 'kbd macro with key combination delimited by commas containing a
+            // plus key'
             assert_eq!(
                 render("kbd:[Ctrl, +, Shift]"),
                 r#"<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>+</kbd>+<kbd>Shift</kbd></span>"#
@@ -8213,7 +8227,8 @@ mod macros {
 "#
             );
 
-            // 'kbd macro with key combination where last key matches plus delimiter'
+            // 'kbd macro with key combination where last key matches plus
+            // delimiter'
             assert_eq!(
                 render("kbd:[Ctrl + +]"),
                 r#"<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>+</kbd></span>"#
@@ -8232,7 +8247,8 @@ mod macros {
 "#
             );
 
-            // 'kbd macro with key combination where last key matches comma delimiter'
+            // 'kbd macro with key combination where last key matches comma
+            // delimiter'
             assert_eq!(
                 render("kbd:[Ctrl, ,]"),
                 r#"<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>,</kbd></span>"#
@@ -8333,7 +8349,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'should process menu for docbook backend': DocBook backend not supported.
+        // - 'should process menu for docbook backend': DocBook backend not
+        //   supported.
         non_normative!(
             r#"
       test 'should process menu for docbook backend' do
@@ -8434,8 +8451,8 @@ mod macros {
 "#
             );
 
-            // 'should process menu with menu item using macro syntax when fonts icons are
-            // enabled'
+            // 'should process menu with menu item using macro syntax when fonts
+            // icons are enabled'
             assert_eq!(
                 render_with_attributes(&[":icons: font"], "menu:Tools[More Tools &gt; Extensions]"),
                 r#"<span class="menuseq"><b class="menu">Tools</b>&#160;<i class="fa fa-angle-right caret"></i> <b class="submenu">More Tools</b>&#160;<i class="fa fa-angle-right caret"></i> <b class="menuitem">Extensions</b></span>"#
@@ -8443,8 +8460,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'should process menu with menu item for docbook backend': DocBook backend
-        //   not supported.
+        // - 'should process menu with menu item for docbook backend': DocBook
+        //   backend not supported.
         non_normative!(
             r#"
       test 'should process menu with menu item for docbook backend' do
@@ -8467,7 +8484,8 @@ mod macros {
 "#
             );
 
-            // 'should process menu with menu item in submenu using macro syntax'
+            // 'should process menu with menu item in submenu using macro
+            // syntax'
             assert_eq!(
                 render("menu:Tools[Project &gt; Build]"),
                 r#"<span class="menuseq"><b class="menu">Tools</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">Project</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Build</b></span>"#
@@ -8475,8 +8493,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'should process menu with menu item in submenu for docbook backend':
-        //   DocBook backend not supported.
+        // - 'should process menu with menu item in submenu for docbook
+        //   backend': DocBook backend not supported.
         non_normative!(
             r#"
       test 'should process menu with menu item in submenu for docbook backend' do
@@ -8499,8 +8517,8 @@ mod macros {
 "#
             );
 
-            // 'should process menu with menu item in submenu using macro syntax and comma
-            // delimiter'
+            // 'should process menu with menu item in submenu using macro syntax
+            // and comma delimiter'
             assert_eq!(
                 render("menu:Tools[Project, Build]"),
                 r#"<span class="menuseq"><b class="menu">Tools</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">Project</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Build</b></span>"#
@@ -8510,10 +8528,10 @@ mod macros {
         // Not ported to this crate:
         // - 'should process menu with menu item using inline syntax': Inline
         //   (shorthand) menu syntax not ported.
-        // - 'should process menu with menu item in submenu using inline syntax': Inline
-        //   (shorthand) menu syntax not ported.
-        // - 'inline menu syntax should not match closing quote of XML attribute':
-        //   Inline (shorthand) menu syntax not ported.
+        // - 'should process menu with menu item in submenu using inline
+        //   syntax': Inline (shorthand) menu syntax not ported.
+        // - 'inline menu syntax should not match closing quote of XML
+        //   attribute': Inline (shorthand) menu syntax not ported.
         non_normative!(
             r#"
       test 'should process menu with menu item using inline syntax' do
@@ -8546,7 +8564,8 @@ mod macros {
 "#
             );
 
-            // 'should process menu macro with items containing multibyte characters'
+            // 'should process menu macro with items containing multibyte
+            // characters'
             assert_eq!(
                 render("menu:视图[放大, 重置]"),
                 r#"<span class="menuseq"><b class="menu">视图</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">放大</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">重置</b></span>"#
@@ -8554,8 +8573,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'should process inline menu with items containing multibyte characters':
-        //   Inline (shorthand) menu syntax not ported.
+        // - 'should process inline menu with items containing multibyte
+        //   characters': Inline (shorthand) menu syntax not ported.
         non_normative!(
             r#"
       test 'should process inline menu with items containing multibyte characters' do
@@ -8578,8 +8597,8 @@ mod macros {
 "#
             );
 
-            // 'should process a menu macro with a target that begins with a character
-            // reference'
+            // 'should process a menu macro with a target that begins with a
+            // character reference'
             assert_eq!(
                 render("menu:&#8942;[More Tools, Extensions]"),
                 r#"<span class="menuseq"><b class="menu">&#8942;</b>&#160;<b class="caret">&#8250;</b> <b class="submenu">More Tools</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Extensions</b></span>"#
@@ -8601,9 +8620,9 @@ mod macros {
 "#
             );
 
-            // 'should not process a menu macro with a target that ends with a space'
-            // Only the second (well-formed) macro is processed; the first is
-            // left as literal text.
+            // 'should not process a menu macro with a target that ends with a
+            // space' Only the second (well-formed) macro is
+            // processed; the first is left as literal text.
             assert_eq!(
                 render("menu:foo [bar] menu:File[Save]"),
                 r#"menu:foo [bar] <span class="menuseq"><b class="menu">File</b>&#160;<b class="caret">&#8250;</b> <b class="menuitem">Save</b></span>"#
@@ -8611,8 +8630,8 @@ mod macros {
         }
 
         // Not ported to this crate:
-        // - 'should process an inline menu that begins with a character reference':
-        //   Inline (shorthand) menu syntax not ported.
+        // - 'should process an inline menu that begins with a character
+        //   reference': Inline (shorthand) menu syntax not ported.
         non_normative!(
             r#"
       test 'should process an inline menu that begins with a character reference' do
@@ -8624,8 +8643,8 @@ mod macros {
 
         #[test]
         fn escaped_macros_are_emitted_verbatim() {
-            // A leading backslash escapes each UI macro, emitting the macro text
-            // without the backslash.
+            // A leading backslash escapes each UI macro, emitting the macro
+            // text without the backslash.
             assert_eq!(render("\\kbd:[F3]"), "kbd:[F3]");
             assert_eq!(render("\\btn:[Save]"), "btn:[Save]");
             assert_eq!(render("\\menu:File[Save]"), "menu:File[Save]");
@@ -8975,7 +8994,8 @@ mod passthroughs {
         // An attribute reference embedded in a passthrough role is resolved
         // before the role is applied, mirroring Asciidoctor's
         // `parse_quoted_text_attributes` (which runs `sub_attributes` on the
-        // attribute list). This is a crate-specific regression test, not a port.
+        // attribute list). This is a crate-specific regression test, not a
+        // port.
         let render = |input: &str| {
             let mut p = Parser::default().with_intrinsic_attribute(
                 "myrole",
@@ -10451,11 +10471,12 @@ mod passthroughs {
         }
 
         // Not ported to this crate:
-        // - 'should convert contents of asciimath macro to MathML in DocBook output if
-        //   asciimath gem is available': DocBook backend / asciimath gem not supported.
-        // - 'should not perform specialcharacters subs on asciimath macro content in
-        //   Docbook output if asciimath gem not available': DocBook backend / asciimath
+        // - 'should convert contents of asciimath macro to MathML in DocBook
+        //   output if asciimath gem is available': DocBook backend / asciimath
         //   gem not supported.
+        // - 'should not perform specialcharacters subs on asciimath macro
+        //   content in Docbook output if asciimath gem not available': DocBook
+        //   backend / asciimath gem not supported.
         non_normative!(
             r#"
       test 'should convert contents of asciimath macro to MathML in DocBook output if asciimath gem is available' do
@@ -10605,8 +10626,9 @@ mod passthroughs {
         }
 
         // Not ported to this crate:
-        // - 'should not perform specialcharacters subs on latexmath macro content in
-        //   docbook backend by default': DocBook backend not supported.
+        // - 'should not perform specialcharacters subs on latexmath macro
+        //   content in docbook backend by default': DocBook backend not
+        //   supported.
         non_normative!(
             r#"
       test 'should not perform specialcharacters subs on latexmath macro content in docbook backend by default' do
@@ -11296,8 +11318,8 @@ foo&#8201;&#8212;&#8201;"#;
         );
 
         // Ported from Asciidoctor's `should replace right single quote marks`.
-        // In Asciidoctor this exercises `sub_replacements`, which corresponds to
-        // the `CharacterReplacements` substitution step here.
+        // In Asciidoctor this exercises `sub_replacements`, which corresponds
+        // to the `CharacterReplacements` substitution step here.
         let cases = [
             (r#"`'Twas the night"#, "&#8217;Twas the night"),
             (r#"a `'57 Chevy!"#, "a &#8217;57 Chevy!"),

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -559,8 +559,9 @@ mod psv {
 
         let doc = Parser::default().parse("|===\nA | here| a | there\n| x\n| y\n| z\n| end\n|===");
 
-        // The content before the first separator (`A`) is recovered as the first
-        // cell, so the first row has four cells and the table four columns.
+        // The content before the first separator (`A`) is recovered as the
+        // first cell, so the first row has four cells and the table
+        // four columns.
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > tbody > tr", 2);
         assert_css(&doc, "table > tbody > tr > td", 8);
@@ -632,8 +633,9 @@ mod psv {
 
         let doc = Parser::default().parse("|===\nl|one\n*two*\nthree\n<four>\n|===");
 
-        // Ruby compares the serialized `<pre>one\n*two*\nthree\n&lt;four&gt;</pre>`;
-        // the test DOM decodes entities in `text()`, so this asserts the decoded
+        // Ruby compares the serialized
+        // `<pre>one\n*two*\nthree\n&lt;four&gt;</pre>`; the test DOM
+        // decodes entities in `text()`, so this asserts the decoded
         // content (formatting markup left literal, specialchars escaped then
         // decoded back).
         assert_css(&doc, "table pre", 1);
@@ -701,9 +703,9 @@ mod psv {
         let doc =
             Parser::default().parse("[cols=2*]\n|===\nv|\n  one\n  two\nthree\n\n  | normal\n|===");
 
-        // The unrecognized `v` style is ignored, so the cell renders as a normal
-        // paragraph (`p.tableblock`) with leading newlines and trailing spaces
-        // stripped but interior indentation preserved.
+        // The unrecognized `v` style is ignored, so the cell renders as a
+        // normal paragraph (`p.tableblock`) with leading newlines and
+        // trailing spaces stripped but interior indentation preserved.
         assert_xpath(
             &doc,
             "(/table/tbody/tr/td)[1]/p[@class=\"tableblock\"][text()=\"one\n  two\nthree\"]",
@@ -788,10 +790,10 @@ mod psv {
         assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"15%\"]", 1);
         assert_xpath(&doc, "(/table/colgroup/col)[1][@autowidth-option]", 0);
 
-        // Each autowidth column still has a computed `colpcwidth` (the remaining
-        // space shared three ways, truncated to four places with the balance
-        // donated to the last column) and the `autowidth-option` marker, but no
-        // HTML `width` attribute.
+        // Each autowidth column still has a computed `colpcwidth` (the
+        // remaining space shared three ways, truncated to four places
+        // with the balance donated to the last column) and the
+        // `autowidth-option` marker, but no HTML `width` attribute.
         for i in 2..=3 {
             assert_xpath(
                 &doc,
@@ -809,8 +811,9 @@ mod psv {
             assert_xpath(&doc, &format!("(/table/colgroup/col)[{i}][@width]"), 0);
         }
 
-        // The HTML-output expectations from the Ruby test: every column renders a
-        // `<col>`, but only the single fixed column carries a `width` attribute.
+        // The HTML-output expectations from the Ruby test: every column renders
+        // a `<col>`, but only the single fixed column carries a `width`
+        // attribute.
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table colgroup col", 4);
         assert_css(&doc, "table colgroup col[width]", 1);
@@ -853,8 +856,9 @@ mod psv {
         );
 
         // Every column is autowidth, so each takes an equal 25% share in
-        // `colpcwidth` and carries the `autowidth-option` marker; none carries an
-        // HTML `width` attribute even though the table itself has a width.
+        // `colpcwidth` and carries the `autowidth-option` marker; none carries
+        // an HTML `width` attribute even though the table itself has a
+        // width.
         for i in 1..=4 {
             assert_xpath(
                 &doc,
@@ -1411,8 +1415,8 @@ mod psv {
 "#
     );
 
-    // Out of scope: DocBook backend. ("should convert frame value ends to topbot
-    // when converting to DocBook")
+    // Out of scope: DocBook backend. ("should convert frame value ends to
+    // topbot when converting to DocBook")
     non_normative!(
         r#"
     test 'should convert frame value ends to topbot when converting to DocBook' do
@@ -2220,8 +2224,8 @@ mod psv {
         assert_css(&doc, "table > tbody > tr", 4);
         assert_css(&doc, "table > tbody > tr > td", 10);
 
-        // Ruby uses `tr:nth-child(N)` / `td:nth-child(N)`; the indexed XPath form
-        // is equivalent and supported by the test DOM.
+        // Ruby uses `tr:nth-child(N)` / `td:nth-child(N)`; the indexed XPath
+        // form is equivalent and supported by the test DOM.
         assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
         assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
         assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 1);
@@ -2320,9 +2324,10 @@ mod psv {
 
         assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
         assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1][@colspan=\"2\"]", 1);
-        // Ruby uses `td:nth-child(1)[colspan]` / `td:nth-child(2):not([colspan])`;
-        // since row 1 has exactly one cell carrying a colspan, asserting the row
-        // has a single colspanned cell is equivalent.
+        // Ruby uses `td:nth-child(1)[colspan]` /
+        // `td:nth-child(2):not([colspan])`; since row 1 has exactly one
+        // cell carrying a colspan, asserting the row has a single
+        // colspanned cell is equivalent.
         assert_xpath(&doc, "(/table/tbody/tr)[1]/td[@colspan]", 1);
         assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
         assert_xpath(&doc, "(/table/tbody/tr)[2]/td[@colspan]", 0);
@@ -2738,11 +2743,12 @@ mod psv {
         assert_css(&doc, "table > tbody > tr", 1);
         assert_css(&doc, "table > tbody > tr > td", 2);
 
-        // The duplicated cell (`2*|`) is cloned into both columns, and each clone
-        // takes its own column's style: the first (default) column renders the
-        // content as seven paragraphs, the second (`^l`) column as a single
-        // centered literal block. (Ruby uses `td:nth-child(N)`; the equivalent
-        // positional `td[N]` is expressed in XPath here.)
+        // The duplicated cell (`2*|`) is cloned into both columns, and each
+        // clone takes its own column's style: the first (default)
+        // column renders the content as seven paragraphs, the second
+        // (`^l`) column as a single centered literal block. (Ruby uses
+        // `td:nth-child(N)`; the equivalent positional `td[N]` is
+        // expressed in XPath here.)
         assert_xpath(
             &doc,
             "/table/tbody/tr/td[1][@class=\"halign-left valign-top\"]/p[@class=\"tableblock\"]",
@@ -2754,8 +2760,8 @@ mod psv {
             1,
         );
 
-        // The literal block preserves every line of the cell, including the blank
-        // lines between paragraphs (26 lines total).
+        // The literal block preserves every line of the cell, including the
+        // blank lines between paragraphs (26 lines total).
         let vdom = doc.to_virtual_dom();
         let pre = query_xpath(&vdom, "/table/tbody/tr/td[2]//pre");
         assert_eq!(pre.len(), 1);
@@ -2991,13 +2997,13 @@ mod psv {
     fn asciidoc_table_cell_cannot_override_the_derived_doctype_flag() {
         // The active `backend-html5-doctype-*` flag is a read-only intrinsic
         // (empty value), so a cell-body assignment to it is silently ignored:
-        // `{backend-html5-doctype-article}` still resolves to the empty intrinsic
-        // value rather than the cell's attempted override.
+        // `{backend-html5-doctype-article}` still resolves to the empty
+        // intrinsic value rather than the cell's attempted override.
         //
         // The parent is a `book`, so the cell's active flag
-        // (`backend-html5-doctype-article`, after the cell resets to the default
-        // doctype) differs from the parent's — the case a lock computed from the
-        // parent's doctype would miss.
+        // (`backend-html5-doctype-article`, after the cell resets to the
+        // default doctype) differs from the parent's — the case a lock
+        // computed from the parent's doctype would miss.
         let doc = Parser::default().parse(
             "= Book Title\n:doctype: book\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n:backend-html5-doctype-article: custom\n\nflag=[{backend-html5-doctype-article}]\n|===",
         );
@@ -3008,13 +3014,14 @@ mod psv {
 
     #[test]
     fn asciidoc_table_cell_cannot_stash_a_derived_doctype_flag_while_it_is_inactive() {
-        // Assigning `:backend-html5-doctype-article:` while the cell's doctype is
-        // `book` (so that flag is not the active synthesized intrinsic) must not
-        // stash a per-parser override that later shadows the intrinsic once the
-        // cell switches its doctype back to `article`. The whole
-        // `backend-html5-doctype-*` namespace is read-only, so the assignment is
-        // ignored and `{backend-html5-doctype-article}` still resolves to the
-        // empty intrinsic value.
+        // Assigning `:backend-html5-doctype-article:` while the cell's doctype
+        // is `book` (so that flag is not the active synthesized
+        // intrinsic) must not stash a per-parser override that later
+        // shadows the intrinsic once the cell switches its doctype back
+        // to `article`. The whole `backend-html5-doctype-*` namespace
+        // is read-only, so the assignment is ignored and
+        // `{backend-html5-doctype-article}` still resolves to the empty
+        // intrinsic value.
         let doc = Parser::default().parse(
             "= Doc Title\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n:doctype: book\n:backend-html5-doctype-article: custom\n:doctype: article\n\nflag=[{backend-html5-doctype-article}]\n|===",
         );
@@ -3431,18 +3438,19 @@ mod psv {
 
     #[test]
     fn asciidoc_table_cell_hides_its_title_by_default() {
-        // An AsciiDoc table cell that opens with a level-0 title but sets neither
-        // `showtitle` nor `notitle` behaves like embedded output: its doctitle is
-        // hidden. Asciidoctor 2.0.26 emits no `<h1>` for such a cell (the "neither
-        // set" default), whereas enabling `showtitle` in the cell renders it.
+        // An AsciiDoc table cell that opens with a level-0 title but sets
+        // neither `showtitle` nor `notitle` behaves like embedded
+        // output: its doctitle is hidden. Asciidoctor 2.0.26 emits no
+        // `<h1>` for such a cell (the "neither set" default), whereas
+        // enabling `showtitle` in the cell renders it.
         let default_doc = Parser::default()
             .parse("= Document Title\n\n|===\na|\n= Nested Document Title\n\ncontent\n|===");
 
         // Neither attribute set: the cell hides its title.
         assert_css(&default_doc, ".tableblock h1", 0);
 
-        // With `showtitle` enabled in the cell, the same title renders — proving
-        // only the "neither set" default changed.
+        // With `showtitle` enabled in the cell, the same title renders —
+        // proving only the "neither set" default changed.
         let shown_doc = Parser::default().parse(
             "= Document Title\n\n|===\na|\n= Nested Document Title\n:showtitle:\n\ncontent\n|===",
         );
@@ -3607,8 +3615,8 @@ mod psv {
             .with_include_file_handler(handler);
         let doc = parser.parse("|===\na|include::fixtures/include-file.adoc[]\n|===");
 
-        // The `include::` on the cell's first line is expanded, so the cell holds
-        // the included content rather than the literal directive.
+        // The `include::` on the cell's first line is expanded, so the cell
+        // holds the included content rather than the literal directive.
         assert_rendered_contains(&doc, "included content");
     }
 
@@ -3650,11 +3658,12 @@ mod psv {
 "#
         );
 
-        // The table (with a cell whose first line is an unresolvable `include::`)
-        // lives in `outer.adoc`, which the primary document reaches via its own
-        // `include::`. The error about the unresolved cell directive must be
-        // attributed to `outer.adoc` at the line the directive appears on there
-        // (line 5), not to the primary document or the synthesized cell content.
+        // The table (with a cell whose first line is an unresolvable
+        // `include::`) lives in `outer.adoc`, which the primary
+        // document reaches via its own `include::`. The error about the
+        // unresolved cell directive must be attributed to `outer.adoc`
+        // at the line the directive appears on there (line 5), not to
+        // the primary document or the synthesized cell content.
         let handler = InlineFileHandler::from_pairs([(
             "outer.adoc",
             "|===\n|A |B\n\n|text\na|include::does-not-exist.adoc[]\n|===",
@@ -3664,8 +3673,8 @@ mod psv {
             .with_include_file_handler(handler);
         let doc = parser.parse("first\n\ninclude::outer.adoc[]\n\nlast");
 
-        // The unresolved directive is replaced (in the cell) with a message that
-        // names the file the directive came from.
+        // The unresolved directive is replaced (in the cell) with a message
+        // that names the file the directive came from.
         assert_rendered_contains(&doc, "Unresolved directive in outer.adoc");
 
         // A single warning is reported, and its cursor maps — through the
@@ -3712,9 +3721,9 @@ mod psv {
         let doc =
             Parser::default().parse("== Some\n\n|===\na|See <<_more>>\n|===\n\n== More\n\ncontent");
 
-        // The cross-reference inside the AsciiDoc cell resolves against the main
-        // document's catalog, even though its target section is defined *after*
-        // the table.
+        // The cross-reference inside the AsciiDoc cell resolves against the
+        // main document's catalog, even though its target section is
+        // defined *after* the table.
         assert_xpath(&doc, "//a[@href=\"#_more\"]", 1);
         assert_xpath(&doc, "//a[@href=\"#_more\"][text()=\"More\"]", 1);
     }
@@ -3883,8 +3892,8 @@ mod psv {
         assert_css(&doc, "a#_footnoteref_1", 1);
 
         // It is *not* shared with the enclosing document: the main document's
-        // footnote registry stays empty, so the footnote would not appear in the
-        // main document's footnote list.
+        // footnote registry stays empty, so the footnote would not appear in
+        // the main document's footnote list.
         assert!(
             doc.catalog().footnotes().is_empty(),
             "cell footnote leaked into the main document's registry"
@@ -3913,9 +3922,9 @@ mod psv {
         assert_eq!(footnotes[0].text, "A lightweight markup language.");
     }
 
-    // Out of scope: DocBook backend. ("callout numbers should be globally unique,
-    // including AsciiDoc table cells" — asserts only against DocBook `//co` /
-    // `//callout` output)
+    // Out of scope: DocBook backend. ("callout numbers should be globally
+    // unique, including AsciiDoc table cells" — asserts only against
+    // DocBook `//co` / `//callout` output)
     non_normative!(
         r#"
     test 'callout numbers should be globally unique, including AsciiDoc table cells' do
@@ -4085,8 +4094,8 @@ mod psv {
 
         assert_css(&doc, "table", 2);
         assert_css(&doc, "table table", 1);
-        // Ruby uses `td:nth-child(2) table`; the nested table sits in the second
-        // cell of the (single) outer row.
+        // Ruby uses `td:nth-child(2) table`; the nested table sits in the
+        // second cell of the (single) outer row.
         assert_xpath(&doc, "/table/tbody/tr/td[2]//table", 1);
         assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 2);
     }
@@ -4154,19 +4163,20 @@ mod psv {
         // document, asserts it is `nested?` and that its `options[:to_dir]`
         // matches the parent's.
         //
-        // This crate has no options bag: a document's configuration is carried by
-        // its attributes, and Asciidoctor itself surfaces the `to_dir` option as
-        // the `outdir` document attribute. So the faithful analog is to configure
-        // the parent with an `outdir` attribute (as if from the API, the way an
-        // option is supplied) and confirm the nested AsciiDoc-cell document both
+        // This crate has no options bag: a document's configuration is carried
+        // by its attributes, and Asciidoctor itself surfaces the
+        // `to_dir` option as the `outdir` document attribute. So the
+        // faithful analog is to configure the parent with an `outdir`
+        // attribute (as if from the API, the way an option is supplied)
+        // and confirm the nested AsciiDoc-cell document both
         // reports itself as nested and has inherited that value.
         let doc = Parser::default()
             .with_intrinsic_attribute("outdir", "/path/to/output", ModificationContext::ApiOnly)
             .parse("|===\na|\nAsciiDoc table cell\n|===");
 
-        // Locate the nested document: the single table's single cell, which is an
-        // AsciiDoc cell (`a|`) and therefore a nested, standalone document. This
-        // is the crate's equivalent of Ruby's
+        // Locate the nested document: the single table's single cell, which is
+        // an AsciiDoc cell (`a|`) and therefore a nested, standalone
+        // document. This is the crate's equivalent of Ruby's
         // `doc.blocks[0].find_by context: :document, traverse_documents: true`.
         let table = match doc.child_blocks().next() {
             Some(crate::blocks::Block::Table(table)) => table,
@@ -4181,9 +4191,9 @@ mod psv {
         // `assert nested_doc.nested?`
         assert!(nested_doc.is_nested());
 
-        // `assert_equal doc.options[:to_dir], nested_doc.options[:to_dir]` — the
-        // inherited option (here the `outdir` attribute) is visible on the nested
-        // document and equals the parent's.
+        // `assert_equal doc.options[:to_dir], nested_doc.options[:to_dir]` —
+        // the inherited option (here the `outdir` attribute) is visible
+        // on the nested document and equals the parent's.
         assert!(nested_doc.is_attribute_set("outdir"));
         assert_eq!(
             nested_doc.attribute_value("outdir"),
@@ -4261,8 +4271,8 @@ mod psv {
             "= Document Title\n\n== Section A\n\n|===\na|\n= Subdocument Title\n:toc:\n\n== Subdocument Section A\n\ncontent\n|===",
         );
 
-        // The outer document has no TOC; the cell enables its own, so the single
-        // TOC is the one inside the table.
+        // The outer document has no TOC; the cell enables its own, so the
+        // single TOC is the one inside the table.
         assert_css(&doc, ".toc", 1);
         assert_css(&doc, "table .toc", 1);
     }
@@ -4270,16 +4280,18 @@ mod psv {
     #[test]
     fn asciidoc_table_cell_renders_a_positional_toc() {
         // A cell that enables an automatically placed *positional* TOC (`top` /
-        // `bottom`, like `left` / `right`) still renders it: the nested-cell path
-        // must treat these the same as an `auto` TOC, not silently drop them. The
-        // positional placement gives the container the `toc2` class.
+        // `bottom`, like `left` / `right`) still renders it: the nested-cell
+        // path must treat these the same as an `auto` TOC, not silently
+        // drop them. The positional placement gives the container the
+        // `toc2` class.
         for value in ["^", "v", "top", "bottom", "<", ">"] {
             let doc = Parser::default().parse(&format!(
                 "= Document Title\n\n== Section A\n\n|===\na|\n= Subdocument Title\n:toc: {value}\n\n== Subdocument Section A\n\ncontent\n|==="
             ));
 
             // The outer document has no TOC; the cell's positional TOC is the
-            // single one, and it renders inside the table with the `toc2` class.
+            // single one, and it renders inside the table with the `toc2`
+            // class.
             assert_css(&doc, "#toc.toc2", 1);
             assert_css(&doc, "table #toc.toc2", 1);
         }
@@ -4405,9 +4417,10 @@ mod psv {
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > tbody > tr > td", 1);
 
-        // The cell is its own (nested) document and does not inherit the parent's
-        // doctitle, so its lone paragraph is not promoted into a preamble: the
-        // cell renders a bare `.paragraph`, never a `#preamble`.
+        // The cell is its own (nested) document and does not inherit the
+        // parent's doctitle, so its lone paragraph is not promoted into
+        // a preamble: the cell renders a bare `.paragraph`, never a
+        // `#preamble`.
         assert_css(&doc, "table > tbody > tr > td #preamble", 0);
         assert_css(&doc, "table > tbody > tr > td .paragraph", 1);
     }
@@ -4481,10 +4494,10 @@ mod psv {
     }
 
     #[test]
-    // An unterminated example block inside an AsciiDoc table cell that is itself
-    // attached to a list item — Asciidoctor reports the warning at the inner
-    // block's line (9). The cursor/line of nested-cell warnings is tracked via
-    // the nested-cell source-map work landed for #542.
+    // An unterminated example block inside an AsciiDoc table cell that is
+    // itself attached to a list item — Asciidoctor reports the warning at
+    // the inner block's line (9). The cursor/line of nested-cell warnings
+    // is tracked via the nested-cell source-map work landed for #542.
     fn should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell()
      {
         verifies!(
@@ -4592,7 +4605,8 @@ mod psv {
 "#
     );
 
-    // Out of scope: DocBook backend. ("table with unbreakable option docbook 5")
+    // Out of scope: DocBook backend. ("table with unbreakable option docbook
+    // 5")
     non_normative!(
         r#"
     test 'table with unbreakable option docbook 5' do
@@ -4970,8 +4984,8 @@ mod csv {
         );
 
         // The `1\t2\t` record ends with a tab, so its third field is empty. The
-        // include is the delivery mechanism; the behavior under test is that the
-        // trailing empty cell survives.
+        // include is the delivery mechanism; the behavior under test is that
+        // the trailing empty cell survives.
         let handler = InlineFileHandler::from_pairs([(
             "fixtures/data.tsv",
             "First\tSecond\tThird\na\tb\tc\n1\t2\t\nx\ty\tz\n",

--- a/parser/src/tests/asciidoctor_rb/text_test.rs
+++ b/parser/src/tests/asciidoctor_rb/text_test.rs
@@ -804,9 +804,10 @@ mod basic_styling {
         assert_xpath(&doc, "//em", 1);
         assert_xpath(&doc, "//code[@class=\"role\"]", 1);
 
-        // The test xpath engine has no `not(@class)`, so the Ruby assertion that
-        // exactly one `<code>` has no class is instead pinned by asserting the
-        // full rendered output (which also subsumes the checks above).
+        // The test xpath engine has no `not(@class)`, so the Ruby assertion
+        // that exactly one `<code>` has no class is instead pinned by
+        // asserting the full rendered output (which also subsumes the
+        // checks above).
         assert_eq!(
             rendered_paragraphs(&doc)[0],
             r#"<strong>B</strong><em>I</em><code>M</code><code class="role">M</code>"#

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -30,8 +30,8 @@ pub(crate) fn query_css<'a>(root: &'a VirtualNode, selector: &str) -> Vec<&'a Vi
 
     // A descendant selector can reach the same node through more than one
     // matching ancestor (e.g. `.tableblock h1` where both the `<table>` and the
-    // `<td>` carry the `tableblock` class). De-duplicate so each node is counted
-    // once, matching a real CSS engine.
+    // `<td>` carry the `tableblock` class). De-duplicate so each node is
+    // counted once, matching a real CSS engine.
     let mut seen: Vec<*const VirtualNode> = Vec::new();
     query_descendant_or_self(root, selector)
         .into_iter()
@@ -63,8 +63,8 @@ fn find_descendant_combinator_space(pattern: &str) -> Option<usize> {
             continue;
         }
 
-        // Whitespace immediately before a `>`/`+` combinator is not a descendant
-        // combinator (e.g. the space in `div >`).
+        // Whitespace immediately before a `>`/`+` combinator is not a
+        // descendant combinator (e.g. the space in `div >`).
         let rest = pattern[i..].trim_start();
         if rest.starts_with('>') || rest.starts_with('+') {
             continue;
@@ -89,8 +89,9 @@ fn find_descendant_combinator_space(pattern: &str) -> Option<usize> {
 fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a VirtualNode> {
     // Check which combinator appears first to process them in correct order.
     // Space (descendant) has lower precedence and should be processed first.
-    // However, we need to distinguish between a space as a descendant combinator
-    // and a space that's just whitespace around `>` or `+` combinators.
+    // However, we need to distinguish between a space as a descendant
+    // combinator and a space that's just whitespace around `>` or `+`
+    // combinators.
     let space_pos = find_descendant_combinator_space(pattern);
     let gt_pos = pattern.find('>');
 
@@ -107,9 +108,10 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
         let mut results = Vec::new();
         collect_descendants_matching(node, first, &mut results);
 
-        // For each matching node, search its descendants (not including itself) for
-        // the rest of the pattern. The descendant combinator (space) means "any
-        // descendant", which by definition excludes the element itself.
+        // For each matching node, search its descendants (not including itself)
+        // for the rest of the pattern. The descendant combinator
+        // (space) means "any descendant", which by definition excludes
+        // the element itself.
         let mut final_results = Vec::new();
         for matched_node in results {
             // Search only children (descendants), not the matched node itself.
@@ -129,12 +131,13 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
         // Find all nodes matching first part.
         // NOTE: We still search all descendants for the first part, because the
         // initial query can match elements anywhere in the tree. The `>` only
-        // constrains the relationship between matched elements and what follows.
+        // constrains the relationship between matched elements and what
+        // follows.
         let mut results = Vec::new();
         collect_descendants_matching(node, first, &mut results);
 
-        // For each matching node, use the direct-child-only query helper to process
-        // rest.
+        // For each matching node, use the direct-child-only query helper to
+        // process rest.
         let mut final_results = Vec::new();
         for matched_node in results {
             let children_matches = query_with_direct_child_constraint(matched_node, rest);
@@ -152,7 +155,8 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
         let mut results = Vec::new();
         collect_descendants_matching_with_siblings(node, first, &mut results);
 
-        // For each matching node, find its next sibling and check if it matches rest.
+        // For each matching node, find its next sibling and check if it matches
+        // rest.
         let mut final_results = Vec::new();
         for (_matched_node, parent, child_index) in results {
             if let Some(next_sibling) = parent.children.get(child_index + 1) {
@@ -245,8 +249,9 @@ fn query_with_direct_child_constraint<'a>(
         let mut results = Vec::new();
         for child in &node.children {
             if matches_selector_with_context(child, first, Some(node)) {
-                // The descendant combinator excludes the matched child itself, so
-                // search its subtrees rather than the child node.
+                // The descendant combinator excludes the matched child itself,
+                // so search its subtrees rather than the child
+                // node.
                 for grandchild in &child.children {
                     results.extend(query_descendant_or_self(grandchild, rest));
                 }
@@ -293,10 +298,11 @@ fn query_with_direct_child_constraint<'a>(
                     && let Some(next_sibling) = node.children.get(idx + 1)
                 {
                     // Check if next sibling matches rest.
-                    // If rest has combinators, we need to continue processing from
-                    // next_sibling.
+                    // If rest has combinators, we need to continue processing
+                    // from next_sibling.
                     if rest.contains('>') || rest.contains('+') {
-                        // Parse the first part of rest to check against next_sibling.
+                        // Parse the first part of rest to check against
+                        // next_sibling.
                         let (next_part, remaining) = if let Some(pos) = rest.find('>') {
                             (rest[..pos].trim(), Some(rest[pos + 1..].trim()))
                         } else if let Some(pos) = rest.find('+') {
@@ -308,13 +314,15 @@ fn query_with_direct_child_constraint<'a>(
                         // Check if next_sibling matches next_part.
                         if matches_selector_with_context(next_sibling, next_part, Some(node)) {
                             if let Some(remaining) = remaining {
-                                // Continue processing from next_sibling with remaining
+                                // Continue processing from next_sibling with
+                                // remaining
                                 // selector.
                                 let further =
                                     query_with_direct_child_constraint(next_sibling, remaining);
                                 results.extend(further);
                             } else {
-                                // No more selector parts, next_sibling is a match.
+                                // No more selector parts, next_sibling is a
+                                // match.
                                 results.push(next_sibling);
                             }
                         }
@@ -509,7 +517,8 @@ fn matches_single_pseudo(node: &VirtualNode, pseudo: &str, parent: Option<&Virtu
 
     match pseudo {
         "first-of-type" => {
-            // Check if this is the first child with the same tag among its siblings.
+            // Check if this is the first child with the same tag among its
+            // siblings.
             if let Some(parent) = parent {
                 // Find the first child with the same tag.
                 for child in &parent.children {
@@ -843,7 +852,8 @@ mod tests {
     #[test]
     fn query_nth_child_and_pseudo_chain() {
         // A two-row, three-column table whose middle row has an empty trailing
-        // cell. Exercises `:nth-child(N)` and a pseudo chain (`:nth-child(3):empty`).
+        // cell. Exercises `:nth-child(N)` and a pseudo chain
+        // (`:nth-child(3):empty`).
         let doc = Parser::default().parse("[format=csv]\n|===\na,b,c\n1,2,\n|===");
         let vdom = doc.to_virtual_dom();
 
@@ -869,8 +879,8 @@ mod tests {
     fn query_child_chain_then_descendant() {
         // A chain of `>` child combinators followed by a trailing descendant
         // combinator (`a > b > c d`). The descendant step is reached only after
-        // the preceding `>` steps are stripped, so it must be handled inside the
-        // direct-child traversal, not just at the top level.
+        // the preceding `>` steps are stripped, so it must be handled inside
+        // the direct-child traversal, not just at the top level.
         let doc = Parser::default().parse("[cols=\"1a\"]\n|===\n|AsciiDoc content\n|===");
         let vdom = doc.to_virtual_dom();
 
@@ -903,7 +913,8 @@ mod tests {
         let doc = Parser::default().parse("* Foo\n[start=2]\n. Boo\n* Blech\n");
         let vdom = doc.to_virtual_dom();
 
-        // Find all ol elements with start attribute using CSS-style attribute selector.
+        // Find all ol elements with start attribute using CSS-style attribute
+        // selector.
         let result = query_css(&vdom, "ol[@start=\"2\"]");
         assert_eq!(result.len(), 1, "Should find one ol with start=2");
 
@@ -990,7 +1001,8 @@ mod tests {
         let ulist_divs = query_css(&vdom, "div.ulist");
         assert_eq!(ulist_divs.len(), 1, "Should find 1 .ulist div");
 
-        // Find divs that have the .ulist class - :not(.ulist) should exclude them.
+        // Find divs that have the .ulist class - :not(.ulist) should exclude
+        // them.
         let ulist_with_not = query_css(&vdom, ".ulist:not(.olist)");
         assert_eq!(
             ulist_with_not.len(),

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -571,8 +571,8 @@ impl ToVirtualDom for Document<'_> {
 
         // The document title renders as an `<h1>` when it is shown. This
         // virtual DOM models the *embedded* output, whose default is
-        // title-hidden: the title shows only when `showtitle` is set, or (absent
-        // `showtitle`) when `notitle` is present and cleared.
+        // title-hidden: the title shows only when `showtitle` is set, or
+        // (absent `showtitle`) when `notitle` is present and cleared.
         let show_doctitle = if self.has_attribute("showtitle") {
             self.is_attribute_set("showtitle")
         } else if self.has_attribute("notitle") {
@@ -590,9 +590,9 @@ impl ToVirtualDom for Document<'_> {
         // body; `preamble` defers it to the preamble; `macro` stashes it for a
         // `toc::[]` macro in the body to pick up. (The side/top/bottom-column
         // styling of the positional placements needs the standalone HTML body
-        // framing this embeddable virtual DOM does not model, so they render like
-        // `auto` here, which is also Asciidoctor's documented fallback for
-        // embeddable output.)
+        // framing this embeddable virtual DOM does not model, so they render
+        // like `auto` here, which is also Asciidoctor's documented
+        // fallback for embeddable output.)
         let toc_mode = self.toc_mode();
         let toc_data = toc_mode.is_enabled().then(|| {
             TocData::build(
@@ -646,8 +646,9 @@ impl ToVirtualDom for Document<'_> {
 /// NOTE: Some block types (like lists) handle their titles internally, so we
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
-    // A `toc::[]` macro renders the table of contents (when a `toc: macro` scope
-    // is active) rather than a paragraph, and never carries a separate title.
+    // A `toc::[]` macro renders the table of contents (when a `toc: macro`
+    // scope is active) rather than a paragraph, and never carries a
+    // separate title.
     if is_toc_macro(block) {
         if let Some(toc) = toc_macro_node(block) {
             parent.children.push(toc);
@@ -657,10 +658,10 @@ fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
 
     // Check if this block type handles its own title internally. Lists render
     // their title inside the list wrapper; tables render it as a <caption>;
-    // admonitions render it inside the content cell; a collapsible block renders
-    // it as the `<summary>` toggle text; a sidebar renders it as the first child
-    // of its `div.content` wrapper; an example block renders it as a numbered
-    // caption before its `div.content` wrapper.
+    // admonitions render it inside the content cell; a collapsible block
+    // renders it as the `<summary>` toggle text; a sidebar renders it as
+    // the first child of its `div.content` wrapper; an example block
+    // renders it as a numbered caption before its `div.content` wrapper.
     let handles_title_internally = is_collapsible(block)
         || is_sidebar(block)
         || is_example(block)
@@ -717,16 +718,16 @@ fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
 
 impl ToVirtualDom for Block<'_> {
     fn to_virtual_dom(&self) -> VirtualNode {
-        // A collapsible example block or paragraph renders as an HTML disclosure
-        // element (`<details>`/`<summary>`) rather than its usual example-block
-        // markup.
+        // A collapsible example block or paragraph renders as an HTML
+        // disclosure element (`<details>`/`<summary>`) rather than its
+        // usual example-block markup.
         if is_collapsible(self) {
             return collapsible_to_node(self);
         }
 
         // A sidebar block (the `****` structural container or the `[sidebar]`
-        // paragraph style) renders as `div.sidebarblock > div.content`, with its
-        // title and content nested inside the content wrapper.
+        // paragraph style) renders as `div.sidebarblock > div.content`, with
+        // its title and content nested inside the content wrapper.
         if is_sidebar(self) {
             return sidebar_to_node(self);
         }
@@ -764,7 +765,8 @@ impl ToVirtualDom for Block<'_> {
 
                 let mut node = simple_block_to_node(simple);
 
-                // For literal and verse blocks, add a <pre> element containing the content.
+                // For literal and verse blocks, add a <pre> element containing
+                // the content.
                 if simple.style() == SimpleBlockStyle::Literal
                     || simple.declared_style() == Some("literal")
                     || simple.declared_style() == Some("verse")
@@ -979,8 +981,10 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
                         dt_node = dt_node.with_html_content(term.rendered_html().to_string());
                         list_element.children.push(dt_node);
 
-                        // Create dd node for the definition, but only if the item has content.
-                        // Multiple consecutive terms can share a single definition.
+                        // Create dd node for the definition, but only if the
+                        // item has content.
+                        // Multiple consecutive terms can share a single
+                        // definition.
                         let nested = list_item.child_blocks().collect::<Vec<_>>();
 
                         if !nested.is_empty() {
@@ -989,7 +993,8 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
                             let has_multiple_blocks = nested.len() > 1;
 
                             // Check if the first block was attached via list
-                            // continuation (+). When content is from continuation,
+                            // continuation (+). When content is from
+                            // continuation,
                             // paragraphs should be wrapped in div.paragraph.
                             let first_block_from_continuation =
                                 nested.first().is_some_and(|first_block| {
@@ -1189,10 +1194,10 @@ fn list_item_to_node<'a>(item: &'a ListItem<'a>) -> VirtualNode {
     for (index, child) in nested.iter().enumerate() {
         let child_vdom = child.to_virtual_dom();
 
-        // Wrap paragraphs in div.paragraph when they appear after other blocks in the
-        // list item. This matches Asciidoctor's HTML output for list
-        // continuations. The first paragraph block is never wrapped, only
-        // subsequent ones.
+        // Wrap paragraphs in div.paragraph when they appear after other blocks
+        // in the list item. This matches Asciidoctor's HTML output for
+        // list continuations. The first paragraph block is never
+        // wrapped, only subsequent ones.
         if has_multiple_blocks
             && index > 0
             && child_vdom.tag == "p"
@@ -1228,9 +1233,9 @@ fn checklist_item_to_node<'a>(
 ) -> VirtualNode {
     let mut node = list_item_to_node(item);
 
-    // The principal paragraph is always the first child (continuation blocks, if
-    // any, follow it). Prefix it with the checkbox marker when this item has
-    // checkbox syntax.
+    // The principal paragraph is always the first child (continuation blocks,
+    // if any, follow it). Prefix it with the checkbox marker when this item
+    // has checkbox syntax.
     if let Some(checked) = item.checkbox()
         && let Some(principal) = node.children.first_mut()
     {
@@ -1584,7 +1589,8 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
     }
 
     if tag != "comment" {
-        // Check if this is a source block by looking for style="source" in attrlist.
+        // Check if this is a source block by looking for style="source" in
+        // attrlist.
         let is_source_block = raw
             .attrlist()
             .and_then(|attrlist| attrlist.attributes().next())
@@ -1595,8 +1601,8 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
             // For source blocks, create pre > code structure.
             let mut code = VirtualNode::new("code");
 
-            // Add data-lang attribute if language is specified (second positional
-            // attribute).
+            // Add data-lang attribute if language is specified (second
+            // positional attribute).
             if let Some(attrlist) = raw.attrlist() {
                 let mut attrs = attrlist.attributes();
 
@@ -1907,9 +1913,9 @@ fn sidebar_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
     }
 
     // The title, when present, is the first child of the content wrapper. It is
-    // inserted *after* the body content because `with_html_content` replaces the
-    // children vector when the rendered content contains inline markup; pushing
-    // the title first would let that replacement silently drop it.
+    // inserted *after* the body content because `with_html_content` replaces
+    // the children vector when the rendered content contains inline markup;
+    // pushing the title first would let that replacement silently drop it.
     if let Some(title) = block.title() {
         content.children.insert(
             0,
@@ -2110,9 +2116,11 @@ fn quote_to_node<'a>(quote: &'a QuoteBlock<'a>) -> VirtualNode {
 
             match quote.content_model() {
                 ContentModel::Compound => {
-                    // `blocks()` returns a slice (rather than the `child_blocks()`
-                    // iterator) so a Markdown-style blockquote's nested blocks,
-                    // which borrow the block's own owned source, are rendered too.
+                    // `blocks()` returns a slice (rather than the
+                    // `child_blocks()` iterator) so a
+                    // Markdown-style blockquote's nested blocks,
+                    // which borrow the block's own owned source, are rendered
+                    // too.
                     for child in quote.blocks() {
                         add_block_with_title(&mut blockquote, child);
                     }
@@ -2253,8 +2261,8 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 
         if column.is_autowidth() {
             // An autowidth column is sized to its content: it carries the
-            // `autowidth-option` marker (present with an empty value) and no HTML
-            // `width` attribute.
+            // `autowidth-option` marker (present with an empty value) and no
+            // HTML `width` attribute.
             col = col.with_attribute("autowidth-option", "");
         } else {
             // A proportional column emits its percentage as the HTML `width`.
@@ -2418,9 +2426,10 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                     content.children.push(toc_block("toc", false, data));
                 }
 
-                // Always (re)scope both stashes for the cell body so a `toc::[]`
-                // inside the cell never picks up the parent document's TOC; only
-                // a cell with its own `toc: macro`/`toc: preamble` provides one.
+                // Always (re)scope both stashes for the cell body so a
+                // `toc::[]` inside the cell never picks up the
+                // parent document's TOC; only a cell with its
+                // own `toc: macro`/`toc: preamble` provides one.
                 let _macro_scope = scoped_toc(
                     &MACRO_TOC,
                     match toc_mode {
@@ -2438,7 +2447,8 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
 
                 if cell.is_inline() {
                     // An `inline` doctype renders block content as bare inline
-                    // content, without the `<div class="paragraph"><p>` wrapper.
+                    // content, without the `<div class="paragraph"><p>`
+                    // wrapper.
                     for block in cell.blocks() {
                         match block.rendered_html_content() {
                             Some(rendered) => {
@@ -2959,9 +2969,10 @@ mod tests {
         #[test]
         fn left_and_right_render_like_auto_at_top() {
             // `left`/`right` request a side column in standalone HTML, but this
-            // embeddable virtual DOM (Asciidoctor's documented fallback) renders
-            // them like `auto`: a `div#toc` at the top of the body. The container
-            // still carries the side-column `toc2` class (see #749).
+            // embeddable virtual DOM (Asciidoctor's documented fallback)
+            // renders them like `auto`: a `div#toc` at the top of
+            // the body. The container still carries the side-column
+            // `toc2` class (see #749).
             for (value, mode) in [("left", TocMode::Left), ("right", TocMode::Right)] {
                 let doc =
                     Parser::default().parse(&format!("= Title\n:toc: {value}\n\n== Section\n\nhi"));
@@ -3006,8 +3017,8 @@ mod tests {
 
         #[test]
         fn preamble_toc_absent_without_preamble() {
-            // The CAUTION on the position page: a `toc: preamble` placement does
-            // not appear when the document has no preamble.
+            // The CAUTION on the position page: a `toc: preamble` placement
+            // does not appear when the document has no preamble.
             let doc = Parser::default().parse("= Title\n:toc: preamble\n\n== Section\n\nhi");
 
             assert_eq!(doc.toc_mode(), TocMode::Preamble);
@@ -3019,8 +3030,8 @@ mod tests {
             let doc = Parser::default()
                 .parse("= Title\n:toc:\n\n== Level 1\n\n=== Level 2\n\n==== Level 3\n\ncontent");
 
-            // The default `toclevels` is 2, so the `==` and `===` sections appear
-            // but the `====` (level 3) section is excluded.
+            // The default `toclevels` is 2, so the `==` and `===` sections
+            // appear but the `====` (level 3) section is excluded.
             assert_eq!(doc.toc_levels(), 2);
             assert_css(&doc, "ul.sectlevel1", 1);
             assert_css(&doc, "ul.sectlevel2", 1);
@@ -3098,8 +3109,8 @@ mod tests {
 
         #[test]
         fn toc_defaults_when_attributes_unset() {
-            // With `toc` enabled but the others unset, the resolved depth, title,
-            // and class are the documented defaults.
+            // With `toc` enabled but the others unset, the resolved depth,
+            // title, and class are the documented defaults.
             let doc = Parser::default().parse("= Title\n:toc:\n\n== Section\n\nhi");
 
             assert_eq!(doc.toc_levels(), 2);
@@ -3136,8 +3147,8 @@ mod tests {
 
         #[test]
         fn macro_placement_without_macro_renders_no_toc() {
-            // `toc: macro` only renders where a `toc::[]` macro appears; with no
-            // such macro, no TOC is generated.
+            // `toc: macro` only renders where a `toc::[]` macro appears; with
+            // no such macro, no TOC is generated.
             let doc = Parser::default().parse("= Title\n:toc: macro\n\n== Section\n\nhi");
 
             assert_eq!(doc.toc_mode(), TocMode::Macro);
@@ -3146,8 +3157,8 @@ mod tests {
 
         #[test]
         fn toc_macro_renders_nothing_when_toc_not_enabled() {
-            // A stray `toc::[]` with no `toc` attribute renders nothing — neither
-            // a TOC nor the literal paragraph text.
+            // A stray `toc::[]` with no `toc` attribute renders nothing —
+            // neither a TOC nor the literal paragraph text.
             let doc = Parser::default().parse("= Title\n\ntoc::[]\n\n== Section\n\nhi");
 
             assert_eq!(doc.toc_mode(), TocMode::Disabled);

--- a/parser/src/tests/assert_dom/xpath.rs
+++ b/parser/src/tests/assert_dom/xpath.rs
@@ -112,7 +112,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
 
                 // Continue with the remaining path if any.
                 if !remaining.is_empty() {
-                    // Check if remaining starts with another predicate (e.g., [text()="value"])
+                    // Check if remaining starts with another predicate (e.g.,
+                    // [text()="value"])
                     if remaining.starts_with('[') {
                         // Extract consecutive predicates.
                         let (predicates, path_after) = extract_predicates(remaining);
@@ -120,7 +121,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
                         // Apply the predicates to filter the results.
                         results.retain(|node| matches_predicate(node, predicates));
 
-                        // If there's more path after the predicates, continue processing.
+                        // If there's more path after the predicates, continue
+                        // processing.
                         if !path_after.is_empty() {
                             let mut final_results = Vec::new();
                             for node in results {
@@ -140,7 +142,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
 
                     // Check for axis specifiers first.
                     if let Some(axis_rest) = remaining.strip_prefix("/preceding-sibling::") {
-                        // Parse the axis_rest to see if there's a continuation after the axis.
+                        // Parse the axis_rest to see if there's a continuation
+                        // after the axis.
                         let (axis_selector, continuation) =
                             if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                                 (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -170,7 +173,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
                     }
 
                     if let Some(axis_rest) = remaining.strip_prefix("/following-sibling::") {
-                        // Parse the axis_rest to see if there's a continuation after the axis.
+                        // Parse the axis_rest to see if there's a continuation
+                        // after the axis.
                         let (axis_selector, continuation) =
                             if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                                 (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -200,9 +204,10 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
                     }
 
                     if let Some(axis_rest) = remaining.strip_prefix("/self::") {
-                        // The `self::` axis tests if the current node matches the given selector.
-                        // Parse to separate the selector (with predicates) from any continuation
-                        // path.
+                        // The `self::` axis tests if the current node matches
+                        // the given selector.
+                        // Parse to separate the selector (with predicates) from
+                        // any continuation path.
                         let (selector, predicate, continuation) =
                             parse_selector_with_predicates(axis_rest);
 
@@ -215,7 +220,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
                         // Filter results to only nodes matching the selector.
                         results.retain(|node| matches_selector(node, &selector_with_pred));
 
-                        // If there's a continuation path, apply it to the filtered results.
+                        // If there's a continuation path, apply it to the
+                        // filtered results.
                         if let Some(cont) = continuation {
                             let mut final_results = Vec::new();
                             for node in results {
@@ -247,7 +253,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
         } else if !rest.is_empty() {
             // Check if rest is a preceding-sibling axis.
             if let Some(axis_rest) = rest.strip_prefix("/preceding-sibling::") {
-                // Parse the axis_rest to see if there's a continuation after the axis.
+                // Parse the axis_rest to see if there's a continuation after
+                // the axis.
                 let (axis_selector, continuation) =
                     if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                         (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -277,7 +284,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
 
             // Check if rest is a following-sibling axis.
             if let Some(axis_rest) = rest.strip_prefix("/following-sibling::") {
-                // Parse the axis_rest to see if there's a continuation after the axis.
+                // Parse the axis_rest to see if there's a continuation after
+                // the axis.
                 let (axis_selector, continuation) =
                     if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                         (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -307,8 +315,9 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
 
             // Check if rest is a `self` axis.
             if let Some(axis_rest) = rest.strip_prefix("/self::") {
-                // The `self::` axis tests if the current node matches the given selector.
-                // Parse to separate the selector (with predicates) from any continuation path.
+                // The `self::` axis tests if the current node matches the given
+                // selector. Parse to separate the selector
+                // (with predicates) from any continuation path.
                 let (selector, predicate, continuation) = parse_selector_with_predicates(axis_rest);
 
                 let selector_with_pred = if let Some(pred) = predicate {
@@ -320,7 +329,8 @@ fn query_parenthesized<'a>(root: &'a VirtualNode, xpath: &str) -> Vec<&'a Virtua
                 // Filter results to only nodes matching the selector.
                 results.retain(|node| matches_selector(node, &selector_with_pred));
 
-                // If there's a continuation path, apply it to the filtered results.
+                // If there's a continuation path, apply it to the filtered
+                // results.
                 if let Some(cont) = continuation {
                     let mut final_results = Vec::new();
                     for node in results {
@@ -487,7 +497,8 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
             collect_descendants_matching(node, first, &mut results);
             results = apply_numeric_predicate(results, first);
 
-            // Parse axis_rest to separate the sibling selector from any continuation.
+            // Parse axis_rest to separate the sibling selector from any
+            // continuation.
             let (axis_selector, axis_predicate, continuation) =
                 parse_selector_with_predicates(axis_rest);
             let axis_selector_with_pred = if let Some(pred) = axis_predicate {
@@ -516,7 +527,8 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
                 }
             }
 
-            // Deduplicate results since the same sibling may be found from multiple nodes.
+            // Deduplicate results since the same sibling may be found from
+            // multiple nodes.
             return deduplicate_nodes(final_results);
         }
 
@@ -526,7 +538,8 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
             collect_descendants_matching(node, first, &mut results);
             results = apply_numeric_predicate(results, first);
 
-            // Parse axis_rest to separate the sibling selector from any continuation.
+            // Parse axis_rest to separate the sibling selector from any
+            // continuation.
             let (axis_selector, axis_predicate, continuation) =
                 parse_selector_with_predicates(axis_rest);
             let axis_selector_with_pred = if let Some(pred) = axis_predicate {
@@ -555,7 +568,8 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
                 }
             }
 
-            // Deduplicate results since the same sibling may be found from multiple nodes.
+            // Deduplicate results since the same sibling may be found from
+            // multiple nodes.
             return deduplicate_nodes(final_results);
         }
 
@@ -574,20 +588,23 @@ fn query_descendant_or_self<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a
                 let descendants = query_descendant_or_self(matched_node, rest);
                 final_results.extend(descendants);
             } else {
-                // Direct child pattern: continue with rest as a path from this node.
+                // Direct child pattern: continue with rest as a path from this
+                // node.
                 let children_results = query_from_root(matched_node, rest);
                 final_results.extend(children_results);
             }
         }
 
-        // Deduplicate since the same node may be reachable from multiple ancestors.
+        // Deduplicate since the same node may be reachable from multiple
+        // ancestors.
         deduplicate_nodes(final_results)
     } else {
         // Simple tag match or tag with predicate.
         // Extract base selector and predicate parts.
         let pattern = pattern.trim();
 
-        // Parse predicates carefully to stop at // or / that appears outside brackets.
+        // Parse predicates carefully to stop at // or / that appears outside
+        // brackets.
         let (base_selector, predicate_part, continuation) = parse_selector_with_predicates(pattern);
 
         let mut results = Vec::new();
@@ -642,7 +659,8 @@ fn query_from_root<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a VirtualN
 
         // Check if rest is an axis specifier.
         if let Some(axis_rest) = rest.strip_prefix("following-sibling::") {
-            // Parse the axis_rest to see if there's a continuation after the axis.
+            // Parse the axis_rest to see if there's a continuation after the
+            // axis.
             let (axis_selector, continuation) =
                 if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                     (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -670,12 +688,14 @@ fn query_from_root<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a VirtualN
                 }
             }
 
-            // Deduplicate results since the same sibling may be found from multiple nodes.
+            // Deduplicate results since the same sibling may be found from
+            // multiple nodes.
             return deduplicate_nodes(final_results);
         }
 
         if let Some(axis_rest) = rest.strip_prefix("preceding-sibling::") {
-            // Parse the axis_rest to see if there's a continuation after the axis.
+            // Parse the axis_rest to see if there's a continuation after the
+            // axis.
             let (axis_selector, continuation) =
                 if let Some(slash_pos) = find_unbracketed_slash(axis_rest) {
                     (&axis_rest[..slash_pos], Some(&axis_rest[slash_pos..]))
@@ -703,7 +723,8 @@ fn query_from_root<'a>(node: &'a VirtualNode, pattern: &str) -> Vec<&'a VirtualN
                 }
             }
 
-            // Deduplicate results since the same sibling may be found from multiple nodes.
+            // Deduplicate results since the same sibling may be found from
+            // multiple nodes.
             return deduplicate_nodes(final_results);
         }
 
@@ -1460,7 +1481,8 @@ mod tests {
         let doc = Parser::default().parse("- Foo\nwrapped content\n");
         let vdom = doc.to_virtual_dom();
 
-        // The text content should be "Foo\nwrapped content" (with actual newline).
+        // The text content should be "Foo\nwrapped content" (with actual
+        // newline).
         let result = query_xpath(&vdom, "//ul/li[1]/p[text() = 'Foo\nwrapped content']");
         assert_eq!(
             result.len(),
@@ -1676,8 +1698,8 @@ mod tests {
 
     #[test]
     fn query_deeply_nested_descendants() {
-        // Test for the failing test case: //ul/li[1]//p should find all p elements
-        // including those nested in divs.
+        // Test for the failing test case: //ul/li[1]//p should find all p
+        // elements including those nested in divs.
         let doc = Parser::default().parse(
             "== Lists\n\n* Item one, paragraph one\n+\nItem one, paragraph two\n+\n* Item two\n",
         );
@@ -1765,7 +1787,8 @@ mod tests {
     #[test]
     fn query_parenthesized_with_predicates_and_child_path() {
         // Test the complex query pattern from the failing test:
-        // (//ul/li[1]/p/following-sibling::*)[1][@id="beck"]/div[@class="title"]
+        // (//ul/li[1]/p/following-sibling::*)[1][@id="beck"]/div[@class="title"
+        // ]
         let doc = Parser::default().parse("== Lists\n\n* Item one, paragraph one\n+\n:foo: bar\n[[beck]]\n.Read the following aloud to yourself\n[source, ruby]\n----\n5.times { print \"Odelay!\" }\n----\n\n* Item two\n");
         let vdom = doc.to_virtual_dom();
 

--- a/parser/src/tests/block_nesting_depth.rs
+++ b/parser/src/tests/block_nesting_depth.rs
@@ -171,8 +171,8 @@ fn limit_is_coerced_like_ruby_to_i() {
     assert_eq!(cap_of("-5"), 0);
 
     // Both non-`Value` forms are reachable only through the API (the attribute
-    // is API-only): an empty (`Set`) value coerces to 0, while an explicit unset
-    // falls back to the default.
+    // is API-only): an empty (`Set`) value coerces to 0, while an explicit
+    // unset falls back to the default.
     assert_eq!(
         Parser::default()
             .with_intrinsic_attribute_bool("max-block-nesting", true, ModificationContext::ApiOnly)

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -716,9 +716,10 @@ fn a_folded_heading_keeps_the_cross_title_coordination() {
 fn the_title_pass_renders_each_title_once() {
     use crate::parser::{CatalogResolver, InlineRenderer, XrefRenderParams};
 
-    // The title-side counterpart of `resolution_renders_a_deferred_content_once`,
-    // and the property that makes the fold a *replacement* for the document-order
-    // pass's template render rather than an addition to it.
+    // The title-side counterpart of
+    // `resolution_renders_a_deferred_content_once`, and the property that
+    // makes the fold a *replacement* for the document-order pass's template
+    // render rather than an addition to it.
     //
     // The pass needs each title's rendering while it runs — it is the link text
     // a reference to that title splices in — so the fold has to happen inside

--- a/parser/src/tests/inline_builder_passthrough_record_parity.rs
+++ b/parser/src/tests/inline_builder_passthrough_record_parity.rs
@@ -277,7 +277,8 @@ fn a_group_that_does_not_extract_reports_nothing() {
     // extraction pass, so there was nothing to retain; now the answer comes
     // from the tree not *holding* a passthrough node under such a group. Same
     // result, different reason — which is exactly the kind of substitution this
-    // branch has twice shipped a hole in, so it is asserted rather than assumed.
+    // branch has twice shipped a hole in, so it is asserted rather than
+    // assumed.
     let parser = Parser::default();
 
     for group in [
@@ -326,9 +327,9 @@ fn the_view_returns_document_order() {
     // lists them in an order that has nothing to do with where the author wrote
     // them. The view walks the tree, which gives document order.
     //
-    // This is a deliberate, documented difference rather than an accident, so it
-    // is asserted from both ends: the view's order is exactly the source's, and
-    // it is *not* the extraction pass's.
+    // This is a deliberate, documented difference rather than an accident, so
+    // it is asserted from both ends: the view's order is exactly the
+    // source's, and it is *not* the extraction pass's.
     let parser = Parser::default();
 
     for (source, expected) in [
@@ -394,9 +395,9 @@ fn a_stem_expression_embedding_a_passthrough_reports_both_entries() {
     // still disagree on a *body* while agreeing on the count.
     //
     // The pass records **two** entries: the inner passthrough, and the STEM
-    // itself — whose own text keeps the `\u{96}0\u{97}` sentinel where that body
-    // was lifted out. The view reports two as well, reaching the inner one
-    // through `Stem::children`; but the STEM entry it reports holds the
+    // itself — whose own text keeps the `\u{96}0\u{97}` sentinel where that
+    // body was lifted out. The view reports two as well, reaching the inner
+    // one through `Stem::children`; but the STEM entry it reports holds the
     // **restored** body, because `stem_expression_value` splices each inner
     // body back in while computing the expression.
     //

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -759,15 +759,15 @@ fn two_shapes_where_a_tree_built_footnote_entry_still_diverges() {
     // diverged for *every* fixture above — and neither is one it can close.
 
     // 1. A passthrough (or a STEM expression) inside a footnote. The string
-    //    pipeline restores a passthrough *after* the macros step, over the whole
-    //    block string — by which time the footnote's text has already been cut out
-    //    of it, so the entry keeps a raw passthrough sentinel that no later pass
-    //    will ever replace. It is one of design §4.2's three sentinel systems
-    //    leaking into public API, and the tree simply has no sentinels: the
-    //    passthrough is a node, so folding the subtree yields the restored text.
-    //    The tree is *right* here and the string pipeline is wrong, which is why
-    //    this is pinned as a divergence rather than fixed on the tree's side to
-    //    match.
+    //    pipeline restores a passthrough *after* the macros step, over the
+    //    whole block string — by which time the footnote's text has already
+    //    been cut out of it, so the entry keeps a raw passthrough sentinel that
+    //    no later pass will ever replace. It is one of design §4.2's three
+    //    sentinel systems leaking into public API, and the tree simply has no
+    //    sentinels: the passthrough is a node, so folding the subtree yields
+    //    the restored text. The tree is *right* here and the string pipeline is
+    //    wrong, which is why this is pinned as a divergence rather than fixed
+    //    on the tree's side to match.
     for (source, string_side, tree_side) in [
         (
             "A footnote:[a +++<b>raw</b>+++ passthrough] here.",
@@ -796,14 +796,14 @@ fn two_shapes_where_a_tree_built_footnote_entry_still_diverges() {
         );
     }
 
-    // 2. A cross-reference inside a **link's display text**. The builder does not
-    //    recognize one there at all — the link family escapes its text rather than
-    //    substituting into it — so the tree holds `CharRef` leaves where the string
-    //    pipeline holds a deferred reference. That is a recognition gap in the
-    //    *link* family, which shows identically outside any footnote (`A
-    //    link:x.html[<<tgt>>] here.` renders `&lt;&lt;tgt&gt;&gt;` in the flow
-    //    either way it is reached); the footnote entry is only where it becomes
-    //    visible in a side effect.
+    // 2. A cross-reference inside a **link's display text**. The builder does
+    //    not recognize one there at all — the link family escapes its text
+    //    rather than substituting into it — so the tree holds `CharRef` leaves
+    //    where the string pipeline holds a deferred reference. That is a
+    //    recognition gap in the *link* family, which shows identically outside
+    //    any footnote (`A link:x.html[<<tgt>>] here.` renders
+    //    `&lt;&lt;tgt&gt;&gt;` in the flow either way it is reached); the
+    //    footnote entry is only where it becomes visible in a side effect.
     let (golden, builder) = side_effects("A footnote:[link:x.html[<<tgt>>]] here.");
 
     assert_eq!(
@@ -1226,10 +1226,11 @@ fn a_real_parse_records_each_side_effect_exactly_once() {
     );
 
     // Pass order, not source order: the auto-link / formal-URL pass runs ahead
-    // of the `link:`/`mailto:` macro pass, so `z` precedes `y` even though it is
-    // written after it. `apply_macro_side_effects` reproduces that ordering
-    // because it composes the families in the string pipeline's own order — the
-    // property `links::apply_link_side_effects` documents for itself.
+    // of the `link:`/`mailto:` macro pass, so `z` precedes `y` even though it
+    // is written after it. `apply_macro_side_effects` reproduces that
+    // ordering because it composes the families in the string pipeline's
+    // own order — the property `links::apply_link_side_effects` documents
+    // for itself.
     assert_eq!(
         catalog.links().to_vec(),
         [
@@ -1273,11 +1274,11 @@ fn a_duplicate_id_warns_once_through_a_real_parse() {
 fn a_description_list_term_still_registers_from_the_string_pipeline() {
     // The carve-out, pinned. A term runs the substitution steps directly rather
     // than through `SubstitutionGroup::apply` (see
-    // `blocks::list_item_marker::DefinedTerm::substitute`), so it builds no tree
-    // and has nothing to replay from — and it stays correct only because it
-    // never enters the suppression window, which lives inside `apply`. Hoisting
-    // the flag to cover a whole parse rather than one pass would drop this
-    // registration silently.
+    // `blocks::list_item_marker::DefinedTerm::substitute`), so it builds no
+    // tree and has nothing to replay from — and it stays correct only
+    // because it never enters the suppression window, which lives inside
+    // `apply`. Hoisting the flag to cover a whole parse rather than one
+    // pass would drop this registration silently.
     let mut parser = Parser::default();
     let doc = parser.parse("[[term-id]]A term:: its description.");
 
@@ -1291,12 +1292,12 @@ fn a_description_list_term_still_registers_from_the_string_pipeline() {
 #[test]
 fn a_passthrough_body_with_its_own_macros_registers_once() {
     // The nesting case the save-and-*restore* exists for. A `pass:` macro with
-    // an explicit substitution list re-enters `SubstitutionGroup::apply` for its
-    // body while the outer content's suppression window is open, and closes a
-    // window of its own on the way out. Restoring the previous value is what
-    // leaves the outer content suppressed for everything *after* the
-    // passthrough; clearing it instead would let the string pipeline record
-    // `outer.png` alongside the replay's copy.
+    // an explicit substitution list re-enters `SubstitutionGroup::apply` for
+    // its body while the outer content's suppression window is open, and
+    // closes a window of its own on the way out. Restoring the previous
+    // value is what leaves the outer content suppressed for everything
+    // *after* the passthrough; clearing it instead would let the string
+    // pipeline record `outer.png` alongside the replay's copy.
     //
     // The body's own image is not catalogued at all, on this branch or before
     // it — a pre-existing gap in how a `pass:`-with-subs body reaches the

--- a/parser/src/tests/inline_renderer.rs
+++ b/parser/src/tests/inline_renderer.rs
@@ -239,8 +239,8 @@ fn an_empty_renderer_matches_the_html_renderer_for_every_substitution() {
     };
 
     // One case per default method body, driving the substitution step that
-    // reaches it. Each exercises the inherited default and confirms it delegates
-    // to the built-in HTML renderer.
+    // reaches it. Each exercises the inherited default and confirms it
+    // delegates to the built-in HTML renderer.
     assert_inherits_html("a < b & c > d", SubstitutionStep::SpecialCharacters, plain);
     assert_inherits_html(
         "(C) (R) (TM) -- ... -> <- => <= it's",

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -195,11 +195,11 @@ fn the_three_non_specialcharacters_bodies_still_consult_the_renderer() {
     // *specialcharacters* body, so no `RawForm` describes it and it has to be
     // computed at build time, against the parse's renderer.
     //
-    //   - `pass:c,q[…]` and `stem:[…]` each run an **arbitrary substitution list**,
-    //     which is a whole pipeline.
-    //   - a bare `+…+` body enclosing an already-extracted construct interleaves
-    //     escaped text with that construct's own **fold** bytes, which is a mixture
-    //     rather than a form.
+    //   - `pass:c,q[…]` and `stem:[…]` each run an **arbitrary substitution
+    //     list**, which is a whole pipeline.
+    //   - a bare `+…+` body enclosing an already-extracted construct
+    //     interleaves escaped text with that construct's own **fold** bytes,
+    //     which is a mixture rather than a form.
     //
     // All three owe `render_with` the same debt every frozen value on this
     // branch does (design §3.3.1), and when that lands this test is what should
@@ -475,10 +475,11 @@ fn is_block_inlines_matches_rendered_html_content_across_every_block_kind() {
     for block in doc.descendant_blocks() {
         seen.insert(block_variant_name(block));
 
-        // `inlines()` is the structured counterpart of `rendered_html_content()`:
-        // the same content-bearing blocks carry each, so their presence agrees
-        // for every kind (this also drives every `Block::inlines()` dispatch
-        // arm and each block type's override).
+        // `inlines()` is the structured counterpart of
+        // `rendered_html_content()`: the same content-bearing blocks
+        // carry each, so their presence agrees for every kind (this
+        // also drives every `Block::inlines()` dispatch arm and each
+        // block type's override).
         assert_eq!(
             block.inlines().is_some(),
             block.rendered_html_content().is_some(),
@@ -518,9 +519,9 @@ fn is_block_inlines_matches_rendered_html_content_across_every_block_kind() {
 fn is_block_inlines_carries_a_real_tree_for_each_content_bearing_kind() {
     use crate::blocks::{Block, FindBlocks, IsBlock};
 
-    // Beyond `Some` vs `None`, the override bodies for the content-bearing block
-    // kinds must return the *actual* parsed tree — so a formatting construct in
-    // each shows up as a `Styled` node, not an empty slice.
+    // Beyond `Some` vs `None`, the override bodies for the content-bearing
+    // block kinds must return the *actual* parsed tree — so a formatting
+    // construct in each shows up as a `Styled` node, not an empty slice.
     let mut parser = Parser::default();
     let doc = parser.parse(concat!(
         "NOTE: A _note_.\n\n",
@@ -1106,7 +1107,8 @@ fn inline_tree_resolution_walks_past_a_footnote_and_a_link() {
         Some("#tgt")
     );
 
-    // ... the link (a `Ref` of variant `Link`) is left untouched by resolution ...
+    // ... the link (a `Ref` of variant `Link`) is left untouched by resolution
+    // ...
     let link = refs
         .iter()
         .find(|r| r.variant == RefVariant::Link)
@@ -1127,9 +1129,9 @@ fn inline_tree_resolution_walks_past_a_footnote_and_a_link() {
 fn inline_tree_same_target_refs_keep_per_reference_resolution() {
     // Two references to the same target, resolved by a custom resolver that
     // varies its destination by the reference's provided text. Correlating each
-    // tree node with its own segment positionally (rather than keying by target)
-    // gives each node its own destination instead of collapsing both onto the
-    // first.
+    // tree node with its own segment positionally (rather than keying by
+    // target) gives each node its own destination instead of collapsing
+    // both onto the first.
     use crate::parser::{
         HtmlInlineRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
     };
@@ -1353,10 +1355,10 @@ fn section_title_forward_xref_is_resolved_in_the_tree() {
 
 #[test]
 fn circular_section_title_xrefs_are_both_resolved_in_the_tree() {
-    // Two headings reference each other. The title pass breaks the cycle for the
-    // rendered link *text*, but each reference still resolves to its target's
-    // destination — and both destinations are now mirrored into the two
-    // headings' trees.
+    // Two headings reference each other. The title pass breaks the cycle for
+    // the rendered link *text*, but each reference still resolves to its
+    // target's destination — and both destinations are now mirrored into
+    // the two headings' trees.
     let mut parser = Parser::default();
     let doc = parser.parse("[#a]\n== See <<b>>\n\n[#b]\n== See <<a>>\n");
 
@@ -1440,13 +1442,14 @@ fn block_title_xref_is_resolved_in_the_tree() {
 
 #[test]
 fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
-    // Resolving a document twice, the second time with a resolver that no longer
-    // recognizes the title's target, must leave the title tree's `Ref` node
-    // *unresolved* — not stale at the first pass's destination. The title pass
-    // rebuilds the ordered destinations each run (the template, and so the list
-    // length, is stable), and the mirror overwrites each slot unconditionally
-    // (to `Some` or `None`), so the tree tracks the rendered title rather than
-    // retaining a superseded link.
+    // Resolving a document twice, the second time with a resolver that no
+    // longer recognizes the title's target, must leave the title tree's
+    // `Ref` node *unresolved* — not stale at the first pass's destination.
+    // The title pass rebuilds the ordered destinations each run (the
+    // template, and so the list length, is stable), and the mirror
+    // overwrites each slot unconditionally (to `Some` or `None`), so the
+    // tree tracks the rendered title rather than retaining a superseded
+    // link.
     use crate::parser::{
         HtmlInlineRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
     };
@@ -1475,8 +1478,8 @@ fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
     let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("== See <<tgt>>\n\n[#tgt]\n== Target\n");
 
-    // First pass: the resolver recognizes the target, so the heading's tree xref
-    // carries its destination.
+    // First pass: the resolver recognizes the target, so the heading's tree
+    // xref carries its destination.
     doc.resolve_references(
         &FixedResolver(Some("#tgt")),
         &HtmlInlineRenderer {},
@@ -1484,8 +1487,9 @@ fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
     );
     assert_eq!(title_xref_href(&doc).as_deref(), Some("#tgt"));
 
-    // Second pass: the resolver no longer recognizes the target, so the tree xref
-    // must fall back to unresolved rather than keep the stale destination.
+    // Second pass: the resolver no longer recognizes the target, so the tree
+    // xref must fall back to unresolved rather than keep the stale
+    // destination.
     doc.resolve_references(&FixedResolver(None), &HtmlInlineRenderer {}, &parser);
     assert_eq!(
         title_xref_href(&doc),
@@ -1623,9 +1627,9 @@ fn footnote_subtree_carries_a_nested_macro() {
 
 #[test]
 fn footnote_reference_keeps_an_empty_subtree() {
-    // `footnote:id[]` defines nothing — it re-uses an earlier footnote's number —
-    // so it consumes no footnote text and keeps the empty subtree its node type
-    // documents, while the defining occurrence carries the text.
+    // `footnote:id[]` defines nothing — it re-uses an earlier footnote's number
+    // — so it consumes no footnote text and keeps the empty subtree its
+    // node type documents, while the defining occurrence carries the text.
     let mut parser = Parser::default();
     let doc = parser.parse("Named.footnote:disc[a *discussion*] then footnote:disc[].");
 
@@ -1699,8 +1703,9 @@ fn footnote_subtrees_track_document_order_across_blocks() {
 #[test]
 fn footnote_embedded_xref_is_resolved_in_the_tree() {
     // The cross-reference lives in the footnote's subtree, and its destination
-    // is mirrored there from the same resolution sweep that resolved the block's
-    // own references — so the tree agrees with the rendered footnote text.
+    // is mirrored there from the same resolution sweep that resolved the
+    // block's own references — so the tree agrees with the rendered
+    // footnote text.
     let mut parser = Parser::default();
     let doc = parser.parse("[[tgt]]The target.\n\nA claim.footnote:[see <<tgt>> for details]");
 
@@ -1732,10 +1737,10 @@ fn footnote_embedded_xref_is_resolved_in_the_tree() {
 
 #[test]
 fn footnote_embedded_xref_does_not_displace_block_xrefs() {
-    // A footnote-embedded reference is re-homed out of the block template, so it
-    // must not consume a slot of the block-level list. Were the block walk to
-    // descend into the footnote subtree, the reference *after* the footnote
-    // would take the footnote's destination.
+    // A footnote-embedded reference is re-homed out of the block template, so
+    // it must not consume a slot of the block-level list. Were the block
+    // walk to descend into the footnote subtree, the reference *after* the
+    // footnote would take the footnote's destination.
     let mut parser = Parser::default();
     let doc = parser.parse(
         "[[one]]First.\n\n[[two]]Second.\n\nSee <<one>>.footnote:[also <<two>>] and <<two>>.",
@@ -1807,8 +1812,8 @@ fn unresolved_footnote_embedded_xref_stays_none() {
 fn re_resolving_clears_a_now_unresolved_footnote_tree_destination() {
     // The footnote mirror overwrites each slot unconditionally, exactly as the
     // block and title mirrors do, so a second resolution that no longer
-    // recognizes the target clears the subtree's destination rather than leaving
-    // the first pass's stale link behind.
+    // recognizes the target clears the subtree's destination rather than
+    // leaving the first pass's stale link behind.
     use crate::parser::{
         HtmlInlineRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
     };
@@ -1923,9 +1928,10 @@ fn a_footnotes_rendering_is_refolded_from_its_subtree_at_resolution() {
 
 #[test]
 fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
-    // A footnote in a section heading is owned by the document-order title pass,
-    // which resolves the heading's cross-references and now mirrors the
-    // footnote-embedded ones into the heading tree's footnote subtree too.
+    // A footnote in a section heading is owned by the document-order title
+    // pass, which resolves the heading's cross-references and now mirrors
+    // the footnote-embedded ones into the heading tree's footnote subtree
+    // too.
     use crate::blocks::{Block, FindBlocks};
 
     let mut parser = Parser::default();

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -220,8 +220,8 @@ fn icon_image_dimensions_and_title_escape_quote_delimiter() {
 
 #[test]
 fn icon_image_src_escapes_quote_delimiter() {
-    // A `"` in the icon target reaches the resolved `src`; it must be escaped so
-    // it cannot break out of the `src` attribute.
+    // A `"` in the icon target reaches the resolved `src`; it must be escaped
+    // so it cannot break out of the `src` attribute.
     assert_eq!(
         render_icon(r#"icon:a"x[]"#, ""),
         r#"<span class="icon"><img src="./images/icons/a&quot;x.png" alt="a&quot;x"></span>"#

--- a/parser/src/tests/table_cell_directive_warnings.rs
+++ b/parser/src/tests/table_cell_directive_warnings.rs
@@ -36,7 +36,8 @@ fn conditional_warning_in_cell_included_content_keeps_its_origin() {
 
     assert_eq!(unmatched.len(), 1, "expected one unmatched-endif warning");
 
-    // The origin points at the *included* file and line, not the cell's own line.
+    // The origin points at the *included* file and line, not the cell's own
+    // line.
     assert_eq!(
         unmatched[0].origin,
         Some(SourceLine(Some("inc.adoc".to_owned()), 3))

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -222,10 +222,11 @@ fn footnote_in_heading_does_not_leak_into_generated_id() {
 
 #[test]
 fn footnote_reaching_a_heading_via_attribute_is_kept_out_of_xref_text() {
-    // The footnote enters the title through an attribute reference, so it is not
-    // visible in the raw title source. Because markers are annotated during the
-    // single title render (not gated on the source text), the footnote is still
-    // kept out of the reference text — and remains a real, numbered footnote.
+    // The footnote enters the title through an attribute reference, so it is
+    // not visible in the raw title source. Because markers are annotated
+    // during the single title render (not gated on the source text), the
+    // footnote is still kept out of the reference text — and remains a
+    // real, numbered footnote.
     let doc = Parser::default().parse(concat!(
         ":disclaimer: footnote:[Not legal advice.]\n",
         "\n",
@@ -338,12 +339,13 @@ fn xrefstyle_survives_deferred_resolution() {
     // `xrefstyle` formatting is compatible with the two-phase resolve mechanism
     // used for forward (and cross-document) references. The two inputs it needs
     // are resolved at their natural points: the effective *style* is a property
-    // of the reference site, captured during parsing (alongside `provided_text`,
-    // `window`, and `roles`), while the target's *signifier and number* live in
-    // the catalog and are read only when references are resolved (alongside the
-    // target's `reftext`). So a forward reference is an unresolved fallback
-    // until resolution, then picks up its full styled text — the same lifecycle
-    // as a plain reference.
+    // of the reference site, captured during parsing (alongside
+    // `provided_text`, `window`, and `roles`), while the target's
+    // *signifier and number* live in the catalog and are read only when
+    // references are resolved (alongside the target's `reftext`). So a
+    // forward reference is an unresolved fallback until resolution, then
+    // picks up its full styled text — the same lifecycle as a plain
+    // reference.
     let src = ":sectnums:\n:xrefstyle: full\n\nSee <<install>>.\n\n\
               == One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n\
               [#install]\n=== Installation\n";
@@ -358,8 +360,9 @@ fn xrefstyle_survives_deferred_resolution() {
         "See <a href=\"#install\">[install]</a>."
     );
 
-    // Resolving against the now-complete catalog applies the full style, drawing
-    // the signifier and number from the catalog entry registered for the target.
+    // Resolving against the now-complete catalog applies the full style,
+    // drawing the signifier and number from the catalog entry registered
+    // for the target.
     let catalog = doc.catalog().clone();
     let resolver = CatalogResolver::new(&catalog);
     let warnings = doc.resolve_references(&resolver, &HtmlInlineRenderer {}, &parser);
@@ -374,8 +377,8 @@ fn xrefstyle_survives_deferred_resolution() {
 fn host_resolver_can_attach_signifier() {
     // A host resolver that builds its `href`/`text` from scratch (rather than
     // from a catalog `RefEntry`) can still opt a target into `full`/`short`
-    // formatting by attaching a signifier with `with_signifier`. The style still
-    // comes from the referencing document.
+    // formatting by attaching a signifier with `with_signifier`. The style
+    // still comes from the referencing document.
     let mut parser = Parser::default();
     let mut doc = parser.parse_deferred(":xrefstyle: full\n\nSee <<install>>.\n");
 
@@ -428,10 +431,11 @@ fn reference_to_this_document_by_name_resolves_within_it() {
 
 #[test]
 fn reference_to_this_document_by_explicit_docname_attribute_resolves_within_it() {
-    // Same as above, but the current document is identified by an explicitly-set
-    // `docname` attribute rather than a primary file name. Asciidoctor treats
-    // `doc.attributes['docname']` as the single source of truth for the
-    // self-reference match, so an API-provided `docname` must be honored too.
+    // Same as above, but the current document is identified by an
+    // explicitly-set `docname` attribute rather than a primary file name.
+    // Asciidoctor treats `doc.attributes['docname']` as the single source
+    // of truth for the self-reference match, so an API-provided `docname`
+    // must be honored too.
     let mut parser = Parser::default().with_intrinsic_attribute(
         "docname",
         "guide",
@@ -501,8 +505,8 @@ fn explicit_reftext_wins_for_document_title_reference() {
 #[test]
 fn reference_to_document_title_with_bracket_anchor_resolves() {
     // A document title whose ID comes from a `[[id]]` block anchor (rather than
-    // the `[#id]` shorthand) is registered the same way, so a cross-reference to
-    // it renders the title text.
+    // the `[#id]` shorthand) is registered the same way, so a cross-reference
+    // to it renders the title text.
     let doc =
         Parser::default().parse("[[manual]]\n= Reference Manual\n\nThis is the <<manual>>.\n");
 
@@ -530,8 +534,8 @@ fn reference_to_document_title_uses_bracket_anchor_reftext() {
 fn host_resolver_can_override_a_derived_destination() {
     // The destination the parser derives for a target that names a document is
     // only a default: it is offered to the resolver (as
-    // `ResolutionContext::derived`) rather than imposed, so a host that resolves
-    // targets across a corpus can answer with its own.
+    // `ResolutionContext::derived`) rather than imposed, so a host that
+    // resolves targets across a corpus can answer with its own.
     let mut parser = Parser::default();
     let mut doc = parser.parse_deferred("See <<tigers#about,About Tigers>>.\n");
 
@@ -602,9 +606,10 @@ fn cross_document_resolution() {
     let doc_b = parser.parse_deferred("[#b-topic]\n== B Topic\n\nContent.\n");
 
     // The host builds a combined index from each document's catalog, assigning
-    // its own cross-document hrefs. Building each entry with `from_entry` carries
-    // the target's reftext and signifier, so cross-document `xrefstyle`
-    // formatting keeps working (see `xrefstyle_carries_across_documents`).
+    // its own cross-document hrefs. Building each entry with `from_entry`
+    // carries the target's reftext and signifier, so cross-document
+    // `xrefstyle` formatting keeps working (see
+    // `xrefstyle_carries_across_documents`).
     let mut index = HashMap::new();
     for id in ["b-topic"] {
         if let Some(entry) = doc_b.catalog().get_ref(id) {
@@ -631,12 +636,13 @@ fn cross_document_resolution() {
 
 #[test]
 fn xrefstyle_carries_across_documents() {
-    // Cross-document `xrefstyle` formatting works when the host resolver carries
-    // the target's signifier. The two inputs come from different documents: the
-    // *style* (`full`) is a property of the referencing document (doc A), while
-    // the *signifier and number* ("Section 2.3") are computed in the target
-    // document (doc B) and travel on its catalog entry. A host that builds its
-    // result with `ResolvedReference::from_entry` carries the signifier through
+    // Cross-document `xrefstyle` formatting works when the host resolver
+    // carries the target's signifier. The two inputs come from different
+    // documents: the *style* (`full`) is a property of the referencing
+    // document (doc A), while the *signifier and number* ("Section 2.3")
+    // are computed in the target document (doc B) and travel on its catalog
+    // entry. A host that builds its result with
+    // `ResolvedReference::from_entry` carries the signifier through
     // automatically.
     let mut parser = Parser::default();
 
@@ -895,9 +901,10 @@ mod unresolved_reference_warnings {
 
     #[test]
     fn reported_for_a_reference_inside_a_footnote() {
-        // A footnote's text is lifted out of the block it was written in, but the
-        // footnote records the location of its defining occurrence, so the
-        // warning is anchored at that content rather than at the whole document.
+        // A footnote's text is lifted out of the block it was written in, but
+        // the footnote records the location of its defining occurrence,
+        // so the warning is anchored at that content rather than at the
+        // whole document.
         let doc = Parser::default().parse("Intro.\n\nText.footnote:[See <<nope>>.]\n");
 
         let warnings: Vec<_> = doc.warnings().collect();
@@ -914,8 +921,8 @@ mod unresolved_reference_warnings {
     #[test]
     fn distinguishes_two_footnotes_by_location() {
         // The whole point of #804: two unresolved references in two different
-        // footnotes must be distinguishable by location, so a host can point the
-        // author at the offending footnote.
+        // footnotes must be distinguishable by location, so a host can point
+        // the author at the offending footnote.
         let doc = Parser::default()
             .parse("First.footnote:[See <<nope-a>>.]\n\nSecond.footnote:[See <<nope-b>>.]\n");
 
@@ -943,10 +950,11 @@ mod unresolved_reference_warnings {
         // document source, so no precise location is recorded and the warning
         // falls back to the whole-document span rather than a misleading one.
         //
-        // The footnote sits on a later line of the quote's owned body (offset > 0
-        // there); were that owned offset stored and applied to the document
-        // source it would resolve to some unrelated line, so asserting the
-        // fallback line 1 guards the owned-sub-source guard specifically.
+        // The footnote sits on a later line of the quote's owned body (offset >
+        // 0 there); were that owned offset stored and applied to the
+        // document source it would resolve to some unrelated line, so
+        // asserting the fallback line 1 guards the owned-sub-source
+        // guard specifically.
         let doc =
             Parser::default().parse("Intro.\n\n> Line one.\n>\n> Text.footnote:[See <<nope>>.]\n");
 
@@ -1093,8 +1101,8 @@ mod included_file_collapses_to_internal_anchor {
     #[test]
     fn include_outside_base_directory_still_registers_and_collapses() {
         // A file included from outside the base directory registers under the
-        // target as written (`../section-a`), and an inter-document reference to
-        // it collapses just the same.
+        // target as written (`../section-a`), and an inter-document reference
+        // to it collapses just the same.
         let handler =
             InlineFileHandler::from_pairs([("../section-a.adoc", "[#section-a]\n== Section A\n")]);
         let doc = Parser::default()

--- a/sdd/src/main.rs
+++ b/sdd/src/main.rs
@@ -51,9 +51,9 @@ fn main() {
         }
     }
 
-    // `saturating_sub` guards the empty case (e.g. a `ref/` source not present):
-    // the loop below then simply doesn't run, emitting a valid empty coverage
-    // object.
+    // `saturating_sub` guards the empty case (e.g. a `ref/` source not
+    // present): the loop below then simply doesn't run, emitting a valid
+    // empty coverage object.
     let last_index = spec_files.len().saturating_sub(1);
 
     for (count, entry) in spec_files.into_iter().enumerate() {
@@ -120,9 +120,9 @@ fn parse_rs_file(path: &Path) -> Option<(String, Vec<(String, bool)>)> {
 
     // Number of `#` guards in the raw-string delimiter that opened the block we
     // are currently inside (`Some(1)` for `r#"`, `Some(2)` for `r##"`, …), or
-    // `None` when not inside a reproduced Ruby block. The closing delimiter must
-    // match this length, so a reproduced line that merely starts with a shorter
-    // `"#` / `"##` sequence does not close the block early.
+    // `None` when not inside a reproduced Ruby block. The closing delimiter
+    // must match this length, so a reproduced line that merely starts with
+    // a shorter `"#` / `"##` sequence does not close the block early.
     let mut raw_hashes: Option<usize> = None;
 
     for line in rs_file.lines() {
@@ -178,8 +178,9 @@ fn parse_rs_file(path: &Path) -> Option<(String, Vec<(String, bool)>)> {
         }
 
         // Closing delimiter of the current block. It must match the hash length
-        // of the opener (`"#` for `r#"`, `"##` for `r##"`, …); a reproduced line
-        // that merely starts with a shorter guard is left as block content.
+        // of the opener (`"#` for `r#"`, `"##` for `r##"`, …); a reproduced
+        // line that merely starts with a shorter guard is left as block
+        // content.
         if let Some(hashes) = raw_hashes {
             let closer = format!("\"{}", "#".repeat(hashes));
             if line.trim_end() == closer {


### PR DESCRIPTION
The nightly toolchain released 2026-08-29 changes how rustfmt's `wrap_comments` re-wraps doc and line comments. CI's "Enforce Rust code format" job installs the latest nightly at run time, so it now rejects the whole workspace as it stands: an **untouched `inline-ast` checkout** fails `cargo +nightly fmt --all -- --check` with 1,221 diffs across 170 files. (This is what turned the format check red on #1334's latest run — the same commit's code passed the check a few hours earlier under the previous nightly.)

This is the output of `cargo +nightly fmt --all` under the new toolchain and nothing else: comment re-wrapping only, no code changes. `cargo test --workspace` (5,476 tests) and `cargo clippy -p asciidoc-parser --all-targets` pass unchanged, and `--check` is clean afterwards.

Companion PR for `main`, which is equally affected: #1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oo8iqW6vPeCwg95AnXxqs