### PR TITLE
chore: Retire the digit-encoded bracket-mask token

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -11968,6 +11968,85 @@ commit this fix branched from once its own new "author literally typed the escap
 branch is exercised — every other newly-uncovered line in the file is a pre-existing
 `other => panic!` test-assertion fallback, not a gap this change opened.
 
+##### The bracket-mask token's own digit-carrying shape was retired too (2026-08-30)
+
+The splice-point gap above and this one are siblings, not the same thing: that fix closed a
+forgery *reachable through* `tokened_bracket`'s token; this one is about the token's own
+*shape*, which carried a design smell independent of whether the escape guard existed. The
+token — `\u{96}`*n*`\u{97}`, an index spelled out in decimal digits between two boundary
+codepoints — dates from when it doubled as the (by this point fully deleted) string
+pipeline's own passthrough sentinel, and `Attrlist::parse` needed to see the *same haystack
+shape* the string pipeline's own text had there. That reason is gone: `SubstitutionGroup::
+apply_inner` says outright "the string pipeline no longer runs here at all," and `content::
+macros`/`content::substitution_step` survive only as a shared regex library the tree builder
+reuses for pattern-matching, not a haystack anything needs to mimic. What was left was a
+bespoke, digit-parsing encoding solving a problem — "an opaque run `Attrlist::parse` won't
+split on" — that the match-string level one layer up (`quotes.rs`'s `SPAN_PLACEHOLDER` +
+`Piece` table) already solves more simply, by recovering which piece an occurrence stands for
+from *position* rather than from an index carried in the text.
+
+*Landed as* (`MASKED_PIECE_PLACEHOLDER`, a fixed two-codepoint pair, restored by position):
+`tokened_bracket` (`image.rs`) and its sibling `tokened_text` (`macros/mod.rs`, shared by the
+link and xref families) now write one `\u{96}\u{97}` occurrence per masked piece — no digits —
+and every reader recovers which piece an occurrence stands for by *counting*, not parsing:
+`Attrlist`/`ElementAttribute::into_owned_restoring` thread a cursor, shared across every
+attribute a list holds, in the same left-to-right order `Attrlist::parse` found them in;
+`untranslated_value`/`restored_value_children` (`macros/mod.rs`) do the same over whichever
+slice of the piece list a caller hands them. That slicing is the one place position-based
+restoration needs help a self-describing index didn't: a caller reading *one* attribute's own
+value out of a larger parsed list (the link family's display text, the xref family's `window`/
+`role`/`xrefstyle`/children) has to know where in the *global* occurrence sequence that one
+attribute's own begin, since a bare occurrence carries nothing to re-align with on its own.
+Three new `Attrlist` accessors answer that by counting placeholder occurrences in the
+still-tokened text of every attribute before the target one —
+`nth_attribute_token_offset`/`named_attribute_token_offset` (by position or by name) and
+`roles_with_token_offset` (`roles()`'s own two sources, the first positional's shorthand items
+and a named `role=`, paired with their own separate offsets, since `roles()` merges them into
+one list with no way back to either). Direct unit coverage of the three accessors lives in
+`attributes/attrlist.rs`'s own test module; end-to-end coverage of the scenario they exist for
+— a named attribute carrying its own masked piece, preceding another one in parse order — is
+`xref.rs`'s `a_masked_piece_in_a_preceding_named_attribute_does_not_misattribute_a_later_one`
+(`role=`/`window=`, both directions). The equivalent scenario for the link family's display
+text turned out to be unconstructible: Asciidoctor's own positional numbering (every
+comma-delimited entry consumes a position, named ones included) means position 1 can only
+ever be a list's literal first entry, so `nth_attribute_token_offset(1)` is provably always
+`0` when non-`None` — the accessor is still called there, correctly, it just never has
+anything to prove it for.
+
+Two things the fixed-pair shape had to get right that a bare single codepoint would not have:
+first, the pair is what keeps the shape's own collision-resistance where the digit-carrying
+one had it — a lone reserved codepoint is indistinguishable from an ordinary control character
+an author types directly in bracket text beside a real masked construct (not reachable through
+`escape_passthrough_sentinels`'s one injection point, since that guards a content-level splice
+this byte never passes through), so `image.rs`'s own
+`a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched` was extended with exactly
+that case (`image:x.png[++a++ \u{96}\u{97}]`) to confirm the pair keeps it as unlikely as the
+digit-carrying shape was, rather than reopening it at a smaller size. Second,
+`escape_passthrough_sentinels` (design note above) is *not* obsoleted by this — it still
+escapes both codepoints, individually rather than as a pair, because a forged value
+contributing only one half, adjacent to the other half from an unrelated source, would still
+complete the pair. Eliminating the guard outright would need the harder structural move: carry
+`tokened_bracket`'s own byte-offset table through `Attrlist::parse`'s split, so restoration
+never re-scans text for the placeholder's byte value at all — the same trick `SPAN_PLACEHOLDER`
+uses one layer up. That was investigated and set aside for this increment: `Attrlist::parse`
+has its own internal attribute-reference re-substitution (for a literal `{missing}` an
+`attribute-missing=skip`/`warn` policy leaves behind), which can in principle shift byte
+offsets inside the very string `tokened_bracket`'s table would be computed against, and ruling
+that out — or handling it — needs more validation than this increment's scope covered. Left as
+open follow-up work, not silently dropped.
+
+`cargo test --workspace` is green (5,485 tests in the library crate, three more than before —
+the same shorthand-role and cross-attribute-offset assertions folded into extended existing
+tests rather than new ones, plus the direct `attrlist.rs` accessor tests). Coverage is
+diff-neutral against a baseline checkout of the commit this increment branched from, file by
+file and in total (region/line/function counts unchanged for every touched file): the one
+file that regressed in an interim pass — `element_attribute.rs`'s own "more occurrences than
+the caller supplied bodies for" leniency branch, newly unreachable once the digit-encoded
+shape's "malformed token" case no longer exists to reach it by a different path — closed once
+`image.rs`'s own sentinel-shaped-bytes test was extended with a case exercising it directly
+(an author-typed adjacent pair after a bracket's only real passthrough already spent the one
+body supplied).
+
 ##### Phase 3's first criterion cannot close before Landing
 
 "Node vocabulary reviewed against the `asciidoctor` port's needs (§6.6)" and Landing's

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -761,27 +761,45 @@ impl<'src> Attrlist<'src> {
     }
 
     /// [`roles`](Self::roles), pairing each role with the offset into a
-    /// global body/node list where *its own* source attribute's placeholder
-    /// occurrences begin (see
-    /// [`token_offset_before`](Self::token_offset_before)) — a role from the
-    /// first positional attribute's own shorthand items and one from a named
-    /// `role=` attribute are two different attributes in this list's own
-    /// parse order, so a caller restoring a role read off a still-tokened
-    /// list (e.g. `untranslated_value` in the macros step) cannot use one
-    /// starting offset for both.
+    /// global body/node list where *its own* placeholder occurrences begin
+    /// (see [`token_offset_before`](Self::token_offset_before)) — a role
+    /// from the first positional attribute's own shorthand items and one
+    /// from a named `role=` attribute are two different attributes in this
+    /// list's own parse order, so a caller restoring a role read off a
+    /// still-tokened list (e.g. `untranslated_value` in the macros step)
+    /// cannot use one starting offset for both.
+    ///
+    /// Nor can two roles split out of the *same* source attribute
+    /// (`role=++a++ ++b++` is one attribute, two space-separated roles, each
+    /// with its own placeholder): each role after the first has to skip past
+    /// every placeholder occurrence the roles *before* it, in the same
+    /// value, already account for — so the offset is a running count, seeded
+    /// from the source attribute's own base offset and advanced by each
+    /// role's own occurrence count as the split walks left to right, not one
+    /// shared starting point per attribute.
     pub(crate) fn roles_with_token_offset(&'src self) -> Vec<(&'src str, usize)> {
-        let mut roles: Vec<(&'src str, usize)> = match self.nth_attribute_token_offset(1) {
-            Some(offset) => self
-                .nth_attribute(1)
-                .map(|attr1| attr1.roles().into_iter().map(|r| (r, offset)).collect())
-                .unwrap_or_default(),
-            None => vec![],
-        };
+        let mut roles: Vec<(&'src str, usize)> = vec![];
 
-        if let Some(offset) = self.named_attribute_token_offset("role")
+        if let Some(base) = self.nth_attribute_token_offset(1)
+            && let Some(attr1) = self.nth_attribute(1)
+        {
+            let mut offset = base;
+
+            for role in attr1.roles() {
+                roles.push((role, offset));
+                offset += role.matches(MASKED_PIECE_PLACEHOLDER).count();
+            }
+        }
+
+        if let Some(base) = self.named_attribute_token_offset("role")
             && let Some(role_attr) = self.named_attribute("role")
         {
-            roles.extend(split_role_value(role_attr.value()).map(|r| (r, offset)));
+            let mut offset = base;
+
+            for role in split_role_value(role_attr.value()) {
+                roles.push((role, offset));
+                offset += role.matches(MASKED_PIECE_PLACEHOLDER).count();
+            }
         }
 
         roles
@@ -1065,6 +1083,35 @@ mod tests {
              (offset 0); the named `role=` attribute — still unrestored, so its \
              value is the placeholder itself — is the second attribute, past the \
              shorthand's own one placeholder occurrence (offset 1)"
+        );
+    }
+
+    #[test]
+    fn roles_with_token_offset_advances_past_each_earlier_role_in_the_same_attribute() {
+        // Two space-separated roles inside the *same* `role=` attribute
+        // (`role=++a++ ++b++`), each carrying its own placeholder — a single
+        // attribute, not two, so `named_attribute_token_offset` gives both
+        // roles the same *base*, and the second role's own offset has to
+        // additionally skip past the first role's own one occurrence, not
+        // reuse the base as if only one role were there (Greptile
+        // https://github.com/asciidoc-rs/asciidoc-parser/pull/1349#discussion_r3890749214).
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let source = format!("role={MASKED_PIECE_PLACEHOLDER} {MASKED_PIECE_PLACEHOLDER}");
+        let p = Parser::default();
+        let attrlist = crate::attributes::Attrlist::parse(
+            crate::Span::new(&source),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        assert_eq!(
+            attrlist.roles_with_token_offset(),
+            vec![(MASKED_PIECE_PLACEHOLDER, 0), (MASKED_PIECE_PLACEHOLDER, 1),],
+            "the first role's own occurrence is offset 0; the second role's own \
+             occurrence must skip past it rather than reusing offset 0"
         );
     }
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -2,7 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{
         ElementAttribute,
-        element_attribute::{ParseShorthand, restore_into},
+        element_attribute::{MASKED_PIECE_PLACEHOLDER, ParseShorthand, restore_into},
     },
     content::{Content, SubstitutionStep},
     internal::{debug::DebugSliceReference, opaque_iter::opaque_slice_iter},
@@ -94,30 +94,46 @@ impl<'src> Attrlist<'src> {
     }
 
     /// [`into_owned`](Self::into_owned), first substituting each
-    /// `\u{96}`*n*`\u{97}` **token** in every parsed value — and in the
-    /// anchor and the retained
-    /// [`source_text`](Self::source_text) — with `bodies[n]`.
+    /// [`MASKED_PIECE_PLACEHOLDER`] occurrence in every parsed value — and in
+    /// the retained [`source_text`](Self::source_text) — with the next of
+    /// `bodies`, in left-to-right document order.
     ///
     /// This is how a caller restores a masked construct that its attribute
     /// list text still holds. The restore has to happen **after** the parse,
-    /// not before it: the string pipeline parses its own haystack with the
-    /// passthrough sentinel still in place, so the body's own bytes never
-    /// reach the split that divides the list into entries, names, and values.
-    /// See [`ElementAttribute::into_owned_restoring`] for the per-attribute
-    /// half, including what it does to the shorthand offsets.
+    /// not before it: [`Attrlist::parse`] has to see the placeholder still in
+    /// place, so the body's own bytes never reach the split that divides the
+    /// list into entries, names, and values.
+    ///
+    /// A single shared cursor, starting at `0`, walks
+    /// [`self.attributes`](Self) in the same order [`Attrlist::parse`] found
+    /// them in — which is left-to-right document order, the same order a
+    /// placeholder's own position in `bodies` was assigned in — so no index
+    /// needs to be carried in the placeholder's own bytes. `source_text` is
+    /// an independent full copy of the same text and is restored with a
+    /// fresh cursor of its own, from `0` again, for the same reason. See
+    /// [`ElementAttribute::into_owned_restoring`] for the per-attribute half,
+    /// including what it does to the shorthand offsets, and
+    /// [`nth_attribute_token_offset`](Self::nth_attribute_token_offset) /
+    /// [`named_attribute_token_offset`](Self::named_attribute_token_offset)
+    /// for a caller that needs to restore one attribute's value against a
+    /// *slice* of a global body/node list instead of the whole list this
+    /// method walks.
     pub(crate) fn into_owned_restoring<'dst>(
         self,
         source: Span<'dst>,
         bodies: &[&str],
     ) -> Attrlist<'dst> {
         let source_text = CowStr::from(self.source_text().to_string());
+        let mut cursor = 0usize;
+
+        let attributes = self
+            .attributes
+            .into_iter()
+            .map(|attribute| attribute.into_owned_restoring(bodies, &mut cursor))
+            .collect();
 
         Attrlist {
-            attributes: self
-                .attributes
-                .into_iter()
-                .map(|attribute| attribute.into_owned_restoring(bodies))
-                .collect(),
+            attributes,
             // The anchor takes the plain conversion rather than a restoring
             // one. An anchor is only ever set for the `[…]`-delimited whole
             // -bracket form, and no restoring caller can present one: each
@@ -125,8 +141,64 @@ impl<'src> Attrlist<'src> {
             // match at the first `]`, so `[x]` never arrives here intact.
             anchor: self.anchor.map(CowStr::into_owned),
             source,
-            source_text: Some(restore_into(source_text, bodies, &mut [], &mut Vec::new())),
+            source_text: Some(restore_into(
+                source_text,
+                bodies,
+                &mut 0usize,
+                &mut [],
+                &mut Vec::new(),
+            )),
         }
+    }
+
+    /// The number of [`MASKED_PIECE_PLACEHOLDER`] occurrences in every
+    /// attribute's name and value that come before `self.attributes[index]`,
+    /// in this list's own parse order.
+    ///
+    /// A caller restoring one attribute's own value against a **slice** of a
+    /// global body/node list — rather than the whole list
+    /// [`into_owned_restoring`](Self::into_owned_restoring) walks — uses this
+    /// to find where that attribute's own occurrences begin: the same
+    /// position `into_owned_restoring`'s own shared cursor would be at once
+    /// it reached this attribute. Counting occurrences needs no restore of
+    /// its own — it reads the still-tokened `name`/`value` text directly — so
+    /// this works before any restore has run.
+    fn token_offset_before(&self, index: usize) -> usize {
+        self.attributes
+            .get(..index)
+            .unwrap_or_default()
+            .iter()
+            .map(|attr| {
+                attr.name()
+                    .map_or(0, |name| name.matches(MASKED_PIECE_PLACEHOLDER).count())
+                    + attr.value().matches(MASKED_PIECE_PLACEHOLDER).count()
+            })
+            .sum()
+    }
+
+    /// [`nth_attribute`](Self::nth_attribute), plus the offset into a global
+    /// body/node list where that attribute's own placeholder occurrences
+    /// begin (see [`token_offset_before`](Self::token_offset_before)).
+    pub(crate) fn nth_attribute_token_offset(&self, n: usize) -> Option<usize> {
+        let index = self
+            .attributes
+            .iter()
+            .position(|attr| attr.positional_index() == Some(n))?;
+
+        Some(self.token_offset_before(index))
+    }
+
+    /// [`named_attribute`](Self::named_attribute), plus the offset into a
+    /// global body/node list where that attribute's own placeholder
+    /// occurrences begin (see
+    /// [`token_offset_before`](Self::token_offset_before)).
+    pub(crate) fn named_attribute_token_offset(&self, name: &str) -> Option<usize> {
+        let index = self
+            .attributes
+            .iter()
+            .position(|attr| attr.name() == Some(name))?;
+
+        Some(self.token_offset_before(index))
     }
 
     /// **IMPORTANT:** This `source` span passed to this function should NOT
@@ -688,6 +760,33 @@ impl<'src> Attrlist<'src> {
         roles
     }
 
+    /// [`roles`](Self::roles), pairing each role with the offset into a
+    /// global body/node list where *its own* source attribute's placeholder
+    /// occurrences begin (see
+    /// [`token_offset_before`](Self::token_offset_before)) — a role from the
+    /// first positional attribute's own shorthand items and one from a named
+    /// `role=` attribute are two different attributes in this list's own
+    /// parse order, so a caller restoring a role read off a still-tokened
+    /// list (e.g. `untranslated_value` in the macros step) cannot use one
+    /// starting offset for both.
+    pub(crate) fn roles_with_token_offset(&'src self) -> Vec<(&'src str, usize)> {
+        let mut roles: Vec<(&'src str, usize)> = match self.nth_attribute_token_offset(1) {
+            Some(offset) => self
+                .nth_attribute(1)
+                .map(|attr1| attr1.roles().into_iter().map(|r| (r, offset)).collect())
+                .unwrap_or_default(),
+            None => vec![],
+        };
+
+        if let Some(offset) = self.named_attribute_token_offset("role")
+            && let Some(role_attr) = self.named_attribute("role")
+        {
+            roles.extend(split_role_value(role_attr.value()).map(|r| (r, offset)));
+        }
+
+        roles
+    }
+
     /// The attrlist text this list was parsed from.
     ///
     /// For every list parsed straight from the source it describes, that is
@@ -899,6 +998,74 @@ mod tests {
 
         let b2 = b1.item.clone();
         assert_eq!(b1.item, b2);
+    }
+
+    #[test]
+    fn token_offset_helpers_count_placeholders_before_the_target_attribute() {
+        // Two masked pieces (each one `MASKED_PIECE_PLACEHOLDER` occurrence,
+        // as `tokened_bracket`/`tokened_text` would leave it before a
+        // restore): one inside a named `role=` attribute, first in this
+        // list's own parse order, and one inside the third (positional)
+        // entry. A caller restoring the third entry's own value against a
+        // *slice* of a global body/node list has to start past the role's
+        // own occurrence, not at the whole list's first one — this is the
+        // scenario the two `_token_offset` accessors exist for.
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let source = format!("role={MASKED_PIECE_PLACEHOLDER},x,{MASKED_PIECE_PLACEHOLDER}");
+        let p = Parser::default();
+        let attrlist = crate::attributes::Attrlist::parse(
+            crate::Span::new(&source),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        // Nothing precedes `role=` itself.
+        assert_eq!(attrlist.named_attribute_token_offset("role"), Some(0));
+
+        // The third entry (positional index 3) is the *third* attribute in
+        // vec order (role, then the blank `x`... no, `x` is itself
+        // positional index 2) — one placeholder (role's own) precedes it.
+        assert_eq!(attrlist.nth_attribute_token_offset(3), Some(1));
+
+        // A name with no matching attribute finds nothing to offset.
+        assert_eq!(attrlist.named_attribute_token_offset("nope"), None);
+        assert_eq!(attrlist.nth_attribute_token_offset(99), None);
+    }
+
+    #[test]
+    fn roles_with_token_offset_pairs_each_role_with_its_own_source_attributes_offset() {
+        // A role from the first positional's own shorthand items and one
+        // from a named `role=` attribute are two different attributes, and
+        // `roles()` merges them into one flat list with no way back to
+        // either source — which is exactly why a restoring caller
+        // (`untranslated_value`) needs the offset alongside each role rather
+        // than one shared starting point.
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let source =
+            format!("{MASKED_PIECE_PLACEHOLDER}.shorthand,role={MASKED_PIECE_PLACEHOLDER}");
+        let p = Parser::default();
+        let attrlist = crate::attributes::Attrlist::parse(
+            crate::Span::new(&source),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        let roles = attrlist.roles_with_token_offset();
+
+        assert_eq!(
+            roles,
+            vec![("shorthand", 0), (MASKED_PIECE_PLACEHOLDER, 1)],
+            "the shorthand role's own attribute is first, so nothing precedes it \
+             (offset 0); the named `role=` attribute — still unrestored, so its \
+             value is the placeholder itself — is the second attribute, past the \
+             shorthand's own one placeholder occurrence (offset 1)"
+        );
     }
 
     #[test]

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -54,8 +54,8 @@ pub struct ElementAttribute<'src> {
     /// every other attribute. A consumer that re-processes the value as a
     /// *path* — the built-in renderer's `web_path` resolution of a `fallback=`
     /// or macro-level `imagesdir=` — masks these ranges around that resolution
-    /// and splices them back afterwards, reproducing the string pipeline's own
-    /// restore-after-resolve order (its resolver only ever sees the sentinel).
+    /// and splices them back afterwards, so a STEM body's backslash or a
+    /// passthrough's own bytes never reach that resolution.
     restored_value_ranges: Vec<std::ops::Range<usize>>,
 }
 
@@ -94,52 +94,59 @@ impl<'src> ElementAttribute<'src> {
     }
 
     /// [`into_owned`](Self::into_owned), first substituting each
-    /// `\u{96}`*n*`\u{97}` **token** in this attribute's name and value with
-    /// `bodies[n]`.
+    /// [`MASKED_PIECE_PLACEHOLDER`] occurrence in this attribute's name and
+    /// value with the next of `bodies`, in the order `cursor` finds them.
     ///
     /// This is the *after the split* half of restoring a masked construct
     /// inside a parsed attribute list. A caller that parses an attribute list
     /// whose text still holds a masked passthrough cannot restore the body
-    /// first: the string pipeline's own
-    /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) reads the
-    /// sentinel — an opaque token carrying none of the `,`/`=`/`"` bytes the
-    /// split reads — so a body holding one of those characters must not
-    /// influence how the list divides (`image:x.png[++a,b++]` is one
-    /// positional whose value is `a,b`, not two). Restoring per *parsed value*
-    /// reproduces that, exactly as
-    /// `Passthroughs::restore_to`
-    /// splices each body over whatever sentinel reached the rendered
-    /// string.
+    /// first: [`Attrlist::parse`](crate::attributes::Attrlist::parse) has to
+    /// see the placeholder — an opaque run carrying none of the `,`/`=`/`"`
+    /// bytes the split reads — so a body holding one of those characters must
+    /// not influence how the list divides (`image:x.png[++a,b++]` is one
+    /// positional whose value is `a,b`, not two). Restoring per *parsed
+    /// value*, after the split, is what keeps that true.
     ///
     /// [`shorthand_item_indices`](Self::shorthand_item_indices) are byte
     /// offsets into `value`, so each is **shifted** past every substitution
-    /// that ends at or before it — a token is one opaque run holding none of
-    /// the `#`/`.`/`%` delimiters the shorthand scan keys off, so the items it
-    /// found stay the same items, only further along
+    /// that ends at or before it — a placeholder is one opaque character
+    /// holding none of the `#`/`.`/`%` delimiters the shorthand scan keys off,
+    /// so the items it found stay the same items, only further along
     /// (`image:x.png[++abc++.myrole]` keeps the `myrole` role while its value
     /// becomes `abc.myrole`). Re-deriving them over the restored text would
-    /// instead find a delimiter *inside* a body, which the string pipeline
-    /// never sees.
+    /// instead find a delimiter *inside* a body, which the placeholder never
+    /// exposes.
     ///
-    /// Substitution is **index-keyed**, as `restore_to` is, so a token whose
-    /// index the caller did not supply is left as written rather than
-    /// renumbering the ones that follow.
+    /// `cursor` is shared across every attribute
+    /// [`Attrlist::into_owned_restoring`](crate::attributes::Attrlist::into_owned_restoring)
+    /// restores, in the same left-to-right order
+    /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) found them in,
+    /// so a placeholder's position — not an index carried in the text — says
+    /// which of `bodies` it stands for. A placeholder `cursor`
+    /// finds past the end of `bodies` (more occurrences than the caller
+    /// tokened) is left as written rather than panicking or misattributing a
+    /// later one.
     ///
     /// Each splice's resulting byte range in the restored value is recorded
     /// in [`restored_value_ranges`](Self::restored_value_ranges), so a
     /// consumer that re-processes the value as a path can keep the restored
     /// bytes out of that resolution's way (see the field's own doc comment).
-    pub(crate) fn into_owned_restoring<'dst>(self, bodies: &[&str]) -> ElementAttribute<'dst> {
+    pub(crate) fn into_owned_restoring<'dst>(
+        self,
+        bodies: &[&str],
+        cursor: &mut usize,
+    ) -> ElementAttribute<'dst> {
         let mut shorthand_item_indices = self.shorthand_item_indices;
         let mut restored_value_ranges = Vec::new();
 
         ElementAttribute {
             name: self
                 .name
-                .map(|name| restore_into(name, bodies, &mut [], &mut Vec::new())),
+                .map(|name| restore_into(name, bodies, cursor, &mut [], &mut Vec::new())),
             value: restore_into(
                 self.value,
                 bodies,
+                cursor,
                 &mut shorthand_item_indices,
                 &mut restored_value_ranges,
             ),
@@ -790,41 +797,79 @@ fn is_shorthand_delimiter(c: char) -> bool {
     c == '#' || c == '%' || c == '.'
 }
 
-/// Substitutes each `\u{96}`*n*`\u{97}` token in `text` with `bodies[n]`,
-/// shifting every offset in `indices` past the substitutions that end at or
-/// before it.
+/// The opaque placeholder `tokened_bracket` (and its sibling `tokened_text`,
+/// both in the macros substitution step) rewrites each masked passthrough,
+/// STEM expression, or other already-recognized construct to inside a macro
+/// bracket's own text, one occurrence per piece, so
+/// [`Attrlist::parse`](crate::attributes::Attrlist::parse) sees an atomic run
+/// carrying none of the `,`/`=`/`"` bytes at that position instead of the
+/// piece's own.
 ///
-/// The token spelling is the string pipeline's own passthrough sentinel (see
-/// `Passthroughs`), which is what
-/// makes this the faithful restore: a caller hands over the very text
-/// `Attrlist::parse` would have seen there, and each body lands where
-/// `Passthroughs::restore_to`
-/// splices it.
+/// Carries no index — which piece a given occurrence stands for is recovered
+/// by *position*: the Nth occurrence, scanned left to right, is `bodies[N]`,
+/// never by parsing anything back out of the placeholder's own bytes.
+/// [`restore_into`] is what walks that position order.
 ///
-/// A run that is not a well-formed token, or whose index `bodies` does not
-/// supply, is copied through verbatim — the same index-keyed leniency
-/// `restore_to` has, so an unsupplied index never renumbers the tokens after
-/// it. Each splice's byte range in the restored text is appended to
-/// `restored_ranges`, in ascending order. See
-/// [`ElementAttribute::into_owned_restoring`] for why the shift is
+/// Two fixed codepoints, adjacent, rather than one: a single reserved
+/// codepoint alone is indistinguishable from an ordinary control character a
+/// document happens to type in the clear (not spliced through an attribute
+/// reference, so the escape guard covering that seam never sees it) sitting
+/// beside a real masked construct in the same bracket — a two-codepoint run
+/// needs both, adjacent, which is exactly as unlikely for ordinary authoring
+/// to produce by accident as the digit-carrying shape this replaced. Kept as
+/// two separate consts too ([`MASKED_PIECE_PLACEHOLDER_START`],
+/// [`MASKED_PIECE_PLACEHOLDER_END`]) for the escape guard, which has to
+/// escape each codepoint on its own — a forged value contributing only one
+/// half, beside the other half from an unrelated source, would complete the
+/// same pair.
+pub(crate) const MASKED_PIECE_PLACEHOLDER_START: char = '\u{96}';
+
+/// See [`MASKED_PIECE_PLACEHOLDER`].
+pub(crate) const MASKED_PIECE_PLACEHOLDER_END: char = '\u{97}';
+
+/// See [`MASKED_PIECE_PLACEHOLDER_START`] / [`MASKED_PIECE_PLACEHOLDER_END`].
+/// Must spell the same two codepoints, adjacent and in the same order.
+pub(crate) const MASKED_PIECE_PLACEHOLDER: &str = "\u{96}\u{97}";
+
+/// Substitutes each [`MASKED_PIECE_PLACEHOLDER`] occurrence in `text` with the
+/// next of `bodies` `*cursor` finds, shifting every offset in `indices` past
+/// the substitutions that end at or before it.
+///
+/// `cursor` is shared across every call this restore makes (see
+/// [`ElementAttribute::into_owned_restoring`] for why), so it is threaded
+/// through rather than reset here: a placeholder's *position* in the whole
+/// attribute list — not an index carried in its own bytes — says which body
+/// it stands for.
+///
+/// An occurrence `*cursor` finds past the end of `bodies` is copied through
+/// verbatim rather than panicking or misattributing a later one — the same
+/// leniency an unsupplied index used to get, for the same reason: it should
+/// never be reachable in practice (every caller tokens exactly as many
+/// pieces as it supplies bodies for), but a caller that someday doesn't
+/// should fail closed, not corrupt a neighboring restore. Each splice's byte
+/// range in the restored text is appended to `restored_ranges`, in ascending
+/// order. See [`ElementAttribute::into_owned_restoring`] for why the shift is
 /// right where a re-derivation would not be.
+///
 /// [`restore_tokens`] over a [`CowStr`], keeping the plain
 /// [`into_owned`](CowStr::into_owned) conversion — and with it the inline
 /// representation a short string prefers — for the overwhelmingly common text
-/// that holds no token at all.
+/// that holds no placeholder at all.
 pub(super) fn restore_into<'dst>(
     text: CowStr<'_>,
     bodies: &[&str],
+    cursor: &mut usize,
     indices: &mut [usize],
     restored_ranges: &mut Vec<std::ops::Range<usize>>,
 ) -> CowStr<'dst> {
-    if bodies.is_empty() || !text.contains('\u{96}') {
+    if bodies.is_empty() || !text.contains(MASKED_PIECE_PLACEHOLDER) {
         return text.into_owned();
     }
 
     CowStr::from(restore_tokens(
         text.as_ref(),
         bodies,
+        cursor,
         indices,
         restored_ranges,
     ))
@@ -833,52 +878,38 @@ pub(super) fn restore_into<'dst>(
 fn restore_tokens(
     text: &str,
     bodies: &[&str],
+    cursor: &mut usize,
     indices: &mut [usize],
     restored_ranges: &mut Vec<std::ops::Range<usize>>,
 ) -> String {
     let mut out = String::with_capacity(text.len());
-    let mut cursor = 0usize;
+    let mut scan_cursor = 0usize;
 
-    // `(offset just past a substituted token, cumulative delta)`, in the
-    // *original* text's coordinates and in increasing order.
+    // `(offset just past a substituted placeholder, cumulative delta)`, in
+    // the *original* text's coordinates and in increasing order.
     let mut shifts: Vec<(usize, isize)> = vec![];
     let mut delta: isize = 0;
 
-    while let Some(rel) = text.get(cursor..).and_then(|rest| rest.find('\u{96}')) {
-        let start = cursor.saturating_add(rel);
-        let digits_start = start.saturating_add('\u{96}'.len_utf8());
+    while let Some(rel) = text
+        .get(scan_cursor..)
+        .and_then(|rest| rest.find(MASKED_PIECE_PLACEHOLDER))
+    {
+        let start = scan_cursor.saturating_add(rel);
+        let end = start.saturating_add(MASKED_PIECE_PLACEHOLDER.len());
 
-        let digits = text
-            .get(digits_start..)
-            .map(|rest| {
-                let len = rest
-                    .find(|c: char| !c.is_ascii_digit())
-                    .unwrap_or(rest.len());
-
-                rest.get(..len).unwrap_or_default()
-            })
-            .unwrap_or_default();
-
-        let digits_end = digits_start.saturating_add(digits.len());
-        let end = digits_end.saturating_add('\u{97}'.len_utf8());
-
-        let body = if digits.is_empty() || text.get(digits_end..end) != Some("\u{97}") {
-            None
-        } else {
-            digits.parse::<usize>().ok().and_then(|n| bodies.get(n))
-        };
-
-        let Some(body) = body else {
-            // Not a token this caller supplied: copy the `\u{96}` through and
-            // resume scanning after it, so a later token in the same text is
-            // still found.
-            let next = start.saturating_add('\u{96}'.len_utf8());
-            out.push_str(text.get(cursor..next).unwrap_or_default());
-            cursor = next;
+        let Some(body) = bodies.get(*cursor).copied() else {
+            // More occurrences than the caller supplied bodies for: copy this
+            // one through and keep scanning, so a body-bearing occurrence
+            // later in the same text is still found. See this function's own
+            // doc comment for why this should be unreachable in practice.
+            out.push_str(text.get(scan_cursor..end).unwrap_or_default());
+            scan_cursor = end;
             continue;
         };
 
-        out.push_str(text.get(cursor..start).unwrap_or_default());
+        *cursor += 1;
+
+        out.push_str(text.get(scan_cursor..start).unwrap_or_default());
         restored_ranges.push(out.len()..out.len() + body.len());
         out.push_str(body);
 
@@ -887,16 +918,16 @@ fn restore_tokens(
             .saturating_sub(isize::try_from(end.saturating_sub(start)).unwrap_or(isize::MAX));
 
         shifts.push((end, delta));
-        cursor = end;
+        scan_cursor = end;
     }
 
-    out.push_str(text.get(cursor..).unwrap_or_default());
+    out.push_str(text.get(scan_cursor..).unwrap_or_default());
 
     for index in indices.iter_mut() {
-        // A token holds none of the `#`/`.`/`%` delimiters the shorthand scan
-        // keys off, so no offset ever falls *inside* one: each is either
-        // before every substitution or after some, and takes that one's
-        // cumulative delta.
+        // A placeholder holds none of the `#`/`.`/`%` delimiters the
+        // shorthand scan keys off, so no offset ever falls *inside* one: each
+        // is either before every substitution or after some, and takes that
+        // one's cumulative delta.
         if let Some((_, delta)) = shifts.iter().rev().find(|(end, _)| *end <= *index) {
             *index = index.saturating_add_signed(*delta);
         }

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{
     Parser, Span,
+    attributes::element_attribute::{MASKED_PIECE_PLACEHOLDER_END, MASKED_PIECE_PLACEHOLDER_START},
     content::{ATTRIBUTE_REFERENCE, AttributeMissing},
     document::InterpretedValue,
     inlines::{InlineNode, RawForm, RawOrigin},
@@ -1133,10 +1134,10 @@ fn rebuild_attribute_level<'src>(
 /// A run is never emitted empty, and an empty `value` (a value-less
 /// `InterpretedValue::Set` attribute) emits no node at all.
 ///
-/// Before either branch runs, `value` has its passthrough-sentinel bytes
-/// escaped by [`escape_passthrough_sentinels`] — see that function's doc
-/// comment for why a value reaching this splice point needs that
-/// unconditionally, regardless of which branch it then takes.
+/// Before either branch runs, `value` has its own copies of the masked-piece
+/// placeholder escaped by [`escape_passthrough_sentinels`] — see that
+/// function's doc comment for why a value reaching this splice point needs
+/// that unconditionally, regardless of which branch it then takes.
 fn split_attribute_value<'src>(
     value: &str,
     location: Span<'src>,
@@ -1189,51 +1190,62 @@ fn split_attribute_value<'src>(
     }
 }
 
-/// Escapes a document's own copies of the passthrough-sentinel pair
-/// (`\u{96}`/`\u{97}`) out of a resolved attribute (or `counter`/`counter2`)
+/// Escapes a document's own copies of the
+/// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER)
+/// pair's two codepoints out of a resolved attribute (or `counter`/`counter2`)
 /// value before [`split_attribute_value`] splices it into the node stream.
 ///
-/// Those two C1 codepoints are the private-use-shaped token
-/// [`tokened_bracket`](super::macros::image::tokened_bracket) writes for a
-/// masked passthrough or STEM expression inside an `image:`/`icon:` bracket
-/// or a link family's display-text list, and
+/// Those two C1 codepoints, adjacent, are the opaque placeholder
+/// [`tokened_bracket`](super::macros::image::tokened_bracket) (and its
+/// sibling `tokened_text`) writes for a masked passthrough or STEM expression
+/// inside an `image:`/`icon:` bracket or a link/xref family's own computed
+/// value, and both
 /// [`Attrlist::into_owned_restoring`](crate::attributes::Attrlist::into_owned_restoring)
-/// (via [`restore_into`](crate::attributes::element_attribute)) restores
-/// **by byte pattern** once that bracket has been parsed: it cannot tell the
-/// pipeline's own token from a document-typed copy of the same two bytes at
-/// the same index. A macro bracket that mixes a genuine masked construct with
-/// an attribute reference whose resolved value happens to spell
-/// `\u{96}`*n*`\u{97}` — `image:x.png[++real++,alt={forge}]` with `:forge:
-/// \u{96}0\u{97}` defined — is exactly that mix: the reference is spliced
-/// here, by this step, *before* the image macro is even recognized, so by
-/// the time the bracket is tokened its forged bytes are indistinguishable
-/// from the passthrough's own restore token, and `alt` ends up holding the
-/// passthrough's rendered body instead of the literal text the document
-/// defined.
+/// (via [`restore_into`](crate::attributes::element_attribute)) and the
+/// macros step's own `untranslated_value`/`restored_value_children` recover
+/// which piece an occurrence stands for **by position** once that bracket has
+/// been parsed: none of the three re-derive structure from anything but the
+/// bytes actually in front of them, so they cannot tell a real occurrence
+/// from a document-typed copy of the same two bytes at the same position. A
+/// macro bracket that mixes a genuine masked construct with an attribute
+/// reference whose resolved value happens to spell
+/// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER) — `image:x.png[++real++,alt={forge}]` with
+/// `:forge: \u{96}\u{97}` defined — is exactly that mix: the reference is
+/// spliced here, by this step, *before* the image macro is even recognized,
+/// so by the time the bracket is tokened the forged pair is indistinguishable
+/// from the passthrough's own placeholder, and every occurrence from that
+/// point on shifts onto the wrong body. Each codepoint is escaped on its
+/// own, not as a pair: a forged value contributing only *one* half, beside
+/// the other half from an unrelated source (a second reference, or a
+/// document-typed copy) landing adjacent to it, would complete the same
+/// pair otherwise.
 ///
 /// This is the same forgery the string pipeline's own attribute-reference
 /// splice guarded against with `escape_sentinels` (since retired) — see
-/// `AttributeReplacer::escaping_sentinels` — for this pair among the five it
-/// covered; the other three guarded a deferred cross-reference's and a
-/// footnote marker's own in-band templates, which the tree builder replaced
-/// with structured piece lists nothing scans, so only this pair still needs
-/// a counterpart here. The escape is unconditional, for the same reason the
-/// string pipeline's was: this step splices at the content level, ahead of
-/// macro recognition, so it cannot know whether its value will end up beside
-/// a masked construct in some later bracket. It is also one-way, like its
-/// predecessor — nothing downstream unescapes it — so a document attribute
-/// whose value happens to hold one of these two rare C1 control codepoints
-/// (or the escape introducer itself) sees it come back escaped rather than
-/// silently enabling a forged restore.
+/// `AttributeReplacer::escaping_sentinels` — for this pair among the five
+/// codepoints it covered; the other three guarded a deferred cross-reference's
+/// and a footnote marker's own in-band templates, which the tree builder
+/// replaced with structured piece lists and a positional walk nothing scans
+/// for a byte pattern, so only this pair still needs a counterpart here. The
+/// escape is unconditional, for the same reason the string pipeline's was:
+/// this step splices at the content level, ahead of macro recognition, so it
+/// cannot know whether its value will end up beside a masked construct in
+/// some later bracket. It is also one-way, like its predecessor — nothing
+/// downstream unescapes it — so a document attribute whose value happens to
+/// hold one of these two rare C1 control codepoints (or the escape
+/// introducer itself) sees it come back escaped rather than silently
+/// enabling a forged restore.
 ///
 /// Text with none of the three reserved codepoints — the overwhelming
 /// majority — is borrowed through unchanged.
 fn escape_passthrough_sentinels(value: &str) -> Cow<'_, str> {
-    const START: char = '\u{96}';
-    const END: char = '\u{97}';
     const ESCAPE: char = '\u{E005}';
 
-    if !value.contains([START, END, ESCAPE]) {
+    if !value.contains([
+        MASKED_PIECE_PLACEHOLDER_START,
+        MASKED_PIECE_PLACEHOLDER_END,
+        ESCAPE,
+    ]) {
         return Cow::Borrowed(value);
     }
 
@@ -1241,8 +1253,8 @@ fn escape_passthrough_sentinels(value: &str) -> Cow<'_, str> {
 
     for c in value.chars() {
         match c {
-            START => out.push_str("\u{E005}s"),
-            END => out.push_str("\u{E005}e"),
+            MASKED_PIECE_PLACEHOLDER_START => out.push_str("\u{E005}s"),
+            MASKED_PIECE_PLACEHOLDER_END => out.push_str("\u{E005}e"),
             ESCAPE => out.push_str("\u{E005}g"),
             other => out.push(other),
         }
@@ -1424,15 +1436,16 @@ mod tests {
 
     #[test]
     fn a_reference_expanding_to_a_passthrough_sentinel_is_escaped() {
-        // A value carrying the passthrough-sentinel pair, or a literal copy
-        // of the escape introducer this step's own escaping uses, is escaped
-        // out rather than spliced in verbatim — see
-        // `escape_passthrough_sentinels`. This test exercises the function
-        // directly (through the one seam that calls it) for all three
-        // codepoints its match arms cover, independent of any macro bracket:
-        // the regression this guards against is pinned end-to-end, over an
-        // actual `image:`/`link:` bracket, by the `sentinels` test module's
-        // own `a_placeholder_from_an_attribute_value_cannot_forge_*` tests.
+        // A value carrying either codepoint of the masked-piece placeholder
+        // pair, or a literal copy of the escape introducer this step's own
+        // escaping uses, is escaped out rather than spliced in verbatim —
+        // see `escape_passthrough_sentinels`. This test exercises the
+        // function directly (through the one seam that calls it) for all
+        // three codepoints its match arms cover, independent of any macro
+        // bracket: the regression this guards against is pinned end-to-end,
+        // over an actual `image:`/`link:` bracket, by the `sentinels` test
+        // module's own `a_placeholder_from_an_attribute_value_cannot_forge_*`
+        // tests.
         let parser = parser_with_attribute("v", "a\u{96}b\u{97}c\u{e005}d");
         let nodes = build(Span::new("{v}"), &parser, None);
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use super::{MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level};
 use crate::{
     Parser, Span,
-    attributes::{Attrlist, AttrlistContext},
+    attributes::{Attrlist, AttrlistContext, element_attribute::MASKED_PIECE_PLACEHOLDER},
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
@@ -968,30 +968,31 @@ pub(in crate::content::inline_builder) enum Tokened {
 }
 
 /// Rewrites a macro **bracket**'s own match-string bytes so each masked piece
-/// in it becomes an index-keyed `\u{96}`*n*`\u{97}` token, returning that text
-/// alongside the [`MaskedPiece`]s those tokens stand for.
+/// in it becomes one [`MASKED_PIECE_PLACEHOLDER`] occurrence, returning that
+/// text alongside the [`MaskedPiece`]s those occurrences stand for, in
+/// left-to-right order.
 ///
-/// This is the *before the split* half of every bracket restore, and it exists
-/// so the text handed to [`Attrlist::parse`] is the same **shape** the string
-/// pipeline's own haystack has there. Two spellings have to be normalized into
-/// one: [`widen_masked_pieces`] has already rewritten a masked piece to a
-/// sentinel-shaped token for the image family's *recognition*, but its
-/// numbering is per level, and for the link families' display-text list a
+/// This is the *before the split* half of every bracket restore, and it
+/// exists so [`Attrlist::parse`] sees an atomic, delimiter-free run at each
+/// masked piece's position instead of the piece's own `,`/`=`/`"` bytes. Two
+/// spellings have to be normalized into one: [`widen_masked_pieces`] has
+/// already rewritten a masked piece to a sentinel-shaped token for the image
+/// family's *recognition*, and for the link families' display-text list a
 /// masked piece is still the bare one-character
-/// [`SPAN_PLACEHOLDER`](super::super::quotes). Renumbering every restorable
-/// piece from zero, per bracket, is what lets the restore be **index-keyed**
-/// on the way back out ([`Attrlist::into_owned_restoring`]) — the parse can
-/// drop a token (a blank slot, a value the split discards) without shifting
-/// the ones that survive, exactly as
-/// `Passthroughs::restore_to` is
-/// unshifted by a sentinel that never reached the rendered string.
+/// [`SPAN_PLACEHOLDER`](super::super::quotes). Both become the same
+/// placeholder here, in the order they occur, which is what lets the restore
+/// find them **by position** on the way back out
+/// ([`Attrlist::into_owned_restoring`]) — a value the split discards simply
+/// never reaches a restore, and every occurrence after it keeps its own
+/// place in the sequence, unaffected.
 ///
 /// Shared by the two families whose bracket comes back from a parse — the
 /// `image:`/`icon:` bracket here, and the link families' display-text list
 /// ([`text_attrlist`](super::links)) — so the two cannot disagree about what
-/// a token may stand for: both masked kinds, the set [`node_is_restorable`]
-/// names. (The image bracket's one `web_path`-bound value, an interactive
-/// SVG's `fallback=`, resolves over its restored ranges *masked* — see
+/// a placeholder may stand for: both masked kinds, the set
+/// [`node_is_restorable`] names. (The image bracket's one `web_path`-bound
+/// value, an interactive SVG's `fallback=`, resolves over its restored ranges
+/// *masked* — see
 /// [`ElementAttribute::into_owned_restoring`](crate::attributes::ElementAttribute) —
 /// so a STEM body's backslash never reaches the resolver there either.)
 pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
@@ -1058,7 +1059,7 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
 
         match masked {
             Some(masked) => {
-                tokened.push_str(&format!("\u{96}{n}\u{97}", n = masked_pieces.len()));
+                tokened.push_str(MASKED_PIECE_PLACEHOLDER);
                 masked_pieces.push(masked);
             }
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2148,20 +2148,19 @@ mod tests {
     fn a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched() {
         // The bracket restore is one left-to-right pass, like
         // `Passthroughs::restore_to`'s own: a body that itself contains the
-        // bytes of a *later* token must not have that token spliced into it,
-        // and a token index the bracket never issued is left as written
-        // rather than renumbering the ones after it.
+        // bytes of a *later* placeholder must not have that placeholder
+        // spliced into it.
         let source = "image:x.png[++x\u{96}1\u{97}y++ ++b++]";
         let nodes = build_src(Span::new(source));
 
         let image = assert_image(&nodes[0]);
         assert_eq!(image.alt.as_deref(), Some("x\u{96}1\u{97}y b"));
 
-        // The leniency the index-keyed restore rests on, in both spellings a
-        // bracket can present: a run that is not a well-formed token (no
-        // digits) and one whose index the bracket never issued are each left
-        // exactly as the author wrote them, rather than renumbering — or
-        // consuming — the real tokens around them.
+        // The leniency the positional restore rests on, in both spellings a
+        // bracket can present: a run that is not the well-formed placeholder
+        // pair (a lone `\u{96}` or `\u{97}`, or the two separated by other
+        // bytes) is left exactly as the author wrote it, rather than being
+        // mistaken for a real occurrence.
         let nodes = build_src(Span::new(
             "image:x.png[++a++ \u{96}x\u{97} \u{96}9\u{97} ++b++]",
         ));
@@ -2172,13 +2171,27 @@ mod tests {
             Some("a \u{96}x\u{97} \u{96}9\u{97} b")
         );
 
-        // The string pipeline reads this one differently, and the difference
-        // is its own wart rather than something to reproduce: `restore_to`
-        // is a `replace_all` over the *finished* rendered string, so it also
-        // rewrites the sentinel-shaped bytes the author wrote — splicing
-        // passthrough 1's body into the middle of passthrough 0's. The tree
-        // restores per token, into the value each token actually stands in,
-        // so an author's own bytes survive. Its sibling
+        // And the leniency on the *other* side of the same shape: an
+        // author-typed **adjacent** pair — the well-formed placeholder shape
+        // itself, with no real masked piece behind it — is left as written
+        // too, rather than consuming a body meant for a later real
+        // occurrence. Only one passthrough (`++a++`) supplies a body here, so
+        // the cursor is already past `bodies.len()` by the time the typed
+        // pair is reached, and `restore_tokens`' own leniency for that case
+        // is what keeps it literal instead of panicking or misattributing.
+        let nodes = build_src(Span::new("image:x.png[++a++ \u{96}\u{97}]"));
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.alt.as_deref(), Some("a \u{96}\u{97}"));
+
+        // The string pipeline reads the first fixture differently, and the
+        // difference is its own wart rather than something to reproduce:
+        // `restore_to` is a `replace_all` over the *finished* rendered
+        // string, so it also rewrites the sentinel-shaped bytes the author
+        // wrote — splicing passthrough 1's body into the middle of
+        // passthrough 0's. The tree restores per occurrence, into the value
+        // each one actually stands in, so an author's own bytes survive. Its
+        // sibling
         // `a_restored_body_carrying_sentinel_shaped_bytes_is_not_re_matched`
         // pins the same reading for a target.
         use super::super::super::test_support::golden_passthroughs;

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     Parser, Span,
-    attributes::Attrlist,
+    attributes::{Attrlist, element_attribute::MASKED_PIECE_PLACEHOLDER},
     content::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
@@ -1538,8 +1538,12 @@ struct TextAttrlist<'src> {
     adopted: bool,
 
     /// The masked nodes [`text`](Self::text) still holds a
-    /// `\u{96}`*n*`\u{97}` token for, in token-index order — empty for a list
-    /// that crossed none.
+    /// [`MASKED_PIECE_PLACEHOLDER`] occurrence for, in the same left-to-right
+    /// order those occurrences
+    /// appear in [`text`](Self::text) — sliced to start at
+    /// [`text`](Self::text)'s own first occurrence (see
+    /// [`Attrlist::nth_attribute_token_offset`]) — empty for a list that
+    /// crossed none.
     ///
     /// The list's *values* are restored on the way out of the parse
     /// ([`Attrlist::into_owned_restoring`]), but the display text becomes the
@@ -1701,14 +1705,25 @@ fn text_attrlist<'src>(
     if pre_restore.iter().any(|n| {
         attrs
             .nth_attribute(*n)
-            .is_some_and(|attribute| attribute.value().contains('\u{96}'))
+            .is_some_and(|attribute| attribute.value().contains(MASKED_PIECE_PLACEHOLDER))
     }) {
         return None;
     }
 
     let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
 
-    let restores = masked.iter().map(|piece| piece.node.clone()).collect();
+    // `text` is attribute 1's own value — a substring of `tokened`, not the
+    // whole of it — so `restores` has to start at the same position
+    // `into_owned_restoring`'s own shared cursor would reach attribute 1 at,
+    // not at the whole bracket's own first occurrence. See
+    // [`restored_value_children`]'s doc comment for why.
+    let restores_start = attrs.nth_attribute_token_offset(1).unwrap_or(0);
+    let restores = masked
+        .get(restores_start..)
+        .unwrap_or_default()
+        .iter()
+        .map(|piece| piece.node.clone())
+        .collect();
 
     Some(TextAttrlist {
         adopted: text != tokened,
@@ -3740,10 +3755,15 @@ mod tests {
     #[test]
     fn an_authors_own_sentinel_shaped_bytes_in_a_display_text_are_a_documented_divergence() {
         // The wart the image family's own bracket already pins, reached from
-        // this side: the string pipeline restores by `replace_all` over the
-        // *finished* string, so an author's own `\u{96}`n`\u{97}` bytes are
-        // rewritten too (both copies become the body), while this restore
-        // splices at the token it placed. Neither reading is reachable by
+        // this side: the (frozen) string pipeline recording restored by
+        // `replace_all` over the *finished* string, so an author's own
+        // `\u{96}0\u{97}` bytes were rewritten too (both copies became the
+        // body). This restore instead finds the placeholder **pair**
+        // (`MASKED_PIECE_PLACEHOLDER`) by position, so the author's own bytes
+        // — `\u{96}`, `0`, `\u{97}`, none of them adjacent to their own
+        // matching half in a way that forms the pair — are never mistaken
+        // for one and stay exactly where the author put them, ahead of the
+        // real passthrough's own body. Neither reading is reachable by
         // ordinary authoring — these are C1 control characters.
         use super::super::super::test_support::golden_passthroughs;
 
@@ -3752,7 +3772,7 @@ mod tests {
 
         assert_eq!(
             fold_html(&build_src(Span::new(source)), &renderer),
-            "<a href=\"https://example.org\" class=\"hl\">a\u{96}0\u{97}</a>"
+            "<a href=\"https://example.org\" class=\"hl\">\u{96}0\u{97}a</a>"
         );
 
         assert_eq!(

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -22,6 +22,7 @@ use super::{
 };
 use crate::{
     HasSpan, Parser, Span,
+    attributes::element_attribute::MASKED_PIECE_PLACEHOLDER,
     content::restored_entity_pattern,
     inlines::{CharRef, InlineNode},
     strings::CowStr,
@@ -734,15 +735,15 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
 }
 
 /// Rewrites the **opaque** pieces inside one computed text's own match-string
-/// bytes into index-keyed `\u{96}`*n*`\u{97}` tokens, returning that text
-/// alongside the nodes those tokens stand for.
+/// bytes into [`MASKED_PIECE_PLACEHOLDER`] occurrences, returning that text
+/// alongside the nodes those occurrences stand for, in left-to-right order.
 ///
 /// This is [`tokened_bracket`](image::tokened_bracket)'s counterpart for a
 /// value that is **carried structurally** rather than restored as bytes, and
 /// the two differ in exactly one way. A masked passthrough or STEM expression
-/// has a body known at build time, so `tokened_bracket` pairs each token with
-/// it and the caller can splice those bytes back into a *parsed* value. A
-/// rendered [`Styled`](crate::inlines::Styled) span — or any
+/// has a body known at build time, so `tokened_bracket` pairs each occurrence
+/// with it and the caller can splice those bytes back into a *parsed* value.
+/// A rendered [`Styled`](crate::inlines::Styled) span — or any
 /// earlier-recognized macro node — has no such body: its markup exists only
 /// when the tree is folded. There is still nothing to restore *into bytes*,
 /// but there is something to carry: the **node**. So this tokens every atomic
@@ -750,18 +751,13 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
 /// as one placeholder, whatever kind it is, and the caller splices each node
 /// back through [`restored_value_children`].
 ///
-/// Why tokening at all, when the placeholder is already one opaque character:
-/// so the split sees the string pipeline's own **shape** there. The
-/// replacer parses an attribute list over the piece's *markup*, which carries
-/// no `,`/`=`/`"` the split could read differently than it reads a token —
-/// and a bare placeholder, being a single `Co` character, would be
-/// indistinguishable from one *inside* a value once the parse hands that value
-/// back. The token's index is what makes the walk back out
-/// unambiguous, exactly as it is for
-/// [`tokened_bracket`](image::tokened_bracket).
+/// The placeholder carries no index of its own — [`Attrlist::parse`] just
+/// needs an atomic run at that position, carrying none of the `,`/`=`/`"` a
+/// value's own bytes might. Which node an occurrence stands for is recovered
+/// by *position*, exactly as for [`tokened_bracket`](image::tokened_bracket):
+/// the Nth occurrence, scanned left to right, is `carried[N]`.
 ///
-/// Renumbering is per call, from zero, so a token the parse drops shifts none
-/// of the ones that survive.
+/// [`Attrlist::parse`]: crate::attributes::Attrlist::parse
 pub(super) fn tokened_text<'src>(
     text: &str,
     range: &std::ops::Range<usize>,
@@ -805,7 +801,7 @@ pub(super) fn tokened_text<'src>(
 
         match opaque {
             Some(node) => {
-                tokened.push_str(&format!("\u{96}{n}\u{97}", n = carried.len()));
+                tokened.push_str(MASKED_PIECE_PLACEHOLDER);
                 carried.push(node.clone());
             }
 
@@ -854,26 +850,39 @@ pub(super) fn tokened_text<'src>(
 /// issue #2661, open since 2018 and settled there as intended behavior), which
 /// is a divergence this crate takes deliberately.
 ///
-/// The walk is index-keyed and left to right, exactly like
-/// [`restored_value_children`]'s: each token is sought only in the bytes after
-/// the previous one, and a token the parse dropped is simply not found.
+/// The walk is left to right and **positional**, exactly like
+/// [`restored_value_children`]'s: each [`MASKED_PIECE_PLACEHOLDER`]
+/// occurrence is sought only in the bytes after the previous one, and is
+/// paired with the next of `carried` in turn. `carried` must already be
+/// sliced to start at `text`'s own first occurrence — see
+/// [`Attrlist::nth_attribute_token_offset`]/
+/// [`Attrlist::named_attribute_token_offset`] for how a caller reading `text`
+/// out of a larger parsed [`Attrlist`] finds that starting point — since a bare
+/// occurrence carries no index of its own to re-align with if `carried` starts
+/// anywhere else.
+///
+/// [`Attrlist`]: crate::attributes::Attrlist
+/// [`Attrlist::nth_attribute_token_offset`]: crate::attributes::Attrlist::nth_attribute_token_offset
+/// [`Attrlist::named_attribute_token_offset`]: crate::attributes::Attrlist::named_attribute_token_offset
 pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
 
-    for (n, node) in carried.iter().enumerate() {
-        let token = format!("\u{96}{n}\u{97}");
+    for node in carried {
+        let Some(pos) = rest.find(MASKED_PIECE_PLACEHOLDER) else {
+            break;
+        };
 
-        if let Some(pos) = rest.find(&token) {
-            out.push_str(rest.get(..pos).unwrap_or_default());
+        out.push_str(rest.get(..pos).unwrap_or_default());
 
-            match node {
-                InlineNode::Raw { value, .. } => out.push_str(value.as_ref()),
-                other => out.push_str(other.span().data()),
-            }
-
-            rest = rest.get(pos + token.len()..).unwrap_or_default();
+        match node {
+            InlineNode::Raw { value, .. } => out.push_str(value.as_ref()),
+            other => out.push_str(other.span().data()),
         }
+
+        rest = rest
+            .get(pos + MASKED_PIECE_PLACEHOLDER.len()..)
+            .unwrap_or_default();
     }
 
     out.push_str(rest);
@@ -898,11 +907,20 @@ pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> Stri
 /// its markup exists only at fold time — so for it the node *is* the only
 /// honest reading.
 ///
-/// The walk is index-keyed and left to right, like
-/// `Passthroughs::restore_to`'s
-/// own: each token is sought only in the bytes after the previous one, and a
-/// token the parse dropped (a value the split discarded) is simply not found,
-/// leaving the ones after it to splice by their own index.
+/// The walk is left to right and **positional**: each
+/// [`MASKED_PIECE_PLACEHOLDER`] occurrence is sought only in the bytes after
+/// the previous one, and is paired with the next of `restores` in turn.
+/// `restores` must already be sliced to start at `text`'s own first
+/// occurrence — see
+/// [`Attrlist::nth_attribute_token_offset`]/
+/// [`Attrlist::named_attribute_token_offset`] for how a caller reading `text`
+/// out of a larger parsed [`Attrlist`] finds that starting point, exactly as
+/// [`untranslated_value`] needs it — since a bare occurrence carries no index
+/// of its own to re-align with if `restores` starts anywhere else.
+///
+/// [`Attrlist`]: crate::attributes::Attrlist
+/// [`Attrlist::nth_attribute_token_offset`]: crate::attributes::Attrlist::nth_attribute_token_offset
+/// [`Attrlist::named_attribute_token_offset`]: crate::attributes::Attrlist::named_attribute_token_offset
 pub(super) fn restored_value_children<'src>(
     text: &str,
     restores: &[InlineNode<'src>],
@@ -912,19 +930,21 @@ pub(super) fn restored_value_children<'src>(
     let mut children: Vec<InlineNode<'src>> = Vec::new();
     let mut rest = text;
 
-    for (n, node) in restores.iter().enumerate() {
-        let token = format!("\u{96}{n}\u{97}");
+    for node in restores {
+        let Some(pos) = rest.find(MASKED_PIECE_PLACEHOLDER) else {
+            break;
+        };
 
-        if let Some(pos) = rest.find(&token) {
-            children.append(&mut computed_value_children(
-                rest.get(..pos).unwrap_or_default(),
-                location,
-                specials,
-            ));
+        children.append(&mut computed_value_children(
+            rest.get(..pos).unwrap_or_default(),
+            location,
+            specials,
+        ));
 
-            children.push(node.clone());
-            rest = rest.get(pos + token.len()..).unwrap_or_default();
-        }
+        children.push(node.clone());
+        rest = rest
+            .get(pos + MASKED_PIECE_PLACEHOLDER.len()..)
+            .unwrap_or_default();
     }
 
     children.append(&mut computed_value_children(rest, location, specials));

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -14,7 +14,10 @@ use super::{
 };
 use crate::{
     Parser, Span,
-    attributes::{Attrlist, AttrlistContext},
+    attributes::{
+        Attrlist, AttrlistContext,
+        element_attribute::{MASKED_PIECE_PLACEHOLDER_END, MASKED_PIECE_PLACEHOLDER_START},
+    },
     content::{
         INLINE_XREF, document_xrefstyle,
         inline_builder::{
@@ -448,27 +451,29 @@ fn attrlist_text_carries_its_opaque_pieces(
 }
 
 /// Whether `raw_text` — a macro's own **match-string** bytes, before any
-/// tokening — carries a byte a [`tokened_text`] token is built from.
+/// tokening — carries either byte of the
+/// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER)
+/// pair a [`tokened_text`] occurrence is built from.
 ///
 /// It should not: [`build_match_string`] stands an opaque piece in as
 /// [`SPAN_PLACEHOLDER`](super::super::quotes), a private-use codepoint, so
-/// every `\u{96}` / `\u{97}` reaching here is one the **author** wrote.
+/// every occurrence of either codepoint reaching here is one the **author**
+/// wrote — checked individually, not as the adjacent pair, since a stray
+/// half sitting beside the *other* half completed by a real placeholder
+/// nearby would be just as ambiguous as a whole stray pair.
 ///
 /// Those bytes make the whole tokening ambiguous, and the ambiguity bites
-/// precisely where a value is read as a *string*. A token is found by
+/// precisely where a value is read as a *string*. An occurrence is found by
 /// searching the parsed value for its bytes, and the search cannot tell an
-/// author's `\u{96}0\u{97}` from the one this pass emitted: it would splice a
-/// node's source into the author's text and leave the real token standing.
-/// (`Passthroughs::restore_to` has the same blind spot — the wart the image
-/// bracket's own sibling test pins — but the string pipeline reaches it over
-/// the *finished* string, where a `role=` it never restores into simply keeps
-/// the author's bytes.)
+/// author's own copy from the one this pass emitted: it would splice a node's
+/// source into the author's text and leave the real occurrence standing (or,
+/// past it, misattribute every occurrence after it).
 ///
-/// So a text carrying one defers, which is what the per-slot check this
+/// So a text carrying either defers, which is what the per-slot check this
 /// replaced did for the same bytes. It is a deferral, not a rewrite: the tree
-/// claims no construct, and the string pipeline's own reading stands.
+/// claims no construct.
 fn text_carries_author_written_token_bytes(raw_text: &str) -> bool {
-    raw_text.contains('\u{96}') || raw_text.contains('\u{97}')
+    raw_text.contains([MASKED_PIECE_PLACEHOLDER_START, MASKED_PIECE_PLACEHOLDER_END])
 }
 
 /// The match-string range of a `<<…>>` shorthand's **id half**: its inner up to
@@ -635,23 +640,48 @@ fn xref_macro_text<'src>(
         if first.as_deref() != Some(normalized.as_str()) {
             // The three values this family reads as **strings**. Each is read
             // off the *tokened* parse, so a value enclosing a rendered span or
-            // a masked passthrough holds that piece's token rather than any
-            // bytes of its own; `untranslated_value` puts the author's source
-            // back in its place (see its own doc comment for the two rules and
-            // for the deliberate divergence from Asciidoctor that follows).
-            let window = attrlist
-                .named_attribute("window")
-                .map(|a| CowStr::from(untranslated_value(a.value(), &carried)));
+            // a masked passthrough holds a placeholder occurrence rather than
+            // any bytes of its own; `untranslated_value` puts the author's
+            // source back in its place (see its own doc comment for the two
+            // rules and for the deliberate divergence from Asciidoctor that
+            // follows). Each is a *different* attribute from `carried`'s own
+            // global sequence, so each needs its own starting offset (see
+            // `untranslated_value`'s doc comment for why a bare occurrence
+            // cannot re-align itself).
+            let window = attrlist.named_attribute("window").map(|a| {
+                let start = attrlist.named_attribute_token_offset("window").unwrap_or(0);
 
+                CowStr::from(untranslated_value(
+                    a.value(),
+                    carried.get(start..).unwrap_or_default(),
+                ))
+            });
+
+            // A role from the first positional attribute's own shorthand
+            // items and one from a named `role=` attribute are two different
+            // attributes, so each needs its own starting offset (see
+            // `Attrlist::roles_with_token_offset`'s own doc comment).
             let roles = attrlist
-                .roles()
-                .iter()
-                .map(|r| CowStr::from(untranslated_value(r, &carried)))
+                .roles_with_token_offset()
+                .into_iter()
+                .map(|(r, start)| {
+                    CowStr::from(untranslated_value(
+                        r,
+                        carried.get(start..).unwrap_or_default(),
+                    ))
+                })
                 .collect();
 
-            let xrefstyle = attrlist
-                .named_attribute("xrefstyle")
-                .map(|a| XrefStyle::parse(&untranslated_value(a.value(), &carried)));
+            let xrefstyle = attrlist.named_attribute("xrefstyle").map(|a| {
+                let start = attrlist
+                    .named_attribute_token_offset("xrefstyle")
+                    .unwrap_or(0);
+
+                XrefStyle::parse(&untranslated_value(
+                    a.value(),
+                    carried.get(start..).unwrap_or_default(),
+                ))
+            });
 
             let children = match first.filter(|s| !s.is_empty()) {
                 None => vec![],
@@ -665,11 +695,18 @@ fn xref_macro_text<'src>(
                     // establishes.
                     let location = source_slice(pieces, text_range.start()..text_range.end(), root);
 
-                    // Each token this value still holds becomes the node it
-                    // stands for, so an enclosed span is carried as the
+                    // Each occurrence this value still holds becomes the node
+                    // it stands for, so an enclosed span is carried as the
                     // construct itself and rendered at fold time; the bytes
-                    // around it take the same rebuild a token-free value does.
-                    restored_value_children(&text, &carried, location, specials)
+                    // around it take the same rebuild an occurrence-free value
+                    // does.
+                    let start = attrlist.nth_attribute_token_offset(1).unwrap_or(0);
+                    restored_value_children(
+                        &text,
+                        carried.get(start..).unwrap_or_default(),
+                        location,
+                        specials,
+                    )
                 }
             };
 
@@ -2116,6 +2153,41 @@ mod tests {
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.roles.len(), 1);
         assert_eq!(reference.roles[0].as_ref(), "myrole");
+    }
+
+    #[test]
+    fn a_masked_piece_in_a_preceding_named_attribute_does_not_misattribute_a_later_one() {
+        // `role=` and `window=` are two different named attributes, tokened
+        // by the same shared `carried` sequence. Asciidoctor's own attribute
+        // numbering (every comma-delimited entry consumes a position,
+        // including named ones) means the *display text* can only ever be
+        // the bracket's first entry — so it is never actually reachable
+        // after a preceding named attribute, and cannot exercise this —
+        // but two named attributes, in either order, both carrying their own
+        // masked construct, are exactly the shape
+        // `Attrlist::named_attribute_token_offset` exists to keep straight:
+        // without it, `window`'s own restore would read off a `carried`
+        // slice that starts too early, splicing `role`'s body into `window`
+        // and leaving `window`'s own body stranded (or the other way
+        // around, in the reverse order).
+        for (source, roles, window) in [
+            ("xref:sec[role=++r++,window=++w++]", ["r"], "w"),
+            ("xref:sec[window=++w++,role=++r++]", ["r"], "w"),
+        ] {
+            let nodes = build_src(Span::new(source));
+            let reference = assert_xref(&nodes[0]);
+
+            assert_eq!(
+                reference
+                    .roles
+                    .iter()
+                    .map(|r| r.as_ref())
+                    .collect::<Vec<_>>(),
+                roles,
+                "for {source:?}"
+            );
+            assert_eq!(reference.window.as_deref(), Some(window), "for {source:?}");
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -2191,6 +2191,30 @@ mod tests {
     }
 
     #[test]
+    fn two_masked_roles_in_the_same_attribute_do_not_misattribute_each_other() {
+        // `role=++a++ ++b++` is one attribute, not two — `roles()` (and
+        // `roles_with_token_offset`) split its value on the space into two
+        // roles, each carrying its own placeholder. Both start from the same
+        // attribute-level offset, so the second role's own restore has to
+        // additionally skip past the first role's own occurrence rather than
+        // reusing that shared starting point (Greptile
+        // https://github.com/asciidoc-rs/asciidoc-parser/pull/1349#discussion_r3890749214) —
+        // otherwise both roles would come back as `"a"`, and `"b"` would
+        // never be reached.
+        let nodes = build_src(Span::new("xref:sec[a,role=++a-role++ ++b-role++]"));
+        let reference = assert_xref(&nodes[0]);
+
+        assert_eq!(
+            reference
+                .roles
+                .iter()
+                .map(|r| r.as_ref())
+                .collect::<Vec<_>>(),
+            ["a-role", "b-role"]
+        );
+    }
+
+    #[test]
     fn an_untranslated_string_attribute_is_escaped_by_the_renderer() {
         // What the slot holds is *text*, and the renderer escapes it for the
         // attribute it is building — so a body carrying a `"` or an `&` lands

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -120,14 +120,15 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_a_cross_reference() {
 fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
     // `image:`/`icon:` and the link families' display-text list are the one
     // place left where a masked passthrough or STEM expression is restored
-    // by scanning parsed text for its own `\u{96}`*n*`\u{97}` token
-    // (`tokened_bracket`/`Attrlist::into_owned_restoring`), rather than by
-    // node structure. An attribute reference is substituted into the bracket
-    // *before* the image macro is even recognized, so an attribute whose
-    // value happens to spell that same byte pattern — sitting in the same
+    // by scanning parsed text for its own [`MASKED_PIECE_PLACEHOLDER`]
+    // occurrence (`tokened_bracket`/`Attrlist::into_owned_restoring`), rather
+    // than by node structure. An attribute reference is substituted into the
+    // bracket *before* the image macro is even recognized, so an attribute
+    // whose value happens to spell that same byte — sitting in the same
     // bracket as a real passthrough — would otherwise be indistinguishable
-    // from the pipeline's own token and splice the passthrough's rendered
-    // body into `alt` instead of the literal text the document defined.
+    // from the pipeline's own placeholder and splice the passthrough's
+    // rendered body into `alt` instead of the literal text the document
+    // defined.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}0\u{97}\n",
         "\n",
@@ -151,8 +152,9 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restor
     // The `link:` macro's display-text list shares `tokened_bracket` and
     // `Attrlist::into_owned_restoring` with the image family's bracket (see
     // `a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore`),
-    // so the same forgery reaches it through a `role=` attribute sitting
-    // beside a real passthrough in the same display-text list.
+    // so the same forgery would reach it through a `role=` attribute sitting
+    // beside a real passthrough in the same display-text list, absent the
+    // same escape guard.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}0\u{97}\n",
         "\n",


### PR DESCRIPTION
## Summary

- Replace the two-boundary-char, decimal-index-carrying token (`\u{96}`*n*`\u{97}`) that `tokened_bracket`/`tokened_text` write for a masked passthrough, STEM expression, or other opaque piece inside a macro bracket's own text with a fixed two-codepoint pair (`MASKED_PIECE_PLACEHOLDER`, `\u{96}\u{97}`, no digits). Restoration now recovers which piece an occurrence stands for **by position** — a shared cursor consumed in left-to-right document order — rather than by parsing an index back out of the placeholder's own bytes.
- Add three `Attrlist` accessors (`nth_attribute_token_offset`, `named_attribute_token_offset`, `roles_with_token_offset`) so a caller reading one attribute's value out of a larger tokened list (the link family's display text, the xref family's `window`/`role`/`xrefstyle`/children) knows where in the *global* occurrence sequence that attribute's own placeholders begin.
- Keep `escape_passthrough_sentinels` (still escapes both codepoints individually) — see the design doc's own landed-as note for why eliminating it outright needs a bigger structural change than this increment covers, and what that would still need to prove out.

## Why

The digit-carrying shape dates from when this token doubled as the (now fully deleted) string-substitution pipeline's own passthrough sentinel — `Attrlist::parse` needed to see the same haystack shape the string pipeline's own text had there. That reason is gone (`SubstitutionGroup::apply_inner`: "the string pipeline no longer runs here at all"), so the doc comments citing it were stale, and the bespoke digit-parsing encoding was solving a problem the match-string level one layer up (`quotes.rs`'s `SPAN_PLACEHOLDER` + `Piece` table) already solves more simply, by position rather than by an in-band index.

Full design-doc note: see the new "The bracket-mask token's own digit-carrying shape was retired too (2026-08-30)" section in `docs/design/inline-ast-architecture.md`, right after the sibling `escape_passthrough_sentinels` landed-as note it follows.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` (clean)
- [x] `cargo test --workspace` (5,485 tests in the library crate, up from 5,482; all green)
- [x] `cargo +nightly doc --no-deps --document-private-items` (clean — fixed several intra-doc links broken by the module-path change)
- [x] Coverage diff-neutral against `origin/inline-ast` for every touched file (region/line/function counts unchanged), confirmed via `cargo-llvm-cov` against a baseline checkout
- [x] New regression coverage: `xref.rs`'s `a_masked_piece_in_a_preceding_named_attribute_does_not_misattribute_a_later_one` (a named attribute carrying its own masked piece, preceding another one, both directions); `attrlist.rs`'s direct unit tests for the three new accessors; `image.rs`'s extended `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched` (an author-typed adjacent pair after the bracket's one real passthrough has already spent its body)
- [x] Existing security regression suite (`tests/sentinels.rs`'s `a_placeholder_from_an_attribute_value_cannot_forge_*`) still passes, confirming the forgery `escape_passthrough_sentinels` guards against is unaffected

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01JzhGVDsGgmYU31AjAxLHLA)_