### PR TITLE
fix: Escape the passthrough sentinel in a spliced attribute value

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -11758,6 +11758,55 @@ Phase 2's "sentinels deleted" gate now closes on the letter of its own wording, 
 producers: no production code emits an in-band control sentinel, and the table that used to
 reserve codepoints for one no longer exists either.
 
+##### The retirement's own audit missed one splice point (found 2026-08-30)
+
+"No production code emits an in-band control sentinel any more" turned out to overstate what
+the retirement actually surveyed: `tokened_bracket` (`inline_builder/macros/image.rs`) still
+writes the passthrough pair's own `\u{96}`*n*`\u{97}` shape, transiently, to give
+`Attrlist::parse` the same haystack shape the string pipeline held there for an `image:`/`icon:`
+bracket or a link family's display-text list — and `Attrlist::into_owned_restoring`
+(`restore_into`, `attributes/element_attribute.rs`) still restores each token **by byte
+pattern** once that parse returns. Neither is `RESERVED_SENTINELS`-tracked (both predate this
+increment and neither was in scope for it), so the retirement's own claim was true of what it
+audited and false of the crate as a whole: this pair's scan-and-restore is the one form the
+tree builder still shares with the string pipeline's own vulnerability, and it needed the same
+counterpart the string pipeline had.
+
+It did not have one. `apply_attribute_references`'s own splice
+(`inline_builder/attribute_refs.rs`, `split_attribute_value`) runs *before* macro recognition,
+content-level, exactly where `AttributeReplacer::escaping_sentinels` used to guard the string
+pipeline's equivalent splice — but nothing on the tree-builder side ever called an equivalent
+of `escape_sentinels` for it, because by the time this increment retired that function, every
+*other* consumer it had guarded (the deferred cross-reference and footnote-marker templates)
+had already moved to structured piece lists nothing scans. A document defining an attribute
+whose value spells the passthrough pair (`:forge: \u{96}0\u{97}`) and referencing it inside an
+`image:`/`icon:` bracket or a `link:` display-text list that also holds a genuine masked
+passthrough or STEM expression (`image:x.png[++real++,alt={forge}]`) could therefore forge the
+restore: the reference's value is spliced in before the bracket is even recognized, so by the
+time it is tokened the forged bytes are indistinguishable from the pipeline's own token at that
+index, and the attribute ends up holding the passthrough's *rendered body* instead of the
+literal text the document defined. Confirmed present on this branch before this increment
+landed (the retirement here only deleted a string-pipeline mechanism nothing downstream read,
+which is orthogonal), so this is a pre-existing gap the retirement's audit did not introduce and
+did not close either.
+
+*Fixed as* `escape_passthrough_sentinels` (`inline_builder/attribute_refs.rs`): the
+`split_attribute_value` splice's own counterpart to the retired `escape_sentinels`, covering
+just this one pair (the other three retired codepoints have no scanning consumer left to
+forge). One-way and unconditional, for the same reasons its predecessor was — this splice
+cannot know whether its value will end up beside a masked construct in some later bracket, and
+nothing downstream ever needs to reverse it. Pinned end-to-end by
+`a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore` and
+`a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restore`
+(`tests/sentinels.rs`), and at the unit level by
+`a_reference_expanding_to_a_passthrough_sentinel_is_escaped`
+(`inline_builder/attribute_refs.rs`), which also covers the escape's own introducer codepoint
+folding back on itself. `cargo test --workspace` is green (5,479 tests, three more than
+before), and `attribute_refs.rs`'s coverage is diff-neutral against a baseline worktree of the
+commit this fix branched from once its own new "author literally typed the escape introducer"
+branch is exercised — every other newly-uncovered line in the file is a pre-existing
+`other => panic!` test-assertion fallback, not a gap this change opened.
+
 ##### Phase 3's first criterion cannot close before Landing
 
 "Node vocabulary reviewed against the `asciidoctor` port's needs (§6.6)" and Landing's

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1,6 +1,6 @@
 //! The attribute-references substitution step.
 
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use super::{
     passthrough_step::is_special,
@@ -1132,12 +1132,20 @@ fn rebuild_attribute_level<'src>(
 /// fallback span (design §4.4: a synthesized value has no source of its own).
 /// A run is never emitted empty, and an empty `value` (a value-less
 /// `InterpretedValue::Set` attribute) emits no node at all.
+///
+/// Before either branch runs, `value` has its passthrough-sentinel bytes
+/// escaped by [`escape_passthrough_sentinels`] — see that function's doc
+/// comment for why a value reaching this splice point needs that
+/// unconditionally, regardless of which branch it then takes.
 fn split_attribute_value<'src>(
     value: &str,
     location: Span<'src>,
     specials: SplicedSpecials,
     out: &mut Vec<InlineNode<'src>>,
 ) {
+    let value = escape_passthrough_sentinels(value);
+    let value = value.as_ref();
+
     if specials == SplicedSpecials::EscapedLater {
         if !value.is_empty() {
             out.push(InlineNode::Text {
@@ -1179,6 +1187,68 @@ fn split_attribute_value<'src>(
             location,
         });
     }
+}
+
+/// Escapes a document's own copies of the passthrough-sentinel pair
+/// (`\u{96}`/`\u{97}`) out of a resolved attribute (or `counter`/`counter2`)
+/// value before [`split_attribute_value`] splices it into the node stream.
+///
+/// Those two C1 codepoints are the private-use-shaped token
+/// [`tokened_bracket`](super::macros::image::tokened_bracket) writes for a
+/// masked passthrough or STEM expression inside an `image:`/`icon:` bracket
+/// or a link family's display-text list, and
+/// [`Attrlist::into_owned_restoring`](crate::attributes::Attrlist::into_owned_restoring)
+/// (via [`restore_into`](crate::attributes::element_attribute)) restores
+/// **by byte pattern** once that bracket has been parsed: it cannot tell the
+/// pipeline's own token from a document-typed copy of the same two bytes at
+/// the same index. A macro bracket that mixes a genuine masked construct with
+/// an attribute reference whose resolved value happens to spell
+/// `\u{96}`*n*`\u{97}` — `image:x.png[++real++,alt={forge}]` with `:forge:
+/// \u{96}0\u{97}` defined — is exactly that mix: the reference is spliced
+/// here, by this step, *before* the image macro is even recognized, so by
+/// the time the bracket is tokened its forged bytes are indistinguishable
+/// from the passthrough's own restore token, and `alt` ends up holding the
+/// passthrough's rendered body instead of the literal text the document
+/// defined.
+///
+/// This is the same forgery the string pipeline's own attribute-reference
+/// splice guarded against with `escape_sentinels` (since retired) — see
+/// `AttributeReplacer::escaping_sentinels` — for this pair among the five it
+/// covered; the other three guarded a deferred cross-reference's and a
+/// footnote marker's own in-band templates, which the tree builder replaced
+/// with structured piece lists nothing scans, so only this pair still needs
+/// a counterpart here. The escape is unconditional, for the same reason the
+/// string pipeline's was: this step splices at the content level, ahead of
+/// macro recognition, so it cannot know whether its value will end up beside
+/// a masked construct in some later bracket. It is also one-way, like its
+/// predecessor — nothing downstream unescapes it — so a document attribute
+/// whose value happens to hold one of these two rare C1 control codepoints
+/// (or the escape introducer itself) sees it come back escaped rather than
+/// silently enabling a forged restore.
+///
+/// Text with none of the three reserved codepoints — the overwhelming
+/// majority — is borrowed through unchanged.
+fn escape_passthrough_sentinels(value: &str) -> Cow<'_, str> {
+    const START: char = '\u{96}';
+    const END: char = '\u{97}';
+    const ESCAPE: char = '\u{E005}';
+
+    if !value.contains([START, END, ESCAPE]) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut out = String::with_capacity(value.len());
+
+    for c in value.chars() {
+        match c {
+            START => out.push_str("\u{E005}s"),
+            END => out.push_str("\u{E005}e"),
+            ESCAPE => out.push_str("\u{E005}g"),
+            other => out.push(other),
+        }
+    }
+
+    Cow::Owned(out)
 }
 
 #[cfg(test)]
@@ -1350,6 +1420,31 @@ mod tests {
         }
 
         assert_text(&nodes[2], "!", 1, 15);
+    }
+
+    #[test]
+    fn a_reference_expanding_to_a_passthrough_sentinel_is_escaped() {
+        // A value carrying the passthrough-sentinel pair, or a literal copy
+        // of the escape introducer this step's own escaping uses, is escaped
+        // out rather than spliced in verbatim — see
+        // `escape_passthrough_sentinels`. This test exercises the function
+        // directly (through the one seam that calls it) for all three
+        // codepoints its match arms cover, independent of any macro bracket:
+        // the regression this guards against is pinned end-to-end, over an
+        // actual `image:`/`link:` bracket, by the `sentinels` test module's
+        // own `a_placeholder_from_an_attribute_value_cannot_forge_*` tests.
+        let parser = parser_with_attribute("v", "a\u{96}b\u{97}c\u{e005}d");
+        let nodes = build(Span::new("{v}"), &parser, None);
+
+        assert_eq!(nodes.len(), 1);
+
+        match &nodes[0] {
+            InlineNode::Text { value, .. } => {
+                assert_eq!(value.as_ref(), "a\u{e005}sb\u{e005}ec\u{e005}gd");
+            }
+
+            other => panic!("expected Text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -117,6 +117,61 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_a_cross_reference() {
 }
 
 #[test]
+fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
+    // `image:`/`icon:` and the link families' display-text list are the one
+    // place left where a masked passthrough or STEM expression is restored
+    // by scanning parsed text for its own `\u{96}`*n*`\u{97}` token
+    // (`tokened_bracket`/`Attrlist::into_owned_restoring`), rather than by
+    // node structure. An attribute reference is substituted into the bracket
+    // *before* the image macro is even recognized, so an attribute whose
+    // value happens to spell that same byte pattern — sitting in the same
+    // bracket as a real passthrough — would otherwise be indistinguishable
+    // from the pipeline's own token and splice the passthrough's rendered
+    // body into `alt` instead of the literal text the document defined.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}0\u{97}\n",
+        "\n",
+        "image:x.png[++real++,alt={forge}]\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("alt=\"real\""),
+        "the forged attribute value must not restore the passthrough's body: {rendered:?}"
+    );
+    assert_eq!(
+        rendered,
+        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{e005}s0\u{e005}e\"></span>"
+    );
+}
+
+#[test]
+fn a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restore() {
+    // The `link:` macro's display-text list shares `tokened_bracket` and
+    // `Attrlist::into_owned_restoring` with the image family's bracket (see
+    // `a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore`),
+    // so the same forgery reaches it through a `role=` attribute sitting
+    // beside a real passthrough in the same display-text list.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}0\u{97}\n",
+        "\n",
+        "link:x[++real++,role={forge}]\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("class=\"real\""),
+        "the forged attribute value must not restore the passthrough's body: {rendered:?}"
+    );
+    assert_eq!(
+        rendered,
+        "<a href=\"x\" class=\"\u{e005}s0\u{e005}e\">real</a>"
+    );
+}
+
+#[test]
 fn a_typed_passthrough_placeholder_cannot_forge_a_passthrough() {
     // The passthrough placeholders are the same kind of in-band mark, and are
     // escaped alongside the cross-reference ones: this document's `<b>` is


### PR DESCRIPTION
## Summary

While reviewing #1341 (retiring the dead `escape_sentinels`/`RESERVED_SENTINELS` table),
Greptile flagged a possible forgery risk. Investigation confirmed a real bug that **predates
#1341 and is unaffected by it** — this PR is the actual fix, tracked separately.

An `image:`/`icon:` bracket and a `link:` family's display-text list are the one place left
where a masked passthrough or STEM expression is restored by **scanning parsed text** for its
own `\u{96}`*n*`\u{97}` token (`tokened_bracket` / `Attrlist::into_owned_restoring`), rather than
by node structure. `attribute_refs.rs`'s attribute-reference substitution splices a resolved
attribute's value into that same bracket **before the macro is even recognized** — so an
attribute value that happens to spell that exact byte pattern, sitting beside a genuine masked
construct in the same bracket, was indistinguishable from the pipeline's own restore token and
could redirect the restore onto the wrong body.

Reproduction (present on `origin/inline-ast` before this PR):

```asciidoc
:forge: \u{96}0\u{97}

image:x.png[++real++,alt={forge}]
```

`alt` ended up as `"real"` (the passthrough's own rendered body) instead of the literal bytes
`:forge:` defines.

This is exactly the forgery the string pipeline's own `escape_sentinels` used to guard against
for its own attribute-reference splice (`AttributeReplacer::escaping_sentinels`) — #1341's
retirement audit didn't miss anything about the mechanism it deleted (nothing downstream reads
the escaped form it removed), it just didn't survey this separate, still-scanning splice point
on the tree-builder side.

## Fix

`escape_passthrough_sentinels` (new, in `attribute_refs.rs`) escapes the `\u{96}`/`\u{97}` pair
— and its own escape introducer, for self-consistency — out of a resolved attribute or
`counter`/`counter2` value before `split_attribute_value` splices it into the node stream. This
mirrors `escape_sentinels`'s old protection, scoped to the one pair that still has a
scan-based restore consumer; the other three retired codepoints no longer have one anywhere in
the tree builder. The escape is one-way (nothing downstream unescapes it) and unconditional
(the splice point can't know whether its value will end up in such a bracket later).

## Tests

- `tests/sentinels.rs`: two new end-to-end regressions,
  `a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore` and
  `a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restore`, following
  the existing suite's style (issue #1235).
- `content/inline_builder/attribute_refs.rs`: a unit test,
  `a_reference_expanding_to_a_passthrough_sentinel_is_escaped`, covering all three escaped
  codepoints directly.

## Design doc

Added a dated note to `docs/design/inline-ast-architecture.md` under the `escape_sentinels`
retirement narrative, recording the gap the retirement's audit didn't cover and how this PR
closes it.

## Preflight (per `CLAUDE.md`)

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo test --workspace` — green (5,479 tests, +3 from before)
- [x] `cargo +nightly doc --no-deps --document-private-items` — clean
- [x] Coverage on `attribute_refs.rs` is diff-neutral against a baseline worktree of the commit
      this branch forked from — every newly-uncovered line is a pre-existing
      `other => panic!` test-assertion fallback, not a gap this change opened


---
_Generated by [Claude Code](https://claude.ai/code/session_01B148zL5RTAzJg8Cw3FJFwx)_