### PR TITLE
fix: Descend once for character replacements, not once per rule

### DIFF
--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -40,20 +40,18 @@ pub(super) fn apply_character_replacements<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
 ) -> Vec<InlineNode<'src>> {
-    let mut nodes = nodes;
-
-    for repl in character_replacements() {
-        nodes = apply_one_replacement(repl, nodes, root, LevelContext::ROOT);
-    }
-
-    nodes
+    apply_replacements_recursive(nodes, root, LevelContext::ROOT)
 }
 
-/// Applies one [`CharacterReplacement`] rule to `nodes`, first descending into
+/// Applies every [`character_replacements`] rule to `nodes`, descending into
 /// the [`Styled`](crate::inlines::Styled)/[`Ref`](InlineNode::Ref) children
-/// earlier steps created (a replacement inside a span is recognized just as the
-/// string pipeline recognizes one inside a rendered tag), then matching and
-/// replacing at this level.
+/// earlier steps created exactly once (a replacement inside a span is
+/// recognized just as the string pipeline recognizes one inside a rendered
+/// tag) rather than once per rule: every rule shares the same
+/// [`level_may_have_replacements`] sniff, so descending, and sniffing, once
+/// per level reaches the same leaves the string pipeline's own per-rule
+/// `replace_all` sweep does, without redoing either for every rule in the
+/// `character_replacements` list in turn.
 ///
 /// `ctx` is the boundary context this level sits in
 /// ([`LevelContext`]): "just as the string pipeline recognizes one inside a
@@ -62,15 +60,13 @@ pub(super) fn apply_character_replacements<'src>(
 /// against either edge of a span (`*x --*` renders `<strong>x --</strong>`,
 /// the `--` staying literal because `<` follows it in that haystack, not the
 /// end of a line).
-fn apply_one_replacement<'src>(
-    repl: &CharacterReplacement,
+fn apply_replacements_recursive<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     // A level with no parent node to descend into — the common leaf-only
-    // case, visited once per rule — skips the rebuild of its node vector
-    // entirely.
+    // case — skips the rebuild of its node vector entirely.
     let nodes = if nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_) | InlineNode::Ref(_)))
@@ -80,13 +76,12 @@ fn apply_one_replacement<'src>(
             .map(|node| match node {
                 InlineNode::Styled(mut styled) => {
                     let inner = LevelContext::inside_styled(&styled, ctx);
-                    styled.children = apply_one_replacement(repl, styled.children, root, inner);
+                    styled.children = apply_replacements_recursive(styled.children, root, inner);
                     InlineNode::Styled(styled)
                 }
 
                 InlineNode::Ref(mut reference) => {
-                    reference.children = apply_one_replacement(
-                        repl,
+                    reference.children = apply_replacements_recursive(
                         reference.children,
                         root,
                         LevelContext::INSIDE_REF,
@@ -101,7 +96,23 @@ fn apply_one_replacement<'src>(
         nodes
     };
 
-    replace_level(repl, nodes, root, ctx)
+    // Cheap pre-filter, shared by every rule below: none of them can match
+    // when this level has nothing replaceable at all, so this skips all of
+    // them at once rather than letting each rediscover the same answer over
+    // `nodes` on its own turn. `replace_level` does not repeat this check
+    // itself — see its own doc comment for why one pass here already covers
+    // every rule's turn.
+    if !level_may_have_replacements(&nodes) {
+        return nodes;
+    }
+
+    let mut nodes = nodes;
+
+    for repl in character_replacements() {
+        nodes = replace_level(repl, nodes, root, ctx);
+    }
+
+    nodes
 }
 
 /// One character-replacement match at a level, in absolute match-string byte
@@ -164,21 +175,25 @@ enum ReplacementKind {
 
 /// Matches `repl` over this level's escaped text, replacing each match with the
 /// leaf node(s) it produces and leaving everything else in place.
+///
+/// Takes no [`level_may_have_replacements`] pre-filter of its own: the caller
+/// ([`apply_replacements_recursive`]) already took it once for `nodes` before
+/// entering the rule loop this is called from, and every rule's own leaf —
+/// [`Replace`](ReplacementKind::Replace),
+/// [`Unescape`](ReplacementKind::Unescape),
+/// or [`Entity`](ReplacementKind::Entity) alike — either keeps the matched
+/// text's own trigger characters in place or produces a [`CharRef`] whose
+/// [`charref_entity`](super::quotes::charref_entity) form always starts with
+/// `&`, which the sniff's own `[&']` alternative always answers `true` for.
+/// So once true for a level, the sniff cannot go false again for the rest of
+/// that level's rule loop, and re-taking it on every rule's own turn would
+/// only ever confirm what the caller already established.
 fn replace_level<'src>(
     repl: &CharacterReplacement,
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: skip
-    // the pattern sweep (and the build's allocations) when nothing replaceable
-    // can be present at this level. Conservative — see
-    // [`level_may_have_replacements`] — so a level it passes still sniffs
-    // nothing more than the built string would.
-    if !level_may_have_replacements(&nodes) {
-        return nodes;
-    }
-
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // The rule runs over the level wrapped in its enclosing construct's own


### PR DESCRIPTION
## What

`apply_character_replacements` iterates the 13 character-replacement rules (copyright, dashes, ellipsis, apostrophes, arrows, entity-restore), calling `apply_one_replacement` once per rule. That function did a full recursive descent into every `Styled`/`Ref` child *every time it was called* — so a document with N nested styled spans paid 13 full re-descents into that subtree, and each visit independently re-evaluated the same rule-*independent* `level_may_have_replacements` sniff over what was frequently an unchanged node list.

This restructures the step to descend into `Styled`/`Ref` children **once**, hoisting the shared sniff to run once per level before the 13-rule loop. A level with nothing replaceable at all now skips the whole loop in one check, instead of every rule rediscovering the same "nothing here" answer on its own turn.

`replace_level`'s own copy of that same check is now dead code, not just redundant: every replacement leaf's canonical entity form always contains `&` (`copyright_becomes_a_replacement_leaf`'s `\u{a9}` → `&#169;`, and so on for every rule — see `replacement_entity`), which the sniff's `[&']` alternative always matches. So once a level's sniff is true, it can never go false again for the rest of that level's rule loop, and the caller having just taken that same check makes `replace_level`'s repeat of it unreachable. Removed rather than left as an untested branch, per this repo's own coverage-diff discipline (see below).

## Why

Profiled with `valgrind --tool=callgrind` against this branch's own `inline_throughput` bench fixtures (2000 iterations each, `-C force-frame-pointers=yes`), comparing this branch to `origin/inline-ast`:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `formatted_prose` | 40.66B instr | 28.78B instr | **-29.2%** |
| `mixed_document`* | 6.21B instr | 5.32B instr | **-14.3%** |
| `macro_prose` | 23.73B instr | 23.34B instr | -1.6% |
| `replacement_prose` | 15.64B instr | 15.62B instr | ~0% (noise) |

\* 300 iterations (larger fixture)

`formatted_prose` — the single worst regression in the original CodSpeed report on #1059 (-76.86%) — benefits most, since it's dense in *nested* `Styled` spans (`*_nested emphasis_*`, `[.term]#styled span#`, etc.), exactly the shape that made the old per-rule re-descent expensive. `replacement_prose` (flat text, genuine replacements throughout, little nesting) sees essentially no change, as expected — there's little redundant descent to remove there, and the level-level sniff was already usually true.

This is a straight continuation of the throughput-regression work in #1345/#1346/#1347: same profiling method, same "no behavior change, only redundant recomputation removed" scope.

## Validation

- Full test suite: 5485 tests pass unmodified — no test needed to change, since this only changes *how many times* the same rule-independent check and recursive descent run, not their outcome.
- `cargo +nightly fmt --all -- --check`, `cargo clippy -p asciidoc-parser --all-targets`, `cargo +nightly doc --no-deps --document-private-items`: all clean.
- Coverage diff against `origin/inline-ast` (`cargo llvm-cov`, via a worktree checkout of the base): identical missed-region/missed-line counts project-wide (544/320) and for `char_replacements.rs` specifically (6/3, same three pre-existing documented gaps, just shifted line numbers) — the dead branch removed above is exactly what would otherwise have shown up as a new gap.
- No corpus-wide fold-parity audit run: that recipe (documented in `CLAUDE.md`) forces `parser.build_inline_tree` on to diff against a live string-pipeline fallback, but that field and the string pipeline it gated were both fully retired by this branch's step 6 cutover (confirmed in `substitution_group.rs`'s `apply_inner` and `content.rs`) — there is no live dual-path left to diff against. This is a pure internal restructuring (no matching-logic change, no new node shapes), validated instead by the existing golden-snapshot differential tests in `char_replacements.rs` (`fold_matches_the_string_pipeline_through_replacements` and friends), which already passed unmodified.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FwZD11jq1xdb7kDTPyttGM)_