### PR TITLE
chore: Retire escape_sentinels and the RESERVED_SENTINELS table

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -11592,7 +11592,7 @@ failed**, 68 ignored.
 | Phase | Criterion | Verdict | Evidence |
 | ----- | --------- | ------- | -------- |
 | 2 | ~277 golden `.rendered()` assertions pass unchanged | ✅ | Suite green, and the §5.3 rename left every asserted string untouched. The renamed accessors have 324 `.rendered_html()` and 173 `.rendered_html_content()` call sites (`git grep -cF` at `25ad4070`). Those are *accessor call sites*, not a recount of §5.3's ~277 golden assertions — most are ordinary reads rather than golden string comparisons — so they evidence the rename's reach, not the size of the oracle. |
-| 2 | sentinels deleted | ⚠️ **producers retired, table not yet deleted** | See below. |
+| 2 | sentinels deleted | ✅ | See below — the table itself and its last reader are gone. |
 | 2 | benchmarks within an agreed budget of `main` | ❓ **no budget on record** | CodSpeed reports no alteration across 5 benchmarks, but no *agreed budget* is written down anywhere in this document, so the criterion cannot be checked as stated. |
 | 3 | node vocabulary reviewed against the `asciidoctor` port's needs (§6.6) | ❌ **not started, and gated on Landing** | See below. |
 | 3 | purely-structural navigation sugar kept minimal | ✅ | The `inlines` module exposes no navigation helpers at all — no `walk`, `descendants`, `children`, `iter`, `visit`, or `find`; the node types are plain public fields (§3.2's sketch). Minimal by construction. |
@@ -11735,6 +11735,29 @@ own wording (the table itself, and `escape_sentinels`'s four legacy string-step 
 still there), but every *producer* the gate's name refers to is retired; what remains is the
 purely mechanical follow-up named throughout this section.
 
+*The follow-up landed as (delete `escape_sentinels` and `RESERVED_SENTINELS`):* the
+mechanical retirement every prior increment's own note deferred, now done. All four call
+sites shared one function, `apply_attributes` (`content/substitution_step.rs`) — reached from
+an attrlist value (`Attrlist::parse`), an author line (`document::author`), a reftext
+(`substitute_attributes_in_reftext`), and a list-item marker (`blocks::list_item_marker`), all
+through `SubstitutionStep::AttributeReferences.apply`, the one arm of that match that still
+has a string implementation; every other step is `unreachable!` since step 6. Grepping for a
+decoder confirmed there was none left to break: no production pass anywhere in the crate reads
+`SENTINEL_ESCAPE`'s tagged form back, so `AttributeReplacer`'s `escape_sentinels` field and
+`.escaping_sentinels()` builder method are deleted along with the call, and the four call
+sites now splice a substituted attribute value unescaped — a behavior-preserving deletion, not
+a behavior change, since nothing downstream ever scanned for or decoded the escaped form.
+`escape_sentinels`, `is_reserved_sentinel`, `SENTINEL_ESCAPE`, `RESERVED_SENTINELS`, and the
+four codepoint consts that fed it (`XREF_PLACEHOLDER_START`/`_END`,
+`PASSTHROUGH_PLACEHOLDER_START`/`_END`) are gone from `content.rs`, and the `escape_sentinels`
+test module goes with them — each of its three tests pinned a mechanism that no longer exists.
+The `sentinels.rs` regression suite (issue #1235) needed no changes at all: those tests assert
+on rendered output, and a typed sentinel was always content there and remains so — the
+escaping and decoding this increment removes were internal machinery, invisible either way.
+Phase 2's "sentinels deleted" gate now closes on the letter of its own wording, not just its
+producers: no production code emits an in-band control sentinel, and the table that used to
+reserve codepoints for one no longer exists either.
+
 ##### Phase 3's first criterion cannot close before Landing
 
 "Node vocabulary reviewed against the `asciidoctor` port's needs (§6.6)" and Landing's
@@ -11756,9 +11779,9 @@ in place by this audit; the remaining struct is Phase 5's own outstanding work.
 ##### What this means for "how much further"
 
 Firm, enumerated, and cheap: Phase 3's README `Raw`-node anchor; Phase 4's four hard-case
-policies written down; §4.6's stale sentence (done here); the now-inert `escape_sentinels`
-pass and the `RESERVED_SENTINELS` table under it (a purely mechanical follow-up, left for its
-own increment when the xref template retirement landed). Firm and substantial: the last
+policies written down; §4.6's stale sentence (done here); the `escape_sentinels` pass and the
+`RESERVED_SENTINELS` table under it (done — see the sentinel table's own landed-as note
+above). Firm and substantial: the last
 `XrefRenderParams` fold (Phase 5) — the xref template mechanism itself is retired now, both
 halves. Open-ended: the `asciidoctor`-port review, which gates both Phase 3 and Landing and
 whose cost is unknown from inside this repository. Any session count that does not separate

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -3,8 +3,6 @@
 //!
 //! [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 
-use std::borrow::Cow;
-
 use crate::{
     Parser, Span,
     content::Passthrough,
@@ -158,10 +156,11 @@ struct DeferredContent {
     /// This used to be one `String` in *escaped sentinel form*: a raw
     /// `U+E000 <index> U+E001` marked each splice point, and every
     /// document-derived byte was escaped so a typed copy of that sequence
-    /// could not forge one (see [`escape_sentinels`]). The structure makes
-    /// both halves of that machinery unnecessary — a splice point is a
-    /// [`Xref`](XrefTemplatePiece::Xref) variant rather than a byte pattern,
-    /// so nothing scans the literal text and nothing in it needs escaping.
+    /// could not forge one (see `escape_sentinels`, since retired). The
+    /// structure makes both halves of that machinery unnecessary — a splice
+    /// point is a [`Xref`](XrefTemplatePiece::Xref) variant rather than a
+    /// byte pattern, so nothing scans the literal text and nothing in it
+    /// needs escaping.
     ///
     /// The one content that *renders* from a template in production — a block
     /// title carried across a section heading, which travels through
@@ -231,10 +230,10 @@ pub(crate) struct XrefSegment {
 ///
 /// This is the **out-of-band** replacement for the in-band placeholder
 /// sentinels (`U+E000 <index> U+E001`) the template used to be written in.
-/// In-band marks needed the escaping pass on [`escape_sentinels`] to stay
-/// unforgeable — a document-typed copy of the byte sequence was otherwise
-/// byte-identical to a real placeholder. A splice point that is a variant
-/// rather than a byte pattern cannot be typed at all: a document's own
+/// In-band marks needed the escaping pass — `escape_sentinels`, since retired
+/// — to stay unforgeable — a document-typed copy of the byte sequence was
+/// otherwise byte-identical to a real placeholder. A splice point that is a
+/// variant rather than a byte pattern cannot be typed at all: a document's own
 /// `U+E000 0 U+E001` is content inside a [`Literal`](Self::Literal), and
 /// nothing reads placeholders back out of text.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -246,115 +245,6 @@ pub(crate) enum XrefTemplatePiece {
     /// rendered from the segment's current (resolved or unresolved) state at
     /// splice time.
     Xref(usize),
-}
-
-/// Sentinel codepoints (Unicode Private Use Area) that used to bracket a
-/// placeholder index in a [`FootnoteDeferred`] template — the last template
-/// written as an in-band string, and design §4.2's third and final sentinel
-/// system. Both [`DeferredContent::template`] and [`FootnoteDeferred`]'s own
-/// are structured [`XrefTemplatePiece`] lists now, so nothing in the crate
-/// produces these codepoints any more; they survive only as entries in
-/// [`RESERVED_SENTINELS`] and [`is_reserved_sentinel`], mirroring how
-/// [`PASSTHROUGH_PLACEHOLDER_START`] and [`PASSTHROUGH_PLACEHOLDER_END`]
-/// already stood — reserved codepoints with nothing left producing them.
-/// Retiring the table itself (with [`escape_sentinels`], its last reader) is
-/// a separate, purely mechanical increment.
-const XREF_PLACEHOLDER_START: char = '\u{E000}';
-const XREF_PLACEHOLDER_END: char = '\u{E001}';
-
-/// Sentinel codepoints (C1 control range) bracketing an extracted
-/// passthrough's index while the other substitutions run. Defined here so the
-/// escaping pass below covers them alongside the Private Use Area sentinels;
-/// they are emitted and consumed by
-/// [`passthroughs`](crate::content::passthroughs).
-pub(crate) const PASSTHROUGH_PLACEHOLDER_START: char = '\u{96}';
-pub(crate) const PASSTHROUGH_PLACEHOLDER_END: char = '\u{97}';
-
-/// Introduces the escaped form of a reserved sentinel (see
-/// [`escape_sentinels`]). A document's own copies of this codepoint are
-/// escaped too, so an occurrence in escaped text always introduces an escape.
-const SENTINEL_ESCAPE: char = '\u{E004}';
-
-/// Every codepoint the substitution pipeline reserves as an in-band control
-/// sentinel, paired with the ASCII tag that stands in for it in escaped text.
-///
-/// The tags are arbitrary; all that matters is that each is distinct and that
-/// the escape introducer itself is in the table, so escaping is reversible.
-const RESERVED_SENTINELS: [(char, char); 5] = [
-    (XREF_PLACEHOLDER_START, 'a'),
-    (XREF_PLACEHOLDER_END, 'b'),
-    (PASSTHROUGH_PLACEHOLDER_START, 'e'),
-    (PASSTHROUGH_PLACEHOLDER_END, 'f'),
-    (SENTINEL_ESCAPE, 'g'),
-];
-
-/// Replaces each reserved sentinel codepoint a *document* typed with an escaped
-/// form, so that the only unescaped sentinels in the text being substituted are
-/// the ones the substitution pipeline wrote itself.
-///
-/// This was the **string pipeline's** own protection: its sentinels were
-/// in-band, spliced into the same string as the document's text, so the passes
-/// that read them back could not otherwise tell a sentinel the parser wrote
-/// from one the document did. The single-pass builder needs no counterpart —
-/// it recognizes constructs by range over the source rather than by scanning a
-/// rendered string for its own marks — and the carried title's template, the
-/// last escaped-form data to cross a seam, is a structured
-/// [`XrefTemplatePiece`] list now, so no production pass unescapes anything
-/// any more.
-///
-/// What survives is this pass itself, on the string-substitution steps the
-/// builder does not own: [`SubstitutionStep::AttributeReferences`] applied to
-/// an attrlist value, an author line, or a reftext still escapes each
-/// substituted attribute value on the way in (see
-/// `AttributeReplacer::escaping_sentinels`). Nothing scans those strings for
-/// sentinels and nothing reverses the escape, so the pass no longer protects
-/// anything — it is a byte-for-byte-preserved vestige, and retiring it (with
-/// the [`RESERVED_SENTINELS`] table under it) is its own increment.
-///
-/// Text with no reserved codepoint — the overwhelming majority — is borrowed
-/// through unchanged.
-///
-/// [`SubstitutionStep::AttributeReferences`]: crate::content::SubstitutionStep::AttributeReferences
-pub(crate) fn escape_sentinels(text: &str) -> Cow<'_, str> {
-    if !text.contains(is_reserved_sentinel) {
-        return Cow::Borrowed(text);
-    }
-
-    let mut out = String::with_capacity(text.len());
-
-    for c in text.chars() {
-        match RESERVED_SENTINELS
-            .iter()
-            .find(|(sentinel, _)| *sentinel == c)
-        {
-            Some((_, tag)) => {
-                out.push(SENTINEL_ESCAPE);
-                out.push(*tag);
-            }
-            None => out.push(c),
-        }
-    }
-
-    Cow::Owned(out)
-}
-
-/// Returns `true` if `c` is one of the codepoints the substitution pipeline
-/// reserves for its own use.
-///
-/// Written as an inline match rather than a scan of [`RESERVED_SENTINELS`]:
-/// this runs over every character of every block's content, while the table
-/// itself is only consulted for text that has a sentinel in it. A unit test
-/// pins the two to the same set of codepoints.
-///
-/// `\u{E002}` and `\u{E003}` are deliberately absent: they were the
-/// footnote-marker sentinels, and this branch's section-title path derives a
-/// heading's reference text by folding its inline subtree instead, so nothing
-/// reserves them any more (design §4.2's first sentinel system).
-fn is_reserved_sentinel(c: char) -> bool {
-    matches!(
-        c,
-        '\u{96}' | '\u{97}' | '\u{E000}' | '\u{E001}' | '\u{E004}'
-    )
 }
 
 /// Strips markup down to plain text, mirroring Asciidoctor's
@@ -1518,9 +1408,10 @@ pub(crate) fn xref_segment_from_node(
 /// is what keeps the template's two populations apart — a splice point is a
 /// variant, not a byte pattern — where the string-form template this replaces
 /// had to write in-band `U+E000 <index> U+E001` sentinels and pass every
-/// document-derived byte through [`escape_sentinels`] so a document-typed copy
-/// of that sequence (see the `sentinels` test module, issue #1235) could not
-/// forge a placeholder. Nothing here scans text, so nothing needs escaping.
+/// document-derived byte through `escape_sentinels` (since retired) so a
+/// document-typed copy of that sequence (see the `sentinels` test module, issue
+/// #1235) could not forge a placeholder. Nothing here scans text, so nothing
+/// needs escaping.
 ///
 /// The price of reading only the top level is a cross-reference **nested**
 /// inside another top-level construct (a styled span's children, a visible
@@ -2009,83 +1900,6 @@ mod tests {
         }
     }
 
-    mod escape_sentinels {
-        use std::borrow::Cow;
-
-        use super::super::{
-            PASSTHROUGH_PLACEHOLDER_END, PASSTHROUGH_PLACEHOLDER_START, RESERVED_SENTINELS,
-            SENTINEL_ESCAPE, XREF_PLACEHOLDER_END, XREF_PLACEHOLDER_START, escape_sentinels,
-            is_reserved_sentinel,
-        };
-
-        #[test]
-        fn the_range_test_and_the_table_describe_the_same_codepoints() {
-            for (sentinel, _) in RESERVED_SENTINELS {
-                assert!(
-                    is_reserved_sentinel(sentinel),
-                    "{sentinel:?} is reserved but not covered by the inline match"
-                );
-            }
-
-            for c in '\u{0}'..=char::MAX {
-                assert_eq!(
-                    is_reserved_sentinel(c),
-                    RESERVED_SENTINELS
-                        .iter()
-                        .any(|(sentinel, _)| *sentinel == c),
-                    "the inline match and the table disagree about {c:?}"
-                );
-            }
-        }
-
-        #[test]
-        fn borrows_text_with_no_reserved_codepoint() {
-            assert!(matches!(
-                escape_sentinels("plain text"),
-                Cow::Borrowed("plain text")
-            ));
-        }
-
-        #[test]
-        fn escaped_text_holds_no_reserved_codepoint() {
-            // No production pass reads the escaped form back any more (the
-            // decoder went with the carried title's escaped template), so what
-            // this pins is the escaping's own output: distinct tags per
-            // codepoint, behind an introducer that is itself escaped.
-            let typed = format!(
-                "a{XREF_PLACEHOLDER_START}0{XREF_PLACEHOLDER_END}b\
-                 {PASSTHROUGH_PLACEHOLDER_START}1{PASSTHROUGH_PLACEHOLDER_END}\
-                 e{SENTINEL_ESCAPE}f"
-            );
-
-            let escaped = escape_sentinels(&typed);
-
-            for reserved in [
-                XREF_PLACEHOLDER_START,
-                XREF_PLACEHOLDER_END,
-                PASSTHROUGH_PLACEHOLDER_START,
-                PASSTHROUGH_PLACEHOLDER_END,
-            ] {
-                assert!(
-                    !escaped.contains(reserved),
-                    "escaped text still contains {reserved:?}: {escaped:?}"
-                );
-            }
-
-            // The escape introducer is the one reserved codepoint that remains,
-            // and every occurrence of it is one the escaping wrote.
-            assert_eq!(escaped.matches(SENTINEL_ESCAPE).count(), 5, "{escaped:?}");
-
-            assert_eq!(
-                escaped,
-                format!(
-                    "a{SENTINEL_ESCAPE}a0{SENTINEL_ESCAPE}bb\
-                     {SENTINEL_ESCAPE}e1{SENTINEL_ESCAPE}f\
-                     e{SENTINEL_ESCAPE}gf"
-                )
-            );
-        }
-    }
     mod sanitize_title {
         use super::super::sanitize_title;
 

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,7 +6,7 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, XrefTemplatePiece, escape_sentinels,
+    DeferredParts, FootnoteDeferred, OwnedTitle, XrefSegment, XrefTemplatePiece,
     fold_resolved_title, render_xref_segment, render_xref_template, resolved_destinations,
     sanitize_title, xref_segment_from_node,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Regex, RegexBuilder, Replacer};
 use crate::{
     Parser, Span,
     attributes::Attrlist,
-    content::{Content, escape_sentinels},
+    content::Content,
     document::InterpretedValue,
     parser::{
         CharacterReplacementType, InlineRenderer, QuoteScope, QuoteType, SpecialCharacter,
@@ -428,12 +428,6 @@ struct AttributeReplacer<'p> {
     /// whole line in `drop-line` mode, or a line the dropped reference left
     /// empty in `drop` mode (Asciidoctor's `reject_if_empty`).
     missing_on_line: bool,
-
-    /// Whether a substituted attribute value should have its reserved sentinel
-    /// codepoints escaped on the way in. Set only when replacing references in
-    /// content being substituted, which is held in escaped form (see
-    /// [`escape_sentinels`]).
-    escape_sentinels: bool,
 }
 
 impl<'p> AttributeReplacer<'p> {
@@ -446,7 +440,6 @@ impl<'p> AttributeReplacer<'p> {
             fallback_source,
             haystack_is_source: false,
             missing_on_line: false,
-            escape_sentinels: false,
         }
     }
 
@@ -455,13 +448,6 @@ impl<'p> AttributeReplacer<'p> {
     /// whole span: the match offsets the regex reports are source offsets.
     fn over_its_own_source(mut self) -> Self {
         self.haystack_is_source = true;
-        self
-    }
-
-    /// Escapes the reserved sentinel codepoints of every attribute value this
-    /// replacer splices in, for the content path (see the field docs).
-    fn escaping_sentinels(mut self) -> Self {
-        self.escape_sentinels = true;
         self
     }
 
@@ -595,17 +581,7 @@ impl Replacer for AttributeReplacer<'_> {
         // A value-less `Set` attribute (e.g. `:foo:` with no `=value`)
         // substitutes to an empty string, matching Asciidoctor.
         if let InterpretedValue::Value(value) = value {
-            // An attribute's value is stored as the document wrote it, so a
-            // reserved sentinel codepoint in it enters the text being
-            // substituted unescaped unless it is escaped here (see
-            // `escape_sentinels`). Only the content path asks for this: a value
-            // spliced into a macro target or an attribute list is not part of
-            // the escaped text and is restored by no one.
-            if self.escape_sentinels {
-                dest.push_str(&escape_sentinels(value.as_ref()));
-            } else {
-                dest.push_str(value.as_ref());
-            }
+            dest.push_str(value.as_ref());
         }
     }
 }
@@ -650,7 +626,7 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
             continue;
         }
 
-        let mut replacer = AttributeReplacer::new(parser, mode, source).escaping_sentinels();
+        let mut replacer = AttributeReplacer::new(parser, mode, source);
 
         let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
 


### PR DESCRIPTION
## Summary

The mechanical follow-up both #1336 (the carried-title sentinel retirement) and #1340 (the footnote sentinel retirement) explicitly deferred: by now every sentinel producer in the crate is gone, so `RESERVED_SENTINELS` (`content.rs`) held five entries, all reserved-but-unproduced, and `escape_sentinels` — its only reader — protected nothing that anything downstream still scans for.

- Confirmed (grepped and read each site, not assumed) that no production pass anywhere in the crate decodes the escaped form back. The three prior "escaped form" readers (the template decoder, the footnote catalog's own escaped registration, `document_text`) were already retired by earlier increments; what was left was a byte-for-byte-preserved vestige.
- Deletes `escape_sentinels`, `RESERVED_SENTINELS`, `is_reserved_sentinel`, `SENTINEL_ESCAPE`, and the four codepoint consts that fed the table (`XREF_PLACEHOLDER_START`/`_END`, `PASSTHROUGH_PLACEHOLDER_START`/`_END`) from `content.rs`, along with the `escape_sentinels` test module (three tests pinning a mechanism that no longer exists).
- Deletes `AttributeReplacer`'s `escape_sentinels` field and `.escaping_sentinels()` builder method (`substitution_step.rs`). The four call sites that used it — an attrlist value (`Attrlist::parse`), an author line (`document::author`), a reftext (`substitute_attributes_in_reftext`), and a list-item marker (`blocks::list_item_marker`) — all funnel through the same `apply_attributes` function (reached via `SubstitutionStep::AttributeReferences.apply`, the one arm of that match with a surviving string implementation — every other step is `unreachable!` since step 6) and now splice a substituted attribute value unescaped. This is behavior-preserving, not a behavior change: nothing ever read the escaped form back.
- The `sentinels.rs` regression suite (issue #1235) needed no changes — those tests assert on rendered output, which this increment does not touch (a typed sentinel was always content and remains so; the escaping/decoding this removes was internal machinery, invisible either way).
- Design doc updated: the several forward references calling this "a separate, purely mechanical increment" get a landed-as note, and Phase 2's "sentinels deleted" exit-gate row closes to ✅ (the gate's own audit had left it ⚠️ pending exactly this deletion).

**Scope note**: internal to the parser crate only — no change to any public API or rendered output.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean, and diff-neutral against a pristine `origin/inline-ast` checkout (verified hunk by hunk; only the four files this PR touches differ)
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo test --workspace` — 5,476 passed, 0 failed (down 1 from before this PR's base commit: three tests deleted with the retired mechanism, offset by unrelated suite drift on the base branch)
- [x] `cargo +nightly doc --no-deps --document-private-items` — clean
- [x] `cargo llvm-cov` diff-neutral on both changed files against a baseline worktree of `origin/inline-ast`: `content.rs` holds at 5 missed regions / 0 missed lines in both; `substitution_step.rs` holds at 4 missed regions in both, and its 1 missed line in the baseline disappears (the ambiguous branch it belonged to is deleted code, not new dead code) — spot-checked line-for-line via the annotated-source (`--text`) rendering to confirm every remaining gap is a pre-existing one, unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAKJrGfWAaogthBjnvZU1G)_