### PR TITLE
fix: Gate every family's match-string build on its own cheap sniff

### DIFF
--- a/parser/snapshots/post_replacements_hardbreaks_block.txt
+++ b/parser/snapshots/post_replacements_hardbreaks_block.txt
@@ -1,3 +1,4 @@
+"*bold* one line"	"<strong>bold</strong> one line"
 "*line one\nline two*\nline three"	"<strong>line one<br>\nline two</strong><br>\nline three"
 "just one line"	"just one line"
 "line one\nline two\nline three"	"line one<br>\nline two<br>\nline three"

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, collections::HashMap};
 
 use super::{
     passthrough_step::is_special,
-    quotes::{Piece, build_match_string, emit_range, source_slice},
+    quotes::{Piece, build_match_string, emit_range, single_text_value, source_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -265,26 +265,36 @@ fn apply_attribute_references_recursive<'src>(
     specials: SplicedSpecials,
     diagnostics: &mut Vec<(Span<'src>, String)>,
 ) -> Vec<InlineNode<'src>> {
-    let nodes: Vec<InlineNode<'src>> = nodes
-        .into_iter()
-        .map(|node| match node {
-            InlineNode::Styled(mut styled) => {
-                styled.children = apply_attribute_references_recursive(
-                    styled.children,
-                    root,
-                    parser,
-                    counters,
-                    missing.nested(),
-                    &[],
-                    specials,
-                    diagnostics,
-                );
-                InlineNode::Styled(styled)
-            }
+    // A level with no `Styled` child — the common leaf-only case — has
+    // nothing to descend into, so it skips the rebuild of its node vector
+    // entirely.
+    let nodes: Vec<InlineNode<'src>> = if nodes
+        .iter()
+        .any(|node| matches!(node, InlineNode::Styled(_)))
+    {
+        nodes
+            .into_iter()
+            .map(|node| match node {
+                InlineNode::Styled(mut styled) => {
+                    styled.children = apply_attribute_references_recursive(
+                        styled.children,
+                        root,
+                        parser,
+                        counters,
+                        missing.nested(),
+                        &[],
+                        specials,
+                        diagnostics,
+                    );
+                    InlineNode::Styled(styled)
+                }
 
-            other => other,
-        })
-        .collect();
+                other => other,
+            })
+            .collect()
+    } else {
+        nodes
+    };
 
     attribute_references_level(
         nodes,
@@ -422,6 +432,14 @@ fn resolve_counters<'nodes, 'src>(
     parser: &Parser,
     out: &mut HashMap<usize, String>,
 ) {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // lone `Text` node has no `Styled` sibling to recurse into, so a `{`-free
+    // one carries neither a counter nor a nested one to resolve — there is
+    // nothing this call could add to `out`.
+    if single_text_value(nodes).is_some_and(|value| !value.contains('{')) {
+        return;
+    }
+
     let (s, pieces) = build_match_string(nodes, Masked::UNKNOWN);
 
     // A counter match's `name`/`seed` borrow from `s`, a local match string
@@ -557,6 +575,14 @@ fn attribute_references_level<'src>(
     specials: SplicedSpecials,
     diagnostics: &mut Vec<(Span<'src>, String)>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // lone `Text` node has no `Styled` sibling of its own, so `span_drops`
+    // (which only ever names one) is necessarily empty here too — nothing to
+    // splice and nothing to drop.
+    if single_text_value(&nodes).is_some_and(|value| !value.contains('{')) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A span that forces a line drop is named by node index; the line decision
@@ -661,6 +687,13 @@ fn styled_drop_indices(nodes: &[InlineNode<'_>], parser: &Parser) -> Vec<usize> 
 /// Recognition is [`find_attribute_matches`]'s own, so the two cannot disagree
 /// about what counts as a missing reference.
 fn subtree_has_missing_reference(nodes: &[InlineNode<'_>], parser: &Parser) -> bool {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // lone `Text` node has no `Styled` child to recurse into either, so a
+    // `{`-free one carries no missing reference at any depth.
+    if single_text_value(nodes).is_some_and(|value| !value.contains('{')) {
+        return false;
+    }
+
     let (s, _) = build_match_string(nodes, Masked::UNKNOWN);
 
     if s.contains('{')

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -3,7 +3,7 @@
 use regex::Regex;
 
 use super::{
-    quotes::{Piece, build_match_string, emit_range, source_slice},
+    quotes::{Piece, build_match_string, emit_range, single_text_value, source_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -108,6 +108,16 @@ pub(super) fn apply_callouts<'src>(
     parser: &Parser,
     attrlist: Option<&Attrlist<'_>>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: the
+    // common case of a single, unsplit `Text` node (nothing for the
+    // preceding `SpecialCharacters` step to have escaped) has the same bytes
+    // in its match string as in its own value, so the `&lt;` check below can
+    // run against that directly. A level already split into more than one
+    // node falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !value.contains("&lt;")) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A callout's opening bracket is always rendered as `&lt;` by

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -3,7 +3,7 @@
 use super::{
     fold_deferring_xrefs,
     macros::{emit_range_unescaping_brackets, image::range_has_no_opaque_piece},
-    quotes::{Piece, build_match_string, source_slice, text_slice},
+    quotes::{Piece, build_match_string, single_text_value, source_slice, text_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -99,6 +99,15 @@ pub(super) fn apply_footnotes<'src>(
 /// could) but allocates no [`InlineNode`], letting a subtree with nothing to
 /// find come back from `apply_footnotes` completely unchanged.
 fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // lone `Text` node has no `Styled`/`Ref`/`IndexTerm` child to recurse
+    // into either, so this level's own value is the whole answer for it —
+    // this is what keeps this recursive scan from paying for a build at
+    // *every* level of a large, footnote-free subtree.
+    if let Some(value) = single_text_value(nodes) {
+        return value.contains("tnote");
+    }
+
     let (s, _) = build_match_string(nodes, Masked::UNKNOWN);
 
     if s.contains("tnote") {

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -14,7 +14,7 @@ use crate::{
             fold_html,
             quotes::{
                 LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
-                range_overlaps_synthesized, source_slice, text_slice,
+                range_overlaps_synthesized, single_text_value, source_slice, text_slice,
             },
             special_chars::Masked,
         },
@@ -107,6 +107,14 @@ pub(super) fn biblio_anchor_level<'src>(
         return nodes;
     }
 
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !value.starts_with("[[[")) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter, mirroring the string step's own `text.contains("[[[")`
@@ -187,6 +195,15 @@ pub(super) fn biblio_anchor_level<'src>(
     out
 }
 
+/// An anchor needs either the shorthand `[[` opener or the `anchor:` macro
+/// prefix. The `[` characters are not special, so a shorthand reaches the
+/// macros step with its `[[` intact. Shared between
+/// [`anchor_macros_level`]'s pre-build sniff and its post-build one, so the
+/// two answers cannot drift apart.
+fn anchor_prefilter(s: &str) -> bool {
+    s.contains("[[") || s.contains("anchor:")
+}
+
 /// Matches `INLINE_ANCHOR` at this level's escaped text, replacing each
 /// recognized inline anchor — the `[[id]]` / `[[id,reftext]]` shorthand and the
 /// `anchor:id[reftext]` macro — with the [`Anchor`](InlineNode::Anchor) node it
@@ -197,12 +214,18 @@ pub(super) fn anchor_macros_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: see
+    // `biblio_anchor_level`'s own copy of this comment.
+    if single_text_value(&nodes).is_some_and(|value| !anchor_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
     // `anchor:` macro prefix. The `[` characters are not special, so a
     // shorthand reaches the macros step with its `[[` intact.
-    if !s.contains("[[") && !s.contains("anchor:") {
+    if !anchor_prefilter(&s) {
         return nodes;
     }
 
@@ -1816,6 +1839,32 @@ mod tests {
         let out = biblio_anchor_level(nodes, root, &biblio_parser(), Masked::UNKNOWN);
         assert_eq!(out.len(), 1);
         assert!(matches!(out[0], InlineNode::Text { .. }));
+    }
+
+    #[test]
+    fn the_bibliography_pass_declines_a_multi_node_level_it_can_never_match() {
+        // The single-`Text`-node pre-filter (`single_text_value`) is silent
+        // for a level already split into more than one node, so this level's
+        // "does it start with `[[[`?" answer still has to come from the built
+        // match string — the same declined answer as the single-node case
+        // above, reached by a different path. Driven directly with two
+        // adjoining `Text` nodes, for the same reason that test is.
+        let root = Span::new("x [[[gof]]]");
+
+        let nodes = vec![
+            InlineNode::Text {
+                value: CowStr::from("x "),
+                location: root.slice(0..2),
+            },
+            InlineNode::Text {
+                value: CowStr::from("[[[gof]]]"),
+                location: root.slice(2..11),
+            },
+        ];
+
+        let out = biblio_anchor_level(nodes, root, &biblio_parser(), Masked::UNKNOWN);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|n| matches!(n, InlineNode::Text { .. })));
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -11,7 +11,8 @@ use crate::{
         inline_builder::{
             fold::{fold_html, fold_stem, render_char},
             quotes::{
-                LevelContext, Piece, build_match_string, charref_entity, source_slice, text_slice,
+                LevelContext, Piece, build_match_string, charref_entity, single_text_value,
+                source_slice, text_slice,
             },
             special_chars::Masked,
         },
@@ -23,6 +24,14 @@ use crate::{
     warnings::WarningType,
 };
 
+/// Mirrors the string step's `found_macroish`: an image or icon macro needs
+/// its name prefix and an opening bracket. Shared between
+/// [`image_macros_level`]'s pre-build sniff and its post-build one, so the
+/// two answers cannot drift apart.
+fn image_macro_prefilter(s: &str) -> bool {
+    (s.contains("image:") || s.contains("icon:")) && s.contains('[')
+}
+
 /// Matches `INLINE_IMAGE_MACRO` at this level's escaped text, replacing each
 /// recognized match with the [`Image`](InlineNode::Image) node it produces and
 /// leaving everything else in place.
@@ -33,11 +42,19 @@ pub(super) fn image_macros_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !image_macro_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's `found_macroish`: an image
     // or icon macro needs its name prefix and an opening bracket.
-    if !((s.contains("image:") || s.contains("icon:")) && s.contains('[')) {
+    if !image_macro_prefilter(&s) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -14,7 +14,8 @@ use crate::{
         INLINE_INDEXTERM,
         inline_builder::{
             quotes::{
-                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range, source_slice,
+                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
+                single_text_value, source_slice,
             },
             special_chars::Masked,
         },
@@ -22,6 +23,15 @@ use crate::{
     inlines::{IndexTerm, InlineNode},
     strings::CowStr,
 };
+
+/// Mirrors the string step's guard: a shorthand needs a `((` … `))` pair (its
+/// parens are not special, so they reach the macros step intact), and a
+/// macro form needs a `:[` and `dexterm` (matching both `indexterm:` and
+/// `indexterm2:`). Shared between [`indexterm_macros_level`]'s pre-build
+/// sniff and its post-build one, so the two answers cannot drift apart.
+fn indexterm_prefilter(s: &str) -> bool {
+    (s.contains("((") && s.contains("))")) || (s.contains(":[") && s.contains("dexterm"))
+}
 
 /// Matches [`INLINE_INDEXTERM`] at this level's escaped text, replacing each
 /// recognized index term — the `((term))` / `(((primary, secondary,
@@ -35,13 +45,21 @@ pub(super) fn indexterm_macros_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !indexterm_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a shorthand needs a
     // `((` … `))` pair (its parens are not special, so they reach the macros
     // step intact), and a macro form needs a `:[` and `dexterm` (matching both
     // `indexterm:` and `indexterm2:`).
-    if !((s.contains("((") && s.contains("))")) || (s.contains(":[") && s.contains("dexterm"))) {
+    if !indexterm_prefilter(&s) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -17,7 +17,10 @@ use crate::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
         inline_builder::{
-            quotes::{LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, source_slice},
+            quotes::{
+                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, single_text_value,
+                source_slice,
+            },
             special_chars::Masked,
         },
     },
@@ -199,6 +202,14 @@ pub(super) fn inline_link_level<'src>(
     masked: Masked<'_>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !value.contains("://")) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: an auto-link needs a
@@ -953,6 +964,13 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// the string step, which neutralizes it, so it renders identically; the
 /// additive builder simply skips the `record_substitution_warning` side effect
 /// the string step performs there.
+/// A `link:`/`mailto:` macro needs its prefix and an opening bracket. Shared
+/// between [`link_macro_level`]'s pre-build sniff and its post-build one, so
+/// the two answers cannot drift apart.
+fn link_macro_prefilter(s: &str) -> bool {
+    (s.contains("link:") || s.contains("mailto:")) && s.contains('[')
+}
+
 pub(super) fn link_macro_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -961,11 +979,19 @@ pub(super) fn link_macro_level<'src>(
     masked: Masked<'_>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !link_macro_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a link/mailto macro
     // needs its prefix and an opening bracket.
-    if !((s.contains("link:") || s.contains("mailto:")) && s.contains('[')) {
+    if !link_macro_prefilter(&s) {
         return nodes;
     }
 
@@ -1811,6 +1837,14 @@ pub(super) fn email_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !value.contains('@')) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter mirroring the string step's own `text.contains('@')`

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -6,7 +6,10 @@ use crate::{
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
         inline_builder::{
-            quotes::{LevelContext, Piece, build_match_string, source_slice, text_slice},
+            quotes::{
+                LevelContext, Piece, build_match_string, single_text_value, source_slice,
+                text_slice,
+            },
             special_chars::Masked,
         },
         normalize_index_text, split_kbd_keys,
@@ -30,15 +33,31 @@ const SUBMENU_DELIMITER: &str = "&gt;";
 /// [`apply_macros`](super::apply_macros)); a cheap prefilter still skips the
 /// pattern sweep when no `kbd:`/`btn:` prefix with a `:[` is present, mirroring
 /// the string step's `found_macroish_short` guard.
+/// Mirrors the string step's `found_macroish_short` guard: a `kbd:`/`btn:`
+/// macro needs its name prefix and a `:[`. Shared between
+/// [`kbd_btn_macros_level`]'s pre-build sniff and its post-build one, so the
+/// two answers cannot drift apart.
+fn kbd_btn_prefilter(s: &str) -> bool {
+    s.contains(":[") && (s.contains("kbd:") || s.contains("btn:"))
+}
+
 pub(super) fn kbd_btn_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !kbd_btn_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
-    if !(s.contains(":[") && (s.contains("kbd:") || s.contains("btn:"))) {
+    if !kbd_btn_prefilter(&s) {
         return nodes;
     }
 
@@ -197,15 +216,28 @@ fn build_kbd_btn_node<'src>(
 /// a masked passthrough — the one boundary every macro family keeps. (A
 /// typographic replacement, `menu:File[Save (C) Exit]`, is admitted too, for
 /// the same reason a restored entity is: it carries its own bytes.)
+/// A `menu:` macro needs its name prefix and an opening bracket. Shared
+/// between [`menu_macros_level`]'s pre-build sniff and its post-build one, so
+/// the two answers cannot drift apart.
+fn menu_prefilter(s: &str) -> bool {
+    s.contains("menu:") && s.contains('[')
+}
+
 pub(super) fn menu_macros_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: see
+    // `kbd_btn_macros_level`'s own copy of this comment.
+    if single_text_value(&nodes).is_some_and(|value| !menu_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
-    if !(s.contains("menu:") && s.contains('[')) {
+    if !menu_prefilter(&s) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -18,7 +18,7 @@ use crate::{
     content::{
         INLINE_XREF, document_xrefstyle,
         inline_builder::{
-            quotes::{LevelContext, Piece, build_match_string, source_slice},
+            quotes::{LevelContext, Piece, build_match_string, single_text_value, source_slice},
             special_chars::Masked,
         },
         xref_target::{
@@ -86,6 +86,17 @@ fn xref_target_and_derived(
     }
 }
 
+/// Both the `xref:` macro form and the `<<id>>` shorthand (seen here as
+/// `&lt;&lt;id&gt;&gt;`, since specials run before macros) are recognized.
+/// Triggers on either the macro prefix or the shorthand's `&lt;&lt;` opener,
+/// mirroring the string step's `text.contains("&lt;&lt;") ||
+/// (found_macroish && text.contains("xref:"))` guard. Shared between
+/// [`xref_macros_level`]'s pre-build sniff and its post-build one, so the two
+/// answers cannot drift apart.
+fn xref_prefilter(s: &str) -> bool {
+    s.contains("xref:") || s.contains("&lt;&lt;")
+}
+
 /// Matches `INLINE_XREF` at this level's escaped text, replacing each
 /// recognized `xref:` macro with the [`Ref`](InlineNode::Ref)`{Xref}` node it
 /// produces and leaving everything else in place.
@@ -97,6 +108,14 @@ pub(super) fn xref_macros_level<'src>(
     masked: Masked<'_>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !xref_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, masked);
 
     // Cheap pre-filter: both the `xref:` macro form and the `<<id>>` shorthand
@@ -105,7 +124,7 @@ pub(super) fn xref_macros_level<'src>(
     // shorthand's `&lt;&lt;` opener, mirroring the string step's
     // `text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:"))`
     // guard.
-    if !s.contains("xref:") && !s.contains("&lt;&lt;") {
+    if !xref_prefilter(&s) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -6,7 +6,7 @@ use super::{
         image::{node_is_restorable, range_is_restorable, range_is_verbatim, restorable_body},
         rebuild_macro_level,
     },
-    quotes::{Piece, attributes_of, build_match_string, source_slice},
+    quotes::{Piece, attributes_of, build_match_string, single_text_value, source_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -187,6 +187,14 @@ pub(super) fn apply_passthroughs<'src>(
     apply_bare_attrlisted_pass_level(nodes, root, parser)
 }
 
+/// Mirrors `Passthroughs::extract_from`'s own guard for `INLINE_PASS_MACRO`:
+/// a recognized form always contains `++`, `$$`, or (for `pass:`) `ss:`.
+/// Shared between [`apply_pass_macro_level`]'s pre-build sniff and its
+/// post-build one, so the two answers cannot drift apart.
+fn pass_macro_prefilter(s: &str) -> bool {
+    s.contains("++") || s.contains("$$") || s.contains("ss:")
+}
+
 /// The `INLINE_PASS_MACRO` pass: `+++…+++`, `++…++`, `$$…$$`, and `pass:[…]`,
 /// with or without an attribute list ahead of the delimiters.
 fn apply_pass_macro_level<'src>(
@@ -194,11 +202,19 @@ fn apply_pass_macro_level<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly. A level already split by
+    // an earlier step falls back to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !pass_macro_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard: a
     // recognized form always contains `++`, `$$`, or (for `pass:`) `ss:`.
-    if !(s.contains("++") || s.contains("$$") || s.contains("ss:")) {
+    if !pass_macro_prefilter(&s) {
         return nodes;
     }
 
@@ -211,6 +227,13 @@ fn apply_pass_macro_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
+/// Mirrors `Passthroughs::extract_from`'s own guard for `INLINE_PASS`.
+/// Shared between [`apply_bare_attrlisted_pass_level`]'s pre-build sniff and
+/// its post-build one, so the two answers cannot drift apart.
+fn bare_attrlisted_pass_prefilter(s: &str) -> bool {
+    s.contains('+') || s.contains("-]")
+}
+
 /// The `INLINE_PASS` pass: the attribute-list-prefixed bare forms
 /// (`` [x-]`text` ``, `[attrs]+text+`). The bare unconstrained form with no
 /// attribute list (`+text+`) is deferred — see
@@ -220,11 +243,17 @@ fn apply_bare_attrlisted_pass_level<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: see
+    // `apply_pass_macro_level`'s own copy of this comment.
+    if single_text_value(&nodes).is_some_and(|value| !bare_attrlisted_pass_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard for
     // `INLINE_PASS`.
-    if !(s.contains('+') || s.contains("-]")) {
+    if !bare_attrlisted_pass_prefilter(&s) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -1,7 +1,7 @@
 //! The post-replacements substitution step (hard line breaks).
 
 use super::{
-    quotes::{Piece, build_match_string, emit_range, source_slice},
+    quotes::{Piece, build_match_string, emit_range, single_text_value, source_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -25,6 +25,16 @@ pub(super) fn apply_post_replacements<'src>(
     apply_level(nodes, root, parser, attrlist, true)
 }
 
+/// A break needs a `+`, and — off the root level, where an end-of-level
+/// match is discarded (see [`apply_level`]) — a `\n` for the pattern's `$` to
+/// anchor against. The string pipeline's own pre-check is the root form of
+/// this: it guards on a `+` alone, since its haystack is the whole rendered
+/// string. Shared between [`apply_level`]'s pre-build sniff and its
+/// post-build one, so the two answers cannot drift apart.
+fn level_prefilter(s: &str, is_root: bool) -> bool {
+    s.contains('+') && (is_root || s.contains('\n'))
+}
+
 /// One level of the post-replacement pass. `is_root` marks the content's own
 /// top level, which is the only level whose end coincides with the end of the
 /// string pipeline's haystack — see the match filter below for why that
@@ -37,28 +47,45 @@ fn apply_level<'src>(
     is_root: bool,
 ) -> Vec<InlineNode<'src>> {
     // Descend into spans/refs first, matching the string pipeline's
-    // whole-string pass. A nested level is never the root.
-    let nodes: Vec<InlineNode<'src>> = nodes
-        .into_iter()
-        .map(|node| match node {
-            InlineNode::Styled(mut styled) => {
-                styled.children = apply_level(styled.children, root, parser, attrlist, false);
-                InlineNode::Styled(styled)
-            }
+    // whole-string pass. A nested level is never the root. A level with
+    // neither — the common leaf-only case — has nothing to descend into, so
+    // it skips the rebuild of its node vector entirely.
+    let nodes: Vec<InlineNode<'src>> = if nodes
+        .iter()
+        .any(|node| matches!(node, InlineNode::Styled(_) | InlineNode::Ref(_)))
+    {
+        nodes
+            .into_iter()
+            .map(|node| match node {
+                InlineNode::Styled(mut styled) => {
+                    styled.children = apply_level(styled.children, root, parser, attrlist, false);
+                    InlineNode::Styled(styled)
+                }
 
-            InlineNode::Ref(mut reference) => {
-                reference.children = apply_level(reference.children, root, parser, attrlist, false);
-                InlineNode::Ref(reference)
-            }
+                InlineNode::Ref(mut reference) => {
+                    reference.children =
+                        apply_level(reference.children, root, parser, attrlist, false);
+                    InlineNode::Ref(reference)
+                }
 
-            other => other,
-        })
-        .collect();
+                other => other,
+            })
+            .collect()
+    } else {
+        nodes
+    };
 
     if parser.is_attribute_set("hardbreaks-option")
         || attrlist.is_some_and(|attrlist| attrlist.has_option("hardbreaks"))
     {
         return apply_hardbreaks(nodes, root);
+    }
+
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly.
+    if single_text_value(&nodes).is_some_and(|value| !level_prefilter(value, is_root)) {
+        return nodes;
     }
 
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
@@ -67,7 +94,7 @@ fn apply_level<'src>(
     // match is discarded below — a `\n` for the pattern's `$` to anchor
     // against. The string pipeline's own pre-check is the root form of this: it
     // guards on a `+` alone, since its haystack is the whole rendered string.
-    if !(s.contains('+') && (is_root || s.contains('\n'))) {
+    if !level_prefilter(&s, is_root) {
         return nodes;
     }
 
@@ -118,6 +145,12 @@ fn apply_level<'src>(
 /// there is none) never gets one, matching the string pipeline leaving the
 /// popped last line unbroken.
 fn apply_hardbreaks<'src>(nodes: Vec<InlineNode<'src>>, root: Span<'src>) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: see
+    // `apply_level`'s own copy of this comment.
+    if single_text_value(&nodes).is_some_and(|value| !value.contains('\n')) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     if !s.contains('\n') {
@@ -476,6 +509,18 @@ mod tests {
         );
 
         assert_hardbreaks_parity("line one\nline two", "", &parser);
+    }
+
+    #[test]
+    fn hardbreaks_option_on_a_multi_node_single_line_breaks_nothing() {
+        // The single-`Text`-node pre-filter (`single_text_value`) is silent
+        // once the quotes step has already split this level into more than
+        // one node (`Styled` plus the trailing text), so this level's "does
+        // it have a newline?" answer still has to come from the built match
+        // string — the same declined answer
+        // `hardbreaks_option_on_a_single_line_breaks_nothing` pins for a
+        // single node, reached by a different path here.
+        assert_hardbreaks_parity("*bold* one line", "%hardbreaks", &Parser::default());
     }
 
     #[test]

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -984,6 +984,30 @@ pub(super) fn level_may_have_replacements(nodes: &[InlineNode<'_>]) -> bool {
     false
 }
 
+/// The level's own text, when `nodes` is *exactly* one verbatim or
+/// synthesized [`Text`](InlineNode::Text) node — the shape
+/// [`build_match_string`] leaves untouched: with nothing else in the level to
+/// contribute a boundary character or a placeholder, its match string is that
+/// one node's `value`, byte for byte (see `build_match_string`'s own `Text`
+/// arms, which just `push_str` it either way).
+///
+/// This is the shape a paragraph is in until *something* has split it —
+/// `specialcharacters` finding a `<`/`>`/`&`, `quotes` wrapping a span,
+/// `attributes` splicing in an expanded value — so a family whose own cheap
+/// `.contains(...)` sniff would otherwise run against the *built* string can
+/// run it against this instead and skip the build (and its `String`/`Vec`
+/// allocations) for the overwhelmingly common level that has nothing for it
+/// to find. A level already split into more than one node falls back to
+/// `None`: multiple nodes are exactly the case a caller's needle can straddle
+/// a boundary the single-node case cannot, so nothing here tries to answer
+/// for it — see each caller's own site for how it stays safe there instead.
+pub(super) fn single_text_value<'src, 'a>(nodes: &'a [InlineNode<'src>]) -> Option<&'a str> {
+    match nodes {
+        [InlineNode::Text { value, .. }] => Some(value.as_ref()),
+        _ => None,
+    }
+}
+
 pub(super) fn build_match_string(
     nodes: &[InlineNode<'_>],
     masked: Masked<'_>,
@@ -2005,6 +2029,32 @@ mod tests {
         parser::HtmlInlineRenderer,
         strings::CowStr,
     };
+
+    #[test]
+    fn single_text_value_answers_only_for_one_lone_text_node() {
+        use super::single_text_value;
+
+        let text = |value: &'static str| InlineNode::Text {
+            value: CowStr::from(value),
+            location: Span::new(value),
+        };
+
+        let charref = || InlineNode::CharRef {
+            value: CharRef::Special('<'),
+            location: Span::new("<"),
+        };
+
+        // The one shape it answers for: exactly one `Text` node.
+        assert_eq!(single_text_value(&[text("abc")]), Some("abc"));
+
+        // Every other shape — none, more than one (even two `Text` nodes),
+        // or a single node of any other kind — answers `None`: a caller
+        // must fall back to building the match string.
+        assert_eq!(single_text_value(&[]), None);
+        assert_eq!(single_text_value(&[text("a"), text("b")]), None);
+        assert_eq!(single_text_value(&[charref()]), None);
+        assert_eq!(single_text_value(&[text("a"), charref()]), None);
+    }
 
     #[test]
     fn every_quote_sub_has_specific_markers() {

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -5,7 +5,7 @@ use regex::Captures;
 use super::{
     macros::{MacroMatch, MacroMatchKind, rebuild_macro_level},
     passthrough_step::passthrough_text,
-    quotes::{Piece, build_match_string, emit_range, source_slice},
+    quotes::{Piece, build_match_string, emit_range, single_text_value, source_slice},
     special_chars::Masked,
 };
 use crate::{
@@ -136,15 +136,33 @@ fn subs_are_local(subs: &SubstitutionGroup) -> bool {
 /// is wired into the parse path.
 ///
 /// [`InlineStemMacroReplacer`]: crate::content::passthroughs
+/// Mirrors `Passthroughs::extract_from`'s own guard: whether `s` could
+/// possibly open a `stem:`/`asciimath:`/`latexmath:` macro. Shared between
+/// [`apply_stem`]'s pre-build sniff (run against a single node's own value)
+/// and its post-build one (run against the level's full match string), so
+/// the two answers cannot drift apart.
+fn stem_prefilter(s: &str) -> bool {
+    s.contains(':') && (s.contains("stem:") || s.contains("math:"))
+}
+
 pub(super) fn apply_stem<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // Cheap pre-filter, taken *before* the match string is materialized: a
+    // single, unsplit `Text` node's match string is its own value, so the
+    // check below can run against that directly rather than paying for the
+    // build first. A level already split by an earlier extraction falls back
+    // to the build, exactly as before.
+    if single_text_value(&nodes).is_some_and(|value| !stem_prefilter(value)) {
+        return nodes;
+    }
+
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // Cheap pre-filter mirroring `Passthroughs::extract_from`'s own guard.
-    if !(s.contains(':') && (s.contains("stem:") || s.contains("math:"))) {
+    if !stem_prefilter(&s) {
         return nodes;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1345, which fixed the quotes step's share of the throughput regressions tracked in #1059. This closes out the larger remaining contributor, flagged in that PR's description.

Profiling traced most of the regression to a recurring shape across `content/inline_builder`: nearly every substitution-step "family" function calls `build_match_string` (a `String` + `Vec<Piece>` allocation over the whole level) **unconditionally**, and only afterward runs its own cheap `.contains(...)` sniff to check whether it could possibly match:

```rust
let (s, pieces) = build_match_string(&nodes, masked);   // always allocates
if !((s.contains("image:") || s.contains("icon:")) && s.contains('[')) {
    return nodes;                                        // ...then bails
}
```

That means a plain paragraph with no image, link, xref, anchor, index term, footnote, passthrough, STEM expression, callout, or attribute reference still pays for a dozen-plus separate full-tree allocations per level, on every parse, for constructs that aren't there at all — which is why even macro-free/quote-free benches (`element attributes`, `inline macro`) regressed 28-58% on `origin/inline-ast` with nothing in them for any of these families to recognize.

## The fix

A new shared helper, `single_text_value` (in `quotes.rs`, alongside `build_match_string` itself): when a level is exactly one un-fragmented `Text` node — the shape a paragraph is in until *something* has actually split it (an earlier step finding a `<`/`>`/`&`, wrapping a quoted span, splicing an attribute reference, extracting a passthrough) — `build_match_string`'s output is byte-for-byte that node's own `value`. So a family's existing sniff can run directly against `value` and skip the build entirely for the overwhelmingly common "nothing here" case:

```rust
if single_text_value(&nodes).is_some_and(|value| !image_macro_prefilter(value)) {
    return nodes;
}
let (s, pieces) = build_match_string(&nodes, masked);
if !image_macro_prefilter(&s) {
    return nodes;
}
```

A level already split into more than one node — rarer, and where the cost is already amortized against real content — falls back to the original build-then-check order, unchanged. This is why the fix is safe even for multi-character needles like `"image:"` that a single ASCII byte can't straddle but two adjacent nodes conceivably could: the fast path only ever answers for the single-node case, where there's nothing to straddle.

Applied across **20 call sites in 9 files**: `attribute_refs.rs` (3), `callouts.rs`, `stem_step.rs`, `passthrough_step.rs` (2), `footnotes.rs` (1 of 2 — see below), `post_replacements.rs` (2), and all six macro families in `macros/` — `image`, `indexterm`, `xref`, `links` (3), `anchors` (2), `ui` (2).

Two files' checks are now duplicated (once against a single node, once against the built string), so each gets a small shared `..._prefilter(s: &str) -> bool` function instead of inlining the condition twice — this also guarantees the pre- and post-build answers can't drift apart.

**Left alone**: `footnotes.rs`'s `apply_footnotes` itself. By the time it runs, its caller (`subtree_might_have_footnote`, which *does* get the fast path) has already established the subtree has a `"tnote"` match somewhere, so a single-`Text`-node level reaching it is guaranteed to need the build — there's no bail to shortcut.

**Bonus, same pattern**: `post_replacements.rs`'s and `attribute_refs.rs`'s recursive descent into `Styled` children ran an unconditional `.into_iter().map().collect()` on every level regardless of whether one was present. Gated it the same way `quotes.rs`'s own recursion already was (`nodes.iter().any(is_styled)` before the rebuild) — same risk profile as the sniff-ordering fix, so it seemed worth including rather than opening a third PR for it.

## Coverage

Two call sites' pre-existing post-build check had its `return nodes` arm go newly-uncovered: `macros/anchors.rs`'s `biblio_anchor_level` and `post_replacements.rs`'s `apply_hardbreaks`. In both cases the new pre-build check now intercepts the single-node input an existing test used to drive through to that line, leaving the *old* check reachable only by a genuinely multi-node level — which nothing exercised. Added one direct test for each (`the_bibliography_pass_declines_a_multi_node_level_it_can_never_match`, `hardbreaks_option_on_a_multi_node_single_line_breaks_nothing`) driving exactly that shape; the latter needed one new recorded golden line in `snapshots/post_replacements_hardbreaks_block.txt` (`"*bold* one line"` → `"<strong>bold</strong> one line"`, verified by inspecting the actual fold before recording it).

`cargo llvm-cov` diff vs. `origin/inline-ast`: every touched file, and the crate total, now carry the **exact same** missed-region/missed-function/missed-line counts as baseline (544/39/320 total, both sides).

## Measured impact

Local `cargo bench -p asciidoc-parser --bench inline_throughput`, median wall time, `origin/inline-ast` vs. this branch (both run back-to-back in the same session — absolute numbers vary with machine load run to run, but the relative deltas within one session should be representative):

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `plain_prose` | 351.2 µs | 265.5 µs | **-24.4%** |
| `formatted_prose` | 2.854 ms | 2.400 ms | **-15.9%** |
| `macro_prose` | 1.771 ms | 1.750 ms | -1.2% |
| `replacement_prose` | 928.4 µs | 871.3 µs | -6.1% |
| `mixed_document` | 3.288 ms | 3.246 ms | -1.3% |

The smaller deltas on `macro_prose`/`mixed_document` are expected, not a shortfall: both fixtures are deliberately dense in the constructs these families recognize, so most of their levels genuinely need the build regardless of this fix — the win is concentrated exactly where the regression was worst, in content with little or nothing for these families to find.

## Test plan

- [x] `cargo test --workspace` — 5485 passed, 0 failed
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo +nightly doc --no-deps --document-private-items` — clean
- [x] `cargo llvm-cov` diff vs. `origin/inline-ast`: identical missed-region/line counts crate-wide
- [x] `cargo bench --bench inline_throughput` before/after comparison (above)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwZD11jq1xdb7kDTPyttGM)_