### PR TITLE
fix: Use ahash for the document-attribute tables

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.88.0"
 version = "0.30.0"
 
 [dependencies]
+ahash = "0.8.12"
 bytecount = "0.6.7"
 memchr = "2.6.4"
 percent-encoding = "2.3.2"

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -1,7 +1,9 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, LazyLock},
-};
+use std::sync::{Arc, LazyLock};
+
+// See the matching comment in `parser.rs` for why this table (looked up on
+// every `attribute_value`/`is_attribute_set`/`has_attribute` miss against a
+// parser's own overrides) uses `ahash` rather than `std`'s `HashMap`.
+use ahash::{HashMap, HashMapExt};
 
 use crate::{
     ASCIIDOCTOR_VERSION,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1,11 +1,20 @@
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
-    collections::{HashMap, HashSet},
     rc::Rc,
     sync::{Arc, LazyLock},
 };
 
+// `ahash`'s `HashMap`/`HashSet`, not `std`'s: a drop-in replacement (same API,
+// same per-process-random keying and so the same resistance to a
+// crafted-input hash-flooding attack — `ahash::RandomState`'s default seeds
+// itself from `getrandom`, exactly as `std`'s `RandomState` does) that is
+// substantially faster to hash into for the short string keys an attribute
+// name always is. `attribute_value`/`is_attribute_set`/`has_attribute` are
+// among the hottest calls in the crate — every substitution step queries a
+// document attribute at least once per level — so the table these three read
+// is worth the one non-`std` dependency.
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use regex::Regex;
 
 use crate::{

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
+
+// See the matching comment in `parser.rs` for why these tables use `ahash`
+// rather than `std`'s `HashMap` — they are the same tables, shared with the
+// parser by `Arc` (see the fields below).
+use ahash::HashMap;
 
 use crate::{
     SafeMode,
@@ -523,7 +528,9 @@ impl ResolvedAttributes {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
+
+    use ahash::{HashMap, HashMapExt};
 
     use crate::{
         SafeMode,
@@ -802,7 +809,9 @@ mod tests {
     }
 
     mod resolve_show_title {
-        use std::{collections::HashMap, sync::Arc};
+        use std::sync::Arc;
+
+        use ahash::{HashMap, HashMapExt};
 
         use crate::{
             SafeMode,


### PR DESCRIPTION
## Summary

Follow-up performance work after #1345/#1346, targeting a different hot spot than either. Profiling the merged `inline-ast` branch (`valgrind --tool=callgrind`) showed `core::hash::sip::Hasher::write` and `BuildHasher::hash_one` together costing ~5-6% of instructions on ordinary prose — none of it in `inline_builder`, and not something either prior PR touched.

It traces to `Parser::attribute_value`/`is_attribute_set`/`has_attribute` — among the hottest calls in the crate, since every substitution step queries at least one document attribute (`experimental`, `hardbreaks-option`, ...) per level, and block-level parsing (admonitions, styles, ...) queries many more. Every one of those calls hashes a short string key into a `std::collections::HashMap`, which defaults to SipHash13 — a cryptographically-strong but comparatively slow hash, particularly for short keys like attribute names.

## The fix

Switch the six attribute/counter tables on `Parser` (`attribute_values`, `baseline_attribute_values`, `default_attribute_values`, `counter_values`, `locked_counter_values`, `locked_attribute_names`) and their two dependents — `built_in_attrs.rs`'s `BUILT_IN_ATTRS`/`BUILT_IN_DEFAULT_VALUES` statics, and `ResolvedAttributes`' own copies in `resolved_attributes.rs` (which must share `Parser`'s exact `HashMap` type, since they're `Arc`-shared from it) — to [`ahash`](https://docs.rs/ahash)'s `HashMap`/`HashSet`.

**This is not a plain swap to a faster-but-weaker hash.** An AsciiDoc document can define arbitrary attribute names via `:name: value`, so a parser processing untrusted documents needs a hasher that resists an attacker choosing keys to collide — the same reason `std`'s own `HashMap` defaults to a randomized `SipHash` rather than a faster fixed one, instead of (say) an FxHash-style hash with no keying at all. `ahash`'s default `RandomState` seeds itself from the OS's real randomness source (`getrandom`) once per process, exactly as `std`'s does — so this keeps that same resistance to a crafted-document hash-flooding attack while being substantially faster to hash into for the short strings attribute names always are.

## Why this is safe

- **`HashMap` iteration order.** Confirmed this isn't new exposure: `std`'s own default hasher is *already* randomly-seeded per process, so no existing behavior could have depended on a fixed iteration order — swapping to a different (still randomized) hasher can't newly break something that already had to tolerate that. `ResolvedAttributes`' own `Hash`/`Eq` impls already fold each table order-independently (see its own pre-existing doc comment at `resolved_attributes.rs:103-120`, unrelated to and predating this change), which is direct evidence the codebase was already written with this nondeterminism in mind.
- **Test suite.** `cargo test --workspace` — 5485 passed, 0 failed — run **4 times** (each a fresh process, so a fresh random seed each time) with identical results.
- **Dependency/license audit.** `cargo deny check`: clean (`ahash` and its own dependency `getrandom` are both MIT/Apache-2.0 like the rest of the crate's dependencies; the only other new transitive dependencies — `r-efi`, `wasip2`, `wit-bindgen`, `version_check` — are target-specific to non-Linux/wasm targets already in `deny.toml`'s target list, and don't create a `multiple-versions` violation: the one place `getrandom` already appeared at a different version is a dev-only dependency, excluded from the graph `cargo-deny` checks).
- **Coverage.** `cargo llvm-cov` diff vs. `origin/inline-ast`: identical missed-region/function/line counts for every touched file — no coverage change.

## Measured impact

Local `cargo bench`, median wall time, `origin/inline-ast` vs. this branch (run back-to-back in one session — absolute numbers vary with machine load run to run, relative deltas should be representative):

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `inline_throughput/plain_prose` | 269.1 µs | 256.5 µs | -4.7% |
| `inline_throughput/formatted_prose` | 2.500 ms | 2.384 ms | -4.6% |
| `inline_throughput/macro_prose` | 1.749 ms | 1.782 ms | +1.9% (noise) |
| `inline_throughput/replacement_prose` | 896.1 µs | 835.4 µs | -6.8% |
| `inline_throughput/mixed_document` | 3.204 ms | 3.140 ms | -2.0% |
| `element_attributes` | 23.41 µs | 22.33 µs | -4.6% |
| `simple_parse` (2 blocks + title) | 12.20 µs | 10.14 µs | **-16.9%** |
| `section_with_two_blocks` | 14.18 µs | 13.51 µs | -4.8% |

`callgrind` on `plain_prose` confirms the mechanism directly: combined `sip::Hasher::write` + `BuildHasher::hash_one` dropped from ~5.8% of instructions to ~1.1% (`hash_one` alone — `SipHasher` is no longer used at all for these tables).

This is a crate-wide change (these tables are read from block parsing, attribute-list parsing, and document-level code, not just `inline_builder`), which is why the two larger benches unrelated to inline substitution (`simple_parse`, `section_with_two_blocks`) improve too — sometimes by more than the inline-heavy ones.

## What's next

This addresses one of the two remaining performance avenues flagged in #1346's description. The other — `regex_automata::nfa::thompson::backtrack::BoundedBacktracker` costing ~9% of instructions on macro-dense content — is still open; it needs comparing against `main`'s string pipeline to determine whether it's a regression `inline-ast` introduced or an inherent cost of capturing regexes the old pipeline paid too.

## Test plan

- [x] `cargo test --workspace`, ×4 — 5485 passed, 0 failed each run
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` — clean
- [x] `cargo +nightly doc --no-deps --document-private-items` — clean
- [x] `cargo deny check` — clean (only a pre-existing, unrelated warning)
- [x] `cargo llvm-cov` diff vs. `origin/inline-ast`: identical missed-region/line counts
- [x] `cargo bench` before/after comparison (above), plus a targeted `callgrind` run confirming the hashing-cost reduction directly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwZD11jq1xdb7kDTPyttGM)_