### PR TITLE
doc: Remove stale inline-ast migration narrative from code comments

### DIFF
--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -70,21 +70,15 @@ pub struct Content<'src> {
     passthroughs: Vec<Passthrough>,
 
     /// The inline AST for this content: the structured representation of its
-    /// inline nodes, built by the single-pass builder
-    /// (the crate-internal `inline_builder` module) directly from the
-    /// pre-substitution source, in parallel with the substitution pass that
-    /// produced [`rendered`](Self::rendered).
+    /// inline nodes, built by the single-pass builder (the crate-internal
+    /// `inline_builder` module) directly from the pre-substitution source.
     ///
-    /// This is a **derived artifact** — built alongside the rendered content,
-    /// which remains the source of truth (making the tree canonical, with
-    /// `rendered_html()` a fold of it, is the remaining half of the [inline
-    /// AST architecture] design's step 6). Every parse builds it: the
-    /// `with_inline_tree` opt-in that used to gate it is retired. Because it is
-    /// derived, it is deliberately excluded from [`PartialEq`]/[`Eq`]/[`Hash`]:
-    /// two `Content`s with equal rendered text compare equal regardless of
-    /// their trees.
-    ///
-    /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    /// This tree is **authoritative**: [`rendered`](Self::rendered) is a fold
+    /// of it (see `SubstitutionGroup::apply`), and every macro family's
+    /// catalog/warning registration replays from it. It is nonetheless
+    /// deliberately excluded from [`PartialEq`]/[`Eq`]/[`Hash`], as a derived
+    /// artifact: two `Content`s with equal rendered text compare equal
+    /// regardless of their trees.
     inlines: Vec<InlineNode<'src>>,
 
     /// The document attributes as of the point in the document this content
@@ -128,12 +122,10 @@ pub struct Content<'src> {
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
 ///
 /// The cross-references are read off the content's own **inline tree** (see
-/// [`block_tree_xref_segments`] and [`footnote_tree_xref_segments`]), which is
-/// what design §5.2's survey named as the first of the six things
-/// `run_pipeline` still solely owned. They arrive already partitioned into the
-/// two lists resolution keeps apart, where the string pipeline produced one
-/// flat list that had to be split by asking which placeholders its template
-/// still spliced.
+/// [`block_tree_xref_segments`] and [`footnote_tree_xref_segments`]), and
+/// arrive already partitioned into the two lists resolution keeps apart —
+/// rather than a flat list that has to be split by asking which placeholder
+/// survived.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct DeferredContent {
     /// The **block-level** cross-references, in the order
@@ -389,10 +381,8 @@ impl<'src> Content<'src> {
     /// [`carried_title_template`]. The snapshot travels across the
     /// `'src`-erasing hop (`Parser::pending_block_title`) with its inline nodes
     /// dropped, so the claiming block's title is the one content that renders
-    /// from a template rather than folding a tree; this is where that template
-    /// stops being the string pipeline's and becomes a product of the tree,
-    /// which is what lets the oracle pipeline be deleted without losing the
-    /// carried title's resolution.
+    /// from a template rather than folding a tree — and that template is a
+    /// product of the tree, synthesized at this hop.
     ///
     /// `parser` supplies the renderer; the fold runs under the title's own
     /// retained render attributes, the same pairing [`refold`](Self::refold)
@@ -475,13 +465,11 @@ impl<'src> Content<'src> {
     /// Returns the default **HTML** rendering of this content: the final text
     /// after all substitutions have been applied.
     ///
-    /// This is the built-in HTML output. (A custom
-    /// [`InlineRenderer`] installed via
+    /// This is the built-in HTML output. A custom [`InlineRenderer`]
+    /// installed via
     /// [`Parser::with_inline_renderer`](crate::Parser::with_inline_renderer)
-    /// still drives this output during migration; moving renderer selection to
-    /// render time is a later step of the [inline AST architecture].)
-    ///
-    /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    /// drives this output too; [`render_with`](Self::render_with) folds the
+    /// same tree through any renderer supplied at render time instead.
     pub fn rendered_html(&'src self) -> &'src str {
         self.rendered.as_ref()
     }
@@ -490,7 +478,7 @@ impl<'src> Content<'src> {
     /// same [`inlines`](Self::inlines) tree
     /// [`rendered_html`](Self::rendered_html) is the built-in HTML answer for.
     /// Returns an owned `String`, and caches nothing — the crate memoizes only
-    /// the default HTML rendering (design §3.3.1).
+    /// the default HTML rendering.
     ///
     /// One parse feeds any number of renders: the tree is built once, with
     /// every order-dependent fact (footnote numbers, counters, expanded
@@ -617,32 +605,26 @@ impl<'src> Content<'src> {
     /// Returns the inline AST for this content: the structured, read-only
     /// representation of its inline nodes.
     ///
-    /// Every parse builds this — the `with_inline_tree` opt-in that used to
-    /// gate it is retired — so it is an empty slice only for content whose tree
-    /// is genuinely empty (empty content). The tree is built by the single-pass
-    /// builder
-    /// (the crate-internal `inline_builder` module) directly from the
-    /// pre-substitution source, so each node carries its own precise source
-    /// [`Span`] (a node born from a transformation, such as an attribute
-    /// expansion, falls back to a documented coarser span) and a macro node
-    /// carries its own parsed attribute list. The fold of the tree reproduces
-    /// [`rendered_html`](Self::rendered_html) byte-for-byte across the
-    /// builder's supported vocabulary; a small set of forms is documented as
-    /// deferred (documented in the `inline_builder`
-    /// module), each left as literal text in the tree rather than a wrong
-    /// node. The tree is not yet the canonical representation (see the
-    /// [inline AST architecture design], Phase 4 step 6).
+    /// Every parse builds this, so it is an empty slice only for content
+    /// whose tree is genuinely empty (empty content). The tree is built by
+    /// the single-pass builder (the crate-internal `inline_builder` module)
+    /// directly from the pre-substitution source, so each node carries its
+    /// own precise source [`Span`] (a node born from a transformation, such
+    /// as an attribute expansion, falls back to a documented coarser span)
+    /// and a macro node carries its own parsed attribute list. The tree is
+    /// **canonical**: [`rendered_html`](Self::rendered_html) is a fold of
+    /// it. A small set of forms is documented as deferred (in the
+    /// `inline_builder` module), each left as literal, already-rendered text
+    /// in the tree rather than a dedicated node — so the rendering is always
+    /// exact, but the tree's structure is coarser for those forms.
     ///
     /// Cross-references in the tree carry their resolved destination once a
     /// full [`Parser::parse`](crate::Parser::parse) has resolved the document's
     /// references: each resolved destination is mirrored into the corresponding
     /// [`Ref`](crate::inlines::Ref) node, so a caller that walks
     /// [`inlines`](Self::inlines) after the parse sees the same destinations
-    /// the rendered string reflects (§4.3 of the design). Before resolution
-    /// — or for a standalone parse with no document catalog — a `Ref`
-    /// node's destination is `None`.
-    ///
-    /// [inline AST architecture design]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    /// the rendered string reflects. Before resolution — or for a standalone
+    /// parse with no document catalog — a `Ref` node's destination is `None`.
     pub fn inlines(&self) -> &[InlineNode<'src>] {
         &self.inlines
     }
@@ -693,8 +675,7 @@ impl<'src> Content<'src> {
     }
 
     /// Installs this content's deferred cross-references, **read off its own
-    /// inline tree** — the sole producer of a production content's deferred
-    /// state now that the string pipeline no longer runs at the seam.
+    /// inline tree** — the sole producer of a content's deferred state.
     ///
     /// The two lists come from [`block_tree_xref_segments`] and
     /// [`footnote_tree_xref_segments`], already partitioned the way resolution
@@ -708,18 +689,11 @@ impl<'src> Content<'src> {
     /// boolean walk answers that first, and cheaply, because *most contents
     /// are exactly that* — a plain paragraph's nodes are text runs the walk
     /// rejects in one pass, where unconditionally deriving both segment lists
-    /// would traverse every tree twice to build two empty vectors. (The old
-    /// early return keyed this on the string pipeline having deferred
-    /// something; the walk is the same question asked of the tree.)
+    /// would traverse every tree twice to build two empty vectors.
     ///
-    /// The carve-out that used to live here — keeping the string pipeline's
-    /// whole answer where the tree held fewer cross-references than the
-    /// pipeline deferred — is gone with the pipeline it fell back to. It was
-    /// measured unreachable before the deletion (zero hits across the suite,
-    /// both of its member forms closed by their own increments); a form the
-    /// builder still declines is simply not a cross-reference of this content
-    /// any more, which is the documented-divergence reading every such form
-    /// already has.
+    /// A cross-reference form the builder declines to recognize is simply not
+    /// a cross-reference of this content — the documented-divergence reading
+    /// every such form already has.
     pub(crate) fn set_tree_xrefs(
         &mut self,
         tree: &[InlineNode<'src>],
@@ -832,13 +806,13 @@ impl<'src> Content<'src> {
     /// Re-renders this content from its **tree**, now that resolution has
     /// installed each cross-reference's destination into it.
     ///
-    /// This is what retires the deferred-cross-reference sentinel system
-    /// (design §4.2's second). `rendered_html()` became a fold of the tree for
-    /// every other content at the cutover; the one exception was content
-    /// carrying a deferred cross-reference, whose rendering is rebuilt on every
-    /// resolution pass and so could not be a fold *taken at parse time*. It can
-    /// be a fold taken **here** instead — after the pass that resolved it —
-    /// which is the same answer reached one step later.
+    /// `rendered_html()` is a fold of the tree for every content, taken once
+    /// at parse time. The one exception is content carrying a deferred
+    /// cross-reference: its rendering must be rebuilt on every resolution
+    /// pass, so it cannot be folded once and for all at parse time — what it
+    /// holds until resolution is the fold of the still-unresolved tree. This
+    /// re-fold, taken **here** after the pass that resolved it, is the same
+    /// answer reached one step later.
     ///
     /// `attributes` are the document attributes this content was parsed under,
     /// which it retained itself because they are order-dependent; they are
@@ -848,9 +822,9 @@ impl<'src> Content<'src> {
     ///
     /// The caller gates this on the content **holding a tree**, which every
     /// production content with deferred state does — the deferred lists are
-    /// read off that tree, the only producer left at the seam. The one
-    /// content that renders from a *template* instead — the carried block
-    /// title (see [`carried_title_template`]) — is resolved by the
+    /// read off that tree, the sole producer of a content's deferred state.
+    /// The one content that renders from a *template* instead — the carried
+    /// block title (see [`carried_title_template`]) — is resolved by the
     /// document-order title pass, never here.
     /// Folds each footnote this content **defines** from its own subtree, and
     /// hands the results to `warnings` for the resolution pass to install into
@@ -1077,26 +1051,19 @@ impl<'src> Content<'src> {
 ///
 /// `None` is the same carve-out
 /// [`mirror_tree_xref_resolution`](Content::mirror_tree_xref_resolution)
-/// reports: a tree holding fewer block-level cross-references than the string
-/// pipeline deferred does not describe this title, so folding it would drop the
-/// construct. The caller renders the template instead.
+/// reports: a tree holding fewer block-level cross-references than were
+/// deferred does not describe this title, so folding it would drop the
+/// construct. The caller renders the template instead — the fallback for a
+/// title with no tree to fold at all (a block title carried across a section
+/// heading, whose inline nodes cannot cross the `'src`-erasing hop it
+/// travels on).
 ///
 /// Folding renders the **whole** title, not just its cross-references — every
 /// styled span, image and special character in it — where the template render
-/// this replaces touched only the placeholders. Measured on a heading carrying
-/// all three, that is three more renderer callbacks per deferred title (13 → 16
-/// for `== A *bold* image:x.png[X] a < b <<t>>`). The calls are duplicates: the
-/// string pipeline already made them at parse time.
-///
-/// That is the transitional cost of an authoritative fold, not a cost this path
-/// adds. Every content already pays it — a plain paragraph's `<` is rendered
-/// twice today, once by `run_pipeline` and once by the fold that overwrites its
-/// answer — and a *deferred paragraph* has paid exactly this since the fold
-/// moved to resolution time. A title was the last content still on the cheaper
-/// template path, and it was cheaper only because its rendering was less
-/// correct. The duplication ends for all of them together, when step 6 takes
-/// the string pipeline off the production path; it cannot end here, because
-/// folding a tree means rendering it.
+/// touches only the placeholders. Measured on a heading carrying all three,
+/// that is three more renderer callbacks per deferred title (13 → 16 for
+/// `== A *bold* image:x.png[X] a < b <<t>>`) — the cost of an authoritative
+/// fold, paid once per deferred title.
 ///
 /// What this *does* avoid is rendering the same title twice within this pass:
 /// the fold replaces the template render rather than joining it — see the

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -1197,8 +1197,9 @@ fn tree_defers_xrefs(nodes: &[InlineNode<'_>]) -> bool {
 /// carries every field an [`XrefSegment`] holds but one — `target`, `window`,
 /// `roles`, `xrefstyle` and `derived` are plain values the builder resolved at
 /// recognition time. Only
-/// [`provided_text`](XrefSegment::provided_text) needs deriving, which the segment holds
-/// as a **string** where the node holds its display text as *children*.
+/// [`provided_text`](XrefSegment::provided_text) needs deriving, which the
+/// segment holds as a **string** where the node holds its display text as
+/// *children*.
 ///
 /// That slot takes the **fold of those children**, and it is a different answer
 /// from the one given `role=` / `window=` / `xrefstyle=`
@@ -1214,8 +1215,8 @@ fn tree_defers_xrefs(nodes: &[InlineNode<'_>]) -> bool {
 /// carried. Deriving it
 /// later, at resolution time, would read whatever renderer that caller passed
 /// and hand the resolver a different [`ResolutionContext`]; taking it at
-/// build time keeps this function a pure function of the tree plus the parse's own
-/// renderer.
+/// build time keeps this function a pure function of the tree plus the parse's
+/// own renderer.
 ///
 /// Present-but-empty is preserved, because it is a distinction the renderer
 /// acts on: the `<<id,>>` shorthand records one empty

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -986,8 +986,8 @@ impl<'src> Content<'src> {
     /// resolved state from `block_ordered` and `footnote_ordered`.
     ///
     /// Returns whether the **block-level** correlation ran — i.e. whether the
-    /// tree holds exactly the cross-reference nodes whose placeholders the
-    /// string pipeline left in the template. A `false` means the builder left
+    /// tree holds exactly the cross-reference nodes the carried title's own
+    /// template expects a slot for. A `false` means the builder left
     /// at least one of them unrecognized, so this content's tree is known not
     /// to describe its rendering; a caller that folds the tree instead of
     /// rebuilding from that template (see [`refold`](Self::refold)) uses this
@@ -1013,7 +1013,7 @@ impl<'src> Content<'src> {
         // documented set of divergent forms unrecognized (e.g. a display text
         // crossing a rendered span — see the `inline_builder` module), so the
         // tree can legitimately hold *fewer* cross-reference nodes than the
-        // string pipeline deferred. When the counts differ the positional
+        // template expects a slot for. When the counts differ the positional
         // pairing is unknowable; the mirror is skipped for that list — leaving
         // its nodes in their honest unresolved state — rather than assigning
         // destinations to the wrong nodes.
@@ -1129,9 +1129,9 @@ fn count_tree_xrefs(nodes: &[InlineNode<'_>]) -> usize {
 
             InlineNode::Styled(styled) => count_tree_xrefs(&styled.children),
 
-            // A **visible index term** shows its text in the flow, so the
-            // string replacer's own haystack holds any cross-reference written
-            // inside it and defers a segment for one. It is the fifth nested
+            // A **visible index term** shows its text in the flow, so a
+            // cross-reference written inside it renders in place and defers a
+            // segment of its own. It is the fifth nested
             // node list a tree can hold a construct in (see the side-effect
             // sweep's own note), and the one a walk written by matching on
             // `children` is bound to miss.
@@ -1187,45 +1187,40 @@ fn tree_defers_xrefs(nodes: &[InlineNode<'_>]) -> bool {
 }
 
 /// Derives the **block-level** deferred cross-reference segments from an
-/// already-built inline tree — the list `run_pipeline`'s own
-/// `InlineXrefReplacer` produced and its `set_deferred_xrefs` installed,
-/// read off the nodes instead.
+/// already-built inline tree, read off the nodes.
 ///
-/// This is one of the six things design §5.2's survey found the string pipeline
-/// still solely owning — the first of them the survey called *blocked* rather
-/// than merely unbuilt. It is **wired**: [`Content::set_tree_xrefs`] installs
+/// [`Content::set_tree_xrefs`] installs
 /// what this returns, so what a content carries for its deferred
 /// cross-references is what its tree said.
 ///
 /// A [`Ref`](InlineNode::Ref)`{`[`Xref`](RefVariant::Xref)`}` node already
 /// carries every field an [`XrefSegment`] holds but one — `target`, `window`,
 /// `roles`, `xrefstyle` and `derived` are plain values the builder resolved at
-/// recognition time — so the survey recorded the family as blocked on
-/// [`provided_text`](XrefSegment::provided_text) alone, which the segment holds
+/// recognition time. Only
+/// [`provided_text`](XrefSegment::provided_text) needs deriving, which the segment holds
 /// as a **string** where the node holds its display text as *children*.
 ///
 /// That slot takes the **fold of those children**, and it is a different answer
-/// from the one the sibling increment gave `role=` / `window=` / `xrefstyle=`
+/// from the one given `role=` / `window=` / `xrefstyle=`
 /// (the author's untranslated source, see
 /// [`untranslated_value`](crate::content::inline_builder)) for a reason worth
 /// stating: a display text *is* markup by nature. `xref:sec[*bold*]` shows
-/// bold text, and the string replacer captures exactly
-/// `<strong>bold</strong>` out of its own already-rendered haystack — so the
-/// fold reproduces the byte string rather than approximating it, where a
-/// computed string slot had no such answer to match.
+/// bold text, and the fold of the node's own children reproduces exactly
+/// `<strong>bold</strong>` — the byte string a display text always renders as,
+/// rather than approximating it, where a computed string slot had no such
+/// answer to match.
 ///
 /// The fold runs **here**, at the end of the parse, with the renderer the parse
-/// carried — which is where the string replacer computes it too. Deriving it
+/// carried. Deriving it
 /// later, at resolution time, would read whatever renderer that caller passed
-/// and hand the resolver a different [`ResolutionContext`] than the string
-/// pipeline does; taking it at build time keeps the two byte-identical and
-/// keeps this function a pure function of the tree plus the parse's own
+/// and hand the resolver a different [`ResolutionContext`]; taking it at
+/// build time keeps this function a pure function of the tree plus the parse's own
 /// renderer.
 ///
 /// Present-but-empty is preserved, because it is a distinction the renderer
 /// acts on: the `<<id,>>` shorthand records one empty
-/// [`Text`](InlineNode::Text) child, which the string replacer carries as
-/// `Some("")` and renders as an empty `<a>…</a>`, where an absent text
+/// [`Text`](InlineNode::Text) child, folding to
+/// `Some("")` and rendering as an empty `<a>…</a>`, where an absent text
 /// (`None`) falls back to the target's reference text. So the `Option` keys on
 /// the **presence of a child**, not on what that child folds to — the same rule
 /// [`fold_xref`](crate::content::inline_builder) already applies, and the

--- a/parser/src/content/inline_builder/README.md
+++ b/parser/src/content/inline_builder/README.md
@@ -1,0 +1,82 @@
+# `inline_builder/`
+
+Builds the [`InlineNode`](../../inlines/mod.rs) tree that every parse's content is made of,
+directly from source in a single forward pass. This is the module `parser/snapshots/README.md`
+refers to when it talks about "the builder" — the two files complement each other: that one
+documents the frozen golden recordings the differential corpora here read from, and its
+"Background" section covers the crate's original string-substitution implementation in more
+depth than is repeated below.
+
+## From string rewriting to a tree
+
+This crate used to implement inline content (bold, links, images, footnotes, cross references,
+…) as **string rewriting**: `Content` held one mutable rendered string, and each substitution
+step edited it in place, recognizing a construct and rendering it to HTML in the same motion.
+Three things that don't fit in a flat string — passthroughs, deferred cross-references, and
+footnote markers — were smuggled through it with Unicode sentinel characters, cut back out once
+their real destination was known.
+
+That model is retired. Inline content is now built as data: each step in this module is a
+**transducer** over a node list, `Vec<InlineNode<'src>> -> Vec<InlineNode<'src>>`, that refines
+the tree in place rather than recovering it after the fact from a rendered string. Passthroughs
+are `Raw` nodes, a deferred cross-reference is a `Ref` node resolution fills in **in place**, and
+a footnote marker is a `Footnote` node — no sentinel encoding is left in production code.
+`SubstitutionGroup::apply` (`parser/src/content/substitution_group.rs`) builds this tree once per
+content, and both `Content::rendered_html()` and every macro family's catalog/warning
+registration are derived from it: the tree is the single source of truth, not a second
+implementation running alongside a string-based one.
+
+Building the tree directly, rather than recovering it from a string, gives two properties a
+post-hoc recovery could not:
+
+- **Honest per-node spans.** A node is sliced straight from the source `Span`, so its `location`
+  reports the real `line`/`col`/`offset` of the construct (issue #944), instead of every node
+  carrying the whole-content span.
+- **`'src` borrowing by construction.** A verbatim text run's `value` borrows the very bytes its
+  `location` covers, so the common case allocates nothing.
+
+## The escaping-order rule
+
+Several steps' comments refer to one recurring rule for how a construct's escaping status is
+decided: whether a byte sequence like `<`/`>`/`&` is treated as already-escaped or as raw text
+depends on where the `specialcharacters` step sits in the content's *effective* substitution
+order (`Normal`'s built-in order runs it first; a `subs=` list can move it, and
+`subs=attributes+` is the case that puts it after `attributes`). A step downstream of
+`specialcharacters` sees markup as logical text; a step upstream of it — or a group that omits
+`specialcharacters` altogether — sees raw, unescaped bytes and must classify them itself
+(`classify_unescaped_specials`, `flatten_prior_markup`). Each step that depends on this reads the
+order at build time (`SplicedSpecials`, `ComputedSpecials`) rather than assuming a fixed
+position, since a `Custom` substitution list can reorder it.
+
+## Match strings and recoverable pieces
+
+Several node kinds have no `Span`-typed field of their own — an anchor's id, a bare e-mail
+address, a UI macro's keys/label/menu path, an index term's shown text, a cross-reference's
+target and reference text. Recognizing these inside content that has no single contiguous `'src`
+slice (an expanded attribute reference, a synthesized multi-line seed) means reading a
+**match string**: a level's own escaped/normalized text, built by `quotes::build_match_string`,
+which carries the same escaped bytes and canonical entities the crate has always produced for
+this content. A **recoverable piece** — an escaped special, a restored entity, a typographic
+replacement, or a masked passthrough placeholder — can be read back out of that string exactly,
+without needing an `'src` slice; what still defers is a piece that only exists as *rendered
+markup* (a `Styled` span), since a span's tags exist only at fold time and there is no range of
+source bytes to recover them from.
+
+## Recognition side effects
+
+Every macro family recognizes its construct without performing the catalog registration or
+warning that goes with it — that happens once per parse, after the tree is built and folded, via
+`apply_macro_side_effects` (and, for callouts, `apply_callout_side_effects`), which replays each
+family's own side effect from the finished tree in the crate's usual family-pass order. Keeping
+recognition and registration separate is what lets every family's tests build and inspect a tree
+without a full `Parser`/`Content` round trip.
+
+## Testing
+
+Per-step differential corpora (`golden_*` helpers) pin each transducer against the frozen
+recordings in `parser/snapshots/`; see that directory's README for the recording format and the
+whole-corpus harnesses. This module's own `tests` submodule additionally runs the *real*,
+assembled pipeline (`build`/`build_for_group` through `SubstitutionGroup::apply`) over broader
+sweeps — a construct × container cross-product, combined-construct fixtures, and
+synthesized-seed fixtures — to catch interactions between steps that a single-family corpus
+cannot.

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -331,20 +331,18 @@ fn apply_attribute_references_recursive<'src>(
 ///   piece in the match string, so its interior `\n`s are invisible here —
 ///   while a flat rendered string, which by this point holds the span's
 ///   rendered markup inline, still shows them and splits on them. The line
-///   correspondence
-///   the drop rests on would therefore be wrong, so
+///   correspondence the drop rests on would therefore be wrong, so
 ///   [`for_content`](Self::for_content) disables dropping for the whole content
 ///   when it finds one. (A masked passthrough or STEM expression is *not*
-///   affected: it too sits in the match string as a single opaque piece with
-///   no embedded `\n`s, so a
-///   multi-line one collapses its lines there too, exactly as the placeholder
-///   does here.)
+///   affected: it too sits in the match string as a single opaque piece with no
+///   embedded `\n`s, so a multi-line one collapses its lines there too, exactly
+///   as the placeholder does here.)
 ///
 /// - A missing reference nested inside a `Styled` span, under
 ///   [`DropLine`](Self::DropLine). Dropping the *enclosing* line is what
-///   line-based processing does, which this level cannot see from inside the span;
-///   [`nested`](Self::nested) therefore leaves such a reference literal. Under
-///   [`DropReference`](Self::DropReference) the nested case *is* handled,
+///   line-based processing does, which this level cannot see from inside the
+///   span; [`nested`](Self::nested) therefore leaves such a reference literal.
+///   Under [`DropReference`](Self::DropReference) the nested case *is* handled,
 ///   because removing the reference is a purely local edit and the span keeps
 ///   its enclosing line non-empty either way.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1067,11 +1065,12 @@ fn rebuild_attribute_level<'src>(
 
     for line in lines {
         // One separator between consecutive survivors — the same "join the
-        // kept lines with `\n`" shape `apply_attributes` uses. The byte emitted is the
-        // `\n` that terminated the *previous survivor*, which is always a real
-        // one: a line range excludes its terminator, and a line followed by
-        // another always has one. Whether lines were dropped in between makes
-        // no difference; exactly one separator belongs here either way.
+        // kept lines with `\n`" shape `apply_attributes` uses. The byte emitted
+        // is the `\n` that terminated the *previous survivor*, which is
+        // always a real one: a line range excludes its terminator, and
+        // a line followed by another always has one. Whether lines were
+        // dropped in between makes no difference; exactly one separator
+        // belongs here either way.
         if let Some(end) = previous_end {
             emit_range(nodes, pieces, end..end + 1, &mut out);
         }
@@ -2127,9 +2126,9 @@ mod tests {
     fn a_counter_directive_survives_a_dropped_neighbouring_line() {
         // A `counter` directive advances during `resolve_counters`, which runs
         // over the whole tree before any line is dropped — exactly as
-        // `AttributeReplacer` advances a counter as its own line loop reaches it.
-        // A directive on a *dropped* line has still advanced, so the survivor
-        // after it numbers from there.
+        // `AttributeReplacer` advances a counter as its own line loop reaches
+        // it. A directive on a *dropped* line has still advanced, so
+        // the survivor after it numbers from there.
         let parser = parser_with_missing_mode("drop-line");
         let source = "{counter:n}\n{undefined-thing} {counter:n}\n{counter:n}";
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -19,21 +19,22 @@ use crate::{
 
 /// The attribute-references substitution, as a node transducer: descends into
 /// [`Styled`](crate::inlines::Styled) children (a reference inside a rendered
-/// span is recognized just as the string pipeline recognizes one inside
-/// rendered markup), then matches and splices at this level.
+/// span is recognized just as one inside rendered markup would be),
+/// then matches and splices at this level.
 ///
-/// It reuses the string pipeline's *exact* recognition —
-/// [`ATTRIBUTE_REFERENCE`] is now shared `pub(crate)` — so only the
-/// recognition *sink* differs (§4.1): a resolved reference's value is spliced
-/// into the node stream, classified by [`split_attribute_value`] (design
-/// §3.4.1) rather than written into a `&mut String`.
+/// It matches with [`ATTRIBUTE_REFERENCE`], the crate's shared,
+/// `pub(crate)` recognition pattern for this construct — so only the
+/// recognition *sink* differs: a resolved reference's value is spliced
+/// into the node stream, classified by [`split_attribute_value`] rather
+/// than written into a `&mut String`.
 ///
 /// A `counter`/`counter2` directive (`{counter:name}`, `{counter2:name:seed}`)
 /// is recognized like any other reference: it resolves *and advances* the
 /// named document counter via [`Parser::counter`] — the same required side
 /// effect [`apply_footnotes`](super::footnotes::apply_footnotes) performs for
 /// footnote numbering, and for the same reason it cannot be deferred to the
-/// cutover the way every other macro family's catalog/warning side effect is
+/// post-fold side-effect pass the way every other macro family's
+/// catalog/warning side effect is
 /// (skipping it would leave the directive's own digits wrong, not just an
 /// absent catalog entry). `counter` splices the advanced value in (classified
 /// by [`split_attribute_value`] exactly like a plain reference's value);
@@ -54,12 +55,11 @@ use crate::{
 /// missing attribute" under `Warn`, and "dropping line containing reference to
 /// missing attribute" under `DropLine`, each recorded as a
 /// [`SkippingReferenceToMissingAttribute`] warning — **is** raised here, by
-/// [`record_missing_reference_warnings`]. It is the fifth and last of the
-/// recognition diagnostics the tree-walk replay cannot carry (design §5.2 Phase
-/// 4, step 6): a dropped or warned-about reference leaves no node to hang a
-/// diagnostic on, so it is recorded where it is *recognized* and carried onto
-/// the real parser afterwards, with the string pipeline's own copy suppressed
-/// for the duration of that window.
+/// [`record_missing_reference_warnings`], because a dropped or warned-about
+/// reference leaves no node in the tree to hang a diagnostic on: unlike a
+/// macro family's diagnostics, which the post-fold side-effect pass replays
+/// from the finished tree, this one is recorded where it is *recognized* and
+/// carried onto the real parser afterwards.
 ///
 /// Two things about it are easy to get wrong, and both have their reasons on
 /// [`record_missing_reference_warnings`]: the mode is read from
@@ -71,8 +71,8 @@ use crate::{
 /// child's content before its own level).
 ///
 /// A literal `<`, `>`, or `&` **in the expanded value** is classified by
-/// design §3.4.1 — "the kind a fragment becomes is decided by which
-/// substitution steps still act on it under the group's effective order" —
+/// this rule: the kind a fragment becomes is decided by which
+/// substitution steps still act on it under the group's effective order —
 /// which for this step means one question: does a
 /// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters)
 /// step still run *after* this one? [`SplicedSpecials`] carries the answer,
@@ -177,9 +177,10 @@ pub(super) fn apply_attribute_references<'src>(
 /// bytes, and [`for_content`](MissingHandling::for_content) and
 /// [`nested`](MissingHandling::nested) both fall back to `Literal` for the two
 /// shapes whose *line* correspondence this transducer cannot reproduce. None of
-/// that is a reason to stop diagnosing: the string pipeline scans a flat
-/// rendered string in which a span's contents are ordinary text, so it warns
-/// for a nested reference and for a line-straddling span alike. Reading
+/// that is a reason to stop diagnosing: Asciidoctor's own attribute-reference
+/// scan treats a span's contents as ordinary text in one flat rendered
+/// string, so it warns for a nested reference and for a line-straddling span
+/// alike. Reading
 /// [`AttributeMissing`] directly keeps the deferrals about output bytes, where
 /// they belong.
 ///
@@ -190,10 +191,10 @@ pub(super) fn apply_attribute_references<'src>(
 /// found before one that sits earlier still at the top level. That is the same
 /// hazard [`resolve_counters`] exists to correct for counter directives, and it
 /// matters here for the same reason: a warning list is compared in order (see
-/// `inline_builder_side_effect_parity`). Sorting by source offset restores the
-/// document order the string pipeline's own left-to-right line scan produces.
+/// `inline_builder_side_effect_parity`). Sorting by source offset restores
+/// left-to-right document order.
 /// The sort is **stable**, so two references that snap to one coarse span
-/// (design §4.4 — both inside a single expanded value) keep the order they were
+/// (both inside a single expanded value) keep the order they were
 /// found in rather than being reordered arbitrarily.
 fn record_missing_reference_warnings(mut diagnostics: Vec<(Span<'_>, String)>, parser: &Parser) {
     if diagnostics.is_empty() {
@@ -221,7 +222,7 @@ fn record_missing_reference_warnings(mut diagnostics: Vec<(Span<'_>, String)>, p
 /// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters)
 /// step still runs **after** the attribute-references step under the group's
 /// effective order — the one thing that decides what a literal `<`, `>`, or
-/// `&` in a spliced attribute value becomes (design §3.4.1).
+/// `&` in a spliced attribute value becomes.
 ///
 /// In every *built-in* group that runs both steps the answer is
 /// [`Verbatim`](Self::Verbatim):
@@ -245,7 +246,7 @@ pub(super) enum SplicedSpecials {
 
     /// No `SpecialCharacters` step runs after this one — because it already
     /// ran (the built-in orders) or because the group never runs it at all —
-    /// so the string pipeline emits the value's specials untouched, and each
+    /// so this step's splice leaves the value's specials untouched, and each
     /// becomes a [`Raw`](InlineNode::Raw) leaf the fold emits verbatim.
     Verbatim,
 }
@@ -309,11 +310,11 @@ fn apply_attribute_references_recursive<'src>(
 }
 
 /// How a level treats a reference to a **missing** attribute — this module's
-/// node-transducer counterpart of the [`AttributeMissing`] mode the string
-/// pipeline's own `AttributeReplacer` reads.
+/// node-transducer counterpart of the [`AttributeMissing`] mode
+/// `AttributeReplacer` reads.
 ///
 /// The two modes that *remove* content need line granularity the node stream
-/// does not have on its own: the string pipeline gets it by splitting
+/// does not have on its own: `AttributeReplacer` gets it by splitting
 /// `content.rendered` on `\n` and processing (and possibly discarding) one
 /// line at a time. [`surviving_lines`] reproduces that split over a level's
 /// own match string, whose `\n` bytes are the same ones the rendered string
@@ -328,18 +329,20 @@ fn apply_attribute_references_recursive<'src>(
 /// - A **`Styled` span straddling a line break** at the content's top level. A
 ///   span is one opaque [`SPAN_PLACEHOLDER`](super::quotes::SPAN_PLACEHOLDER)
 ///   piece in the match string, so its interior `\n`s are invisible here —
-///   while the string pipeline, which by this point holds the span's rendered
-///   markup inline, still sees them and splits on them. The line correspondence
+///   while a flat rendered string, which by this point holds the span's
+///   rendered markup inline, still shows them and splits on them. The line
+///   correspondence
 ///   the drop rests on would therefore be wrong, so
 ///   [`for_content`](Self::for_content) disables dropping for the whole content
 ///   when it finds one. (A masked passthrough or STEM expression is *not*
-///   affected: the string pipeline holds a sentinel for it at this point, so a
+///   affected: it too sits in the match string as a single opaque piece with
+///   no embedded `\n`s, so a
 ///   multi-line one collapses its lines there too, exactly as the placeholder
 ///   does here.)
 ///
 /// - A missing reference nested inside a `Styled` span, under
-///   [`DropLine`](Self::DropLine). Dropping the *enclosing* line is what the
-///   string pipeline does, which this level cannot see from inside the span;
+///   [`DropLine`](Self::DropLine). Dropping the *enclosing* line is what
+///   line-based processing does, which this level cannot see from inside the span;
 ///   [`nested`](Self::nested) therefore leaves such a reference literal. Under
 ///   [`DropReference`](Self::DropReference) the nested case *is* handled,
 ///   because removing the reference is a purely local edit and the span keeps
@@ -527,14 +530,14 @@ struct AttributeMatch {
 enum AttributeMatchKind {
     /// An escaped reference (`\{name}`, `{name\}`, `\{name\}`): drop the
     /// escaping backslash(es) and keep the rest of the match as literal
-    /// text, replacing nothing — mirroring the string replacer's
+    /// text, replacing nothing — mirroring `AttributeReplacer`'s
     /// `caps[1]`/`caps[5]` branch. One or two absolute offsets, ascending.
     Unescape { backslashes: Vec<usize> },
 
     /// A reference to a set attribute: its `value` (already resolved from
     /// `parser`) is spliced in, classified by [`split_attribute_value`]. A
     /// value-less `InterpretedValue::Set` attribute resolves to an empty
-    /// `value`, mirroring the string replacer (see `AttributeReplacer`); an
+    /// `value`, mirroring `AttributeReplacer`; an
     /// `InterpretedValue::Unset` one never becomes an `Expand` at all,
     /// counting as missing instead.
     Expand { value: String },
@@ -608,7 +611,7 @@ fn attribute_references_level<'src>(
         let scan = find_attribute_matches(&s, parser, missing);
 
         // Each level's own missing references, located against `'src` exactly
-        // as every other node this step builds is (design §4.4's coarse
+        // as every other node this step builds is (the coarse
         // fallback where a reference has no honest source of its own). Every
         // reference is seen at exactly one level — a `Styled` span is a single
         // opaque piece in its parent's match string, so its interior is only
@@ -652,18 +655,18 @@ fn attribute_references_level<'src>(
 /// The indices into `nodes` of every [`Styled`](crate::inlines::Styled) span
 /// whose own subtree carries a live reference to a missing attribute — the
 /// spans that force their enclosing line to be dropped under
-/// [`MissingHandling::DropLine`], since the string pipeline drops the line the
-/// span's rendered markup sits on.
+/// [`MissingHandling::DropLine`], since line-based dropping removes the line
+/// the span's rendered markup sits on.
 ///
 /// # Why this runs before the splicing recursion
 ///
-/// It must read the content's **pre-expansion** text. The string pipeline
+/// It must read the content's **pre-expansion** text. `AttributeReplacer`
 /// replaces every reference on a line in one `replace_all` pass, which never
 /// re-scans its own replacements: a value that happens to expand *to*
 /// `{something}` leaves that text in the output literally, and it neither is
 /// nor arms a missing reference. Run after the recursion, this walk would see
-/// the already-spliced value and read it as one — dropping a line the string
-/// pipeline keeps. Hoisting the whole detection to
+/// the already-spliced value and read it as one — dropping a line
+/// `AttributeReplacer` keeps. Hoisting the whole detection to
 /// [`apply_attribute_references`], before anything is spliced, is what keeps
 /// the two in step; it also means a synthesized *seed* (a filtered multi-line
 /// block, reached through `build_from_value`) is still scanned, since its text
@@ -716,11 +719,11 @@ fn subtree_has_missing_reference(nodes: &[InlineNode<'_>], parser: &Parser) -> b
 /// [`MissingHandling::Literal`] and the overwhelming majority of levels under
 /// the other two.
 ///
-/// This mirrors the string pipeline's own line loop (`apply_attributes`
-/// splits `content.rendered` on `\n`, replaces within each line, and skips a
+/// This mirrors `apply_attributes`'s own line loop (it splits
+/// `content.rendered` on `\n`, replaces within each line, and skips a
 /// line the mode calls for). A returned range covers a line's *content* only:
 /// [`rebuild_attribute_level`] re-emits one `\n` between consecutive
-/// survivors, which reproduces the string pipeline's "join the kept lines"
+/// survivors, which reproduces the same "join the kept lines"
 /// shape for a drop anywhere — first line, last line, or a run in the middle.
 #[allow(clippy::too_many_arguments)]
 fn surviving_lines(
@@ -772,7 +775,7 @@ fn surviving_lines(
 /// `unconditional` ([`MissingHandling::DropLine`]) once it carries a missing
 /// reference, and otherwise ([`MissingHandling::DropReference`]) only when
 /// removing that reference is all it took to empty the line (Asciidoctor's
-/// `reject_if_empty`, which the string pipeline reproduces in
+/// `reject_if_empty`, implemented in
 /// `drop_emptied_line`).
 ///
 /// Only [`surviving_lines`] calls this, and only once it has established that
@@ -813,13 +816,14 @@ fn line_is_dropped(
 }
 
 /// The text the line covering `range` would become once every match in it is
-/// replaced — the string pipeline's `replaced` for that line, reconstructed
+/// replaced — `AttributeReplacer`'s `replaced` for that line, reconstructed
 /// from this level's own matches so the emptied-line test above sees what
 /// `apply_attributes` sees.
 ///
 /// An opaque piece (a rendered span, a masked passthrough) contributes its
-/// single [`SPAN_PLACEHOLDER`](super::quotes::SPAN_PLACEHOLDER) here where the
-/// string pipeline holds its markup or sentinel; the two differ in length but
+/// single [`SPAN_PLACEHOLDER`](super::quotes::SPAN_PLACEHOLDER) here where a
+/// flat rendered string would hold its markup or masking token instead; the
+/// two differ in length but
 /// agree on the only thing this test asks, which is whether anything is left.
 fn line_replacement(
     s: &str,
@@ -906,7 +910,7 @@ fn counter_value<'c>(
 /// rebuild emits, and under [`MissingHandling::Literal`] a missing reference
 /// emits nothing at all (the surrounding gap logic carries its source text
 /// through unchanged), so there is no match to hang a diagnostic on — while
-/// the string pipeline warns in exactly that case. The two questions have
+/// `AttributeReplacer` warns in exactly that case. The two questions have
 /// different answers and so travel separately.
 struct MissingReference {
     /// The whole `{name}` match, in match-string offsets.
@@ -927,7 +931,7 @@ struct AttributeScan {
 }
 
 /// Finds every non-overlapping [`ATTRIBUTE_REFERENCE`] match in the escaped
-/// match string `s`, left to right, exactly as the string pipeline's
+/// match string `s`, left to right, exactly as `AttributeReplacer`'s
 /// `replace_all` does. A `counter`/`counter2` directive is recorded as a
 /// match here but not yet resolved (see [`AttributeMatchKind::Counter`]); a
 /// reference to a missing attribute becomes a
@@ -1062,8 +1066,8 @@ fn rebuild_attribute_level<'src>(
     let mut previous_end: Option<usize> = None;
 
     for line in lines {
-        // One separator between consecutive survivors — the string pipeline's
-        // own "join the kept lines with `\n`" shape. The byte emitted is the
+        // One separator between consecutive survivors — the same "join the
+        // kept lines with `\n`" shape `apply_attributes` uses. The byte emitted is the
         // `\n` that terminated the *previous survivor*, which is always a real
         // one: a line range excludes its terminator, and a line followed by
         // another always has one. Whether lines were dropped in between makes
@@ -1136,7 +1140,8 @@ fn rebuild_attribute_level<'src>(
 }
 
 /// Splices a resolved attribute `value` into the node stream, classifying its
-/// literal `<`, `>`, and `&` by design §3.4.1 — which, here, is exactly the
+/// literal `<`, `>`, and `&` by which substitution steps still act on it
+/// under the group's effective order — which, here, is exactly the
 /// question [`SplicedSpecials`] answers.
 ///
 /// Under [`SplicedSpecials::Verbatim`] — every built-in group that runs both
@@ -1148,13 +1153,13 @@ fn rebuild_attribute_level<'src>(
 /// the classification this step has always emitted.
 ///
 /// Under [`SplicedSpecials::EscapedLater`] the step is still ahead, so the
-/// string pipeline *does* escape the spliced value — `subs=attributes+` on a
+/// value *is* escaped later — `subs=attributes+` on a
 /// verbatim block renders `pass:quotes[MyApp^2^]`'s stored
 /// `MyApp<sup>2</sup>` as `MyApp&lt;sup&gt;2&lt;/sup&gt;`. The value is
 /// therefore spliced as one ordinary `Text` run and **left unsplit**, for
 /// `apply_special_characters` to split at its own position in the order. Doing
 /// it there rather than here is what keeps the intervening steps faithful: the
-/// string pipeline's own `quotes`/`replacements`/`macros` passes match over
+/// `quotes`/`replacements`/`macros` steps match over
 /// text whose specials are still literal, and a `Raw` leaf is *opaque* to
 /// [`build_match_string`] where a `Text` run's bytes are not — the same
 /// argument
@@ -1162,11 +1167,11 @@ fn rebuild_attribute_level<'src>(
 /// makes for running last.
 ///
 /// Every node emitted carries the reference's own `location` as its coarse
-/// fallback span (design §4.4: a synthesized value has no source of its own).
+/// fallback span (a synthesized value has no source of its own).
 /// A run is never emitted empty, and an empty `value` (a value-less
 /// `InterpretedValue::Set` attribute) emits no node at all.
 ///
-/// Before either branch runs, `value` has its passthrough-sentinel bytes
+/// Before either branch runs, `value` has its passthrough-token bytes
 /// escaped by [`escape_passthrough_sentinels`] — see that function's doc
 /// comment for why a value reaching this splice point needs that
 /// unconditionally, regardless of which branch it then takes.
@@ -1222,7 +1227,7 @@ fn split_attribute_value<'src>(
     }
 }
 
-/// Escapes a document's own copies of the passthrough-sentinel pair
+/// Escapes a document's own copies of the passthrough-token pair
 /// (`\u{96}`/`\u{97}`) out of a resolved attribute (or `counter`/`counter2`)
 /// value before [`split_attribute_value`] splices it into the node stream.
 ///
@@ -1244,14 +1249,14 @@ fn split_attribute_value<'src>(
 /// passthrough's rendered body instead of the literal text the document
 /// defined.
 ///
-/// This is the same forgery the string pipeline's own attribute-reference
-/// splice guarded against with `escape_sentinels` (since retired) — see
-/// `AttributeReplacer::escaping_sentinels` — for this pair among the five it
+/// This is the same forgery the old string-substitution implementation's own
+/// attribute-reference splice guarded against with `escape_sentinels` (since
+/// retired) for this pair among the five it
 /// covered; the other three guarded a deferred cross-reference's and a
 /// footnote marker's own in-band templates, which the tree builder replaced
 /// with structured piece lists nothing scans, so only this pair still needs
-/// a counterpart here. The escape is unconditional, for the same reason the
-/// string pipeline's was: this step splices at the content level, ahead of
+/// a counterpart here. The escape is unconditional, for the same reason that
+/// one's was: this step splices at the content level, ahead of
 /// macro recognition, so it cannot know whether its value will end up beside
 /// a masked construct in some later bracket. It is also one-way, like its
 /// predecessor — nothing downstream unescapes it — so a document attribute
@@ -1312,9 +1317,10 @@ mod tests {
         Parser::default().with_intrinsic_attribute(name, value, ModificationContext::Anywhere)
     }
 
-    /// The string pipeline's recorded output through the
-    /// **attribute-references** step for `source` — what that pipeline
-    /// produced while it existed: the six steps [`build`] runs, in order
+    /// The frozen golden recording of the
+    /// **attribute-references** step's output for `source` — what the old
+    /// string-substitution implementation produced
+    /// while it existed: the six steps [`build`] runs, in order
     /// (special characters, quotes, attribute references, character
     /// replacements, macros, post replacement), frozen into
     /// `snapshots/attribute_refs.txt`. The `_parser` no longer participates —
@@ -1337,9 +1343,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_attribute_references() {
         // For each fixture, folding the single-pass tree (all six steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the attribute-references
-        // increment (part 5b).
+        // reproduces the golden recording's output byte-for-byte. This is the
+        // differential corpus that pins the attribute-references
+        // step.
         let fixtures = [
             // No reference despite brace-ish characters.
             "plain text without a reference",
@@ -1386,12 +1392,13 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_attributes_with(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
 
         // A reference expanding to a literal special character emits it
-        // unescaped (`Raw`), exactly as design §3.4.1 requires.
+        // unescaped (`Raw`), exactly as this step's classification rule
+        // requires.
         let special_fixtures = [("tag", "<b>", "a {tag} value"), ("amp", "A & B", "{amp}")];
 
         for (name, value, fixture) in special_fixtures {
@@ -1405,7 +1412,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_attributes_with(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
 
@@ -1427,7 +1434,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_attributes_with(fixture, &bool_parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }
@@ -1445,7 +1452,7 @@ mod tests {
             InlineNode::Text { value, location } => {
                 assert_eq!(value.as_ref(), "Hello");
                 // A synthesized value has no source of its own, so it falls
-                // back to the whole reference's span (design §4.4).
+                // back to the whole reference's span (its coarse fallback).
                 assert_eq!(location.data(), "{greeting}");
             }
 
@@ -1457,7 +1464,7 @@ mod tests {
 
     #[test]
     fn a_reference_expanding_to_a_passthrough_sentinel_is_escaped() {
-        // A value carrying the passthrough-sentinel pair, or a literal copy
+        // A value carrying the passthrough-token pair, or a literal copy
         // of the escape introducer this step's own escaping uses, is escaped
         // out rather than spliced in verbatim — see
         // `escape_passthrough_sentinels`. This test exercises the function
@@ -1520,8 +1527,9 @@ mod tests {
         let nodes = build(Span::new("{tag}"), &parser, None);
 
         // The expansion splits into `Raw("<")`, `Text("b")`, `Raw(">")` —
-        // design §3.4.1's mix of node kinds, since `specialcharacters` has
-        // already run and will not re-escape this spliced-in content.
+        // the mix of node kinds this classification rule produces, since
+        // `specialcharacters` has already run and will not re-escape this
+        // spliced-in content.
         assert_eq!(nodes.len(), 3);
         let raw_location = assert_raw(&nodes[0], "<");
 
@@ -1529,8 +1537,8 @@ mod tests {
             InlineNode::Text { value, location } => {
                 assert_eq!(value.as_ref(), "b");
                 // A synthesized value has no source of its own, so every
-                // sub-node falls back to the whole reference's span (design
-                // §4.4) — the same coarse fallback as `raw_location`.
+                // sub-node falls back to the whole reference's span — the
+                // same coarse fallback as `raw_location`.
                 assert_eq!(*location, raw_location);
             }
 
@@ -1549,9 +1557,9 @@ mod tests {
         // reverses the two steps: `subs=attributes+` on a verbatim block
         // resolves to `[attributes, specialcharacters, callouts]`, so the
         // `SpecialCharacters` step is still *ahead* when the value is spliced
-        // and the string pipeline escapes it like any other text.
+        // and gets escaped like any other text.
         //
-        // Design §3.4.1: what the fragment becomes is decided by which steps
+        // What the fragment becomes is decided by which steps
         // still act on it, so the value is spliced as one ordinary `Text` run
         // (`SplicedSpecials::EscapedLater`) and `apply_special_characters`
         // splits it at its own position in the order — leaving the `CharRef`
@@ -1589,7 +1597,7 @@ mod tests {
         match &nodes[1] {
             InlineNode::Text { value, location } => {
                 assert_eq!(value.as_ref(), "b");
-                // Still the coarse §4.4 fallback: a synthesized value has no
+                // Still the coarse fallback: a synthesized value has no
                 // source of its own, whichever leaf kind its specials take.
                 assert_eq!(*location, char_ref_location);
             }
@@ -1599,8 +1607,9 @@ mod tests {
 
         assert_special_char(&nodes[2], '>');
 
-        // And the fold escapes the tag, byte-for-byte as the real pipeline
-        // did (`&lt;b&gt;`, its recorded rendering for this order) — the
+        // And the fold escapes the tag, byte-for-byte as the old
+        // string-substitution implementation did (`&lt;b&gt;`, its recorded
+        // rendering for this order) — the
         // documented `subs=attributes+` trick for inspecting a stored
         // attribute value.
         assert_eq!(fold_html(&nodes, &HtmlInlineRenderer {}), "&lt;b&gt;");
@@ -1608,7 +1617,7 @@ mod tests {
 
     #[test]
     fn a_replacement_inside_an_expanded_value_is_recognized() {
-        // Design §3.4.1 says `replacements` still runs over an expanded
+        // `replacements` still runs over an expanded
         // value, so a `(C)` inside it becomes a `CharRef` — closing the gap
         // `build_match_string` documented as a follow-up: a synthesized
         // `Text` piece now contributes its own `value` to the match string
@@ -1699,8 +1708,9 @@ mod tests {
         // Every macro family is now recognized inside a spliced value (see
         // this module's own doc comment, and each family's own parity corpus),
         // and so is every attribute list one of them carries: a capture with no
-        // `'src` slice is parsed from the level's match string — the same bytes
-        // the string replacer parses — and owned off it, for an image's own
+        // `'src` slice is parsed from the level's match string — the same
+        // escaped bytes an author-written attribute list would present — and
+        // owned off it, for an image's own
         // bracket (`macros/image.rs`) and for a link's display text
         // (`macros/links.rs`) alike.
         let parser = parser_with_attribute("label", "Docs");
@@ -1734,7 +1744,7 @@ mod tests {
         // every value it holds from the level's match string — here the
         // `link:` macro, whose own marker is written in the source — is
         // recognized inside a spliced value, with only the node's `location`
-        // taking design §4.4's coarse fallback.
+        // taking the coarse fallback.
         let parser = parser_with_attribute("target", "https://example.org");
         let nodes = build(Span::new("see link:{target}[Example] now"), &parser, None);
 
@@ -1751,7 +1761,8 @@ mod tests {
         // across the `CharRef::Replacement` leaf it produces — so an image's
         // attribute list and a link's display text, each crossing a
         // replacement that exists only because an attribute expanded, are
-        // recognized with the string replacer's own bytes.
+        // recognized using the same canonical bytes the replacements step
+        // contributes to the match string.
         let parser = parser_with_attribute("note", "Pause (C) Resume");
 
         for source in ["image:x.png[title={note}]", "link:x.html[{note}]"] {
@@ -1760,7 +1771,7 @@ mod tests {
             assert_eq!(
                 fold_html(&nodes, &HtmlInlineRenderer {}),
                 golden_attributes_with(source, &parser),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
         }
     }
@@ -1783,7 +1794,7 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_counter_directives() {
         // For each fixture, folding the single-pass tree reproduces the
-        // string pipeline's output byte-for-byte. Each fixture uses its own
+        // golden recording's output byte-for-byte. Each fixture uses its own
         // pair of *independent* default parsers (one for `build`, one for
         // `golden_attributes_with`), so the counter each one advances never
         // crosses over — the same test-independence footnote numbering needs
@@ -1826,7 +1837,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_attributes_with(fixture, &Parser::default()),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }
@@ -1927,12 +1938,11 @@ mod tests {
     }
 
     /// Asserts that folding the single-pass tree for `source` reproduces the
-    /// string pipeline's output byte-for-byte under `attribute-missing=mode`.
+    /// golden recording's output byte-for-byte under `attribute-missing=mode`.
     ///
     /// Each side gets its own independently-built parser: a fixture carrying a
     /// `counter` directive advances a real document counter on both, so
-    /// sharing one would number them twice (design §5.3's
-    /// two-independent-parsers discipline).
+    /// sharing one would number them twice.
     fn assert_missing_mode_parity(source: &str, mode: &str) {
         let nodes = build(Span::new(source), &parser_with_missing_mode(mode), None);
 
@@ -2049,7 +2059,7 @@ mod tests {
             "keep\n*bold* and {undefined-thing}\nkeep too",
             "keep\nlink:index.html[Docs] {undefined-thing}\nkeep too",
             // A missing reference nested in a *single-line* span drops the
-            // enclosing line, exactly as the string pipeline drops the line
+            // enclosing line, exactly as line-based dropping removes the line
             // the span's rendered markup sits on.
             "*{undefined-thing}*",
             "keep\na *{undefined-thing}* span\nkeep too",
@@ -2096,7 +2106,7 @@ mod tests {
         // The regression the span-drop detection's own ordering guards
         // against, asserted directly rather than only through the corpus: the
         // spliced `{nope}` must reach the output literally, with its line
-        // intact, exactly as the string pipeline's single `replace_all` pass
+        // intact, exactly as `AttributeReplacer`'s single `replace_all` pass
         // leaves it.
         let source = "keep\n_{looks-like-a-ref}_\nkeep too";
 
@@ -2116,8 +2126,8 @@ mod tests {
     #[test]
     fn a_counter_directive_survives_a_dropped_neighbouring_line() {
         // A `counter` directive advances during `resolve_counters`, which runs
-        // over the whole tree before any line is dropped — exactly as the
-        // string pipeline advances a counter as its own line loop reaches it.
+        // over the whole tree before any line is dropped — exactly as
+        // `AttributeReplacer` advances a counter as its own line loop reaches it.
         // A directive on a *dropped* line has still advanced, so the survivor
         // after it numbers from there.
         let parser = parser_with_missing_mode("drop-line");
@@ -2128,9 +2138,8 @@ mod tests {
 
         assert_eq!(folded, "1\n3");
 
-        // The string pipeline, driven by its own independent parser (each side
-        // advances the counter for real — design §5.3's two-independent-parsers
-        // discipline), agrees.
+        // The golden recording, driven by its own independent parser (each
+        // side advances the counter for real), agrees.
         assert_eq!(
             golden_attributes_in(
                 "attribute_refs_missing_drop-line",
@@ -2147,8 +2156,8 @@ mod tests {
         // every surviving node still borrows from `'src` with its own precise
         // line/col, including the re-emitted `\n` separator — which is the
         // byte that terminated the previous survivor (line 1 here), not the
-        // one that terminated the dropped line (design §4.4's precision stage
-        // — the structural assertion the Strategy-A tree cannot make).
+        // one that terminated the dropped line — the honest per-node span a
+        // post-hoc string recovery could not give.
         let parser = parser_with_missing_mode("drop-line");
         let source = "first\n{undefined-thing}\nthird";
 
@@ -2165,10 +2174,10 @@ mod tests {
         // End-to-end, through the real parse path: `attribute-missing` is read
         // off the document's own header, and `SubstitutionGroup::apply` clones
         // the parser to build each content's tree — so a real paragraph whose
-        // middle line the string pipeline dropped folds to exactly the
-        // rendered string it produced. This is the shape that made this a
+        // middle line drop-line removes folds to exactly its golden
+        // recording's rendered string. This is the shape that made this a
         // *blocker* for the authoritative fold rather than an unclaimed form:
-        // golden tests already exercise it (design §5.3's oracle).
+        // golden tests already exercise it.
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default()
@@ -2201,8 +2210,8 @@ mod tests {
         // escaped, and the tree `SubstitutionGroup::apply` builds alongside it
         // must fold to exactly those bytes. This is the shape that makes the
         // reversed order a *blocker* for the authoritative fold rather than an
-        // unclaimed form: a golden test already exercises it (design §5.3's
-        // oracle — see `attribute_entry_substitutions`).
+        // unclaimed form: a golden test already exercises it (see
+        // `attribute_entry_substitutions`).
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default().parse(
@@ -2231,8 +2240,8 @@ mod tests {
     #[test]
     fn a_missing_reference_inside_a_multi_line_span_is_a_documented_divergence() {
         // A `Styled` span is one opaque placeholder in the match string, so a
-        // span straddling a line break hides the `\n`s the string pipeline
-        // still sees in its own rendered markup — and with them the line
+        // span straddling a line break hides the `\n`s a flat rendered string
+        // would still show — and with them the line
         // correspondence a drop rests on. `MissingHandling::for_content`
         // therefore disables dropping for the whole content, leaving every
         // reference literal (this step's pre-increment behavior).
@@ -2247,7 +2256,7 @@ mod tests {
             "the reference must be left literal: {folded:?}"
         );
 
-        // The string pipeline, by contrast, drops the line the reference sits
+        // The golden recording, by contrast, drops the line the reference sits
         // on — which here is the span's own second half.
         assert_eq!(
             golden_attributes_in("attribute_refs_missing_drop-line", source, &parser),
@@ -2270,7 +2279,7 @@ mod tests {
             "the reference must be left literal: {folded:?}"
         );
 
-        // The string pipeline drops the (now empty) middle line from inside
+        // The golden recording drops the (now empty) middle line from inside
         // the span's rendered markup.
         assert_eq!(
             golden_attributes_in("attribute_refs_missing_drop", source, &parser),

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -491,7 +491,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_callouts(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -528,7 +528,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_callouts_in(corpus, fixture, parser, None),
-                "fold diverged from the string pipeline under a custom `icons` attribute"
+                "fold diverged from golden under a custom `icons` attribute"
             );
         }
     }

--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -30,8 +30,7 @@ use crate::{
 ///
 /// A [`Callout`](InlineNode::Callout) node's `number` is already the resolved
 /// sequential value for an auto-numbered `<.>`, so no counter is consulted
-/// here. A number that does not parse as a `u32` is skipped, exactly as the
-/// string pipeline skips it.
+/// here. A number that does not parse as a `u32` is skipped.
 ///
 /// The walk recurses into every container a node can nest inside. Callouts are
 /// recognized in **verbatim** content, where no quotes or macros step runs, so
@@ -81,19 +80,15 @@ pub(crate) fn apply_callout_side_effects(nodes: &[InlineNode<'_>], parser: &Pars
 /// carry the step, directly after
 /// [`apply_special_characters`](super::special_chars::apply_special_characters).
 ///
-/// It reuses the string pipeline's *exact* recognition —
-/// [`build_callout_regexes`] is now shared `pub(crate)` — so only the
-/// recognition *sink* differs (§4.1): a matched, trailing-position callout
-/// becomes a node instead of rendered markup, folding through the same
-/// `render_callout` the string step calls (see `fold_callout`) so the
-/// output is byte-for-byte identical. `attrlist` is the block's own
-/// attribute list (`None` when the caller has none); together with `parser`
-/// it resolves the `line-comment` attribute exactly as
-/// [`apply_callouts`](crate::content::substitution_step)'s string-pipeline
-/// counterpart does: absent, the default line-comment prefixes (`//`, `#`,
-/// `--`, `;;`) and XML callouts are recognized; present (non-empty), only
-/// that prefix is; present but empty, no prefix is recognized (and neither
-/// are XML callouts).
+/// It reuses [`build_callout_regexes`] (shared `pub(crate)`): a matched,
+/// trailing-position callout becomes a node instead of rendered markup,
+/// folding through the same `render_callout` (see `fold_callout`).
+/// `attrlist` is the block's own attribute list (`None` when the caller has
+/// none); together with `parser` it resolves the `line-comment` attribute:
+/// absent, the default line-comment prefixes (`//`, `#`, `--`, `;;`) and XML
+/// callouts are recognized; present (non-empty), only that prefix is;
+/// present but empty, no prefix is recognized (and neither are XML
+/// callouts).
 ///
 /// An escaped callout (`\<1>`) drops its backslash and stays literal,
 /// mirroring every other macro family's escape handling. This pass performs
@@ -121,8 +116,7 @@ pub(super) fn apply_callouts<'src>(
     let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 
     // A callout's opening bracket is always rendered as `&lt;` by
-    // `apply_special_characters`, so we can cheaply skip content without any
-    // (mirrors the string pipeline's own guard).
+    // `apply_special_characters`, so we can cheaply skip content without any.
     if !s.contains("&lt;") {
         return nodes;
     }
@@ -188,14 +182,11 @@ enum CalloutMatchKind {
 }
 
 /// Finds every [`build_callout_regexes`] match in the match string `s`, left
-/// to right, honoring the trailing-position lookahead (`tail_rx`) exactly as
-/// the string pipeline's `CalloutReplacer` does: a callout is only recognized
-/// when nothing but further callouts follows it up to the end of the line.
-/// Unlike the string pipeline (whose `LookaheadReplacer` never skips ahead
-/// and retries for this step), a match that fails the lookahead is simply
-/// left out of the returned list — the surrounding gap then reproduces its
-/// original nodes unchanged, exactly the same outcome as the string
-/// pipeline's `dest.push_str(&caps[0])` fallback.
+/// to right, honoring the trailing-position lookahead (`tail_rx`): a callout
+/// is only recognized when nothing but further callouts follows it up to the
+/// end of the line. A match that fails the lookahead is simply left out of
+/// the returned list — the surrounding gap then reproduces its original
+/// nodes unchanged.
 fn find_callout_matches(s: &str, callout_rx: &Regex, tail_rx: &Regex) -> Vec<CalloutMatch> {
     let mut matches = Vec::new();
     let mut autonum = 0u32;
@@ -230,10 +221,9 @@ fn find_callout_matches(s: &str, callout_rx: &Regex, tail_rx: &Regex) -> Vec<Cal
             (caps.name("num").unwrap().as_str(), false)
         };
 
-        // Auto-numbering (`<.>`) is scoped to this level's whole scan, exactly
-        // as the string pipeline's `CalloutReplacer::autonum` is scoped to one
-        // block, and only advances for a match that reaches this point (past
-        // the lookahead and escape checks).
+        // Auto-numbering (`<.>`) is scoped to this level's whole scan — one
+        // block's worth of callouts — and only advances for a match that
+        // reaches this point (past the lookahead and escape checks).
         let number = if number_raw == "." {
             autonum += 1;
             autonum.to_string()
@@ -260,10 +250,10 @@ fn find_callout_matches(s: &str, callout_rx: &Regex, tail_rx: &Regex) -> Vec<Cal
 /// original nodes; each match becomes its unescaped literal text (an
 /// [`Unescape`](CalloutMatchKind::Unescape)) or a
 /// [`Callout`](InlineNode::Callout) node (a
-/// [`Callout`](CalloutMatchKind::Callout) match), whose guard mirrors
-/// [`CalloutReplacer`](crate::content::substitution_step)'s resolution: a
-/// captured line-comment prefix takes precedence; otherwise an XML callout
-/// uses the XML guard; failing both, an empty line-comment guard (there is no
+/// [`Callout`](CalloutMatchKind::Callout) match), whose guard resolves the
+/// same way: a captured line-comment prefix takes precedence; otherwise an
+/// XML callout uses the XML guard; failing both, an empty line-comment guard
+/// (there is no
 /// "no guard" state — the fold's non-icon fallback always guards with
 /// *something*).
 fn rebuild_callout_level<'src>(
@@ -323,9 +313,9 @@ fn rebuild_callout_level<'src>(
 /// The inverse of the classifier's value assignment: the
 /// [`CharacterReplacementType`] the fold renders a
 /// [`CharRef::Replacement`](crate::inlines::CharRef::Replacement) value with.
-/// The mapping is a bijection — each replacement type produces a
-/// distinct logical string — so the fold reproduces the string pipeline's bytes
-/// through the same [`render_character_replacement`] the step calls.
+/// The mapping is a bijection — each replacement type produces a distinct
+/// logical string — so the fold reproduces the right output bytes through
+/// the same [`render_character_replacement`] the step calls.
 ///
 /// [`render_character_replacement`]:
 ///     crate::parser::InlineRenderer::render_character_replacement
@@ -419,13 +409,12 @@ mod tests {
         build_verbatim(source, &Parser::default(), None)
     }
 
-    /// The string pipeline's recorded output through the **callouts** step
-    /// for `source` — what that pipeline produced while it existed:
-    /// `SubstitutionGroup::Verbatim`'s two steps, in order (special
-    /// characters, then callouts), frozen into `snapshots/callouts.txt`. The
-    /// `_parser` and `_attrlist` no longer participate — a recording is keyed
-    /// by source alone — but the parameters stay so the call sites that
-    /// configured them do not churn.
+    /// The frozen recording (see `parser/snapshots/README.md`) through the
+    /// **callouts** step for `source`: `SubstitutionGroup::Verbatim`'s two
+    /// steps, in order (special characters, then callouts), frozen into
+    /// `snapshots/callouts.txt`. The `_parser` and `_attrlist` no longer
+    /// participate — a recording is keyed by source alone — but the
+    /// parameters stay so the call sites that configured them do not churn.
     fn golden_callouts_with(
         source: &str,
         parser: &Parser,
@@ -468,9 +457,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_callouts() {
         // For each fixture, folding the single-pass tree (special characters
-        // then callouts) reproduces the string pipeline's output
-        // byte-for-byte. This is the differential corpus (design §5.3) that
-        // pins the callouts increment (part 5c).
+        // then callouts) reproduces the frozen recording's output
+        // byte-for-byte. This is the differential corpus that pins callout
+        // recognition.
         let fixtures = [
             "just some text",
             "a <b> c",

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -22,20 +22,18 @@ use crate::{
 /// a [`CharRef::Entity`] (a restored named/numeric entity such as `&amp;copy;`
 /// → `&copy;`) leaf.
 ///
-/// Like the string pipeline's step, the rules match over the level's
-/// **escaped** text (built by [`build_match_string`], where a
-/// [`CharRef::Special`] contributes its canonical entity) — which is exactly
-/// why the arrow (`-&gt;`, `&lt;-`) and entity (`&amp;copy;`) rules can
-/// straddle a `Text`/`CharRef` boundary, and, since a
-/// [`synthesized`](super::quotes::Piece::synthesized) run (an
+/// The rules match over the level's **escaped** text (built by
+/// [`build_match_string`], where a [`CharRef::Special`] contributes its
+/// canonical entity) — which is exactly why the arrow (`-&gt;`, `&lt;-`) and
+/// entity (`&amp;copy;`) rules can straddle a `Text`/`CharRef` boundary, and,
+/// since a [`synthesized`](super::quotes::Piece::synthesized) run (an
 /// attribute-expanded value) contributes its own `value` there too, why they
-/// can straddle a `Text`/synthesized-`Text` boundary as well (design §3.4.1) —
-/// pinned by
+/// can straddle a `Text`/synthesized-`Text` boundary as well — pinned by
 /// `attribute_refs::tests::a_replacement_straddling_a_synthesized_and_a_real_piece_is_recognized`.
 /// `root` is the whole-content source span; every leaf's precise `location`
 /// is sliced from it — or, for a leaf recognized *inside* a synthesized run,
-/// falls back to that run's own whole span (design §4.4), since its bytes
-/// have no honest source counterpart of their own.
+/// falls back to that run's own whole span, since its bytes have no honest
+/// source counterpart of their own.
 pub(super) fn apply_character_replacements<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -51,17 +49,15 @@ pub(super) fn apply_character_replacements<'src>(
 
 /// Applies one [`CharacterReplacement`] rule to `nodes`, first descending into
 /// the [`Styled`](crate::inlines::Styled)/[`Ref`](InlineNode::Ref) children
-/// earlier steps created (a replacement inside a span is recognized just as the
-/// string pipeline recognizes one inside a rendered tag), then matching and
-/// replacing at this level.
+/// earlier steps created (a replacement inside a span is recognized against
+/// that span's own rendered tag), then matching and replacing at this level.
 ///
-/// `ctx` is the boundary context this level sits in
-/// ([`LevelContext`]): "just as the string pipeline recognizes one inside a
-/// rendered tag" is true of the tag's *inside* only once the tag's own
-/// characters are there to be read, which is what decides an em dash written
-/// against either edge of a span (`*x --*` renders `<strong>x --</strong>`,
-/// the `--` staying literal because `<` follows it in that haystack, not the
-/// end of a line).
+/// `ctx` is the boundary context this level sits in ([`LevelContext`]):
+/// recognition inside a span is scoped to the *inside* of its tag, which only
+/// opens up once the tag's own characters are there to be read — that is what
+/// decides an em dash written against either edge of a span (`*x --*` renders
+/// `<strong>x --</strong>`, the `--` staying literal because `<` follows it in
+/// that haystack, not the end of a line).
 fn apply_one_replacement<'src>(
     repl: &CharacterReplacement,
     nodes: Vec<InlineNode<'src>>,
@@ -143,7 +139,7 @@ impl ReplacementMatch {
 enum ReplacementKind {
     /// An escaped construct (`\(C)`, `\-&gt;`, …): drop the single backslash at
     /// this offset and keep the rest of the match as literal nodes, replacing
-    /// nothing — mirroring the string replacer's `caps[0].replace("\\", "")`.
+    /// nothing.
     Unescape { backslash: usize },
 
     /// A recognized typographic replacement. Only the `consumed` sub-range
@@ -203,8 +199,8 @@ fn replace_level<'src>(
     rebuild_replacements(&nodes, &pieces, &s, &matches, root)
 }
 
-/// Finds every non-overlapping match of `repl` in the escaped match string `s`,
-/// left to right, exactly as the string pipeline's `replace_all` does.
+/// Finds every non-overlapping match of `repl` in the escaped match string
+/// `s`, left to right.
 fn find_replacement_matches(repl: &CharacterReplacement, s: &str) -> Vec<ReplacementMatch> {
     let mut matches = Vec::new();
 
@@ -372,13 +368,12 @@ mod tests {
         strings::CowStr,
     };
 
-    /// The string pipeline's recorded output through the **post-replacement**
-    /// step for `source` — what that pipeline produced while it existed: the
-    /// four steps [`build`] runs, in order (special characters, quotes,
-    /// character replacements, post replacement), frozen into
-    /// `snapshots/char_replacements.txt`. Attribute references and macros were
-    /// skipped — exactly as the additive builder skips them — so the fixtures
-    /// deliberately contain neither.
+    /// The frozen recording (see `parser/snapshots/README.md`) through the
+    /// **post-replacement** step for `source`: the four steps [`build`] runs,
+    /// in order (special characters, quotes, character replacements, post
+    /// replacement), frozen into `snapshots/char_replacements.txt`. Attribute
+    /// references and macros were skipped — exactly as the additive builder
+    /// skips them — so the fixtures deliberately contain neither.
     fn golden_replacements(source: &str) -> String {
         crate::content::inline_builder::snapshot::recorded("char_replacements", source)
     }
@@ -387,11 +382,10 @@ mod tests {
     fn a_replacement_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
         // A rule whose pattern reads what surrounds its match — the spaced em
         // dash's `(^|\n| )--( |\n|$)` is the one in this step — must see the
-        // enclosing span's own markup where the string pipeline's flat
-        // haystack holds it, not the start or end of a level. `*x --*` renders
-        // `<strong>x --</strong>`: the `--` stays literal because `<` follows
-        // it there, and a level matched in isolation would take its own end as
-        // the line end the rule wants.
+        // enclosing span's own markup, not the start or end of a level. `*x
+        // --*` renders `<strong>x --</strong>`: the `--` stays literal because
+        // `<` follows it there, and a level matched in isolation would take
+        // its own end as the line end the rule wants.
         for source in [
             // Against either edge, in each variant's own rendering shape.
             "*-- x*",
@@ -406,8 +400,8 @@ mod tests {
             r#""`-- x`""#,
             r#""`x --`""#,
             r#"'`x --`'"#,
-            // Away from either edge, where the rule matches inside the span in
-            // both pipelines.
+            // Away from either edge, where the rule matches inside the span
+            // regardless.
             "*a -- b*",
             "_a -- b_",
             r#""`a -- b`""#,
@@ -421,12 +415,12 @@ mod tests {
             // rather than a boundary one.
             "*one--two*",
             // And the same constructs at the content's own top level, where a
-            // pattern's `^`/`$` is exactly what the string pipeline presents.
+            // pattern's `^`/`$` matches the line boundaries directly.
             "-- x",
             "x --",
             "a -- b",
             // A span *beside* a replacement, where the placeholder standing in
-            // for it is not the space the rule requires — in either pipeline.
+            // for it is not the space the rule requires.
             "*x*-- y",
             "*x* -- y",
         ] {
@@ -445,11 +439,11 @@ mod tests {
         // the context the span itself sits in
         // ([`LevelContext::inside_styled`]). That is right whenever the span
         // is all its parent's level holds — `[width=10]#x --#` at the top
-        // level replaces the dash in both pipelines — and wrong when a sibling
-        // follows it, because the string pipeline's haystack then shows what
-        // that sibling begins with (here a space, which is exactly the em
-        // dash's own trailing class) where the tree shows the parent's closing
-        // markup.
+        // level replaces the dash the same way in the tree and the frozen
+        // recording — and wrong when a sibling follows it, because the
+        // recording's flat haystack then shows what that sibling begins with
+        // (here a space, which is exactly the em dash's own trailing class)
+        // where the tree shows the parent's closing markup.
         //
         // [`LevelContext::child_contexts`] derives exactly that character from
         // a level's siblings for the two steps that can take it, and this step
@@ -472,7 +466,7 @@ mod tests {
             "expected the documented divergence to still reproduce for {source:?}"
         );
 
-        // The string pipeline replaces the *first* dash (a space follows it,
+        // The frozen recording replaces the *first* dash (a space follows it,
         // the transparent span having rendered nothing); the tree leaves both
         // literal.
         assert_eq!(folded, "<strong>x -- --</strong>");
@@ -491,8 +485,8 @@ mod tests {
     fn fold_matches_the_string_pipeline_through_replacements() {
         // For each fixture, folding the single-pass tree (special characters +
         // quotes + character replacements + post replacement) reproduces the
-        // string pipeline's output byte-for-byte. This is the differential
-        // corpus (design §5.3) that pins this increment.
+        // frozen recording's output byte-for-byte. This is the differential
+        // corpus that pins this step.
         let fixtures = [
             // No replacements.
             "plain text",
@@ -607,7 +601,7 @@ mod tests {
 
         assert_eq!(nodes.len(), 1);
         // The logical value is the copyright character; the fold encodes it as
-        // the numeric entity the string pipeline emits.
+        // a numeric entity.
         assert_replacement(&nodes[0], "\u{a9}", "(C)");
 
         assert_eq!(fold_html(&nodes, &HtmlInlineRenderer {}), "&#169;");
@@ -694,8 +688,8 @@ mod tests {
 
     #[test]
     fn a_replacement_inside_a_span_is_recognized() {
-        // A `(C)` inside a strong span is replaced just as the string pipeline
-        // replaces one inside a rendered `<strong>` tag.
+        // A `(C)` inside a strong span is replaced the same way it would be at
+        // the top level.
         let nodes = build_src(Span::new("*Acme (C)*"));
 
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -706,9 +700,9 @@ mod tests {
 
     #[test]
     fn character_replacements_recurse_into_ref_children() {
-        // A reference's display text is subject to replacements, just as the
-        // string pipeline processes it inside the rendered anchor. (No macros
-        // step yet builds `Ref` nodes, so this drives the recursion directly.)
+        // A reference's display text is subject to replacements just like any
+        // other span's. (This constructs the `Ref` node directly, without
+        // running the macros step, to drive the recursion in isolation.)
         let loc = Span::new("(C)");
 
         let reference = InlineNode::Ref(Ref {
@@ -745,11 +739,10 @@ mod tests {
     fn a_later_rule_never_splits_an_earlier_replacement_leaf() {
         // Now that a `CharRef::Replacement` leaf contributes its rendered
         // entity to the match string, a *later* rule in the ordered sweep sees
-        // those bytes — the same ones the string pipeline's own sequential
-        // passes see, which is the point. What such a rule must never do is
-        // match *partially* into one: `rebuild_replacements`' gap would then
-        // clone the whole atomic leaf and emit the new leaf beside it,
-        // duplicating bytes the string pipeline emits once.
+        // those bytes too. What such a rule must never do is match
+        // *partially* into one: `rebuild_replacements`' gap would then clone
+        // the whole atomic leaf and emit the new leaf beside it, duplicating
+        // bytes that should appear once.
         //
         // It cannot, and the reason is structural. Every entity this table
         // produces is `&#…;` — only `&`, `#`, digits and a terminating `;` —
@@ -765,7 +758,8 @@ mod tests {
         // This pins that as behavior rather than as an argument: every
         // replacement-producing token is glued to every token that could
         // extend a match, in both orders and with a word character between, and
-        // each pairing must fold to exactly what the string pipeline emits.
+        // each pairing must fold to exactly what the frozen recording holds
+        // for it.
         let replacements = [
             "(C)",
             "(R)",

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -427,7 +427,7 @@ mod tests {
             assert_eq!(
                 golden_replacements(source),
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from golden for {source:?}"
             );
         }
     }
@@ -574,7 +574,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_replacements(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -801,7 +801,7 @@ mod tests {
                     assert_eq!(
                         fold_html(&nodes, &HtmlInlineRenderer {}),
                         golden_replacements(&source),
-                        "fold diverged from the string pipeline for {source:?}"
+                        "fold diverged from golden for {source:?}"
                     );
                 }
             }

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -111,8 +111,7 @@ pub(crate) enum Xrefs<'a> {
 /// cross-reference **nested** inside that other node — `footnote:[*<<tgt>>*]`,
 /// a `<<tgt>>` inside a styled span's body — cannot itself become a splice
 /// point: its placeholder would sit *inside* the span's own rendered markup,
-/// which a flat piece list cannot represent (the string pipeline's in-band
-/// placeholders could sit anywhere in a byte string; a piece list has no
+/// which a flat piece list cannot represent (it has no
 /// "inside another piece" position). It is folded in
 /// [`Deferred`](Xrefs::Deferred) mode regardless, though — not
 /// [`Rendered`](Xrefs::Rendered) — so its segment is still recorded: it is
@@ -152,16 +151,17 @@ pub(crate) enum Xrefs<'a> {
 ///
 /// # Why the template is built at *registration* time
 ///
-/// A footnote's catalog entry is registered when the footnote is recognized,
-/// which is the same moment the string replacer registers its own. That is not
+/// A footnote's catalog entry is registered when the footnote is recognized.
+/// That is not
 /// a convenience: `Footnote::resolve_references` runs on the **catalog entry**,
 /// driven from the catalog, with no access to the tree the footnote came from,
 /// so nothing later in the parse can go back and derive the pair. Recognition
 /// is also the last moment the subtree is still final —
 /// [`apply_post_replacements`](super::apply_post_replacements) descends into a
 /// [`Styled`](crate::inlines::Styled)/[`Ref`](InlineNode::Ref) child but not
-/// into a [`Footnote`](InlineNode::Footnote)'s, exactly as the string pipeline
-/// has the footnote's text out of the flat string by then.
+/// into a [`Footnote`](InlineNode::Footnote)'s — matching Asciidoctor's own
+/// order, whose footnote text is already extracted from the flow by the time
+/// post-replacements run.
 ///
 /// # This is a *build-time* fold, and the only one
 ///
@@ -171,16 +171,15 @@ pub(crate) enum Xrefs<'a> {
 /// stateful renderer. A footnote is the documented exception, and not by
 /// choice: its catalog entry is a **required** recognition side effect (the
 /// same reason its number is), and that entry's payload is a *rendered
-/// string*, so registering it and rendering it are one act. The string
-/// pipeline does exactly the same thing at exactly the same moment — its
-/// footnote replacer cuts already-rendered bytes out of the flat string it is
+/// string*, so registering it and rendering it are one act — as they were in
+/// this crate's original string-substitution implementation too, whose
+/// footnote replacer cut already-rendered bytes out of the flat string it was
 /// substituting.
 ///
 /// This adds no second rendering of the subtree. `fold_footnote` writes only
 /// the in-flow **marker**, never the footnote's children, so the block's own
 /// fold does not re-render what this one rendered: a footnote's subtree is
-/// folded exactly once per parse, here — the same once the string pipeline
-/// spends on it.
+/// folded exactly once per parse, here.
 ///
 /// [`Footnote::resolve_references`]: crate::document::Footnote::resolve_references
 pub(crate) fn fold_deferring_xrefs(
@@ -209,8 +208,8 @@ pub(crate) fn fold_deferring_xrefs(
         // its own piece.
         //
         // The footnote axis is inert here whichever way it is set: `nodes`
-        // is one footnote's own children, and footnotes do not nest (the
-        // string pipeline's lazy bracket match cannot recognize one inside
+        // is one footnote's own children, and footnotes do not nest (a
+        // footnote's own lazy bracket match cannot recognize one inside
         // another's content either), so no `Footnote` node can be reached.
         // `Marked` is the ordinary fold, which is the honest default for a
         // mode nothing consults.
@@ -255,8 +254,9 @@ pub(crate) fn fold_deferring_xrefs(
 /// folds of the same tree, and "which regions were footnote markers" is a
 /// question about node kinds rather than about bytes — still one substitution
 /// pass, so the counters are still processed once. `Section::parse` calls this
-/// for a heading's reference text, and the whole sentinel system (design
-/// §4.2's **first of three**) is deleted.
+/// for a heading's reference text, and the whole sentinel system — one of the
+/// three Unicode-sentinel hacks the string pipeline used (see this module's
+/// own `README.md`) — is deleted.
 ///
 /// The strip recurses, exactly as the byte-level one does over the whole
 /// rendered string: a footnote nested inside a rendered span, or inside a
@@ -411,9 +411,9 @@ fn fold_into_html(
             }
 
             InlineNode::Styled(styled) => {
-                // Fold the children to the body, then wrap it exactly as the
-                // string pipeline's quotes step did: the same `QuoteType`,
-                // attribute list, and id it recognized, so the bytes match.
+                // Fold the children to the body, then wrap it with the same
+                // `QuoteType`, attribute list, and id the quotes step
+                // recognized, matching Asciidoctor's own output.
                 let mut body = String::new();
                 fold_into_html(
                     &styled.children,
@@ -478,9 +478,8 @@ pub(super) fn render_char(ch: char, renderer: &dyn InlineRenderer, out: &mut Str
     renderer.render_special_character(type_, out);
 }
 
-/// Folds an [`Image`](InlineNode::Image) node through the same
-/// `render_image`/`render_icon` the string pipeline's macros step calls, so the
-/// output is byte-for-byte identical — handing over the node itself, since
+/// Folds an [`Image`](InlineNode::Image) node through `render_image`/
+/// `render_icon` — handing over the node itself, since
 /// `target`, `alt`, `width`/`height` and the restored-range list are all on it.
 ///
 /// The attribute list — which a renderer reads `title`, `link`, `format`, roles
@@ -501,10 +500,9 @@ fn fold_image(
     }
 }
 
-/// Folds a [`Ui`](InlineNode::Ui) node through the same
-/// `render_keyboard`/`render_button`/`render_menu` the string pipeline's macros
-/// step calls, reconstructing the render parameters from the keys / label /
-/// menu path the macro step captured, so the output is byte-for-byte identical.
+/// Folds a [`Ui`](InlineNode::Ui) node through
+/// `render_keyboard`/`render_button`/`render_menu`, reconstructing the render
+/// parameters from the keys / label / menu path the macro step captured.
 /// `context` is threaded through because rendering a menu reads the document's
 /// `icons` attribute to choose the caret between menu levels.
 fn fold_ui(ui: &Ui<'_>, renderer: &dyn InlineRenderer, context: &RenderContext, out: &mut String) {
@@ -527,8 +525,8 @@ fn fold_ui(ui: &Ui<'_>, renderer: &dyn InlineRenderer, context: &RenderContext, 
     }
 }
 
-/// Folds a link [`Ref`](InlineNode::Ref) node through the same `render_link`
-/// the string pipeline's macros step calls — handing over the node itself,
+/// Folds a link [`Ref`](InlineNode::Ref) node through `render_link` —
+/// handing over the node itself,
 /// since the target, window, roles (the `bare` class an auto-recognized URL
 /// picks up) and attribute list are all on it.
 ///
@@ -559,23 +557,21 @@ fn fold_link(
     renderer.render_link(reference, &link_text, out);
 }
 
-/// Folds a cross-reference [`Ref`](InlineNode::Ref) node through the same
-/// `render_xref` the string pipeline's macros step feeds at resolution time,
-/// reconstructing the [`XrefRenderParams`] from the node: the provided text is
-/// the fold of the children (empty children ⇒ no text, so the renderer emits
-/// the bracketed `[id]` fallback), and the target/window/roles/derived come
-/// straight off the node.
+/// Folds a cross-reference [`Ref`](InlineNode::Ref) node through
+/// `render_xref`, reconstructing the [`XrefRenderParams`] from the node: the
+/// provided text is the fold of the children (empty children ⇒ no text, so
+/// the renderer emits the bracketed `[id]` fallback), and the
+/// target/window/roles/derived come straight off the node.
 ///
-/// This increment recognizes both a same-document reference to a specific id
-/// (unresolved — no catalog-resolution pass runs, so `resolved` is always
-/// `None` here) and a target that carries its own destination without a
-/// catalog (`derived`, populated at build time — see the `Ref::derived` field
-/// docs): an inter-document target, and the empty target naming the current
-/// document as a whole. The `xrefstyle` is taken straight off the node, which
-/// carries the **effective** style resolved at build time (see the
-/// `Ref::xrefstyle` field docs), so this fold consults no document state for
-/// it; the cutover (design §5.2 Phase 4, step 6) wires catalog resolution to
-/// the tree.
+/// This handles both a same-document reference to a specific id — resolved by
+/// a later catalog-resolution pass that writes the outcome back into the
+/// node's own [`Ref::resolved`] field, which this fold simply reads — and a
+/// target that carries its own destination without a catalog (`derived`,
+/// populated at build time — see the `Ref::derived` field docs): an
+/// inter-document target, and the empty target naming the current document as
+/// a whole. The `xrefstyle` is taken straight off the node, which carries the
+/// **effective** style resolved at build time (see the `Ref::xrefstyle` field
+/// docs), so this fold consults no document state for it.
 fn fold_xref(
     reference: &Ref<'_>,
     renderer: &dyn InlineRenderer,
@@ -613,8 +609,8 @@ fn fold_xref(
 
     // Whether a display text was *provided* is the presence of a child, not
     // what that child folds to: the `<<id,>>` shorthand records a
-    // present-but-empty text (one empty `Text` child) that the string replacer
-    // carries as `Some("")` — an empty `<a>…</a>` — which an absent text
+    // present-but-empty text (one empty `Text` child), matching Asciidoctor's
+    // own `Some("")` — an empty `<a>…</a>` — which an absent text
     // (`None`, the bracketed `[id]` / reference-text fallback) renders quite
     // differently. Every text the builder recognizes is baked into exactly one
     // child, so the two cases never collide.
@@ -647,29 +643,29 @@ fn fold_xref(
     renderer.render_xref(&params, out);
 }
 
-/// Folds an [`Anchor`](InlineNode::Anchor) through the same `render_anchor` the
-/// string step calls. The built-in HTML backend emits only `<a id="…"></a>`, so
+/// Folds an [`Anchor`](InlineNode::Anchor) through `render_anchor`. The
+/// built-in HTML backend emits only `<a id="…"></a>`, so
 /// the reference text never reaches the flow; a custom backend that consults it
 /// (e.g. one using it as an `xreflabel`) receives the folded reference text
 /// **when the node captured it**.
 ///
 /// That capture is verbatim-only: a *non-verbatim* reference text (a rendered
 /// span or an escaped special) is `None` on the node (see
-/// `build_anchor_reftext`), so `render_anchor` receives `None` here where the
-/// string replacer would have passed the substituted text. This changes no HTML
+/// `build_anchor_reftext`), so `render_anchor` receives `None` here where
+/// Asciidoctor would have passed the substituted text. This changes no HTML
 /// output — the built-in backend ignores the reference text entirely — and is
 /// the same verbatim boundary the node documents; a custom backend that needs
 /// the full reference text unconditionally will get it once a re-flow consumer
 /// pins richer `reftext` population.
 ///
 /// A **bibliography** anchor (`[[[label]]]`) passes `None` regardless of what
-/// its node carries, mirroring its own replacer exactly: that pass calls
+/// its node carries, matching Asciidoctor's own handling exactly: it calls
 /// `render_anchor(id, None, …)` and pushes the bracketed label into the flow
 /// itself. The label is in the flow here too — as the sibling nodes following
 /// this one (see `biblio_anchor_level`) — so folding the node's `reftext`,
 /// which holds that same bracketed label as the entry's *registered* reference
-/// text, into `render_anchor` would hand a custom backend a reference text the
-/// string pipeline never passes it.
+/// text, into `render_anchor` would hand a custom backend a reference text
+/// Asciidoctor never passes it.
 fn fold_anchor(
     anchor: &Anchor<'_>,
     renderer: &dyn InlineRenderer,
@@ -706,15 +702,15 @@ fn fold_anchor(
     renderer.render_anchor(&anchor.id, reftext, out);
 }
 
-/// Folds an [`IndexTerm`](InlineNode::IndexTerm) through the same
-/// `render_index_term` the string step's macros pass calls.
+/// Folds an [`IndexTerm`](InlineNode::IndexTerm) through
+/// `render_index_term`.
 ///
 /// A **concealed** term (`visible == false`) has an empty `terms` and renders
 /// nothing — the HTML backend generates no index. A **visible** (flow) term
 /// carries its shown text as `terms[0]` in the *already-substituted* form the
 /// recognizer computed (matching the seam's "already-substituted visible term"
 /// contract), so `render_index_term` emits it verbatim and the fold reproduces
-/// the string pipeline's bytes exactly.
+/// those bytes exactly.
 ///
 /// A visible term whose text encloses an earlier-recognized construct
 /// (`((*tiger*))`) carries it as [`children`](IndexTerm::children) instead, and
@@ -731,7 +727,7 @@ fn fold_anchor(
 /// (test-only) `inline_tree` recorder stores — the single
 /// shown term for a visible node, empty for a concealed one; the richer
 /// primary/secondary/tertiary structure the field can hold is left to a re-flow
-/// consumer to pin (the field is provisional, per the node's Phase-0 note),
+/// consumer to pin (the field is provisional, per its own doc comment),
 /// exactly as an anchor's `reftext` is.
 fn fold_index_term(
     index_term: &IndexTerm<'_>,
@@ -764,10 +760,10 @@ fn fold_index_term(
     renderer.render_index_term(index_term, visible_term, out);
 }
 
-/// Folds a [`Footnote`](InlineNode::Footnote) through the same
-/// `render_footnote` the string step calls — handing over the node itself,
+/// Folds a [`Footnote`](InlineNode::Footnote) through
+/// `render_footnote` — handing over the node itself,
 /// since everything the marker needs is on it (`is_reference`, `number`, `id`)
-/// and no build-time state is required (design §3.3.1).
+/// and no build-time state is required.
 ///
 /// Only the in-flow **marker** is folded here (`[1]`, or `[id]` for an
 /// unresolved reference): `render_footnote` never emits the footnote's own
@@ -785,13 +781,12 @@ fn fold_footnote(footnote: &Footnote<'_>, renderer: &dyn InlineRenderer, out: &m
     renderer.render_footnote(footnote, out);
 }
 
-/// Folds a [`Callout`](InlineNode::Callout) through the same `render_callout`
-/// the string step's `Callouts` group calls, handing over the node itself —
-/// no build-time state is needed, mirroring [`fold_footnote`]. This is design
-/// §4.6's Phase 5 reshape arrived at: the node was already the canonical
-/// structured record, and the render-params struct this fold used to rebuild
-/// from it (along with a second `CalloutGuard` differing only in whether the
-/// prefix was a `CowStr` or a `&str`) is gone.
+/// Folds a [`Callout`](InlineNode::Callout) through `render_callout`,
+/// handing over the node itself — no build-time state is needed, mirroring
+/// [`fold_footnote`]. The node was already the canonical structured record,
+/// so the render-params struct this fold used to rebuild from it (along with
+/// a second `CalloutGuard` differing only in whether the prefix was a
+/// `CowStr` or a `&str`) is gone.
 fn fold_callout(
     callout: &Callout<'_>,
     renderer: &dyn InlineRenderer,

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -796,14 +796,12 @@ fn fold_callout(
     renderer.render_callout(callout, context, out);
 }
 
-/// Folds a [`Stem`](InlineNode::Stem) through the same
-/// `render_styled` the string pipeline's passthrough-restore step
-/// calls for a STEM entry (design §3.3.1's fold-time seam). The node's `value`
-/// already carries the resolved substitution group's output (special
+/// Folds a [`Stem`](InlineNode::Stem) through `render_styled`. The node's
+/// `value` already carries the resolved substitution group's output (special
 /// characters only, by default), so the fold passes it straight through as
-/// the body — no further processing is needed, mirroring how a STEM
-/// passthrough is restored with no attribute list or id (`INLINE_STEM_MACRO`
-/// captures neither).
+/// the body — no further processing is needed, matching how Asciidoctor
+/// restores a STEM passthrough with no attribute list or id
+/// (`INLINE_STEM_MACRO` captures neither).
 ///
 /// Shared with the macro families, whose *restore* of a masked STEM
 /// expression into a computed target must emit exactly the bytes this fold
@@ -855,20 +853,22 @@ mod tests {
 
     #[test]
     fn fold_reference_text_omits_a_headings_footnote_markers() {
-        // The tree's answer to the footnote-marker sentinel system this
-        // increment deleted: the two strings `Section::parse` needs — the
+        // The tree's answer to the footnote-marker sentinel system that was
+        // deleted: the two strings `Section::parse` needs — the
         // rendering the heading shows, and the footnote-free text its reference
         // and auto-generated id are derived from — are two *folds of the same
         // tree*, and "which regions were footnote markers" is a question about
         // node kinds rather than about bytes.
         //
         // Every fixture is checked from both ends. The heading's own rendering
-        // is compared against the string pipeline, which still produces it and
-        // is the golden-HTML oracle (§5.3). The footnote-free reference text is
-        // compared against a **literal** expected string: with the sentinel
-        // strip gone there is no second implementation left to differentiate
-        // against, so the expectation is written down instead — these are the
-        // exact bytes that strip produced, captured before it was deleted.
+        // is compared against `Content::rendered_html()` for the same source
+        // under the `Title` group — the public entry point's own
+        // build-and-fold of the same tree, confirming the two paths agree.
+        // The footnote-free reference text is compared against a **literal**
+        // expected string: with the sentinel strip gone there is no second
+        // implementation left to differentiate against, so the expectation is
+        // written down instead — these are the exact bytes that strip
+        // produced, captured before it was deleted.
         let fixtures = [
             // No footnote at all: the two strings are the same.
             ("Plain title", "Plain title"),
@@ -911,7 +911,7 @@ mod tests {
 
         for (fixture, expected_reftext) in fixtures {
             // Two independent parsers, since a footnote's number is document
-            // state: one for each side of the comparison (design §5.3).
+            // state: one for each side of the comparison.
             let golden_parser = Parser::default();
             let mut golden = crate::content::Content::from(Span::new(fixture));
             crate::content::SubstitutionGroup::Title.apply(&mut golden, &golden_parser, None);
@@ -1074,7 +1074,8 @@ mod tests {
         // `xrefstyle` in effect *there* is whatever the last `:xrefstyle:` line
         // in the document left set — not what was in effect where the
         // reference was written. Reading it at fold time would therefore
-        // silently re-style a reference the string pipeline had already styled.
+        // silently re-style a reference that was already styled correctly at
+        // the point it was written.
         let renderer = HtmlInlineRenderer {};
 
         // A parser whose document-wide `xrefstyle` says `full`, which the

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1081,7 +1081,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }
@@ -1125,7 +1125,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &renderer),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }
@@ -1149,7 +1149,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
 
             assert!(
@@ -1445,7 +1445,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
 
             let nodes = build_src(Span::new(source));
@@ -1674,7 +1674,7 @@ mod tests {
                     &expanding_parser().render_context()
                 ),
                 golden_normal(source, &expanding_parser()),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -403,27 +403,28 @@ fn build_candidate_node<'src>(
 }
 
 /// Builds one [`Footnote`](InlineNode::Footnote) node from a `footnote:` match,
-/// resolving it into the same three (id, content) cases the string
-/// replacer's `InlineFootnoteMacroReplacer` distinguishes, so the fold —
-/// which hands the node straight to
+/// resolving it into the three (id, content) cases Asciidoctor's own footnote
+/// macro distinguishes, so the fold — which hands the node straight to
 /// [`render_footnote`](crate::parser::InlineRenderer::render_footnote) (see
 /// `fold_footnote`) — reproduces the same bytes. Returns `None` for
-/// a form this increment defers, or for `footnote:[]` (neither an id nor
-/// content), which is not a footnote at all.
+/// a form this family leaves unrecognized, or for `footnote:[]` (neither an
+/// id nor content), which is not a footnote at all.
 ///
 /// # The one *required* recognition side effect
 ///
 /// Every other macro family in this module performs *no* recognition side
-/// effect (no catalog registration, no warning), deferring that to the
-/// cutover (design §5.2 Phase 4, step 6) because omitting it does not change
-/// the fold's output bytes. A footnote's own marker is the one exception: its
-/// rendered digits (`[1]`, `[2]`, …) *are* the assigned footnote number, so
-/// this builder must call [`Parser::footnote_index_for_id`] /
-/// [`Parser::define_footnote`] — the same document-counter-advancing calls
-/// the string replacer makes — or the differential corpus below could never
-/// pass. The two code paths never share a `Parser` (each independently
-/// numbers footnotes over the same source in the same left-to-right order),
-/// so this never double-counts a registration; see the module's test helpers.
+/// effect (no catalog registration, no warning) — that happens once per
+/// parse, after the tree is built and folded, via `apply_macro_side_effects`
+/// (see this module's `README.md`, "Recognition side effects"), since
+/// omitting it here does not change the fold's output bytes. A footnote's own
+/// marker is the one exception: its rendered digits (`[1]`, `[2]`, …) *are*
+/// the assigned footnote number, so this builder must call
+/// [`Parser::footnote_index_for_id`] / [`Parser::define_footnote`] directly,
+/// advancing the document's footnote counter as each occurrence is
+/// recognized, or the differential corpus below could never pass. Each test
+/// fixture's `build_src` call gets its own `Parser` (each independently
+/// numbers footnotes over its own source in left-to-right order), so no two
+/// fixtures' counters ever cross; see the module's test helpers.
 ///
 /// The registered catalog `text` is the footnote's **own subtree, folded** —
 /// see [`register_footnote_number`], which is where the entry a
@@ -432,11 +433,10 @@ fn build_candidate_node<'src>(
 ///
 /// # Content carrying an escaped closing bracket
 ///
-/// A content bracket may carry an escaped closing bracket (`\]`), which the
-/// string replacer unescapes to a literal `]`
-/// (`normalize_footnote_text`).
-/// The subtree carries it the same way: [`footnote_children`] emits the
-/// content through the reference-bearing families' own
+/// A content bracket may carry an escaped closing bracket (`\]`), which is
+/// unescaped to a literal `]`, matching Asciidoctor's own footnote-text
+/// normalization. The subtree carries it the same way: [`footnote_children`]
+/// emits the content through the reference-bearing families' own
 /// [`emit_range_unescaping_brackets`], which drops each backslash as a *gap*
 /// in the ranges it emits rather than rebuilding the pieces around it — see
 /// that helper for why a per-node `replace` cannot express the same unescape.
@@ -493,8 +493,8 @@ fn build_footnote_node<'src>(
                 }))
             }
 
-            // A reference to an id that was never defined, reported exactly
-            // where the string replacer reports it. Recorded rather than
+            // A reference to an id that was never defined, reported right
+            // here. Recorded rather than
             // replayed: the node is a reference with no number, which is also
             // what a *forward* reference looks like mid-parse, so the tree
             // cannot tell the two apart after the fact.
@@ -535,8 +535,8 @@ fn build_footnote_node<'src>(
 /// Unlike `footnote:id[…]`, which takes its id from the macro target,
 /// `footnoteref:[id,text]` / `footnoteref:[id]` packs both into one bracket
 /// (`raw`, group 3 of [`INLINE_FOOTNOTE_MACRO`]), split on the **first**
-/// comma — mirroring `InlineFootnoteMacroReplacer`'s own `raw.split_once(',')`
-/// exactly, including that an id is *always* present (a bracket with no
+/// comma — matching Asciidoctor's own `footnoteref:` parsing exactly,
+/// including that an id is *always* present (a bracket with no
 /// comma is the id alone, with no text — a bare reference) and that a
 /// trailing comma (`footnoteref:[id,]`) yields an *empty*, not absent,
 /// content (a defining occurrence with empty text), unlike `footnote:id[]`'s
@@ -548,9 +548,10 @@ fn build_footnote_node<'src>(
 /// required `footnote_index_for_id`/`define_footnote` side effect, and how a
 /// content-side `\]` is unescaped, which applies here identically since `raw`
 /// is matched by the very same bracket group). The **id** half is the one
-/// place the two differ: the string replacer splits the *raw* bracket on its
-/// first comma and never normalizes what precedes it, so an id carrying a `\]`
-/// keeps its backslash — as the id [`footnote_id_text`] recovers does.
+/// place the two differ: Asciidoctor's own `footnoteref:` handling splits
+/// the *raw* bracket on its first comma and never normalizes what precedes
+/// it, so an id carrying a `\]` keeps its backslash — as the id
+/// [`footnote_id_text`] recovers does.
 ///
 /// The deprecation warning `InlineFootnoteMacroReplacer` records outside
 /// `compat-mode` is raised here too, from the whole match's own text, exactly
@@ -594,11 +595,11 @@ fn build_footnoteref_node<'src>(
 
     // Unlike the `footnote:` form's own `[\w-]+` id — which no opaque piece
     // can reach — this id is *whatever precedes the first comma* in an
-    // arbitrary bracket, so it can cross a rendered span, whose markup the
-    // string replacer splits on and reads as the id while this side sees one
-    // placeholder standing in for it. Such a macro is left unrecognized (the
-    // boundary every macro family keeps), rather than built with an id no
-    // pipeline would produce.
+    // arbitrary bracket, so it can cross a rendered span, whose raw markup
+    // Asciidoctor splits on and reads as the id, while this side sees one
+    // opaque placeholder standing in for it. Such a macro is left unrecognized
+    // (the boundary every macro family keeps), rather than built with an id
+    // that has no faithful source-text reading.
     if !range_has_no_opaque_piece(nodes, pieces, &id_range) {
         return None;
     }
@@ -652,14 +653,13 @@ fn build_footnoteref_node<'src>(
 }
 
 /// Recovers a footnote **id** from the level's match-string `range` — the
-/// *already-substituted* text the string replacer itself reads out of its own
-/// escaped haystack (`caps[2]`, or the first half of a `footnoteref:`
-/// bracket), and the exact string it looks the footnote up by, registers under,
-/// and — for an unresolved reference — renders.
+/// already-substituted text (`caps[2]`, or the first half of a
+/// `footnoteref:` bracket) — and the exact string the footnote is looked up
+/// by, registered under, and — for an unresolved reference — rendered as.
 ///
 /// [`text_slice`] recovers that text precisely wherever the range's pieces are
-/// [`Text`](InlineNode::Text) runs: borrowed from `'src` for a verbatim one
-/// (design §4.5), and the expansion's own bytes for a
+/// [`Text`](InlineNode::Text) runs: borrowed from `'src` for a verbatim one,
+/// and the expansion's own bytes for a
 /// [`synthesized`](Piece::synthesized) one — an attribute reference
 /// (`{fn-disclaimer}` expanding to `footnote:disclaimer[…]`), or a filtered
 /// multi-line block's own joined seed. That is the lift this helper exists for:
@@ -672,8 +672,8 @@ fn build_footnoteref_node<'src>(
 /// `'src` slice at all (the source holds one character where the match string
 /// holds an entity), which is exactly what `text_slice` declines to recover, so
 /// it falls back to the match string's own bytes: `footnoteref:[a&b,…]`
-/// registers `a&amp;b`, precisely what the string replacer's
-/// `raw.split_once(',')` reads from its own haystack. Only an **opaque** piece
+/// registers `a&amp;b`, matching what Asciidoctor's own `footnoteref:`
+/// parsing reads from its escaped haystack. Only an **opaque** piece
 /// cannot be recovered this way, and its one reachable call site rejects such a
 /// range before calling here.
 fn footnote_id_text<'src>(
@@ -692,22 +692,21 @@ fn footnote_id_text<'src>(
 /// becomes structured children rather than a literal attribute value, so a
 /// range crossing an already-recognized construct is not a boundary to defer
 /// on; it is the whole point — the emitter clones that construct's node
-/// whole into the footnote's subtree, exactly mirroring how the string
-/// pipeline's footnote text captures an already-substituted macro verbatim
+/// whole into the footnote's subtree, matching Asciidoctor's own behavior,
+/// whose footnote text captures an already-rendered macro verbatim
 /// (see [`apply_footnotes`]'s doc comment on ordering). It emits through the
 /// plain [`emit_range`](super::quotes::emit_range), not the recursing
-/// [`emit_range_recursing_footnotes`] — footnotes do not nest (the string
-/// pipeline's own lazy bracket match cannot recognize one inside another's
+/// [`emit_range_recursing_footnotes`] — footnotes do not nest (this family's
+/// own lazy bracket match cannot recognize one inside another's
 /// content either, since it always stops at the *first* unescaped `]`), so a
 /// footnote's own content is captured as-is.
 ///
 /// # The `\]` unescape
 ///
 /// A bracket's content may carry an **escaped closing bracket** (`\]`), which
-/// `normalize_footnote_text`
-/// — the string replacer's own normalization — turns back into a literal `]`.
-/// The subtree must carry the same text, so the shared
-/// [`emit_range_unescaping_brackets`] drops
+/// is unescaped back into a literal `]`, matching Asciidoctor's own
+/// footnote-text normalization. The subtree must carry the same text, so the
+/// shared [`emit_range_unescaping_brackets`] drops
 /// each backslash as a *gap* in the ranges it emits: `footnote:[a \] b]`
 /// becomes the two `'src`-borrowing [`Text`](InlineNode::Text) children `a `
 /// and `] b`, never an owned rebuild. Sharing the reference-bearing families'
@@ -744,43 +743,37 @@ fn footnote_children<'src>(
 /// placeholder **template** the entry stores and the cross-reference
 /// **segments** that fill it, which is exactly the pair `define_footnote`
 /// turns into a
-/// [`FootnoteDeferred`](crate::content::FootnoteDeferred). The string
-/// replacer reaches the same pair from the other direction — it re-homes the
-/// block template's placeholders out of the already-substituted text it cut
-/// the footnote from
-/// (`rehome_xref_placeholders`) —
-/// so a footnote's own `<<tgt>>` resolves on either side.
+/// [`FootnoteDeferred`](crate::content::FootnoteDeferred), so a footnote's
+/// own `<<tgt>>` resolves the same way any other deferred cross-reference
+/// does.
 ///
-/// Folding the subtree is also what makes the entry's `text` byte-faithful at
-/// all: the raw bracket content this used to register is the *match string*,
-/// in which an already-recognized construct is one opaque `SPAN_PLACEHOLDER`
-/// codepoint, so `footnote:[see https://github.com[GitHub\]]` registered
-/// `"see \u{e0f0}"` where the string pipeline registers
-/// `"see <a href=\"https://github.com\">GitHub</a>"`.
+/// Folding the subtree is also what makes the entry's `text` byte-faithful:
+/// registering the raw *match string* instead — in which an already-recognized
+/// construct is one opaque `SPAN_PLACEHOLDER` codepoint — would register
+/// `footnote:[see https://github.com[GitHub\]]` as `"see \u{e0f0}"` rather
+/// than the correct `"see <a href=\"https://github.com\">GitHub</a>"`.
 ///
 /// # Why the anchor is `root`, not the macro's own span
 ///
 /// `define_footnote` records where the *enclosing content* was written, not
 /// where the macro sits: the entry's location anchors an unresolved-reference
 /// warning raised much later, when the catalog resolves the footnote's own
-/// cross-references, and the string replacer passes its whole `self.source`
-/// there (paragraph granularity, matching how a non-footnote reference is
-/// anchored at its `Content` — see the field's own docs). `root` is that same
-/// span; it is what this pass already passes to
+/// cross-references, at paragraph granularity — matching how a non-footnote
+/// reference is anchored at its `Content` (see the field's own docs). `root`
+/// is that same span; it is what this pass already passes to
 /// [`Parser::record_builder_diagnostic`] for the two diagnostics it raises.
 /// The macro's own span is the *node's* `location`, a different question with
 /// a different answer.
 ///
 /// # Normalization
 ///
-/// `normalize_footnote_text`
-/// does three things to the string replacer's raw content: trims it, collapses
-/// each embedded newline to a space, and unescapes `\]` to `]`. The first two
-/// apply here unchanged — they are about the *text*, whichever pipeline
-/// produced it — via [`normalize_footnote_template`], their piece-list reading.
-/// The third does **not**: [`footnote_children`] already dropped each such
-/// backslash while emitting the subtree (see its doc comment), so re-applying
-/// the unescape here would be a second pass over an already-unescaped string.
+/// Footnote text normalization does three things to a footnote's raw content:
+/// trims it, collapses each embedded newline to a space, and unescapes `\]`
+/// to `]`. The first two apply here unchanged, via
+/// [`normalize_footnote_template`], their piece-list reading. The third does
+/// **not**: [`footnote_children`] already dropped each such backslash while
+/// emitting the subtree (see its doc comment), so re-applying the unescape
+/// here would be a second pass over an already-unescaped string.
 fn register_footnote_number(
     parser: &Parser,
     id: Option<&str>,
@@ -792,14 +785,14 @@ fn register_footnote_number(
 
     let template = normalize_footnote_template(template);
 
-    // The builder folds this entry from the footnote's own subtree, which
-    // never enters the string pipeline's escaped sentinel form.
+    // The builder folds this entry from the footnote's own subtree directly,
+    // with no intermediate escaped-placeholder encoding.
     parser.define_footnote(id, template, xrefs, root)
 }
 
-/// Trims and collapses a footnote's structured template exactly as the string
-/// replacer's `normalize_footnote_text` did its flat one: a leading or
-/// trailing literal piece is trimmed of surrounding whitespace, and every
+/// Trims and collapses a footnote's structured template the same way
+/// Asciidoctor's own footnote-text normalization treats a flat one: a leading
+/// or trailing literal piece is trimmed of surrounding whitespace, and every
 /// literal piece has each embedded newline collapsed to a space. An
 /// [`Xref`](XrefTemplatePiece::Xref) piece is untouched either way — a splice
 /// point carries no bytes of its own to trim or collapse — so only whichever
@@ -875,7 +868,7 @@ mod tests {
         );
 
         // The macro stays literal bytes: the level folds back to the source
-        // (the unescaped `<`/`>` as §3.4.1 `Raw` leaves, emitted as-is).
+        // (the unescaped `<`/`>` as `Raw` leaves, emitted as-is).
         assert_eq!(
             fold_html(&macros_only, &HtmlInlineRenderer {}),
             "x footnote:[note]</a>"
@@ -949,10 +942,9 @@ mod tests {
         // source (`"{produ"`) instead of the resolved value.
         use crate::{Parser, content::inline_builder::build, parser::ModificationContext};
 
-        // Two *independent* parsers (design §5.3's discipline, established by
-        // this module's own differential corpus below): `build` and the real
-        // pipeline each advance the footnote registry for real, so sharing
-        // one parser would double-count the footnote's assigned number.
+        // `configure` builds a fresh `Parser`; the comparison target below is
+        // a frozen recording (`snapshot::recorded`), not a second live parse,
+        // so only this one `Parser` ever advances the footnote registry.
         let configure = || {
             Parser::default().with_intrinsic_attribute(
                 "product",
@@ -979,20 +971,19 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_footnotes() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the footnote increment —
-        // the last of the macro families (part 4c). Each fixture uses its own
-        // pair of *independent* default parsers (one inside `build_src`, one
-        // inside `golden_macros`), so the `footnote-number` counter each one
-        // advances never crosses over; as long as both recognize the same
-        // occurrences in the same left-to-right order, their numbering stays in
-        // lockstep.
+        // reproduces the frozen golden recording byte-for-byte — the
+        // differential corpus that pins footnote recognition, the last of
+        // the macro families. `build_src` uses its own default `Parser` per
+        // fixture, so the `footnote-number` counter it advances never
+        // crosses fixtures; the numbering only has to match the recording's
+        // own left-to-right order.
         let fixtures = [
             // No footnote despite macro-ish characters.
             "plain text without a footnote",
             "a footnote without a bracket footnote:foo stays literal",
             // `footnote:[]` (neither an id nor content) is not a footnote at
-            // all — left untouched by both the string replacer and the builder.
+            // all — left untouched by the builder, matching Asciidoctor's
+            // own behavior.
             "footnote:[]",
             // An anonymous defining occurrence, and one whose text needs no
             // further substitution.
@@ -1066,8 +1057,8 @@ mod tests {
             "footnote:[a \\] b \\] c]",
             "footnoteref:[disc,a note ending in a\\]bracket]",
             // No comma at all: the whole (still-escaped) bracket is the id of
-            // an unresolved reference, which the string replacer never
-            // normalizes.
+            // an unresolved reference, which is never normalized (matching
+            // Asciidoctor's own behavior).
             "footnoteref:[a note ending in a\\]bracket]",
             "footnote:[the *strong* \\] evidence]",
             "footnote:[an escaped \\] beside a < special]",
@@ -1099,9 +1090,8 @@ mod tests {
     fn a_footnote_nested_in_a_child_numbers_in_source_order() {
         // The property this pass exists for, asserted where it is actually
         // decided: a footnote nested in a child that falls **between** two of
-        // its level's own footnotes is numbered between them, because the
-        // string pipeline recognizes in one left-to-right sweep over one flat
-        // string.
+        // its level's own footnotes is numbered between them, because
+        // footnotes are numbered in one left-to-right sweep over the source.
         //
         // Every fixture here places a nested footnote in that position — after
         // one sibling and before another — since that is the only arrangement
@@ -1143,11 +1133,10 @@ mod tests {
     #[test]
     fn an_anchors_reference_text_is_not_scanned_for_footnotes() {
         // The complement, and the reason the walk descends into an index term
-        // but not into an anchor's reference text: the anchor replacer
+        // but not into an anchor's reference text: the anchor family
         // *consumes* that text rather than emitting it, so a `footnote:[…]`
-        // written there never reaches the string pipeline's footnote pass
-        // either. Both sides agree that nothing is numbered — and a real
-        // footnote beside it still takes number 1.
+        // written there is never recognized either — nothing is numbered,
+        // and a real footnote beside it still takes number 1.
         let renderer = HtmlInlineRenderer {};
 
         for fixture in [
@@ -1288,8 +1277,8 @@ mod tests {
     #[test]
     fn an_empty_footnote_macro_stays_literal() {
         // `footnote:[]` carries neither an id nor content, so it is not a
-        // footnote at all — left as literal text, exactly as the string
-        // replacer's `next $&` branch leaves it.
+        // footnote at all — left as literal text, matching Asciidoctor's own
+        // behavior for this form.
         let nodes = build_src(Span::new("footnote:[]"));
 
         assert_eq!(nodes.len(), 1);
@@ -1303,10 +1292,9 @@ mod tests {
         // from `footnote:id[text]`'s own (id from the macro target, text
         // from the bracket) — but resolves into the same node shape and
         // folds through the same `render_footnote`, so its output is
-        // byte-for-byte identical to the golden pipeline's (the deprecation
-        // warning itself remains deferred to the cutover; it does not affect
-        // the fold's output bytes — see `build_footnoteref_node`'s doc
-        // comment).
+        // byte-for-byte identical to the golden recording's (the deprecation
+        // warning is raised directly too and does not affect the fold's
+        // output bytes — see `build_footnoteref_node`'s doc comment).
         let source = "footnoteref:[disc,a discussion]";
         let folded = fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {});
 
@@ -1342,10 +1330,9 @@ mod tests {
     #[test]
     fn a_deprecated_footnoteref_macro_referencing_an_undefined_id_falls_back_to_it() {
         // A comma-free `footnoteref:[id]` whose id was never defined resolves
-        // through the same unresolved fallback `footnote:id[]` does (the
-        // string replacer's own `InvalidFootnoteReference` warning is a
-        // diagnostic, deferred to the cutover like every other one this
-        // builder skips).
+        // through the same unresolved fallback `footnote:id[]` does, raising
+        // the same `InvalidFootnoteReference` diagnostic (see
+        // `build_footnoteref_node`'s doc comment).
         let source = "footnoteref:[missing]";
         let folded = fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {});
 
@@ -1378,8 +1365,8 @@ mod tests {
     #[test]
     fn an_empty_footnoteref_macro_stays_literal() {
         // `footnoteref:[]` carries no bracketed text at all, so it is left
-        // unrecognized — mirroring the string replacer's `next $&` branch,
-        // the same way `footnote:[]` is.
+        // unrecognized, matching Asciidoctor's own behavior, the same way
+        // `footnote:[]` is.
         let nodes = build_src(Span::new("footnoteref:[]"));
 
         assert_eq!(nodes.len(), 1);
@@ -1443,8 +1430,8 @@ mod tests {
     #[test]
     fn a_footnote_with_an_escaped_bracket_unescapes_it_into_the_subtree() {
         // Content carrying an escaped closing bracket (`\]`) is recognized:
-        // the string replacer unescapes it to a literal `]`
-        // (`normalize_footnote_text`) and the subtree carries the same text,
+        // it is unescaped to a literal `]`, matching Asciidoctor's own
+        // footnote-text normalization, and the subtree carries the same text,
         // `footnote_children` dropping the backslash as a *gap* in the ranges
         // it emits (see `emit_range_unescaping_brackets`). Both the anonymous
         // form and the id-carrying form share that path, so both are

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -1552,15 +1552,16 @@ mod tests {
         // exercises: nesting an *earlier*-running macro inside a footnote's
         // content is fine (by the time footnotes run, that macro's brackets
         // are already consumed into a node), but nesting *footnote* syntax
-        // inside an earlier macro's argument is not, in the string pipeline
-        // or otherwise.
+        // inside an earlier macro's argument is not — for either this crate
+        // or Asciidoctor.
         //
-        // In the *string* pipeline, the footnote pass runs over the
+        // Asciidoctor's own footnote substitution runs over the
         // *already-rendered* flat string, where the link's `</a>` is just
-        // literal text no different from any other — so the footnote regex,
+        // literal text no different from any other — so its footnote regex,
         // finding only one `]` left in the whole string, matches straight
         // through the `</a>` and consumes it as part of its own (nonsensical)
-        // content, producing malformed, never-closed markup. That is a direct
+        // content, producing malformed, never-closed markup: the golden
+        // recording below preserves exactly that output. That is a direct
         // consequence of matching over *rendered* text rather than structure
         // — exactly the class of divergence
         // `crossed_delimiters_are_a_documented_divergence` documents for
@@ -1568,8 +1569,7 @@ mod tests {
         // tree (it exists only as fold *output*, not as node content), so
         // the builder's footnote pass has no way to "reach into" it, and
         // correctly does not: the link's label stays literal, unrecognized
-        // text, and the tree never reproduces the string pipeline's
-        // malformed markup here.
+        // text, and the tree never reproduces that malformed markup here.
         let source = "link:https://example.org[footnote:[note]]";
         let nodes = build_src(Span::new(source));
 
@@ -1582,10 +1582,11 @@ mod tests {
             "<a href=\"https://example.org\">footnote:[note</a>]"
         );
 
-        // The string pipeline, by contrast, produces unclosed markup: the
-        // link's own closing `</a>` is consumed into the footnote's content,
-        // and the footnote's own numbered marker (with its *own*, unrelated
-        // `<a>…</a>`) takes its place.
+        // The golden recording, by contrast, holds the unclosed markup
+        // Asciidoctor itself produces here: the link's own closing `</a>` is
+        // consumed into the footnote's content, and the footnote's own
+        // numbered marker (with its *own*, unrelated `<a>…</a>`) takes its
+        // place.
         assert_eq!(
             golden_macros(source),
             "<a href=\"https://example.org\"><sup class=\"footnote\">\
@@ -1616,7 +1617,7 @@ mod tests {
             )
     }
 
-    /// The real, public pipeline's output for `source` — the golden for the
+    /// The frozen golden recording for `source` — the golden for the
     /// expanded-value fixtures, which need the `AttributeReferences` step the
     /// module's own [`golden_macros`] helper deliberately omits.
     fn golden_normal(source: &str, _parser: &crate::Parser) -> String {
@@ -1635,9 +1636,10 @@ mod tests {
         // registered and looked up under) one that renumbered every later
         // reference to it.
         //
-        // Each fixture uses its own pair of *independent* parsers (design
-        // §5.3's discipline), since both `build` and the real pipeline
-        // advance the `footnote-number` counter for real.
+        // Each fixture builds its own `expanding_parser()` for `build`, so
+        // its `footnote-number` counter never crosses fixtures; the
+        // comparison target (`golden_normal`) is a frozen recording, not a
+        // second live parse.
         use crate::content::inline_builder::build;
 
         let fixtures = [
@@ -1682,7 +1684,7 @@ mod tests {
         // The id is exact — recovered from the expansion's own bytes by
         // `footnote_id_text`, and necessarily owned — while only the node's
         // `location` falls back to the enclosing synthesized run's coarse
-        // span (design §4.4), since an expanded value's bytes have no `'src`
+        // span, since an expanded value's bytes have no `'src`
         // counterpart of their own.
         use crate::content::inline_builder::build;
 
@@ -1757,8 +1759,8 @@ and another.footnote:[note two]",
         // cross an escaped special. `text_slice` declines such a range (the
         // source holds one character where the match string holds an entity),
         // so `footnote_id_text` falls back to the match string's own bytes:
-        // exactly what the string replacer's `raw.split_once(',')` reads out
-        // of its own escaped haystack, and registers.
+        // exactly what Asciidoctor's own `footnoteref:` parsing reads out
+        // of its escaped haystack, and registers.
         let source = "footnoteref:[a&b,a note] then footnoteref:[a&b]";
         let nodes = build_src(Span::new(source));
 
@@ -1781,11 +1783,11 @@ and another.footnote:[note two]",
     fn a_footnoteref_id_crossing_a_rendered_span_is_a_documented_divergence() {
         // The one piece class `footnote_id_text` cannot recover: a rendered
         // span, whose markup exists only at fold time, is one opaque
-        // placeholder here where the string replacer's own haystack holds the
+        // placeholder here where Asciidoctor's own haystack holds the
         // `<strong>…</strong>` tags it happily splits on and registers as the
         // id. Such a macro is left unrecognized — literal text, never a wrong
-        // node — the boundary every macro family keeps. (If a later increment
-        // lifts it, fold this fixture into the parity corpus above.)
+        // node — the boundary every macro family keeps. (If this limitation
+        // is ever lifted, fold this fixture into the parity corpus above.)
         let source = "footnoteref:[*bold*,a note]";
         let nodes = build_src(Span::new(source));
 
@@ -1794,7 +1796,7 @@ and another.footnote:[note two]",
             "a footnoteref: id crossing a rendered span must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, does build a footnote here.
+        // Asciidoctor, by contrast, does build a footnote here.
         assert!(golden_macros(source).contains("class=\"footnote\""));
     }
 

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -20,11 +20,12 @@ use crate::{
 /// every [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref) child
 /// it finds along the way.
 ///
-/// This is the last macro family (design §5.2 Phase 4, step 4b(ii) part 4c)
-/// and runs as [`build`](super::build)'s own step, *after*
-/// [`apply_macros`](super::macros::apply_macros) has fully resolved every other
-/// family at every level, mirroring the string step's order exactly: footnotes
-/// run last, once, over the whole (already substituted) string (macros.rs).
+/// This is the last macro family recognized, running as
+/// [`build`](super::build)'s own step *after*
+/// [`apply_macros`](super::macros::apply_macros) has fully resolved every
+/// other family at every level: footnotes are recognized last, once, over
+/// the whole already-substituted tree, matching Asciidoctor's own
+/// footnote-numbering order.
 ///
 /// # Why this cannot be a level pass *within* [`apply_macros`](super::macros::apply_macros)
 ///
@@ -40,7 +41,7 @@ use crate::{
 /// span [`apply_quotes`](super::quotes::apply_quotes) already built before
 /// [`apply_macros`](super::macros::apply_macros) ever runs) **before** a
 /// footnote that precedes that span in the source, reversing their markers
-/// relative to the string pipeline's left-to-right sweep over one flat string.
+/// relative to a strict left-to-right numbering over the source.
 /// This function fixes that by walking `nodes` in true source order: it
 /// recognizes every footnote at *this* level, but recurses
 /// into a [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref) child
@@ -132,7 +133,7 @@ fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
 ///
 /// Each candidate's node is **built here**, immediately after the gap that
 /// precedes it, rather than during the scan (see [`FootnoteMatch`]). That is
-/// what puts the numbers in the string pipeline's own order: a footnote nested
+/// what puts the numbers in true source order: a footnote nested
 /// in a child that falls between two of this level's is numbered between them,
 /// because the gap carrying that child is emitted — and recursed into — before
 /// this match's own node is made.
@@ -250,15 +251,15 @@ fn emit_range_recursing_footnotes<'src>(
                 }
 
                 // A **visible** index term's shown text reaches the flow, so
-                // the string replacer's footnote pass scans it like any other
+                // this pass scans it for footnotes like any other
                 // text — the same reason the later macro families are handed
                 // that text (see the index-term family's own note).
                 //
                 // An [`Anchor`](InlineNode::Anchor)'s `reftext` is the
                 // opposite case and is deliberately *not* recursed into: the
-                // anchor replacer consumes that text rather than emitting it,
-                // so a `footnote:[…]` written there never reaches the string
-                // pipeline's footnote pass either.
+                // anchor family consumes that text rather than emitting it,
+                // so a `footnote:[…]` written there never reaches this
+                // footnote pass either.
                 InlineNode::IndexTerm(mut index_term) => {
                     index_term.children = apply_footnotes(index_term.children, root, parser);
                     out.push(InlineNode::IndexTerm(index_term));
@@ -301,8 +302,8 @@ fn emit_range_recursing_footnotes<'src>(
 /// yet built**.
 ///
 /// Deferring construction is what keeps the numbers right. A footnote's
-/// assigned number is a side effect of *recognition order*, and the string
-/// pipeline recognizes in one left-to-right sweep over one flat string — so a
+/// assigned number is a side effect of *recognition order*, and footnotes are
+/// numbered in one left-to-right sweep over the source — so a
 /// footnote nested in a [`Styled`](crate::inlines::Styled) span that sits
 /// between two of this level's own footnotes must be numbered between them.
 /// Building every match up front (as this scan used to) assigns all of this
@@ -312,10 +313,10 @@ fn emit_range_recursing_footnotes<'src>(
 /// it, after the gap before it — children and all — has been emitted.
 enum FootnoteMatch<'h> {
     /// An escape (`\footnote:…`, `\footnoteref:…`): the backslash is dropped
-    /// and the rest kept literal, mirroring the string replacer's leading
-    /// `caps[0].starts_with('\\')` check — which runs *before* the
-    /// ref-vs-plain branch, so this is decided during the scan, not at build
-    /// time. It creates no node and needs no number.
+    /// and the rest kept literal. Whether the match is escaped is checked
+    /// (`whole.as_str().starts_with('\\')`, see [`find_footnote_matches`])
+    /// *before* the ref-vs-plain branch, so this is decided during the scan,
+    /// not at build time. It creates no node and needs no number.
     Unescape {
         full: std::ops::Range<usize>,
         backslash: usize,
@@ -352,13 +353,13 @@ fn find_footnote_matches(s: &str) -> Vec<FootnoteMatch<'_>> {
             continue;
         }
 
-        // Asciidoctor's `(?!</a>)` look-ahead, the same way the string
-        // replacer re-created it: a closing bracket immediately followed by a
-        // literal `</a>` is not a footnote (it closes an already-rendered
-        // link), so the bytes stay text. The match string holds the *escaped*
-        // form, so under the normal order a document's own `</a>` reaches here
-        // as `&lt;/a&gt;` and the guard — exactly like the string replacer's —
-        // fires only for the orders whose escaping step has not run.
+        // Recreates Asciidoctor's `(?!</a>)` look-ahead, which the Rust regex
+        // engine has no native support for: a closing bracket immediately
+        // followed by a literal `</a>` is not a footnote (it closes an
+        // already-rendered link), so the bytes stay text. The match string
+        // holds the *escaped* form, so under the normal order a document's
+        // own `</a>` reaches here as `&lt;/a&gt;`, and this guard fires only
+        // for the orders whose escaping step has not run.
         if s.get(full.end..)
             .is_some_and(|after| after.starts_with("</a>"))
         {
@@ -391,7 +392,8 @@ fn build_candidate_node<'src>(
     // `footnote:id[…]` does.
     if caps.get(1).is_some() {
         // With no bracketed text at all (`footnoteref:[]`), it is left
-        // unrecognized — mirroring the string replacer's `next $&`.
+        // unrecognized: the match's own text is emitted unchanged, matching
+        // Asciidoctor's behavior for this form.
         let raw = caps.get(3)?;
 
         return build_footnoteref_node(raw, full, s, pieces, nodes, root, parser);

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -28,54 +28,57 @@ use crate::{
 /// Matches `INLINE_BIBLIO_ANCHOR` at the **content's own top level**, replacing
 /// a bibliography anchor (`[[[label]]]` / `[[[label,xreftext]]]`) with the
 /// [`Anchor`](InlineNode::Anchor) node it produces — `is_bibliography` set —
-/// followed by the bracketed label the string replacer emits into the flow.
+/// followed by the bracketed label pushed into the flow, matching
+/// Asciidoctor's own rendering.
 ///
 /// # Where this runs, and why only here
 ///
-/// The string pipeline runs this pass **first**, ahead of every other macro
+/// This pass runs **first**, ahead of every other macro
 /// family, and only when the parser flags that it is substituting the principal
 /// text of a bibliography list item
 /// ([`in_bibliography_list_item`](Parser::in_bibliography_list_item), set in
-/// `blocks::list_item`); this mirrors both. The pattern is `^`-anchored — a
+/// `blocks::list_item`) — matching Asciidoctor on both counts. The pattern is
+/// `^`-anchored — a
 /// `[[[…]]]` appearing later in the entry is left to the ordinary inline-anchor
 /// pass, which renders it but never catalogs its id (see
 /// [`is_bibliography_inner`]) — so this level pass runs once, at the top level
 /// [`apply_macros`](super::apply_macros) is called with, and never descends
 /// into a span's children: `^` matches only the very start of the *whole*
-/// content, exactly as it does for the string pipeline's own haystack.
+/// content, matching Asciidoctor's own anchoring.
 ///
 /// # The bracketed label stays in the flow
 ///
-/// The replacer renders the anchor from its id alone (`render_anchor(id,
-/// None)`) and then pushes the bracketed label (`[label]`, or `[xreftext]` when
-/// one was supplied) into the output as ordinary text — text every *later*
-/// string pass then scans. So the label is emitted here as the sibling nodes
+/// The anchor renders from its id alone (`render_anchor(id,
+/// None)`), and the bracketed label (`[label]`, or `[xreftext]` when
+/// one was supplied) is pushed into the output as ordinary text — text every
+/// *later* step then scans. So the label is emitted here as the sibling nodes
 /// that follow the anchor node (sliced from the match's own outer brackets and
 /// its label range with [`emit_range`], so each keeps its exact `'src`
 /// provenance), rather than as the anchor's own children: that is what lets
-/// every family after this one see the label exactly as the string pipeline's
-/// later passes see it (an auto-link written in an xreftext is linked in both),
+/// every family after this one see the label as ordinary flow text (an
+/// auto-link written in an xreftext is linked),
 /// with no container to descend into.
 ///
 /// The node's own `reftext` instead carries the bracketed label as the
 /// **registered** reference text — what a cross-reference to the entry
 /// displays, and what [`apply_biblio_side_effects`] hands
-/// [`register_ref`](Parser::register_ref), mirroring the replacer's own single
-/// `format!("[{label}]")` serving both purposes.
+/// [`register_ref`](Parser::register_ref) — one
+/// `format!("[{label}]")` serving both the displayed and the registered
+/// purpose.
 ///
 /// # The registered label is already-substituted text
 ///
-/// The string replacer captures its label out of the *escaped,
-/// already-rendered* haystack and registers **that** (`[[[gof,A & B]]]`
-/// catalogs `[A &amp; B]`), so the node's `reftext` holds the label in the same
-/// already-substituted form — the contract an
+/// The registered label is captured in *escaped,
+/// already-substituted* form (`[[[gof,A & B]]]`
+/// catalogs `[A &amp; B]`), so the node's `reftext` holds the label in that
+/// same already-substituted form — the contract an
 /// [`IndexTerm`](InlineNode::IndexTerm)'s own `terms` already uses — taken
-/// straight from this level's match string, which reconstructs exactly that
-/// haystack (a [`CharRef`](InlineNode::CharRef) contributes its
+/// straight from this level's match string (a [`CharRef`](InlineNode::CharRef)
+/// contributes its
 /// canonical entity, so an escaped special and a character replacement alike
-/// come out byte-identical to the replacer's own capture). Nothing re-escapes
+/// come out byte-identical to what Asciidoctor captures). Nothing re-escapes
 /// it: the fold hands `render_anchor` `None` for a bibliography anchor (see
-/// `fold_anchor`), exactly as the replacer does.
+/// `fold_anchor`), matching Asciidoctor's own rendering.
 ///
 /// # Deferred: a label crossing an opaque piece
 ///
@@ -83,20 +86,19 @@ use crate::{
 /// [`Styled`](crate::inlines::Styled) span (`[[[gof,*G*]]]`), a passthrough or
 /// STEM expression (not even restored yet), or a character replacement
 /// (`[[[gof,(C) 1995]]]`, `[[[oreilly,O'Reilly]]]`) — which stands in as a
-/// single [`SPAN_PLACEHOLDER`] here rather than as the markup or entity the
-/// string pipeline's haystack holds there. Such an anchor is left unrecognized,
+/// single [`SPAN_PLACEHOLDER`] here rather than as the markup or entity
+/// itself. Such an anchor is left unrecognized,
 /// exactly the boundary the index-term family's own visible term documents
 /// (and, for the character replacements, the same one every macro family
 /// already has at this point: `build_match_string` serves the quotes step too,
 /// where the replacements have not run yet, so it can only treat them as
 /// opaque). A label reached through a synthesized run (an attribute expansion,
 /// or a filtered block's joined seed) *is* recognized — the run contributes its
-/// expanded value to the match string, just as it does to the string pipeline's
-/// own haystack.
+/// expanded value to the match string directly.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
-/// effect; [`apply_biblio_side_effects`] stages the `register_ref` for the
-/// cutover.
+/// effect itself; [`apply_biblio_side_effects`] performs the `register_ref`
+/// call once per parse, after the tree is built and folded.
 pub(super) fn biblio_anchor_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -140,8 +142,7 @@ pub(super) fn biblio_anchor_level<'src>(
     let id_match = caps.get(1).unwrap();
 
     // The displayed (and registered) label is the xreftext when one was
-    // supplied, else the id itself — exactly the string replacer's own
-    // `caps.get(2)…unwrap_or(id)`.
+    // supplied, else the id itself — `caps.get(2)…unwrap_or(id)`.
     let label_match = caps.get(2).unwrap_or(id_match);
 
     let id_range = id_match.start()..id_match.end();
@@ -181,7 +182,7 @@ pub(super) fn biblio_anchor_level<'src>(
         location,
     })];
 
-    // The bracketed label the replacer pushes into the flow. Its brackets are
+    // The bracketed label pushed into the flow. Its brackets are
     // the match's own outer `[` and `]` (the very characters the triple bracket
     // opens and closes with), so each emitted piece keeps an honest `'src`
     // slice instead of a synthesized value.
@@ -255,11 +256,12 @@ pub(super) fn anchor_macros_level<'src>(
 /// expanded value happens to contain `[[id]]`, or — reached at a tree's root —
 /// a filtered multi-line block's own joined seed): [`build_anchor_node`] no
 /// longer defers on that alone, recovering the id's exact text via
-/// [`text_slice`] even though it has no honest `'src` slice of its own (design
-/// §3.4.1/§4.1's "a macro inside an expanded value" boundary, reached here
+/// [`text_slice`] even though it has no honest `'src` slice of its own (the
+/// "a macro inside an expanded value" boundary, reached here
 /// through the id rather than a target/attribute list) — the node's
-/// `location` still falls back to the coarse enclosing span design §4.4
-/// documents, since only the *text* needed the precision. A non-verbatim
+/// `location` still falls back to the coarse enclosing span used when a
+/// construct has no `Span`-typed field of its own, since only the *text*
+/// needed the precision. A non-verbatim
 /// *reference text* (one carrying a rendered span or an escaped special) is a
 /// narrower case that does not reach the flow at all, so it only leaves the
 /// node's `reftext` unpopulated rather than deferring the whole anchor (see
@@ -280,9 +282,9 @@ pub(super) fn find_anchor_matches<'src>(
         let full = whole.start()..whole.end();
 
         // An escape (`\[[…` / `\anchor:…`) is honored by dropping the backslash
-        // and keeping the rest literal, mirroring the string replacer's leading
-        // `caps.get(1)` check. [`rebuild_macro_level`] emits the kept range
-        // with [`emit_range`], which clones an atomic piece (a
+        // and keeping the rest literal, checked *before* anything else via a
+        // leading `caps.get(1)` check. [`rebuild_macro_level`] emits the kept
+        // range with [`emit_range`], which clones an atomic piece (a
         // rendered-span reference text) whole, so the unescape works
         // even across a non-verbatim reference text — just as the id
         // itself is always verbatim, the whole anchor
@@ -323,7 +325,7 @@ pub(super) fn find_anchor_matches<'src>(
 
 /// Builds one [`Anchor`](InlineNode::Anchor) node from an inline-anchor match,
 /// recovering the id's exact text via [`text_slice`] so the fold reproduces
-/// the string replacer's `<a id="…"></a>` exactly. Returns `None` only when
+/// `<a id="…"></a>` exactly. Returns `None` only when
 /// the id crosses an [`atomic`](Piece::atomic) piece (see below) — a form this
 /// increment still defers.
 ///
@@ -337,10 +339,10 @@ pub(super) fn find_anchor_matches<'src>(
 /// every other macro family's own gate. Its bytes *can* come from a
 /// [`synthesized`](Piece::synthesized) run — an attribute reference whose
 /// expanded value happens to contain `[[id]]`, or — reached at a tree's root —
-/// a filtered multi-line block's own joined seed (design §3.4.1's "a macro
+/// a filtered multi-line block's own joined seed (the "a macro
 /// inside an expanded value" boundary) — and [`text_slice`] recovers the exact
 /// id text for that case too, unlike [`source_slice`], which would silently
-/// fall back to the enclosing synthesized run's *coarse* span (design §4.4)
+/// fall back to the enclosing synthesized run's *coarse* span
 /// for both the id and the node's `location`. Only `location` keeps that
 /// coarse fallback here; the id text itself is always precise.
 ///
@@ -349,8 +351,8 @@ pub(super) fn find_anchor_matches<'src>(
 /// piece (the common verbatim case borrows `'src`; a synthesized one is
 /// recovered via [`text_slice`] into an owned value, `location` falling back
 /// to the coarse span exactly as the id's own does). A shorthand's trailing
-/// whitespace is trimmed and a macro's escaped `\]` is unescaped, mirroring
-/// the string replacer. A reference text that carries a rendered span or an
+/// whitespace is trimmed and a macro's escaped `\]` is unescaped, matching
+/// Asciidoctor. A reference text that carries a rendered span or an
 /// escaped special is left non-verbatim; because it never reaches the flow
 /// (the anchor renders from its id alone), the anchor is still recognized but
 /// its `reftext` is left `None` rather than sliced wrongly — a narrower
@@ -358,10 +360,10 @@ pub(super) fn find_anchor_matches<'src>(
 /// (the field is provisional, per the node's Phase-0 note).
 ///
 /// As in the additive builder generally, this performs *no* recognition side
-/// effect — notably it does **not** `register_ref` the id in the catalog (so a
-/// cross-reference can resolve against it), nor emit the duplicate-id warning
-/// the string replacer raises; the cutover (design §5.2 Phase 4, step 6) wires
-/// those in.
+/// effect itself — notably it does **not** `register_ref` the id in the catalog
+/// (so a cross-reference can resolve against it), nor emit the duplicate-id
+/// warning; [`apply_ref_side_effects`] performs both once per parse, after the
+/// tree is built and folded.
 fn build_anchor_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
@@ -416,16 +418,16 @@ fn build_anchor_node<'src>(
 /// [`build_anchor_node`] for why crossing an atomic piece is not an error for
 /// the anchor as a whole).
 ///
-/// A `shorthand` reference text has its trailing whitespace stripped (the
-/// string replacer's `trim_end`; leading whitespace was already excluded by
-/// the pattern's `, \s*`). A macro reference text unescapes an escaped `\]`
-/// into an owned value, mirroring the replacer's `replace("\\]", "]")`.
+/// A `shorthand` reference text has its trailing whitespace stripped
+/// (`trim_end`, matching Asciidoctor; leading whitespace was already excluded
+/// by the pattern's `, \s*`). A macro reference text unescapes an escaped `\]`
+/// into an owned value, matching Asciidoctor's `replace("\\]", "]")`.
 ///
 /// The verbatim case (the common one) keeps its exact prior shape: the value
 /// borrows `'src`, and a shorthand's `location` is sliced down to the trimmed
 /// text precisely. A [`synthesized`](Piece::synthesized) range instead
 /// recovers its exact text via [`text_slice`] but keeps the whole range's
-/// coarse `location` regardless of trimming or unescaping (design §4.4) —
+/// coarse `location` regardless of trimming or unescaping —
 /// sub-slicing a location has no honest meaning for bytes with no `'src`
 /// counterpart of their own, the same policy
 /// [`emit_range`] already applies to every fragment of an expanded value.
@@ -537,34 +539,27 @@ fn structural_anchor_reftext<'src>(
     (!out.is_empty()).then_some(out)
 }
 
-/// Performs the recognition side effects the string pipeline attaches to an
-/// assigned id at two distinct points — `InlineAnchorReplacer` (an inline
-/// anchor, `[[id]]` / `anchor:id[…]`) and the attributed-quote handling in
+/// Performs the recognition side effects an assigned id needs at two distinct
+/// points — an inline anchor (`[[id]]` / `anchor:id[…]`) and the
+/// attributed-quote handling in
 /// [`SubstitutionStep::Quotes`](crate::content::SubstitutionStep::Quotes)
-/// (`[#id]#…#`) — by walking an already-built tree and reading each
+/// (`[#id]#…#`) — by walking the built tree and reading each
 /// [`Anchor`](InlineNode::Anchor) node's own stored `id`/`reftext` and each
-/// [`Styled`](crate::inlines::Styled) span's own optional `id`, instead of a
-/// regex capture. Both register the id in the document's reference catalog
+/// [`Styled`](crate::inlines::Styled) span's own optional `id`. Both register
+/// the id in the document's reference catalog
 /// under [`RefType::Anchor`] so a later cross-reference can resolve against
 /// it; only the inline-anchor form also raises a duplicate-id warning (the
-/// attributed-span form is silently non-fatal in the string pipeline too —
+/// attributed-span form is silently non-fatal —
 /// see [`attributes_of`](super::super::quotes::attributes_of)'s own note).
 ///
 /// Every macro family this module recognizes defers exactly this kind of side
 /// effect (see
 /// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
-/// s own note): while the additive builder runs *alongside* the authoritative
-/// string pipeline — each against its own, independent [`Parser`] — performing
-/// it from every additive pass would risk double-counting a registration once
-/// the two paths ever share one `Parser`. This function is the last of the
-/// deferred registrations, staged as its own building block for the eventual
-/// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
-/// calling it exactly once per parse, after the single-pass builder replaces
-/// the recorder as `Content`'s tree source. That is now done:
+/// s own note): recognition and registration are kept separate so a family's
+/// own tests can build and inspect a tree without a full `Parser`/`Content`
+/// round trip.
 /// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) calls this
-/// once per content, from the tree it just built, and the string replacer's own
-/// `register_ref` is suppressed for that content (see
-/// `Parser::suppress_macro_side_effects`).
+/// once per content, from the tree it just built.
 ///
 /// `source` is the whole original content span being processed, used — like
 /// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
@@ -667,8 +662,7 @@ pub(crate) fn apply_ref_side_effects(
     }
 }
 
-/// Performs the recognition side effect the string pipeline's
-/// `InlineBiblioAnchorReplacer` attaches to a **bibliography** anchor: it
+/// Performs the recognition side effect a **bibliography** anchor needs: it
 /// registers the entry's id under [`RefType::Bibliography`], with the bracketed
 /// label the node carries as its `reftext` (so a cross-reference to the entry
 /// renders identically to the label shown in the flow), and raises the same
@@ -676,9 +670,9 @@ pub(crate) fn apply_ref_side_effects(
 /// is already taken.
 ///
 /// Kept separate from [`apply_ref_side_effects`] — rather than folded into its
-/// walk — because the string pipeline runs the bibliography-anchor pass
+/// walk — because the bibliography-anchor pass runs
 /// **first**, ahead of every other macro family, and
-/// [`apply_macro_side_effects`](super::apply_macro_side_effects) must reproduce
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects) must preserve
 /// that order: a duplicate-id warning from a bibliography anchor precedes an
 /// image's dangerous-link-scheme warning in the one shared warnings list, the
 /// same ordering concern that function's own doc comment already records for
@@ -723,9 +717,8 @@ pub(crate) fn apply_biblio_side_effects(
 /// **string** [`register_ref`](Parser::register_ref) takes.
 ///
 /// A cross-reference to this anchor shows what the catalog holds, so the
-/// registered text has to be the reference text's *rendering* — which is what
-/// the string replacer registers, having rendered it already by the time it
-/// catalogs the id.
+/// registered text has to be the reference text's *rendering* — matching
+/// Asciidoctor, which likewise renders it before cataloging the id.
 ///
 /// A reference text of a single verbatim [`Text`](InlineNode::Text) run — the
 /// overwhelmingly common case — is that rendering already, and contributes its
@@ -782,7 +775,7 @@ fn anchor_reftext_string(anchor: &Anchor<'_>, parser: &Parser) -> Option<String>
 /// This peeks at `anchor.location`'s own bytes and the byte immediately
 /// before it in `source`, which is only honest for a **verbatim** anchor: its
 /// `location` is then a precise slice of the real source, so both reads are
-/// meaningful. A **synthesized** anchor's `id` (design §4.4's coarse-fallback
+/// meaningful. A **synthesized** anchor's `id` (the coarse-fallback
 /// case, lifted for this family by [`text_slice`]) instead carries a
 /// `location` that is only the enclosing run's *whole* coarse span, not the
 /// exact `[[id]]` text — peeking at a byte relative to that span would answer
@@ -792,10 +785,10 @@ fn anchor_reftext_string(anchor: &Anchor<'_>, parser: &Parser) -> Option<String>
 /// rather than risk a wrong answer in either direction from bytes that were
 /// never the id's own. A genuinely bibliography-style `[[[id]]]` sequence
 /// reached through an attribute expansion is therefore registered as an
-/// ordinary reference rather than suppressed — a narrower, documented gap the
-/// eventual `apply_ref_side_effects` wiring (design §5.2 Phase 4, step 6) can
-/// close if it proves to matter, the same "a coarse fallback trades precision
-/// for correctness of the common case" policy design §4.4 already establishes
+/// ordinary reference rather than suppressed — a narrower, documented gap that
+/// could be closed in [`apply_ref_side_effects`] if it proves to matter, the
+/// same "a coarse fallback trades precision
+/// for correctness of the common case" policy already established
 /// elsewhere.
 fn is_bibliography_inner(anchor: &Anchor<'_>, source: Span<'_>) -> bool {
     if !matches!(anchor.id, CowStr::Borrowed(_)) {
@@ -847,9 +840,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_anchors() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the inline-anchor
-        // increment. An anchor renders from its id alone, so every fixture is
+        // reproduces the frozen recording byte-for-byte. This is the
+        // differential corpus that pins inline-anchor behavior. An anchor
+        // renders from its id alone, so every fixture is
         // recognized (there is no deferred-output boundary for anchors); the
         // reference-text cases additionally exercise the node's `reftext`
         // population, which does not affect the flow.
@@ -871,8 +864,8 @@ mod tests {
             "[[a-b.c:d]]",
             "[[sect_1]]",
             "anchor:a.b-c:d[]",
-            // A reference text with trailing whitespace (trimmed by the string
-            // replacer) and an escaped `]` (unescaped by the macro form).
+            // A reference text with trailing whitespace (trimmed, matching
+            // Asciidoctor) and an escaped `]` (unescaped by the macro form).
             "[[install, Installation ]]",
             "anchor:foo[a\\]b]",
             // A shorthand whose reference text is whitespace only trims to empty:
@@ -900,8 +893,7 @@ mod tests {
             "[[id,A & B]]",
             // A triple-bracket `[[[id]]]` outside a bibliography list item is not
             // a bibliography anchor (that pass fires only inside such an item); the
-            // inner `[[id]]` is a plain anchor with literal outer brackets, exactly
-            // as the string pipeline routes it here.
+            // inner `[[id]]` is a plain anchor with literal outer brackets.
             "[[[id]]]",
         ];
 
@@ -969,9 +961,9 @@ mod tests {
 
     #[test]
     fn an_anchor_shorthand_reftext_is_trimmed() {
-        // A shorthand's trailing whitespace is stripped (the string replacer's
-        // `trim_end`); leading whitespace was already excluded by the pattern's
-        // `, \s*`.
+        // A shorthand's trailing whitespace is stripped (`trim_end`, matching
+        // Asciidoctor); leading whitespace was already excluded by the
+        // pattern's `, \s*`.
         let nodes = build_src(Span::new("[[install, Installation ]]"));
 
         let anchor = assert_anchor(&nodes[0]);
@@ -985,10 +977,9 @@ mod tests {
     #[test]
     fn an_anchor_shorthand_reftext_that_is_whitespace_only_has_no_reftext() {
         // A shorthand reference text that trims to empty (the pattern's `(.+?)`
-        // matched only the whitespace the string replacer's `trim_end` strips)
+        // matched only the whitespace `trim_end` strips)
         // leaves `reftext` `None`, the same shape as the bare `[[id]]` form —
-        // and it still folds to the same `<a id="…"></a>` the string
-        // pipeline emits.
+        // and it still folds to the same `<a id="…"></a>`.
         let source = "[[install, ]]";
         let nodes = build_src(Span::new(source));
 
@@ -1047,8 +1038,7 @@ mod tests {
     #[test]
     fn an_escaped_anchor_stays_literal() {
         // `\[[…]]` and `\anchor:…[…]` drop the backslash and keep the anchor as
-        // literal text — no anchor node — exactly as the string replacer's
-        // escape branch does.
+        // literal text — no anchor node.
         for source in ["\\[[install]]", "\\anchor:install[Installation]"] {
             let nodes = build_src(Span::new(source));
 
@@ -1143,13 +1133,14 @@ mod tests {
         assert!(!folded.contains("<strong>"), "folded: {folded}");
     }
 
-    /// The string pipeline's output through the **attribute-references** step
-    /// for `source`, run against `parser` — the six steps [`build`] runs, in
-    /// order (special characters, quotes, attribute references, character
-    /// replacements, macros, post replacement). Unlike [`golden_macros_with`],
-    /// this exercises `AttributeReferences` too, so an attribute whose
-    /// expanded value contains `[[id]]` is spliced in before `Macros` runs —
-    /// the scenario the divergence test below needs.
+    /// The frozen recording of `source`'s rendered output through the
+    /// **attribute-references** step, run against `parser` — the six steps
+    /// [`build`] runs, in order (special characters, quotes, attribute
+    /// references, character replacements, macros, post replacement).
+    /// Unlike [`golden_macros_with`], this exercises `AttributeReferences`
+    /// too, so an attribute whose expanded value contains `[[id]]` is
+    /// spliced in before `Macros` runs — the scenario the divergence test
+    /// below needs.
     fn golden_attributes_with(source: &str, _parser: &Parser) -> String {
         crate::content::inline_builder::snapshot::recorded("anchors_attributes", source)
     }
@@ -1157,16 +1148,16 @@ mod tests {
     #[test]
     fn an_anchor_inside_an_expanded_attribute_value_is_now_recognized() {
         // An attribute reference whose resolved value happens to contain
-        // `[[id]]` (design §3.4.1's "a macro inside an expanded value" case,
+        // `[[id]]` (the "a macro inside an expanded value" case,
         // reached here through an anchor's own id instead of a target/
-        // attribute list). The string pipeline splices the value in during
-        // `AttributeReferences`, then genuinely recognizes the anchor when
-        // `Macros` runs over the now-literal `[[custom-id]]` text. Once this
-        // was a documented divergence (#1177 made `build_anchor_node` defer
-        // here rather than build a wrongly-sourced node); this increment
-        // lifts it: [`text_slice`] recovers the id's exact text from the
-        // synthesized run, so the anchor is now recognized and the fold
-        // matches the golden string pipeline byte-for-byte.
+        // attribute list). The value is spliced in during the
+        // attribute-references step, then genuinely recognized as an anchor
+        // once the macros step runs over the now-literal `[[custom-id]]`
+        // text: [`text_slice`] recovers the id's exact text from the
+        // synthesized run, so the fold matches the frozen recording
+        // byte-for-byte. (Once this was a documented divergence — #1177 made
+        // `build_anchor_node` defer here rather than build a wrongly-sourced
+        // node.)
         use crate::parser::ModificationContext;
 
         let parser = Parser::default().with_intrinsic_attribute(
@@ -1210,7 +1201,7 @@ mod tests {
     fn an_anchor_is_recognized_when_the_whole_seed_is_synthesized() {
         // The same boundary as the test above, reached at the tree's root
         // instead of a nested splice: `build_from_value`'s synthesized-seed
-        // path (design §4.4, the shape `Content::from_filtered_lines`
+        // path (the shape `Content::from_filtered_lines`
         // produces for a genuinely multi-line, filtered block) now also
         // recognizes an anchor, mirroring `mod.rs`'s own
         // `a_macro_construct_is_deferred_when_the_whole_seed_is_synthesized`
@@ -1257,7 +1248,7 @@ mod tests {
     fn an_anchors_reftext_inside_an_expanded_attribute_value_is_now_recognized() {
         // `build_anchor_reftext`'s own synthesized branch: the reference text
         // — not just the id — can come from a synthesized run too. Its
-        // `location` falls back to the coarse enclosing span (design §4.4)
+        // `location` falls back to the coarse enclosing span
         // rather than a sub-slice of it, since there is no honest source
         // position to slice for owned bytes; only the recovered `value` is
         // exact.
@@ -1301,7 +1292,7 @@ mod tests {
         assert_eq!(folded, golden, "fold diverged from the string pipeline");
     }
 
-    // ---- `apply_ref_side_effects` (staged for the eventual cutover) -------
+    // ---- `apply_ref_side_effects` -------
 
     use super::apply_ref_side_effects;
     use crate::{content::inline_builder::build, document::RefType, warnings::WarningType};
@@ -1376,8 +1367,8 @@ mod tests {
     #[test]
     fn an_attributed_spans_duplicate_id_is_silently_non_fatal() {
         // Unlike an inline anchor, a duplicate id assigned via an attributed
-        // span raises no warning, mirroring the string pipeline's own
-        // `let _ = register_ref(...)` in `SubstitutionStep::Quotes`.
+        // span raises no warning — `attributes_of` performs a
+        // `let _ = register_ref(...)` there too.
         let source = "[#dup]*a* [#dup]*b*";
         let parser = Parser::default();
         let nodes = build_with(Span::new(source), &parser);
@@ -1393,8 +1384,8 @@ mod tests {
     fn does_not_register_the_inner_anchor_of_a_bibliography_style_triple_bracket() {
         // The `[[id]]` inside `[[[id]]]` is recognized as an `Anchor` node
         // (see the differential corpus above), but — outside a bibliography
-        // list item — the string pipeline renders it without cataloging its
-        // id (`is_bibliography_inner`); this mirrors that.
+        // list item — Asciidoctor renders it without cataloging its
+        // id (`is_bibliography_inner`); this matches that.
         let source = "[[[id]]]";
         let parser = Parser::default();
         let nodes = build_with(Span::new(source), &parser);
@@ -1523,11 +1514,12 @@ mod tests {
     #[test]
     fn registers_the_recorded_ids_for_a_broad_fixture_set() {
         // Each expected set is **frozen at the last differentially-verified
-        // parity**: while the string pipeline existed this test registered
+        // parity**: while the crate's old string-rewriting implementation
+        // existed, this test registered
         // each fixture through it on an independent parser and compared the
         // two catalogs, and the suite was green at the commit that deleted
-        // it — so the literals below are the pipeline's own answer, recorded
-        // the same way every frozen corpus's bytes were.
+        // it — so the literals below are that implementation's own answer,
+        // recorded the same way every frozen corpus's bytes were.
         let fixtures = [
             ("[[install]]", r#"["install"]"#),
             ("[[install,Installation]]", r#"["install"]"#),
@@ -1572,9 +1564,9 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_for_a_bibliography_anchor() {
-        // The differential corpus (design §5.3) pinning the bibliography-anchor
-        // increment: for each fixture, folding the single-pass tree reproduces
-        // the string pipeline's output byte-for-byte, with both sides run
+        // The differential corpus pinning bibliography-anchor behavior: for
+        // each fixture, folding the single-pass tree reproduces
+        // the frozen recording byte-for-byte, with both run
         // against a parser flagged as being inside a bibliography list item.
         let fixtures = [
             // Both spellings, alone and prefixing a real entry.
@@ -1600,14 +1592,14 @@ mod tests {
             // with `[[[`, so it is not a bibliography anchor at all.
             "\\[[[gof]]] Gamma.",
             // An xreftext carrying flow constructs of its own: the label stays
-            // in the flow, so every later family sees it exactly as the string
-            // pipeline's later passes do.
+            // in the flow, so every later family sees it as ordinary flow
+            // text.
             "[[[gof,see https://example.org]]] auto-linked inside the label",
             "[[[gof,see link:x.html[X]]]] a link macro inside the label",
             // A label carrying an escaped special: a `CharRef::Special` piece
             // contributes its canonical entity to this level's match string, so
-            // the label is reconstructed — and registered — exactly as the
-            // string replacer captures it.
+            // the label is reconstructed — and registered — in the same
+            // already-substituted form Asciidoctor captures.
             "[[[gof,A & B]]] an escaped special inside the label",
             // Constructs after the entry's anchor.
             "[[[gof]]] *bold* and _em_ and https://example.org",
@@ -1714,8 +1706,8 @@ mod tests {
         // A whole bibliography anchor supplied by an attribute reference: its
         // id and label have no `'src` slice of their own, but — as with the
         // ordinary anchor family's id — `text_slice` recovers their exact text,
-        // so the anchor is recognized (its `location` taking design §4.4's
-        // coarse fallback), and the fold matches the string pipeline.
+        // so the anchor is recognized (its `location` taking the coarse
+        // fallback span), and the fold matches the frozen recording.
         use crate::parser::ModificationContext;
 
         let parser = biblio_parser().with_intrinsic_attribute(
@@ -1746,13 +1738,12 @@ mod tests {
         // A label crossing a *typographic replacement* — a `(C)` the
         // replacements step turned into a copyright sign, a smart apostrophe —
         // is recognized, because `build_match_string` gives such a leaf the
-        // entity the built-in backend renders it as (`&#169;`, `&#8217;`),
-        // which is the very byte sequence the string pipeline's own haystack
-        // holds there; `text_slice` therefore recovers exactly the
-        // already-substituted label the string replacer registers and shows.
-        // Once a documented divergence (a replacement was one opaque
-        // placeholder, like a rendered span); the "third recoverable piece"
-        // increment lifts it for every family at once.
+        // entity the built-in backend renders it as (`&#169;`, `&#8217;`);
+        // `text_slice` therefore recovers exactly the
+        // already-substituted label that gets registered and shown.
+        // (Once a documented divergence — a replacement was one opaque
+        // placeholder, like a rendered span — before the "third recoverable
+        // piece" work lifted it for every family at once.)
         let parser = biblio_parser();
 
         for (source, id, label) in [
@@ -1773,8 +1764,7 @@ mod tests {
 
             assert_eq!(folded, golden_passthroughs_with(source, &parser));
 
-            // The registered reference text is the already-substituted label,
-            // exactly as the string replacer registers it.
+            // The registered reference text is the already-substituted label.
             let side_effect_parser = biblio_parser();
             apply_biblio_side_effects(&nodes, &side_effect_parser, Span::new(source));
 
@@ -1791,11 +1781,12 @@ mod tests {
     fn a_bibliography_label_over_an_opaque_piece_is_a_documented_divergence() {
         // A label crossing an opaque piece — a rendered span or a passthrough,
         // each a single placeholder in this level's match string rather than
-        // the markup the string pipeline's haystack holds there — cannot be
-        // reconstructed as the already-substituted text the string replacer
-        // registers and shows, so the anchor is left unrecognized. The entry
-        // then keeps the shape it had before this increment (the inner `[[…]]`
-        // as an ordinary anchor), which is what diverges. This is exactly the
+        // the markup itself — cannot be
+        // reconstructed as the already-substituted text that gets registered
+        // and shown, so the anchor is left unrecognized. The entry
+        // then keeps the shape of an ordinary, unregistered anchor (the inner
+        // `[[…]]` as an ordinary anchor), which is what diverges from the
+        // frozen recording. This is exactly the
         // boundary the index-term family's own visible term documents, and the
         // one every macro family still has for a rendered span.
         let parser = biblio_parser();
@@ -1889,8 +1880,9 @@ mod tests {
         // Frozen at the last differentially-verified parity — see
         // `registers_the_recorded_ids_for_a_broad_fixture_set` for the
         // provenance of these literals (id, reference text, and `RefType`
-        // alike were compared against the string pipeline's own registrations
-        // until the commit that deleted it).
+        // alike were compared against the old string-rewriting
+        // implementation's own registrations until the commit that deleted
+        // it).
         let fixtures = [
             (
                 "[[[gof]]] Gamma.",
@@ -2001,7 +1993,7 @@ mod tests {
         // set by `blocks::list_item` while the entry's principal text is
         // substituted, and `SubstitutionGroup::apply` clones the parser (flag
         // included) to build the tree — so a real bibliography entry's tree
-        // folds to exactly the rendered string the string pipeline produced.
+        // folds to exactly its own rendered string.
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default().parse(

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -905,7 +905,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -1194,7 +1194,7 @@ mod tests {
             &parser.render_context(),
         );
 
-        assert_eq!(folded, golden, "fold diverged from the string pipeline");
+        assert_eq!(folded, golden, "fold diverged from the frozen recording");
     }
 
     #[test]
@@ -1289,7 +1289,7 @@ mod tests {
             &HtmlInlineRenderer {},
             &parser.render_context(),
         );
-        assert_eq!(folded, golden, "fold diverged from the string pipeline");
+        assert_eq!(folded, golden, "fold diverged from the frozen recording");
     }
 
     // ---- `apply_ref_side_effects` -------
@@ -1619,7 +1619,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_with(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1232,8 +1232,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_macros() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the image/icon increment.
+        // reproduces the frozen golden output byte-for-byte. This is the
+        // differential corpus that pins the image/icon increment.
         let fixtures = [
             // No macro despite macro-ish characters.
             "plain text",
@@ -1292,7 +1292,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1331,7 +1331,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_imagesdir", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1468,7 +1468,7 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_for_a_target_crossing_an_escaped_special() {
-        // The string pipeline matches macros over *escaped* text, so a target
+        // Macros are matched over *escaped* text, so a target
         // containing `&` is matched as `a&amp;b.png`. Those entity bytes are
         // exactly what this level's match string carries, so the node's target
         // is read off it and the fold reproduces the same `src`/default alt —
@@ -1513,14 +1513,14 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
 
     #[test]
     fn a_target_crossing_an_escaped_special_carries_the_entity_bytes() {
-        // The node's `target` is the string replacer's own `caps[1]` — the
+        // The node's `target` is exactly `caps[1]` — the
         // escaped haystack's bytes, not the source's single `&` — which is
         // also what `apply_image_side_effects` registers. The default alt
         // derives from that same string, exactly as `default_alt` does.
@@ -1545,9 +1545,9 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_an_attribute_list_crossing_an_escaped_special() {
         // The bracket has no `'src` slice here — the source holds one
         // character where the match string holds an entity — so it is parsed
-        // from the match string, which is the very `caps[2]` the string
-        // replacer parses out of its own escaped haystack, and owned off that
-        // temporary. Every attribute the two read is therefore the same.
+        // from the match string, which is the very `caps[2]` parsed out of
+        // its own escaped haystack, and owned off that
+        // temporary.
         let fixtures = [
             // A special in a positional alt, in a named value, and in both a
             // named value and the target at once.
@@ -1580,18 +1580,18 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
 
     #[test]
     fn an_attribute_list_crossing_an_escaped_special_is_owned_and_coarsely_located() {
-        // The parsed values are the *escaped* ones the string replacer reads
+        // The parsed values are the *escaped* ones
         // (`a &lt; b`, not `a < b`), they own their bytes rather than
         // borrowing from the temporary they were parsed from, and the list's
-        // own span falls back to the bracket's coarse source range (design
-        // §4.4) — the same split the node's `location` already takes for a
+        // own span falls back to the bracket's coarse source range — the
+        // same split the node's `location` already takes for a
         // synthesized run.
         let source = "image:x.png[a < b,role=hl]";
         let nodes = build_src(Span::new(source));
@@ -1621,7 +1621,7 @@ mod tests {
         // An author-written entity (`&amp;copy;`, `&amp;#8217;`) is escaped by
         // `SpecialCharacters` and then *restored* by `CharacterReplacements`
         // into a `CharRef::Entity` leaf whose value is the entity itself. Those
-        // bytes are what the string pipeline's own haystack carries from the
+        // bytes are what the match string carries from the
         // replacements step onward, and what the fold emits verbatim, so
         // `range_has_no_opaque_piece` admits the leaf exactly as it admits an
         // escaped special.
@@ -1659,7 +1659,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1690,8 +1690,8 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_an_attribute_list_crossing_a_restored_entity() {
         // A restored entity takes the same lift as an escaped special, for the
         // same reason: the source holds `&amp;copy;` where the match string
-        // holds `&copy;`, so the bracket has no `'src` slice — and the match
-        // string's bytes are the ones the string replacer parses.
+        // holds `&copy;`, so the bracket has no `'src` slice — and it is
+        // parsed from the match string's own bytes.
         let fixtures = [
             "image:x.png[Tom &amp; Jerry]",
             "image:x.png[alt=a &copy; b]",
@@ -1718,7 +1718,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1728,10 +1728,10 @@ mod tests {
         // A typographic replacement (`(C)`, `(R)`, `'`, `...`) is the third
         // recoverable piece, admitted for the same reason the two `CharRef`
         // entity leaves are: `build_match_string` gives it the entity the
-        // built-in backend renders it as, which is what the string pipeline's
-        // own haystack carries from the replacements step onward — so both the
-        // target read off that string and the bracket parsed from it are the
-        // string replacer's own bytes.
+        // built-in backend renders it as, and that is what the match string
+        // carries from the replacements step onward — so both the
+        // target read off that string and the bracket parsed from it carry
+        // those same bytes.
         let fixtures = [
             // A target crossing one, alone and beside an attribute list.
             "image:a(C)b.png[]",
@@ -1769,7 +1769,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1778,9 +1778,9 @@ mod tests {
     fn an_attribute_list_crossing_a_character_replacement_reads_the_rendered_entity() {
         // The structural companion: the bracket has no `'src` slice (the
         // source holds `(C)` where the match string holds `&#169;`), so it is
-        // parsed from the match string and owned onto design §4.4's coarse
-        // span — carrying the already-substituted value the string replacer
-        // parses, entity and all.
+        // parsed from the match string and owned onto the bracket's coarse
+        // span — carrying the already-substituted value,
+        // entity and all.
         let source = "image:x.png[title=Pause (C) Resume]";
         let nodes = build_src(Span::new(source));
 
@@ -1830,7 +1830,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from golden for {source:?}"
             );
         }
     }
@@ -1863,26 +1863,26 @@ mod tests {
             "a target crossing a rendered span must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, *does* build an image here.
+        // The frozen golden recording, by contrast, *does* build an image here.
         assert!(golden_macros(source).contains("<img"));
     }
 
     #[test]
     fn fold_matches_the_string_pipeline_for_an_image_target_over_a_passthrough() {
         // The differential corpus for an `image:`/`icon:` target crossing a
-        // masked **passthrough** — the string pipeline swallows the
-        // `\u{96}`*n*`\u{97}` sentinel into the target (the widened match
-        // string carries the same bytes, see [`widen_masked_pieces`])
-        // and the restore pass then splices the extracted body over every
-        // sentinel in the rendered string, so the tree's computed target
-        // substitutes the `Raw` node's value for its placeholder the same
-        // way, and the `default_alt` *arithmetic* runs over the masked bytes
+        // masked **passthrough** — the widened match string carries the
+        // `\u{96}`*n*`\u{97}` placeholder into the target (see
+        // [`widen_masked_pieces`]), and the restore then splices the
+        // extracted body over every placeholder in the computed value, so
+        // the tree's computed target
+        // substitutes the `Raw` node's value for its placeholder, and the
+        // `default_alt` *arithmetic* runs over the masked bytes
         // first (see [`masked_default_alt`]).
         use super::super::super::test_support::golden_passthroughs;
 
         let fixtures = [
             // The double-plus idiom, bare-bracketed and with an alt — and the
-            // default-alt arithmetic over the sentinel: the underscores and
+            // default-alt arithmetic over the placeholder: the underscores and
             // the extension hide inside it, so the whole restored body is the
             // alt (`alt="a_b-c.jpg"`), where the verbatim spelling shows
             // `a b c`.
@@ -1905,8 +1905,7 @@ mod tests {
             "image:https://++example.org/x++.png[]",
             // `web_path`'s own `..` arithmetic consumes the masked segment,
             // so the token never reaches the resolved path and its body is
-            // dropped — in both pipelines (the string pipeline's restore
-            // cannot find the sentinel either).
+            // dropped, unrestored.
             "image:++dropped++/../kept.png[]",
             // The icon form, which derives its default alt the same way.
             "icon:++a_b++[]",
@@ -1928,7 +1927,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -1936,9 +1935,9 @@ mod tests {
     #[test]
     fn an_image_target_over_a_passthrough_is_recognized() {
         // The target is the restored bytes; the default alt is the masked
-        // derivation with the surviving sentinel restored — the whole body,
+        // derivation with the surviving placeholder restored — the whole body,
         // underscores, hyphens, and extension intact, since all of them hide
-        // from the arithmetic inside the sentinel.
+        // from the arithmetic inside the placeholder.
         let nodes = build_src(Span::new("image:++a_b-c.jpg++[]"));
 
         let image = assert_image(&nodes[0]);
@@ -1975,10 +1974,10 @@ mod tests {
         // The one place this increment chooses the safe reading over byte
         // parity, mirroring the link family's own passthrough increment: the
         // renderer's `link=self` dangerous-target check runs over the node's
-        // *restored* target, where the string pipeline's renderer checks the
-        // sentinel it matched — through which a smuggled `javascript:` target
-        // passes, the restore then completing a live link around the image in
-        // the golden output. The tree's fold rejects it instead (the image
+        // *restored* target, where the golden output's renderer instead
+        // checked the raw placeholder it matched — through which a smuggled
+        // `javascript:` target passed, completing a live link around the
+        // image. The tree's fold rejects it instead (the image
         // renders without the wrapping anchor), pinned here rather than by
         // the corpus above.
         use super::super::super::test_support::golden_passthroughs;
@@ -2009,13 +2008,13 @@ mod tests {
         // Formerly this module's own documented divergence: the fold-time
         // `web_path` used to run over the node's *restored* target, so a
         // space the passthrough smuggled past the target class was
-        // percent-encoded into the `src` where the string pipeline
-        // normalized its space-free sentinel and spliced the raw space in
+        // percent-encoded into the `src`, where the golden output kept its
+        // space-free placeholder and spliced the raw space in
         // afterwards. The masked-resolve order closed it — `render_image`
         // resolves the `src` with the node's
         // [`restored_target_ranges`](Image) masked
-        // to the same sentinel shape and splices the bodies back in, so the
-        // space never reaches `web_path` in either pipeline.
+        // to the same placeholder shape and splices the bodies back in, so the
+        // space never reaches `web_path`.
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "image:pass:[My Documents/chart.png][]";
@@ -2039,11 +2038,10 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_an_image_bracket_over_a_passthrough() {
         // The differential corpus for an `image:`/`icon:` **bracket**
         // crossing a masked passthrough. The bracket comes back from a
-        // *parse*, so the restore is the one the string pipeline performs:
-        // `Attrlist::parse` reads the `\u{96}`*n*`\u{97}` sentinel as one
-        // opaque run — carrying none of the `,`/`=`/`"` bytes the split
-        // reads — and the restore pass splices each body over whatever
-        // sentinel reached the rendered string. `tokened_bracket` puts the
+        // *parse*: `Attrlist::parse` reads the `\u{96}`*n*`\u{97}` placeholder
+        // as one opaque run — carrying none of the `,`/`=`/`"` bytes the
+        // split reads — and the restore then splices each body over whatever
+        // placeholder survived the parse. `tokened_bracket` puts the
         // match string into that same shape and
         // `Attrlist::into_owned_restoring` performs the after-the-split
         // half.
@@ -2056,7 +2054,7 @@ mod tests {
             "image:x.png[a ++b_c__d++ e]",
             "image:x.png[++a++ and ++b++]",
             // The split invariant: a `,` or an `=` inside the body must not
-            // divide the list, because the string pipeline's own parse never
+            // divide the list, because the parse never
             // sees it. These are the fixtures a restore-*then*-parse fails.
             "image:x.png[++a,b++]",
             "image:x.png[++a=b++]",
@@ -2068,7 +2066,7 @@ mod tests {
             "image:x.png[++a++,++200++]",
             // Shorthand: the `#id`/`.role` the scan finds sit *after* a
             // token, so their offsets have to shift with the restore while
-            // the items themselves stay the ones the string pipeline found.
+            // the items themselves stay the ones the parse found.
             "image:x.png[++abc++#myid]",
             "image:x.png[++abc++.myrole]",
             "image:x.png[++a b++.myrole#myid]",
@@ -2105,7 +2103,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -2114,7 +2112,7 @@ mod tests {
     fn an_image_bracket_over_a_passthrough_is_recognized() {
         // The parsed values carry the *restored* bytes, owned off the
         // temporary the parse read and tagged with the bracket's own coarse
-        // span (design §4.4), exactly as every other non-verbatim bracket is.
+        // span, exactly as every other non-verbatim bracket is.
         let source = "image:x.png[++Alt text++,++100++,50]";
         let nodes = build_src(Span::new(source));
 
@@ -2301,7 +2299,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -2431,7 +2429,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -2496,7 +2494,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs_with(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -3024,7 +3022,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_normal(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }
@@ -3124,7 +3122,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_normal(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -167,10 +167,10 @@ fn find_image_matches<'src>(
 /// (an attribute-expanded value, a `counter` directive) is rejected here too:
 /// [`apply_character_replacements`](super::super::char_replacements::apply_character_replacements)
 /// can recognize a construct inside one (it produces a leaf needing no `'src`
-/// slice of its own, falling back to the piece's coarse `location`), but a macro node bakes
-/// its target/attribute list straight from source, so it still needs a real
-/// `'src` slice a synthesized run cannot provide — the same boundary an
-/// escaped-special or a rendered span already documents.
+/// slice of its own, falling back to the piece's coarse `location`), but a
+/// macro node bakes its target/attribute list straight from source, so it still
+/// needs a real `'src` slice a synthesized run cannot provide — the same
+/// boundary an escaped-special or a rendered span already documents.
 pub(in crate::content::inline_builder) fn range_is_verbatim(
     pieces: &[Piece],
     range: &std::ops::Range<usize>,
@@ -304,8 +304,8 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
 
 /// [`range_has_no_opaque_piece`], further admitting a
 /// [`Raw`](InlineNode::Raw) leaf a **substitution produced in place** — an
-/// expanded attribute value's literal `<`, `>`, or `&`, which §3.4.1 leaves
-/// unescaped because the value expands *after* `specialcharacters` ran
+/// expanded attribute value's literal `<`, `>`, or `&`, left unescaped
+/// because the value expands *after* `specialcharacters` ran
 /// ([`RawOrigin::Substitution`]).
 ///
 /// The match string stands such a leaf in as one placeholder, so a value
@@ -316,14 +316,15 @@ fn atomic_piece_is_recoverable(nodes: &[InlineNode<'_>], piece: &Piece) -> bool 
 ///
 /// - A **masked passthrough** is restored by a later pass. A deferred
 ///   cross-reference's target is captured into its segment *before* that pass
-///   runs, so the string pipeline's own `href` holds the sentinel — and a tree
-///   that read the restored bytes would diverge from it (see
+///   runs, so the captured segment still holds the placeholder — and a tree
+///   that read the restored bytes instead would diverge from that documented
+///   behavior (see
 ///   `a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`).
 ///   [`range_is_restorable`] admits it; this does not.
 ///
 /// - A **substitution-produced** leaf was never extracted and is never
-///   restored. Its bytes are simply *there*, in the very haystack the string
-///   replacer reads, so filling the placeholder in reaches parity rather than
+///   restored. Its bytes are simply *there*, in the match string's own
+///   haystack, so filling the placeholder in reaches parity rather than
 ///   departing from it.
 ///
 /// Deciding this from the node's own [`RawOrigin`] rather than from the
@@ -368,41 +369,40 @@ pub(in crate::content::inline_builder) fn range_is_substitution_restorable(
 
 /// [`range_has_no_opaque_piece`], further admitting a **masked** piece — a
 /// passthrough or a STEM expression — for a value the caller *restores*
-/// rather than reads: the placeholder's bytes are not the string pipeline's
-/// (its haystack holds the `\u{96}`*n*`\u{97}` sentinel there), but the
-/// masked construct's own rendered body **is** known at build time — it is
-/// what `Passthroughs::restore_to` splices
-/// over the sentinel after the steps run — so a computed value that
-/// substitutes it for the placeholder (see
+/// rather than reads: the match string represents it only as the
+/// `\u{96}`*n*`\u{97}` placeholder, not its real rendered body, but that body
+/// **is** known at build time — it is what `Passthroughs::restore_to`
+/// splices over the placeholder after the steps run — so a computed value
+/// that substitutes it for the placeholder (see
 /// [`restore_masked_passthroughs`](super::links))
 /// finishes with exactly the restored string's bytes.
 ///
 /// That makes this gate right only for a value whose *recognition* treats the
 /// masked span as one swallowed token and whose *use* happens after restore —
 /// the `link:`/`mailto:` macro family's **target**, whose
-/// `[^\s\[\]]+` body class swallows the sentinel and the placeholder alike,
+/// `[^\s\[\]]+` body class swallows the placeholder like any other byte run,
 /// and whose bytes reach the output (the `href`, and a bare macro's shown
 /// text) only in the restored rendered string; and the `image:`/`icon:`
-/// family's target, whose recognition needs the placeholder widened to the
-/// sentinel's own shape first ([`widen_masked_pieces`]), whose one
+/// family's target, whose recognition needs the placeholder widened to that
+/// same shape first ([`widen_masked_pieces`]), whose one
 /// pre-restore computation, the `default_alt` derivation, runs over the
 /// masked bytes itself ([`masked_default_alt`]), and whose fold-time
 /// `web_path` runs over the restored ranges *masked* (see
-/// [`Image::restored_target_ranges`](crate::inlines::Image) — the string
-/// pipeline's own resolver only ever sees the sentinel); and the auto-link /
-/// formal-URL family's target, whose three URL classes swallow either
-/// spelling with no widening at all and whose two pre-restore decisions —
-/// rejecting a quoted URL, stripping a bare one's trailing punctuation — read
-/// a placeholder exactly as the string replacer's own sentinel reads
-/// (`links::build_inline_link_node`). It is right for a value that comes back
-/// from a **parse** too, once that parse is given the sentinel's own shape
-/// first — the `image:`/`icon:` bracket and the link families' display-text
-/// attribute list, each tokened by [`tokened_bracket`] and restored after the
+/// [`Image::restored_target_ranges`](crate::inlines::Image)); and the
+/// auto-link / formal-URL family's target, whose three URL classes swallow
+/// either spelling with no widening at all and whose two pre-restore
+/// decisions — rejecting a quoted URL, stripping a bare one's trailing
+/// punctuation — read the placeholder token the same way they read ordinary
+/// text (`links::build_inline_link_node`). It is right for a value that
+/// comes back from a **parse** too, once that parse is given the
+/// placeholder's own shape first — the `image:`/`icon:` bracket and the
+/// link families' display-text attribute list, each tokened by
+/// [`tokened_bracket`] and restored after the
 /// split. A family that *matches
 /// over* the masked bytes with a class the two spellings answer differently,
-/// or reads them into a value the string pipeline uses **before** restore (a
+/// or reads them into a value used **before** restore (a
 /// deferred cross-reference's target, captured into its placeholder template
-/// with the sentinel still in it — see
+/// with the placeholder still in it — see
 /// `a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`),
 /// keeps [`range_has_no_opaque_piece`].
 pub(in crate::content::inline_builder) fn range_is_restorable(
@@ -443,11 +443,10 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
 /// (`Passthroughs::extract_from`)
 /// masks before any substitution step runs — STEM being an implicit
 /// passthrough, as [`Stem::value`](crate::inlines::Stem) documents — so each
-/// stands in the string pipeline's haystack as one `\u{96}`*n*`\u{97}` sentinel
-/// and in this module's match string as one
+/// stands in this module's match string as one
 /// [`SPAN_PLACEHOLDER`](super::super::quotes) character, and each has a body
 /// known at build time that `Passthroughs::restore_to` splices over that
-/// sentinel once the steps have run.
+/// placeholder once the steps have run.
 ///
 /// Every restoring family admits both kinds. The `image:`/`icon:` family's
 /// values are the only restored ones the **fold** re-processes —
@@ -455,9 +454,8 @@ pub(in crate::content::inline_builder) fn range_is_restorable(
 /// the target (and an interactive SVG's `fallback=`) into the `src`, and a
 /// rendered STEM body always carries a backslash `web_path` would posixify
 /// on a Windows-separator resolver — but that re-processing runs over the
-/// restored ranges *masked*, reproducing the string pipeline's own order
-/// (its `web_path` only ever sees the backslash-free sentinel; the restore
-/// splices the body in afterwards). See
+/// restored ranges *masked*: `web_path` only ever sees the backslash-free
+/// placeholder there, and the restore splices the body in afterwards. See
 /// [`Image::restored_target_ranges`](crate::inlines::Image) and
 /// [`ElementAttribute`]'s own restored ranges.
 ///
@@ -473,7 +471,7 @@ pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'
 
 /// The bytes a [`node_is_restorable`] node restores to — the very text
 /// `Passthroughs::restore_to`
-/// splices over the string pipeline's own sentinel — or `None` for any other
+/// splices over the placeholder — or `None` for any other
 /// node.
 ///
 /// The invariant both callers rest on is that this returns **exactly what the
@@ -491,11 +489,10 @@ pub(in crate::content::inline_builder) fn node_is_restorable(node: &InlineNode<'
 /// `renderer` is the **parser's** renderer, mirroring `restore_to`'s own
 /// (`Passthroughs::restore_to` renders a STEM entry through `parser.renderer`
 /// before splicing it into the rendered string). A computed target therefore
-/// freezes its STEM bytes at build time, exactly as the string pipeline
-/// freezes them into its `href`, where a `Stem` node standing in the flow is
-/// rendered at fold time instead; the two agree whenever the fold uses the
-/// parser's renderer, which is the seam design §3.3.1 defines and the only
-/// one `Content` uses.
+/// freezes its STEM bytes at build time to match what a `Stem` node standing
+/// in the flow renders at fold time instead; the two agree whenever the fold
+/// uses the parser's renderer, which is the only renderer seam `Content`
+/// uses.
 pub(in crate::content::inline_builder) fn restorable_body<'a>(
     node: &'a InlineNode<'_>,
     renderer: &dyn InlineRenderer,
@@ -508,7 +505,7 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
         } => Some(Cow::Borrowed(value.as_ref())),
 
         // An escaped-form body carries the author's logical text, so the bytes
-        // the string pipeline splices over its own sentinel are that text
+        // spliced over the placeholder are that text
         // *escaped* — the same bytes this node's own fold emits, which is the
         // invariant this function exists to hold (see `node_is_restorable`).
         InlineNode::Raw {
@@ -536,8 +533,8 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
 }
 
 /// Builds one [`Image`](InlineNode::Image) node from a recognized image/icon
-/// match, pre-extracting the alt/width/height the way the string replacer does
-/// so the fold reproduces the same bytes.
+/// match, pre-extracting the alt/width/height up front so the fold
+/// reproduces the same bytes.
 ///
 /// # What must be verbatim, and what need not be
 ///
@@ -546,17 +543,16 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
 /// source slice, so both are exact even when they come from a
 /// [`synthesized`](Piece::synthesized) run — an expanded attribute value
 /// (`image:{logo}[Logo]`) or a filtered multi-line block's own joined seed —
-/// or cross an **escaped special** (`image:a&b.png[]`, whose target the string
-/// replacer reads as `a&amp;b.png` out of its own escaped haystack: the very
+/// or cross an **escaped special** (`image:a&b.png[]`, whose target reads as
+/// `a&amp;b.png` out of the match string's own escaped haystack: the very
 /// bytes this match string carries, and the ones
 /// [`apply_image_side_effects`] registers). Only the node's `location` then
-/// takes design §4.4's coarse fallback. A target crossing a masked
-/// **passthrough** or **STEM** expression finishes into the restored bytes
-/// instead — see
+/// falls back to the enclosing piece's coarse span. A target crossing a
+/// masked **passthrough** or **STEM** expression finishes into the restored
+/// bytes instead — see
 /// [`restore_masked_passthroughs`] and [`masked_default_alt`] — and the side
-/// effect registers that honest restored value where the string pipeline
-/// registers its own sentinel bytes verbatim (a wart the cutover deliberately
-/// will not reproduce; see
+/// effect registers that honest restored value rather than the raw
+/// placeholder bytes (see
 /// `registers_the_restored_target_for_an_image_over_a_passthrough`).
 ///
 /// The **attribute list** follows the same rule, one step removed. An
@@ -566,12 +562,12 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
 /// (`image:sunset.jpg[{caption}]`), an escaped special
 /// (`image:x.png[a < b]`), or a restored entity (`image:x.png[Tom &amp;
 /// Jerry]`) — cannot be parsed from the source. It is parsed from the **match
-/// string** instead, through [`bracket_attrlist`], which is what the string
-/// replacer itself parses (`Attrlist::parse(Span::new(&caps[2]), …)`, over its
-/// own escaped, already-expanded haystack); the resulting list is then
+/// string** instead, through [`bracket_attrlist`]
+/// (`Attrlist::parse(Span::new(&caps[2]), …)`, over the match string's own
+/// escaped, already-expanded haystack); the resulting list is then
 /// [`into_owned`](Attrlist::into_owned)ed off that temporary and tagged with
-/// design §4.4's coarse span. A bracket that *is* verbatim keeps its `'src`
-/// slice, so its attribute values still borrow (§4.5).
+/// the enclosing piece's coarse span. A bracket that *is* verbatim keeps its
+/// `'src` slice, so its attribute values still borrow.
 fn build_image_node<'src>(
     caps: &regex::Captures<'_>,
     whole: &str,
@@ -599,18 +595,18 @@ fn build_image_node<'src>(
     // wonder about.
     let (target, restored_target_ranges) = caps.get(1).map_or(
         (CowStr::from(""), Vec::new()),
-        // Borrowed from `'src` for a verbatim target (§4.5), the expansion's
+        // Borrowed from `'src` for a verbatim target, the expansion's
         // own exact bytes for a synthesized one. A target crossing an escaped
         // special has no `'src` slice at all — the source holds one character
         // where the match string holds an entity — so it falls back to the
         // match string's own bytes, which is what `text_slice` declines to
-        // recover and precisely what the string replacer reads as `caps[1]`.
+        // recover and precisely what `caps[1]` holds.
         // A target crossing a masked **passthrough** or **STEM** expression
         // finishes into the restored bytes — the node's own rendered body
         // substituted for its placeholder, the same rewrite
         // `Passthroughs::restore_to` performs on the rendered `src` — while
         // the `default_alt` *arithmetic* below stays on the bytes as
-        // matched, where the string replacer's own runs (see
+        // matched (see
         // [`masked_default_alt`]), and the node records which ranges of the
         // restored target came from a masked body, so the fold-time
         // `web_path` can keep them out of its own way (see
@@ -639,10 +635,9 @@ fn build_image_node<'src>(
     let attrlist = bracket_attrlist(bracket_text, bracket_range, nodes, pieces, root, parser);
 
     // The default alt text derives from the target's basename, with `_`/`-`
-    // read as spaces — exactly the string replacer's `default_alt`, which
-    // runs over the *masked* bytes (its haystack holds the passthrough or
-    // STEM sentinel), with the masked bodies restored into whatever survives
-    // the arithmetic.
+    // read as spaces, running over the *masked* bytes (the haystack holds the
+    // passthrough or STEM placeholder there), with the masked bodies restored
+    // into whatever survives the arithmetic.
     let default_alt = caps.get(1).map_or_else(String::new, |m| {
         masked_default_alt(
             m.as_str(),
@@ -695,22 +690,21 @@ fn build_image_node<'src>(
 }
 
 /// Rewrites this level's match string so each masked **passthrough** or
-/// **STEM** expression's placeholder becomes a sentinel-shaped token —
-/// `\u{96}`*n*`\u{97}`, the very bytes the string pipeline's own haystack
-/// holds there — moving the pieces into the rewritten string's coordinates
-/// (each [`node_is_restorable`] piece keeps its node, wider; every other
-/// piece keeps its bytes).
+/// **STEM** expression's placeholder becomes a three-byte token —
+/// `\u{96}`*n*`\u{97}` — moving the pieces into the rewritten string's
+/// coordinates (each [`node_is_restorable`] piece keeps its node, wider;
+/// every other piece keeps its bytes).
 ///
 /// This family alone needs the widening because [`INLINE_IMAGE_MACRO`]'s
 /// target class is the one in this module that requires **two** characters
 /// (`[^:\s\[\n][^\[\n]*?[^\s\[\n]`): a target written wholly inside a
 /// passthrough (`image:++sunset.jpg++[]`) or a STEM expression
 /// (`image:stem:[x][]`) is a single placeholder character, which that class
-/// cannot match — where the string replacer's three-byte sentinel matches it
-/// exactly. Widening the placeholder to the sentinel's own shape makes
-/// recognition agree byte-for-byte with the string step without touching the
-/// shared pattern. (The `link:`/`mailto:` family's one-or-more target class
-/// never faced this, so its increment left the placeholder bare.)
+/// cannot match — where the three-byte token matches it exactly. Widening
+/// the placeholder to that shape makes recognition agree byte-for-byte with
+/// [`INLINE_IMAGE_MACRO`]'s own pattern without touching the shared regex.
+/// (The `link:`/`mailto:` family's one-or-more target class never faced
+/// this, so its increment left the placeholder bare.)
 ///
 /// The token's bytes never reach an output node: an unmatched token sits in
 /// a gap [`rebuild_macro_level`] re-emits from the piece's own *node*, a
@@ -719,8 +713,7 @@ fn build_image_node<'src>(
 /// node's own body over, and no match boundary can cut one (no byte of
 /// `\u{96}`, a digit, `\u{97}` can begin or end an image match, whose ends
 /// are the literal macro name and `]`). The numbering is per level and
-/// exists only to keep tokens distinct; the string pipeline's own sentinel
-/// numbers are global to the content, and neither survives into any output.
+/// exists only to keep tokens distinct across this level's own placeholders.
 fn widen_masked_pieces(
     s: String,
     pieces: Vec<Piece>,
@@ -770,22 +763,21 @@ fn widen_masked_pieces(
     (out, out_pieces)
 }
 
-/// The string replacer's `default_alt` derivation —
+/// This family's `default_alt` derivation —
 /// `basename(&target.replace(['_', '-'], " "))` — performed over the
 /// **masked** bytes, with each masked passthrough's or STEM expression's
 /// body restored into whatever survives the arithmetic.
 ///
-/// The string pipeline computes `default_alt` from its own haystack, where a
-/// masked construct is the `\u{96}`*n*`\u{97}` sentinel: an opaque token
-/// carrying none of the bytes the arithmetic acts on (no `_`/`-` for the
-/// replace, no `/` or `.` for [`basename`]'s stem cut), so the derivation
-/// treats it as one indivisible character and the restore pass then splices
-/// the extracted body over whatever sentinel reaches the rendered `alt` —
-/// which is how `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"` where the
-/// verbatim spelling shows `a b c`, its underscores hidden from the replace
-/// inside the sentinel. This reproduces that byte-for-byte: each overlapping
-/// [`node_is_restorable`] piece's placeholder becomes the same
-/// sentinel-shaped token, the arithmetic runs, and each *surviving* token is
+/// A masked construct sits in the haystack as the `\u{96}`*n*`\u{97}`
+/// token: an opaque run carrying none of the bytes the arithmetic acts on
+/// (no `_`/`-` for the replace, no `/` or `.` for [`basename`]'s stem cut),
+/// so the derivation treats it as one indivisible run and the restore then
+/// splices the extracted body over whatever token reaches the derived
+/// `alt` — which is how `image:++a_b-c.jpg++[]` keeps `alt="a_b-c.jpg"`
+/// where the verbatim spelling shows `a b c`, its underscores hidden from
+/// the replace inside the token. Each overlapping
+/// [`node_is_restorable`] piece's placeholder becomes that same
+/// token, the arithmetic runs, and each *surviving* token is
 /// restored with its own node's body ([`restorable_body`]) — index-keyed, as
 /// `Passthroughs::restore_to` is,
 /// so a token the basename cut dropped (a masked construct wholly inside a
@@ -794,9 +786,8 @@ fn widen_masked_pieces(
 /// [`basename`] reads (the last `/`, the last `.`) are bytes no token contains.
 ///
 /// A range holding no masked construct takes the plain derivation over the
-/// match-string bytes — exactly what this family computed before the restore
-/// existed, since `masked` here is the same `caps[1]` the string replacer
-/// reads.
+/// match-string bytes, since `masked` here is the same value `caps[1]`
+/// holds.
 fn masked_default_alt(
     masked: &str,
     range: &std::ops::Range<usize>,
@@ -879,7 +870,7 @@ fn masked_default_alt(
 /// Parses the macro's bracket into the [`Attrlist`]`<'src>` its node carries.
 ///
 /// A **verbatim** bracket is parsed straight from its `'src` slice, so its
-/// attribute names and values borrow from the source (§4.5) — the shape every
+/// attribute names and values borrow from the source — the shape every
 /// ordinary `image:x.png[Alt,200]` takes.
 ///
 /// Any other bracket has no `'src` slice whose bytes are the attrlist text: a
@@ -892,7 +883,7 @@ fn masked_default_alt(
 /// parses the same bytes — from a [`Span::new`] over the capture, whose
 /// `line`/`col`/`offset` are meaningless and never escape this function —
 /// and [`into_owned`](Attrlist::into_owned)s the result onto the bracket's
-/// coarse source span (design §4.4), the same fallback the node's `location`
+/// coarse source span, the same fallback the node's `location`
 /// takes.
 ///
 /// An **empty** bracket carries no bytes either way and parses from a
@@ -940,7 +931,7 @@ fn bracket_attrlist<'src>(
 /// attribute values ([`Attrlist::into_owned_restoring`]), while the link
 /// families' display text — which becomes a node's *children* rather than a
 /// string — splices the **node**, so the fold emits those same bytes without
-/// re-escaping them (design §3.4). Pairing them here rather than re-deriving
+/// re-escaping them. Pairing them here rather than re-deriving
 /// one from the other is what keeps the two spellings of "what this token
 /// restores to" from drifting.
 pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
@@ -952,13 +943,11 @@ pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
     /// What the token restores to: exactly what the fold of
     /// [`node`](Self::node) emits (see [`restorable_body`]).
     ///
-    /// For a *masked* construct those bytes are known at build time in the
-    /// same sense the string pipeline knows them —
+    /// For a *masked* construct those bytes are known at build time —
     /// `Passthroughs::restore_to` splices exactly these into its own finished
     /// string. For a **rendered** piece (admitted under
     /// [`Tokened::MaskedOrRendered`]) they are the build-time fold with the
-    /// parser's own renderer, which is what the string replacer's
-    /// already-rendered haystack holds there; freezing them is what lets a
+    /// parser's own renderer; freezing them is what lets a
     /// slot a renderer writes out carry markup the author wrote, at the cost
     /// of a *later* fold with some other renderer seeing the parse-time
     /// renderer's bytes in that slot.

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -64,9 +64,9 @@ pub(super) fn image_macros_level<'src>(
     let (s, pieces) = ctx.shift(s, pieces);
 
     // …and with each masked passthrough's or STEM expression's placeholder
-    // widened into the sentinel-shaped token the string pipeline's own
-    // haystack holds there — see `widen_masked_pieces` for why this family
-    // alone needs that.
+    // widened into the three-byte token [`INLINE_IMAGE_MACRO`]'s target class
+    // needs to match it — see `widen_masked_pieces` for why this family alone
+    // needs that.
     let (s, pieces) = widen_masked_pieces(s, pieces, &nodes);
 
     let matches = find_image_matches(&s, &pieces, root, parser, &nodes);
@@ -125,8 +125,8 @@ fn find_image_matches<'src>(
         // `bracket_attrlist` reads its bytes as content — so a placeholder
         // there would be read as literal text, and it keeps the opaque-piece
         // gate for a rendered span, admitting a masked passthrough or STEM
-        // expression (whose sentinel the string pipeline's `Attrlist::parse`
-        // swallows into a value that only *restores* after the split — the
+        // expression (whose placeholder `Attrlist::parse` swallows into a
+        // value that only *restores* after the split — the
         // order [`tokened_bracket`] and
         // [`Attrlist::into_owned_restoring`](Attrlist) reproduce). The
         // **target** (group 1) is the one value this family computes off the
@@ -167,7 +167,7 @@ fn find_image_matches<'src>(
 /// (an attribute-expanded value, a `counter` directive) is rejected here too:
 /// [`apply_character_replacements`](super::super::char_replacements::apply_character_replacements)
 /// can recognize a construct inside one (it produces a leaf needing no `'src`
-/// slice of its own — design §4.4's coarse fallback), but a macro node bakes
+/// slice of its own, falling back to the piece's coarse `location`), but a macro node bakes
 /// its target/attribute list straight from source, so it still needs a real
 /// `'src` slice a synthesized run cannot provide — the same boundary an
 /// escaped-special or a rendered span already documents.
@@ -203,7 +203,7 @@ pub(in crate::content::inline_builder) fn range_is_verbatim(
 /// [`text_slice`] rather than
 /// [`source_slice`] to recover the
 /// range's own *text* precisely, since `source_slice` only ever offers a
-/// synthesized piece's coarse *location* fallback (design §4.4), never its
+/// synthesized piece's coarse *location* as a fallback, never its
 /// exact bytes.
 pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
     pieces: &[Piece],
@@ -238,17 +238,15 @@ pub(in crate::content::inline_builder) fn range_is_verbatim_or_synthesized(
 /// [`Styled`](crate::inlines::Styled) span, an
 /// earlier-recognized macro node, or a masked passthrough or STEM expression,
 /// each of which [`build_match_string`] stands in as one
-/// `SPAN_PLACEHOLDER` rather than the markup or entity the string pipeline's
-/// own haystack holds there.
+/// `SPAN_PLACEHOLDER` rather than its rendered markup or entity.
 ///
 /// All three `CharRef` leaves are admissible for the same reason: their
 /// match-string bytes — a special's canonical entity (`&lt;`, `&gt;`,
 /// `&amp;`), a restored entity's own text (`&copy;`, `&#8217;`), a
 /// replacement's built-in rendering (`&#169;` for `(C)`, `&#8217;` for `'`,
 /// via [`replacement_entity`](super::super::quotes::replacement_entity)) — are
-/// the very byte sequence the string pipeline's own haystack carries at that
-/// position, so a family that reads its values out of the match string sees
-/// exactly what the string replacer sees.
+/// exactly the bytes each leaf renders as, so a family that reads its values
+/// out of the match string sees the same escaped form its own output would.
 /// What such a family cannot do is *slice* those bytes from `'src` (the source
 /// holds one character, or `(C)`, where the match string holds an entity, and
 /// `&amp;copy;` where it holds `&copy;`), so a value that must ride on the node

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2971,10 +2971,10 @@ mod tests {
         // crosses a synthesized run is now recognized: the name and target are
         // read from the level's match string, which carries an expanded value's
         // bytes exactly, so only the node's `location` falls back to the
-        // enclosing piece's coarse span. The macro's own attribute list is the one part that
-        // still needs an honest `'src` slice — see the divergence test below —
-        // so every fixture here either carries a verbatim bracket or an empty
-        // one.
+        // enclosing piece's coarse span. The macro's own attribute list is the
+        // one part that still needs an honest `'src` slice — see the
+        // divergence test below — so every fixture here either carries
+        // a verbatim bracket or an empty one.
         let parser = expanding_parser();
 
         let fixtures = [

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -846,7 +846,7 @@ fn masked_default_alt(
     // One left-to-right pass, like `Passthroughs::restore_to`'s own
     // `replace_all`: each token is sought only in the bytes after the
     // previous splice, so a restored body that itself carries
-    // sentinel-shaped bytes can never be matched as a later token. Surviving
+    // placeholder-shaped bytes can never be matched as a later token. Surviving
     // tokens appear in index order (they were emitted in piece order and the
     // arithmetic never reorders), and a dropped token is simply not found —
     // the ones after it still restore, keyed by their own index.
@@ -958,14 +958,13 @@ pub(in crate::content::inline_builder) struct MaskedPiece<'a, 'src> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::content::inline_builder) enum Tokened {
     /// Only a **masked** construct — a passthrough or a STEM expression —
-    /// whose body the string pipeline itself splices over its own sentinel.
+    /// whose body `Passthroughs::restore_to` splices over its own placeholder.
     /// The bracket's parsed values may then be restored wherever they go.
     Masked,
 
     /// Also any other **opaque** piece: a rendered span, an
     /// earlier-recognized macro node. Its body is the build-time **fold** with
-    /// the parser's own renderer — the bytes the string replacer reads out of
-    /// its own already-rendered haystack there — which is what lets a value
+    /// the parser's own renderer, which is what lets a value
     /// carry markup an author wrote into a slot a renderer writes out (see
     /// [`MaskedPiece::body`]).
     MaskedOrRendered,
@@ -975,11 +974,12 @@ pub(in crate::content::inline_builder) enum Tokened {
 /// in it becomes an index-keyed `\u{96}`*n*`\u{97}` token, returning that text
 /// alongside the [`MaskedPiece`]s those tokens stand for.
 ///
-/// This is the *before the split* half of every bracket restore, and it exists
-/// so the text handed to [`Attrlist::parse`] is the same **shape** the string
-/// pipeline's own haystack has there. Two spellings have to be normalized into
+/// This is the *before the split* half of every bracket restore, and it
+/// exists so the text handed to [`Attrlist::parse`] holds the placeholder
+/// token in place of each masked body's own bytes. Two spellings have to be
+/// normalized into
 /// one: [`widen_masked_pieces`] has already rewritten a masked piece to a
-/// sentinel-shaped token for the image family's *recognition*, but its
+/// three-byte token for the image family's *recognition*, but its
 /// numbering is per level, and for the link families' display-text list a
 /// masked piece is still the bare one-character
 /// [`SPAN_PLACEHOLDER`](super::super::quotes). Renumbering every restorable
@@ -988,7 +988,7 @@ pub(in crate::content::inline_builder) enum Tokened {
 /// drop a token (a blank slot, a value the split discards) without shifting
 /// the ones that survive, exactly as
 /// `Passthroughs::restore_to` is
-/// unshifted by a sentinel that never reached the rendered string.
+/// unshifted by a placeholder that never reached the rendered string.
 ///
 /// Shared by the two families whose bracket comes back from a parse — the
 /// `image:`/`icon:` bracket here, and the link families' display-text list
@@ -1035,8 +1035,7 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
         // (pinned by `restorable_body_agrees_with_node_is_restorable`), so
         // gating on one before producing the other would leave a branch no
         // input can take. A piece this leaves untokened contributes its own
-        // bytes: a `Text` run's, or a `CharRef` leaf's canonical entity, which
-        // are the string replacer's own bytes there.
+        // bytes: a `Text` run's, or a `CharRef` leaf's canonical entity.
         let masked = piece
             .atomic
             .then(|| nodes.get(piece.node_index))
@@ -1089,8 +1088,7 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
         .item
 }
 
-/// Performs the recognition side effects the string pipeline's own
-/// `InlineImageMacroReplacer` attaches to an `image:`/`icon:` match —
+/// Performs the recognition side effects an `image:`/`icon:` match needs —
 /// registering the image target in the document's asset catalog (`image:`
 /// only, and only when [`catalog_assets`](Parser::with_catalog_assets) is
 /// enabled) and recording the `link=` dangerous-scheme/self-href warning —
@@ -1100,16 +1098,12 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 ///
 /// Every macro family this module recognizes defers exactly this kind of
 /// side effect (see this file's own `register_image` note, and the anchor,
-/// link, and footnote increments' own): while the additive builder runs
-/// *alongside* the authoritative string pipeline — each against its own,
-/// independent [`Parser`] — performing it from every additive pass would risk
-/// double-counting a registration once the two paths ever share one `Parser`.
-/// This function is that deferred piece, staged as its own building block for
-/// the eventual cutover (design §5.2, Phase 4 step 6): re-attaching it for
-/// real means calling it exactly once per parse, after the single-pass
-/// builder replaces the recorder as `Content`'s tree source, so nothing here
-/// is now wired into the real parse path — see
-/// [`apply_macro_side_effects`](super::apply_macro_side_effects) — and is also
+/// link, and footnote families' own): recognition runs once per level as the
+/// tree is built, but a side effect must run exactly once per parse, so it is
+/// replayed from the finished tree afterward, via
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects), rather than
+/// performed inline as each family recognizes its construct. This function is
+/// that replay for the image/icon family, and is also
 /// exercised directly by this module's own tests, against their own `Parser`.
 ///
 /// Recurses into every container an `Image` node can be nested inside —

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2167,10 +2167,10 @@ mod tests {
             Some("a \u{96}x\u{97} \u{96}9\u{97} b")
         );
 
-        // The string pipeline reads this one differently, and the difference
+        // The golden output reads this one differently, and the difference
         // is its own wart rather than something to reproduce: `restore_to`
         // is a `replace_all` over the *finished* rendered string, so it also
-        // rewrites the sentinel-shaped bytes the author wrote — splicing
+        // rewrites the placeholder-shaped bytes the author wrote — splicing
         // passthrough 1's body into the middle of passthrough 0's. The tree
         // restores per token, into the value each token actually stands in,
         // so an author's own bytes survive. Its sibling
@@ -2190,9 +2190,9 @@ mod tests {
         // `a_dangerous_target_inside_a_passthrough_is_a_documented_divergence`,
         // and the same safe reading. The renderer's dangerous-scheme check
         // reads the `link=` attribute, which now carries the *restored*
-        // bytes; the string pipeline's renderer checks the sentinel its own
-        // parse put there, so a smuggled `javascript:` passes and its restore
-        // pass then completes a live anchor around the image.
+        // bytes; the golden output's renderer instead checks the placeholder
+        // its own parse put there, so a smuggled `javascript:` passes and the
+        // restore then completes a live anchor around the image.
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "image:x.png[Alt,link=++javascript:alert(1)++]";
@@ -2224,8 +2224,8 @@ mod tests {
     fn a_quote_restored_into_an_image_bracket_is_a_documented_divergence() {
         // The one shape the bracket restore does not reach byte-for-byte,
         // and the same well-formed reading the two link families' own
-        // restores take for a `"` in a target. The string pipeline encodes
-        // its quote-free *sentinel* into `alt="…"` and the restore pass then
+        // restores take for a `"` in a target. The golden output encodes
+        // its quote-free *placeholder* into `alt="…"` and its restore then
         // splices the raw `"` into the finished attribute, closing it; the
         // tree holds the restored bytes as the node's own `alt`, so the
         // fold's `encode_attribute_value` escapes the quote and the
@@ -2270,8 +2270,8 @@ mod tests {
             "image:x.png[see stem:[y] here]",
             "icon:home[stem:[y]]",
             // The split invariant: a `,` or `=` inside the STEM body must
-            // not divide the list — the string pipeline's own parse only
-            // ever sees the sentinel.
+            // not divide the list — the parse only
+            // ever sees the placeholder.
             "image:x.png[stem:[a,b]]",
             "image:x.png[stem:[a=b],200]",
             // Named values, the positional width slot, and a role.
@@ -2306,12 +2306,12 @@ mod tests {
 
     #[test]
     fn registers_the_restored_target_for_an_image_over_a_passthrough() {
-        // The staged side effect registers the node's own target — the
-        // *restored* bytes. The string pipeline registers the sentinel it
-        // matched (its restore pass rewrites only the rendered string, never
-        // the catalog), which no consumer can read anything from; the cutover
-        // deliberately adopts the tree's honest answer rather than
-        // reproducing that wart, so this pins the policy with no
+        // The side effect registers the node's own target — the
+        // *restored* bytes. The golden output instead registers the raw
+        // placeholder it matched (its restore rewrites only the rendered
+        // string, never the catalog), which no consumer can read anything
+        // from; the tree deliberately registers its honest answer instead,
+        // so this pins that policy with no
         // golden-catalog comparison — exactly as the link family's own
         // increment did.
         let source = "image:++sunset photo.jpg++[] and image:pass:[My Documents/chart.png][] and image:stem:[s].png[]";
@@ -2438,7 +2438,7 @@ mod tests {
     fn an_image_target_over_a_stem_expression_is_recognized() {
         // The target is the restored bytes with the spliced ranges recorded
         // on the node, and the default alt is the masked derivation — the
-        // rendered expression hides whole inside the sentinel, so the
+        // rendered expression hides whole inside the placeholder, so the
         // extension still comes off around it.
         let nodes = build_src(Span::new("image:stem:[x].png[]"));
 
@@ -2507,7 +2507,7 @@ mod tests {
         // resolver would make the `src` differ by platform (CI runs all
         // three). The masked resolve keeps the body away from the resolver,
         // so the fold is byte-identical under either separator — and equal
-        // to the golden, whose own resolver only ever saw the sentinel.
+        // to the golden, whose own resolver only ever saw the placeholder.
         use super::super::super::test_support::golden_passthroughs;
 
         for source in [
@@ -2600,9 +2600,9 @@ mod tests {
 
     #[test]
     fn registers_the_recorded_target_for_a_target_crossing_an_escaped_special() {
-        // The staged `register_image` reads the node's own stored `target`,
-        // which is the escaped one — byte-identical to the `caps[1]` the
-        // string replacer registered. Frozen at the last differentially-
+        // `register_image` reads the node's own stored `target`,
+        // which is the escaped one — byte-identical to what `caps[1]`
+        // would hold. Frozen at the last differentially-
         // verified parity, like the broad set above.
         let fixtures = [
             ("image:a&b.png[]", r#"["a&amp;b.png"]"#),
@@ -2642,7 +2642,7 @@ mod tests {
         apply_character_replacements(build_through_quotes(source), source)
     }
 
-    // ---- `apply_image_side_effects` (staged for the eventual cutover) -----
+    // ---- `apply_image_side_effects` ----------------------------------------
 
     use super::apply_image_side_effects;
     use crate::warnings::WarningType;
@@ -2684,8 +2684,7 @@ mod tests {
 
     #[test]
     fn registration_is_a_no_op_when_catalog_assets_is_disabled() {
-        // `catalog_assets` defaults to off; `register_image` is then a no-op,
-        // mirroring the string pipeline's own `Parser::register_image`.
+        // `catalog_assets` defaults to off; `register_image` is then a no-op.
         let source = "image:sunset.jpg[Sunset]";
         let parser = Parser::default();
         let nodes = build_with(Span::new(source), &parser);
@@ -2697,8 +2696,8 @@ mod tests {
 
     #[test]
     fn registers_an_image_nested_inside_a_styled_span_and_a_footnote() {
-        // An `Image` node can be nested inside a `Styled` span (matched inside
-        // a rendered span, mirroring the string pipeline) or captured whole
+        // An `Image` node can be nested inside a `Styled` span (recognized
+        // inside the span body by `apply_macros`) or captured whole
         // into a `Footnote`'s own children (the footnote increment's own
         // `emit_range`); both containers must be walked.
         let source = "*see image:a.png[]* and footnote:[see image:b.png[]]";
@@ -2754,10 +2753,10 @@ mod tests {
     #[test]
     fn registers_the_recorded_targets_for_a_broad_fixture_set() {
         // Each expected set is **frozen at the last differentially-verified
-        // parity**: until the string pipeline's deletion this test registered
-        // each fixture through it on an independent parser and compared the
-        // two catalogs, green at the commit that deleted it — the literals are
-        // that pipeline's own answer.
+        // parity**: until the string-rewriting implementation was deleted,
+        // this test registered each fixture through it on an independent
+        // parser and compared the two catalogs, green at the commit that
+        // deleted it — the literals are that implementation's own answer.
         let fixtures = [
             ("image:sunset.jpg[Sunset]", r#"["sunset.jpg"]"#),
             ("icon:home[]", "[]"),
@@ -2971,8 +2970,8 @@ mod tests {
         // An image or icon macro whose *target* (or whose whole macro name)
         // crosses a synthesized run is now recognized: the name and target are
         // read from the level's match string, which carries an expanded value's
-        // bytes exactly, so only the node's `location` takes design §4.4's
-        // coarse fallback. The macro's own attribute list is the one part that
+        // bytes exactly, so only the node's `location` falls back to the
+        // enclosing piece's coarse span. The macro's own attribute list is the one part that
         // still needs an honest `'src` slice — see the divergence test below —
         // so every fixture here either carries a verbatim bracket or an empty
         // one.
@@ -3031,7 +3030,7 @@ mod tests {
     fn an_image_inside_an_expanded_value_keeps_a_coarse_location() {
         // The target is recovered *exactly* (through `text_slice`), while the
         // node's `location` falls back to the enclosing synthesized run's own
-        // span — design §4.4's documented split, the same one the anchor, UI,
+        // span — the same documented split the anchor, UI,
         // index-term, and cross-reference families already take.
         let parser = expanding_parser();
         let source = "image:{logo}[Logo]";
@@ -3078,9 +3077,8 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_an_attribute_list_inside_an_expanded_value() {
         // A non-empty attribute list crossing a synthesized run takes the same
         // lift: the expansion's bytes live only in the level's match string —
-        // which is exactly the already-substituted haystack the string
-        // replacer parses its own `caps[2]` out of — so the bracket is parsed
-        // from there and owned off it.
+        // the same already-substituted haystack `caps[2]` would read — so the
+        // bracket is parsed from there and owned off it.
         let parser = expanding_parser();
 
         let fixtures = [
@@ -3131,8 +3129,9 @@ mod tests {
     fn an_attribute_list_inside_an_expanded_value_is_owned_and_coarsely_located() {
         // The attribute values are the expansion's own bytes, owned rather
         // than borrowed from the temporary they were parsed from; the list's
-        // span takes design §4.4's coarse fallback — here the whole enclosing
-        // synthesized run — exactly as the node's `location` does.
+        // span falls back to the enclosing piece's coarse span — here the
+        // whole enclosing synthesized run — exactly as the node's `location`
+        // does.
         let parser = expanding_parser();
         let source = "image:sunset.jpg[{caption},role=hl]";
         let nodes = build(Span::new(source), &parser, None);
@@ -3154,9 +3153,9 @@ mod tests {
 
     #[test]
     fn registers_the_recorded_target_for_images_inside_expanded_values() {
-        // The staged `register_image` side effect reads the node's own stored
-        // `target`, which is the *expanded* one — what the string pipeline's
-        // own expanded haystack matched and registered. Frozen at the last
+        // The `register_image` side effect reads the node's own stored
+        // `target`, which is the *expanded* one — what an expanded haystack
+        // matches and registers. Frozen at the last
         // differentially-verified parity, like the broad set above.
         let fixtures = [
             ("image:{logo}[Logo]", r#"["sunset.jpg"]"#),
@@ -3196,8 +3195,9 @@ mod tests {
         // stays on the page as literal text and no node is built.
         //
         // Until the target group was made mandatory this shape *did* match
-        // here, with an empty target — while the string pipeline's own
-        // `InlineImageMacroReplacer` panicked reading `&caps[1]`, so the two
+        // here, with an empty target — while the string-rewriting
+        // implementation's own `InlineImageMacroReplacer` panicked reading
+        // `&caps[1]`, so the two
         // could not be compared at all. Both families read the one shared
         // pattern, so the fix reached this side with it; the shape now sits in
         // the differential corpus above, and what is pinned here is the

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -74,24 +74,18 @@ pub(super) fn indexterm_macros_level<'src>(
         return nodes;
     }
 
-    // The string replacer runs the shorthand through
-    // [`replace_with_lookahead`], whose look-ahead retry (a shorthand
-    // absorbing trailing parens) has a subtle consequence: if the whole
-    // substitution accumulates *no* output and the last event is such a
-    // retry, the helper returns `Cow::Borrowed` and the caller
-    // keeps the original text **unchanged**. Concretely, content that is
-    // nothing but concealed shorthand terms (`(((coffee)))`,
-    // `(((a)))(((b)))`) is left *literal*, where the same terms with any
-    // surrounding output render to nothing. Detect that no-op and mirror
-    // it: leave the level untouched.
+    // A shorthand's look-ahead retry (absorbing trailing parens) has a subtle
+    // consequence: if the whole level accumulates *no* output and the last
+    // match is such a retry, the level is left **unchanged** rather than
+    // replaced. Concretely, content that is nothing but concealed shorthand
+    // terms (`(((coffee)))`, `(((a)))(((b)))`) is left *literal*, where the
+    // same terms with any surrounding output render to nothing. Detect that
+    // no-op and mirror it: leave the level untouched.
     //
-    // This mirrors a **known string-pipeline bug**
-    // (asciidoc-rs/asciidoc-parser#1123): a whole-content concealed term should
-    // render empty, not literal. The additive builder reproduces it here to
-    // keep byte-for-byte parity (design §5.3); the fix for both is to drop this
-    // call at the cutover (design §5.2, Phase 4, step 6),
-    // where `rendered_html()` becomes the fold and the golden output is
-    // updated.
+    // This is a **known bug** (asciidoc-rs/asciidoc-parser#1123): a
+    // whole-content concealed term should render empty, not literal. The tree
+    // reproduces it here to keep parity with the golden output; fixing both
+    // is future work, tracked by that issue.
     if indexterm_substitution_is_a_noop(&matches) {
         return nodes;
     }
@@ -101,9 +95,9 @@ pub(super) fn indexterm_macros_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, macro_matches)
 }
 
-/// A recognized index-term match, plus the two facts the string replacer's
-/// look-ahead loop needs to reproduce its `Cow::Borrowed` (no-op) return (see
-/// [`indexterm_substitution_is_a_noop`]).
+/// A recognized index-term match, plus the two facts
+/// [`indexterm_substitution_is_a_noop`] needs to reproduce the whole-level
+/// no-op case.
 struct RecognizedIndexterm<'src> {
     macro_match: MacroMatch<'src>,
 
@@ -111,22 +105,21 @@ struct RecognizedIndexterm<'src> {
     /// or an unescaped literal). A concealed term renders nothing.
     rendered_nonempty: bool,
 
-    /// Whether recognizing this match advances the string replacer via a
-    /// look-ahead retry (`SkipAheadAndRetry`) — true only for a shorthand that
-    /// absorbed trailing parens. The macro forms always `Continue`.
+    /// Whether recognizing this match advanced via a look-ahead retry — true
+    /// only for a shorthand that absorbed trailing parens. The macro forms
+    /// never retry.
     is_skip: bool,
 }
 
-/// Reports whether the string replacer's index-term substitution over this
-/// level would be a **no-op** — returning `Cow::Borrowed` and so leaving the
-/// content unchanged (see [`indexterm_macros_level`]).
+/// Reports whether this level's index-term substitution would be a **no-op**,
+/// leaving the content unchanged rather than replaced (see
+/// [`indexterm_macros_level`]).
 ///
 /// That happens exactly when the accumulated output is empty *and* the last
 /// recognized match advanced via a look-ahead retry: an empty gap before every
 /// match, every match rendering nothing, and the final match a paren-absorbing
-/// shorthand. Any non-empty gap or shown term — or a trailing macro form, which
-/// `Continue`s instead of retrying — makes the substitution `Cow::Owned` and
-/// the terms are recognized normally.
+/// shorthand. Any non-empty gap or shown term — or a trailing macro form,
+/// which never retries — means the terms are recognized normally.
 fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
     let mut emitted_nonempty = false;
     let mut prev_end = 0;
@@ -135,8 +128,8 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
     for m in matches {
         let full = &m.macro_match.full;
 
-        // A non-empty gap before the match is literal text the replacer pushes,
-        // making the accumulated output non-empty.
+        // A non-empty gap before the match is literal text, making the
+        // accumulated output non-empty.
         if full.start > prev_end {
             emitted_nonempty = true;
         }
@@ -164,15 +157,15 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// function of its id alone (see
 /// [`find_anchor_matches`](super::anchors::find_anchor_matches)), it is
 /// recognized regardless of what its argument crosses; the node simply carries
-/// an empty `terms`. (The one exception is the string replacer's
-/// whole-substitution no-op for a level of *only* concealed shorthand terms,
-/// which [`indexterm_macros_level`] mirrors by leaving the level literal.)
+/// an empty `terms`. (The one exception is the whole-level no-op for a level
+/// of *only* concealed shorthand terms, which [`indexterm_macros_level`]
+/// handles by leaving the level literal.)
 ///
 /// A **visible** (flow) term (`indexterm2:[…]`, `((term))`) shows its term text
 /// in the flow, so that text must be reconstructible from this level's escaped
-/// match string. It is — with the *same* entity bytes the string pipeline sees,
-/// since a [`CharRef`](InlineNode::CharRef) contributes its canonical entity to
-/// the match string — whenever the term crosses no *opaque span* (an
+/// match string. It is — since a [`CharRef`](InlineNode::CharRef) contributes
+/// its canonical entity to the match string — whenever the term crosses no
+/// *opaque span* (an
 /// earlier-recognized
 /// [`Styled`](crate::inlines::Styled)/[`Ref`](crate::inlines::Ref), carried
 /// here as a single [`SPAN_PLACEHOLDER`] rather than its rendered markup). A
@@ -190,12 +183,12 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// bytes exactly, and this family reads its term from nowhere else — it never
 /// slices `'src`, and an [`IndexTerm`] node carries no `Span`-typed field — so
 /// the shown text is recovered precisely; only the node's `location` takes
-/// design §4.4's coarse fallback. This is the same lift the anchor and
+/// the coarse fallback. This is the same lift the anchor and
 /// bare-e-mail families already made, for the same reason.
 ///
 /// A visible term's shown text is **not** a boundary the other macro families
-/// stop at, because the string replacer puts that text back into the one flat
-/// haystack every later pass scans. So the shorthand spellings carry it as
+/// stop at: it is ordinary flow content, and a later family must still be able
+/// to recognize a construct inside it. So the shorthand spellings carry it as
 /// nodes in [`children`](crate::inlines::IndexTerm::children) — always, not
 /// only when it encloses a rendered span — and
 /// [`apply_macro_families`](super::apply_macro_families) hands those children
@@ -213,8 +206,8 @@ fn indexterm_substitution_is_a_noop(matches: &[RecognizedIndexterm]) -> bool {
 /// test.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
-/// effect; the string replacer records nothing in a catalog either (the HTML
-/// backend generates no index), so there is none to skip here.
+/// effect; the HTML backend generates no index, so there is nothing to record
+/// here regardless.
 fn find_indexterm_matches<'src>(
     s: &str,
     nodes: &[InlineNode<'src>],

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1746,12 +1746,13 @@ mod tests {
     fn fold_matches_the_string_pipeline_through_escaped_paren_wrapped_shorthands() {
         // The one escaped shorthand rendered rather than
         // left literal: a paren-wrapped `\(((x)))`, whose wrapping parens are
-        // stripped off `encl_text` before rendering what is left as a **visible**
-        // term between two literal parens ("an escaped concealed term still
-        // processes a nested flow term"), so the whole thing collapses to
-        // `(x)`. The builder expresses that as a pair of matches — an
-        // `Unescape` over the backslash alone, then a `Node` whose `consumed`
-        // sub-range keeps a paren at each end — and folds to the same bytes.
+        // stripped off `encl_text` before rendering what is left as a
+        // **visible** term between two literal parens ("an escaped
+        // concealed term still processes a nested flow term"), so the
+        // whole thing collapses to `(x)`. The builder expresses that as
+        // a pair of matches — an `Unescape` over the backslash alone,
+        // then a `Node` whose `consumed` sub-range keeps a paren at
+        // each end — and folds to the same bytes.
         for fixture in [
             // The shape itself, alone and in flow.
             r"\(((x)))",

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1004,7 +1004,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -1128,7 +1128,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
             assert_ne!(folded, source, "the term should be consumed for {source:?}");
         }
@@ -1246,7 +1246,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -1333,7 +1333,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -1504,7 +1504,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
         }
     }
@@ -1576,7 +1576,7 @@ mod tests {
             assert_eq!(
                 fold_html(&nodes, &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
 
             assert!(
@@ -1700,7 +1700,7 @@ mod tests {
                     &parser.render_context()
                 ),
                 crate::content::inline_builder::snapshot::recorded("indexterm_expanded", source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
         }
     }
@@ -1803,7 +1803,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -244,8 +244,8 @@ fn find_indexterm_matches<'src>(
 
         // Shorthand form: group 3 is the text enclosed by the outermost `((` …
         // `))`. Absorb any `)` immediately after the matched `))` so the
-        // closing pair is the *last* in the run, mirroring the string
-        // replacer's `(?!\))` look-ahead re-creation. `captures_iter`
+        // closing pair is the *last* in the run — a `(?!\))` look-ahead in
+        // spirit, though `captures_iter`
         // cannot skip ahead, so the absorbed parens are folded into
         // this match's `full` range instead; a run of `)` never starts
         // a new match, so the next `captures_iter` match still lands
@@ -257,10 +257,10 @@ fn find_indexterm_matches<'src>(
         let full = whole.start()..(whole.end() + extra);
 
         // `encl_text` — the enclosed text plus any absorbed trailing parens —
-        // is the string replacer's own classification input, and the two runs
-        // it concatenates are *not* adjacent in the match string (the matched
-        // `))` sits between them), so it is carried as the pair of ranges it
-        // really is (see [`TermSource`]).
+        // is what classifies the shorthand as concealed vs. visible, and the
+        // two runs it concatenates are *not* adjacent in the match string (the
+        // matched `))` sits between them), so it is carried as the pair
+        // of ranges it really is (see [`TermSource`]).
         let encl = TermSource {
             head: inner,
             tail: whole.end()..(whole.end() + extra),
@@ -287,8 +287,8 @@ fn find_indexterm_matches<'src>(
 ///
 /// A macro form's argument, and a shorthand whose closing `))` is the last pair
 /// in its run, are one range and leave `tail` empty. A shorthand that
-/// **absorbed** trailing parentheses is the case that needs two: the string
-/// replacer builds its `encl_text` as the enclosed text *plus* those parens,
+/// **absorbed** trailing parentheses is the case that needs two: `encl_text`
+/// is the enclosed text *plus* those parens,
 /// and the matched `))` sits between the two in the match string, so
 /// `((coffee))))` spells `coffee))` out of `coffee` and the run of `)` that
 /// follows. Every narrowing below is expressed in `encl_text`'s own
@@ -304,7 +304,7 @@ struct TermSource {
 }
 
 impl TermSource {
-    /// The bytes this source spells — the string replacer's own `encl_text`.
+    /// The bytes this source spells — its own `encl_text`.
     fn text(&self, s: &str) -> String {
         let mut out = String::with_capacity(self.head.len() + self.tail.len());
         out.push_str(&s[self.head.clone()]);
@@ -337,7 +337,7 @@ impl TermSource {
 /// offsets, and [`emit_shown_term_range`] performs the two remaining byte
 /// rewrites structurally — so a caller is free to take either or both.
 struct ShownTerm<'src> {
-    /// The already-substituted string the string replacer computes.
+    /// The already-substituted, fully computed string.
     ///
     /// `None` when the term crosses a construct whose rendering exists only at
     /// fold time, which no string built now can spell.
@@ -347,7 +347,7 @@ struct ShownTerm<'src> {
     children: Vec<InlineNode<'src>>,
 }
 
-/// The range of `text` the string replacer *shows*, as a narrowing of the
+/// The range of `text` that is *shown*, as a narrowing of the
 /// term's own bytes.
 ///
 /// This is [`normalize_index_text`] and `strip_see_and_seealso` re-expressed
@@ -393,12 +393,11 @@ fn shown_term_range(text: &str, strip_see: bool) -> std::ops::Range<usize> {
 ///
 /// # The boundary this crosses
 ///
-/// A visible term shows its text in the flow, and the string replacer reads
-/// that text straight out of its own escaped haystack — where an
-/// earlier-recognized construct already stands as its *rendered markup*. This
-/// level's match string stands the same construct in as one opaque
+/// A visible term shows its text in the flow, so recovering it needs its
+/// bytes read straight out of this level's own escaped match string. An
+/// earlier-recognized construct stands in that string as one opaque
 /// [`SPAN_PLACEHOLDER`], whose markup exists only when the tree is folded, so a
-/// term crossing one had no string to compute and was left literal.
+/// term crossing one has no string to compute from directly.
 ///
 /// It needs none. The shown text is not a value this family *decides* anything
 /// from — every decision (`trim`, the `see` clause, the attribute-list `=`) is
@@ -418,10 +417,10 @@ fn shown_term_range(text: &str, strip_see: bool) -> std::ops::Range<usize> {
 /// [`shown_term_range`] answers `trim` and the `see` / `see-also` strip as
 /// offsets. The other two rewrites [`normalize_index_text`] performs are
 /// emitted rather than applied: a `\n` becomes its own one-space
-/// [`Text`](InlineNode::Text) node (the collapse the string replacer performs
-/// with `replace`), and — for the macro form alone — an escaped closing bracket
-/// drops its backslash as a *gap* between two emitted ranges, the same
-/// structural unescape
+/// [`Text`](InlineNode::Text) node (the same collapse `normalize_index_text`
+/// performs with `replace`), and — for the macro form alone — an escaped
+/// closing bracket drops its backslash as a *gap* between two emitted ranges,
+/// the same structural unescape
 /// [`emit_range_unescaping_brackets`](super::emit_range_unescaping_brackets)
 /// performs for the reference-bearing families. Neither rewrite can straddle
 /// the two ranges of a [`TermSource`]: its `tail` is a run of `)` and holds
@@ -520,8 +519,8 @@ fn emit_shown_term_range<'src>(
 ///
 /// A concealed `indexterm:[…]` is always recognized (it renders nothing, so its
 /// argument is never reconstructed). A visible `indexterm2:[…]`'s term is
-/// normalized exactly as the string replacer does ([`normalize_index_text`]
-/// with bracket-unescaping) and reduced through [`shown_macro_term`] when the
+/// normalized via [`normalize_index_text`]
+/// with bracket-unescaping, and reduced through [`shown_macro_term`] when the
 /// argument is an attribute list, then baked into the node's `terms` in its
 /// already-substituted form — or, when it encloses a construct whose rendering
 /// exists only at fold time, carried as the node's `children` instead (see
@@ -552,9 +551,8 @@ fn build_indexterm_macro_match<'src>(
     parser: &Parser,
 ) -> Option<RecognizedIndexterm<'src>> {
     // An escape (`\indexterm:…`) drops the backslash and keeps the rest
-    // literal, mirroring the string replacer's `caps[0][1..]`. A macro form
-    // always `Continue`s (no look-ahead retry), and the unescaped literal
-    // is non-empty.
+    // literal. A macro form never retries via a look-ahead, and the
+    // unescaped literal is non-empty.
     if escaped {
         return Some(RecognizedIndexterm {
             macro_match: MacroMatch {
@@ -672,11 +670,9 @@ fn build_indexterm_macro_match<'src>(
 /// whole argument is shown verbatim, which is also the answer for an `=` that
 /// was never an attribute list to begin with.
 ///
-/// This is [`InlineIndextermReplacer`]'s own arithmetic, reached with the same
-/// bytes: the argument is read from this level's escaped match string, which
-/// holds exactly what the string pipeline's flat haystack holds at that
-/// position — and the caller has already refused an argument crossing an
-/// opaque span, the one case where the two differ.
+/// The argument is read from this level's escaped match string — the
+/// caller has already refused an argument crossing an opaque span, so this
+/// always has the same bytes the flow itself shows.
 ///
 /// # Why the node needs no `Attrlist`
 ///
@@ -688,20 +684,16 @@ fn build_indexterm_macro_match<'src>(
 /// `visible_term`, which
 /// carries the shown term and nothing else — so the list is *consumed* here
 /// rather than carried, and the [`IndexTerm`] node goes on holding the same
-/// already-substituted shown text every other visible spelling gives it. That
-/// is what the deferral this closes was waiting on, and the answer is that it
-/// was waiting on nothing.
-///
-/// [`InlineIndextermReplacer`]: crate::content::macros
+/// already-substituted shown text every other visible spelling gives it.
 fn shown_macro_term(arg: String, parser: &Parser) -> String {
     if !arg.contains('=') {
         return arg;
     }
 
-    // Parsed over the normalized copy, exactly as the string replacer parses
-    // its own (`Attrlist::parse(Span::new(&arg), …)`): the value read back out
-    // is owned, so nothing borrows `'src` and the node keeps the coarse
-    // whole-match location design §4.4 gives a computed value.
+    // Parsed over the normalized copy (`Attrlist::parse(Span::new(&arg), …)`):
+    // the value read back out is owned, so nothing borrows `'src` and the
+    // node keeps the coarse whole-match location a computed value falls
+    // back to.
     let attrlist = Attrlist::parse(Span::new(&arg), parser, AttrlistContext::Inline)
         .item
         .item;
@@ -717,7 +709,7 @@ fn shown_macro_term(arg: String, parser: &Parser) -> String {
 ///
 /// `inner` is the text between the outermost `((` and `))` (match group 3);
 /// `extra` is the count of `)` absorbed after the closing pair. Together they
-/// form the string replacer's `encl_text`, whose leading/trailing parentheses
+/// form `encl_text`, whose leading/trailing parentheses
 /// classify the term as concealed vs. visible and carry any literal parenthesis
 /// adjacent to (but not part of) the term:
 ///
@@ -736,12 +728,11 @@ fn shown_macro_term(arg: String, parser: &Parser) -> String {
 ///
 /// An **escaped** shorthand (`\((…))`) drops its backslash and keeps the rest —
 /// absorbed parens included — literal, an
-/// [`Unescape`](MacroMatchKind::Unescape) matching the string replacer's plain
-/// `caps[0][1..]` byte-for-byte.
+/// [`Unescape`](MacroMatchKind::Unescape) over just the backslash.
 ///
-/// An escaped **paren-wrapped** one (`\(((x)))`) is the exception, and the
-/// replacer's own branch says why: *an escaped concealed term still processes a
-/// nested flow term*. It strips the wrapping parentheses off `encl_text` and
+/// An escaped **paren-wrapped** one (`\(((x)))`) is the exception: Asciidoctor
+/// still renders it as an escaped concealed term wrapping a
+/// nested flow term. It strips the wrapping parentheses off `encl_text` and
 /// renders what is left as a **visible** term between two literal parens, so
 /// `\(((x)))` collapses to `(x)` rather than staying literal. That is one
 /// match's source doing two things, which is exactly what a **pair** of matches
@@ -768,12 +759,12 @@ fn push_indexterm_shorthand_matches<'src>(
     matches: &mut Vec<RecognizedIndexterm<'src>>,
 ) {
     // `encl_text` = the enclosed text plus any absorbed trailing parens,
-    // exactly as the string replacer builds it before classifying.
+    // built before classifying.
     let encl_text = encl.text(s);
 
     if escaped {
         // The escaped branch's own classification: a paren-wrapped `encl_text`
-        // is the nested flow term the replacer still renders (see this
+        // is the nested flow term Asciidoctor still renders (see this
         // function's doc comment); anything else stays literal.
         let nested =
             (encl_text.starts_with('(') && encl_text.len() >= 2 && encl_text.ends_with(')'))
@@ -795,7 +786,7 @@ fn push_indexterm_shorthand_matches<'src>(
         };
 
         // The backslash alone. An `Unescape` whose match *is* the character it
-        // drops emits nothing, which is what the replacer does with this one.
+        // drops emits nothing.
         matches.push(RecognizedIndexterm {
             macro_match: MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -809,7 +800,7 @@ fn push_indexterm_shorthand_matches<'src>(
 
         // Everything after it: the nested term, with the wrapping parenthesis
         // at each end left outside `consumed` so `rebuild_macro_level`
-        // emits both as the literal text the replacer pushes around the
+        // emits both as the literal text kept around the
         // rendered term.
         let term_full = (full.start + 1)..full.end;
         let consumed = (term_full.start + 1)..(term_full.end - 1);
@@ -843,7 +834,7 @@ fn push_indexterm_shorthand_matches<'src>(
         return;
     }
 
-    // Classify the term, mirroring the string replacer's paren stripping.
+    // Classify the term by its paren stripping.
     // `term` is the inner text whose primary term is shown (visible) or
     // indexed only (concealed); `before`/`after` flag a single literal
     // parenthesis kept beside the term.
@@ -942,8 +933,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_index_terms() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the index-term increment.
+        // reproduces the golden output byte-for-byte. This is the
+        // differential corpus that pins the index-term family.
         // A concealed term renders nothing, a visible term renders its shown
         // text; both spellings and the trailing-paren / see-also handling are
         // exercised.
@@ -990,7 +981,7 @@ mod tests {
             // A visible term crossing a *typographic replacement* — the third
             // recoverable piece, whose match-string bytes are the entity the
             // built-in backend renders it as, so the shown text is
-            // reconstructed exactly as the string replacer computes it.
+            // reconstructed exactly, matching the golden output.
             "((Coffee (C) Beans))",
             "((O'Reilly))",
             "an indexterm2:[Tom (C) Jerry] in the flow",
@@ -1071,7 +1062,7 @@ mod tests {
     #[test]
     fn a_concealed_shorthand_becomes_an_empty_node() {
         // Embedded after literal text so the level is not the all-concealed
-        // no-op the string replacer leaves untouched (see the parity test
+        // no-op that gets left untouched (see the parity test
         // below); the concealed term is then recognized as an empty node.
         let nodes = build_src(Span::new("x (((coffee, robusta)))"));
 
@@ -1088,19 +1079,19 @@ mod tests {
     #[test]
     fn an_all_concealed_shorthand_level_stays_literal() {
         // A level whose only *output* would be from concealed shorthand terms
-        // accumulates no output and ends in a look-ahead retry, so the string
-        // replacer returns `Cow::Borrowed` and leaves it literal (the #1123
-        // bug). The builder mirrors that byte-for-byte: the terms are left
+        // accumulates no output and ends in a look-ahead retry, so the level
+        // is left literal (the #1123 bug — see
+        // `indexterm_substitution_is_a_noop`). The terms are left
         // unrecognized (no `IndexTerm` node).
         //
         // Note the `(((coffee))) trailing` case: **trailing** text does *not*
-        // rescue recognition, because it is appended only on the replacer's
-        // normal completion — the `Cow::Borrowed` early-return on the
-        // empty-`new` retry happens first and discards it. Only output
+        // rescue recognition, because the no-op check only looks at output
+        // accumulated *up to* the retry — trailing text after it is never
+        // examined. Only output
         // emitted *before* the retry (a leading/between gap, or a shown
-        // term) makes `new` non-empty;
+        // term) counts;
         // see `a_concealed_term_after_leading_output_is_consumed` for that
-        // contrast. (Both mirror the string pipeline exactly — verified below.)
+        // contrast. (Both match the golden output exactly — verified below.)
         for source in [
             "(((coffee)))",
             "(((a)))(((b)))",
@@ -1127,12 +1118,11 @@ mod tests {
     #[test]
     fn a_concealed_term_after_leading_output_is_consumed() {
         // The contrast to the all-concealed no-op: **leading** text makes the
-        // replacer's accumulator non-empty *before* the look-ahead retry, so
-        // the substitution is `Cow::Owned` and the concealed term is
+        // accumulated output non-empty *before* the look-ahead retry, so
+        // the level is not a no-op and the concealed term is
         // recognized and consumed (renders nothing) — leaving only the
-        // leading text. The builder reproduces this byte-for-byte, so
-        // `leading (((coffee)))` folds to `leading `, not the literal
-        // source.
+        // leading text. `leading (((coffee)))` folds to `leading `, not the
+        // literal source.
         for source in ["leading (((coffee)))", "((a)) (((b)))"] {
             let folded = fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {});
             assert_eq!(
@@ -1148,7 +1138,7 @@ mod tests {
     fn a_see_clause_leaves_only_the_primary_term() {
         // The `see` separator (` >> `) is `&gt;&gt;` by macro time; the term is
         // reconstructed from the escaped match string, so the node carries only
-        // the primary `Coffee`, exactly as the string replacer renders.
+        // the primary `Coffee`, matching the golden output.
         let nodes = build_src(Span::new("((Coffee >> Beans))"));
 
         let index_term = assert_index_term(&nodes[0]);
@@ -1199,10 +1189,7 @@ mod tests {
         // A *visible* term whose shown text encloses a rendered span (`*bold*`
         // became a `Styled` placeholder by macro time) is carried as the node's
         // `children` rather than as a computed string, so the span's markup is
-        // written by the fold — the very bytes the string replacer read out of
-        // its own already-rendered haystack. This closes the divergences
-        // `a_visible_term_over_a_span_is_a_documented_divergence` and its
-        // `indexterm2:` / escaped-nested twins used to pin.
+        // written by the fold itself, matching the golden output byte-for-byte.
         let fixtures = [
             // The three visible spellings, alone and in flow.
             "((*bold* term))",
@@ -1298,9 +1285,8 @@ mod tests {
         // attribute list whose first *positional* attribute is the shown term;
         // everything else it holds names an entry in an index the HTML backend
         // does not build, so it reaches the flow through nothing. The builder
-        // reads the argument from this level's escaped match string — the same
-        // bytes the string pipeline's flat haystack holds there — and runs the
-        // replacer's own arithmetic over them ([`shown_macro_term`]).
+        // reads the argument from this level's escaped match string and runs
+        // [`shown_macro_term`] over it.
         for fixture in [
             // The shown term is the first positional attribute.
             "indexterm2:[Coffee, region=Kona]",
@@ -1474,13 +1460,11 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_for_a_later_family_inside_a_visible_term() {
-        // The shorthand half of the boundary the side-effect sweep found, now
-        // closed. The string replacer puts a visible term's shown text back
-        // into the one flat haystack every later pass scans, so a `link:`
+        // A visible term's shown text is ordinary flow content, so a `link:`
         // macro, a bare URL or address, an inline anchor, or a
         // cross-reference written inside `((…))` is recognized by the pass
         // that runs after this one, exactly as if the parentheses were not
-        // there. The tree reaches the same answer by handing the term's own
+        // there. The tree reaches that by handing the term's own
         // `children` to those same passes, as their own level.
         for source in [
             "((a term with a link:t.html[T] inside)) end",
@@ -1490,7 +1474,7 @@ mod tests {
             "((a term with an anchor:t[Ref] inside)) end",
             // A cross-reference is not in this corpus: `golden_macros` runs a
             // bare `Content`, which has no catalog, so *every* `xref:`/`<<…>>`
-            // is left as the deferred-cross-reference sentinel there whether
+            // renders to its unresolved placeholder there whether
             // or not a term encloses it. The whole-document test below drives
             // that spelling through the real parse path instead.
             // At either edge of the shown text, and as the whole of it.
@@ -1725,8 +1709,8 @@ mod tests {
     fn a_term_inside_an_expanded_value_keeps_a_coarse_location() {
         // The shown term is exact — and necessarily owned, since an expanded
         // value's bytes have no `'src` counterpart — while the node's
-        // `location` falls back to the whole match's source span (design
-        // §4.4), exactly as an anchor's does.
+        // `location` falls back to the whole match's source span,
+        // exactly as an anchor's does.
         use crate::{
             Parser, content::inline_builder::build, parser::ModificationContext, strings::CowStr,
         };
@@ -1760,9 +1744,9 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_through_escaped_paren_wrapped_shorthands() {
-        // The one escaped shorthand the string replacer re-renders rather than
-        // leaving literal: a paren-wrapped `\(((x)))`, whose wrapping parens it
-        // strips off `encl_text` before rendering what is left as a **visible**
+        // The one escaped shorthand rendered rather than
+        // left literal: a paren-wrapped `\(((x)))`, whose wrapping parens are
+        // stripped off `encl_text` before rendering what is left as a **visible**
         // term between two literal parens ("an escaped concealed term still
         // processes a nested flow term"), so the whole thing collapses to
         // `(x)`. The builder expresses that as a pair of matches — an
@@ -1782,8 +1766,8 @@ mod tests {
             "\\(((multi\nline)))",
             r"\((( spaced )))",
             // …and a special character, a restored entity, and a typographic
-            // replacement all reach the shown text as the same entity bytes the
-            // string pipeline holds there.
+            // replacement all reach the shown text as the same entity bytes
+            // recorded in the golden output.
             r"\(((a < b)))",
             r"\(((a &copy; b)))",
             r"\(((Tom (C) Jerry)))",

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1279,18 +1279,18 @@ pub(super) fn build_link_node<'src>(
     //
     // The check reads the *restored* target, which for a scheme smuggled
     // inside a passthrough (`link:++javascript:...++[]`) is deliberately
-    // **stricter** than the string pipeline: its replacer checks the masked
-    // haystack, where the sentinel hides the scheme, so it emits a live
-    // dangerous link the restore then completes. That is the one place this
+    // **stricter** than checking the masked bytes directly would be: the
+    // placeholder there hides the scheme, so a check against it would treat
+    // the link as safe and emit a live dangerous link, which the restore
+    // would then complete. That is the one place this
     // increment chooses the safe reading over byte parity — see
     // `a_dangerous_scheme_inside_a_passthrough_is_a_documented_divergence`.
     if !is_mailto && has_dangerous_scheme(&target) {
-        // Reported where `InlineLinkMacroReplacer` reports it. This is the
-        // recognition diagnostic design §5.2's survey singled out as needing "a
-        // node-level fact the way `RawOrigin` was one": a rejected macro stays
-        // literal, so there is no `Ref` node to hang it on and nothing for a
-        // tree walk to replay. Recording it at the rejection site — the site
-        // that already holds `parser` — is what that fact would have been for.
+        // Reported at the recognition site itself: a rejected macro stays
+        // literal, so there is no `Ref` node to hang the diagnostic on
+        // afterward and nothing for a tree walk to replay it from. Recording
+        // it here, where `parser` is already in scope, is what makes that
+        // possible.
         parser.record_builder_diagnostic(
             root,
             crate::warnings::WarningType::UnsafeLinkSchemeRejected(target),
@@ -1433,16 +1433,15 @@ pub(super) fn build_link_node<'src>(
                 // `URI_SNIFF` is `^`-anchored, so `replace_all` strips exactly
                 // one prefix and the shown text is always a suffix of the
                 // target. A strip that would leave nothing falls back to the
-                // whole target, mirroring the string replacer's own
-                // `if lt.is_empty()` guard.
+                // whole target instead.
                 //
                 // Sniffed over the bytes as *matched* (`target_str`, not the
-                // restored `target`): the string replacer sniffs its own
-                // haystack, where a scheme inside a passthrough is hidden
-                // behind the sentinel — so `link:++https://x++[]` shows its
-                // scheme even under `hide-uri-scheme`, and the strip offset,
-                // being a match of literal ASCII the placeholder cannot take
-                // part in, indexes the restored bytes identically.
+                // restored `target`): a scheme inside a passthrough is hidden
+                // behind its placeholder there — so `link:++https://x++[]`
+                // shows its scheme even under `hide-uri-scheme` — and the
+                // strip offset, being a match of literal ASCII the
+                // placeholder cannot take part in, indexes the restored
+                // bytes identically.
                 URI_SNIFF
                     .find(target_str)
                     .map(|m| m.end())
@@ -1539,17 +1538,17 @@ struct TextAttrlist<'src> {
 
     /// The list itself, which rides on the node's own
     /// [`attrs`](Ref::attrs) so the fold can hand `render_link` the same
-    /// `id`/`title`/`nofollow`/`noopener` the string replacer hands it.
+    /// `id`/`title`/`nofollow`/`noopener` Asciidoctor's own rendering does.
     attrs: Attrlist<'src>,
 
     /// Whether [`text`](Self::text) came back from a parse of the level's
-    /// **match string** (the string replacer's own bytes) rather than of the
+    /// **match string** (already-escaped bytes) rather than of the
     /// source's own (logical text). The caller rebuilds the former through
     /// [`computed_value_children`] so an entity in it is not escaped twice.
     escaped: bool,
 
-    /// Whether a real named attribute actually split off — the string
-    /// replacers' own `lt != link_text_for_attrlist` guard, which
+    /// Whether a real named attribute actually split off, mirroring the
+    /// `lt != link_text_for_attrlist` guard that
     /// [`InlineLinkReplacer`](crate::content::macros) applies and
     /// `InlineLinkMacroReplacer` does not (see this module's two call sites).
     /// `false` means the `=` was incidental and the whole text is the sole
@@ -1564,16 +1563,16 @@ struct TextAttrlist<'src> {
     /// ([`Attrlist::into_owned_restoring`]), but the display text becomes the
     /// node's **children**, where the honest reading is the node itself: a
     /// [`Raw`](InlineNode::Raw) or [`Stem`](InlineNode::Stem) child folds to
-    /// the very bytes `Passthroughs::restore_to` splices into the string
-    /// pipeline's own display text, where the same bytes spliced into a
-    /// [`Text`](InlineNode::Text) would be escaped a second time (design
-    /// §3.4). The caller re-splits [`text`](Self::text) on these tokens in
+    /// the very bytes `Passthroughs::restore_to` splices into the display
+    /// text, where the same bytes spliced into a
+    /// [`Text`](InlineNode::Text) node would be escaped a second time. The
+    /// caller re-splits [`text`](Self::text) on these tokens in
     /// [`restored_value_children`].
     restores: Vec<InlineNode<'src>>,
 }
 
 /// Parses a link's bracketed **display text** as the [`Attrlist`]`<'src>` its
-/// node carries, mirroring what the string replacers parse: a
+/// node carries, mirroring Asciidoctor's own parse: a
 /// newline-normalized copy of the (pre-`\]`-unescape) bracketed text, joined
 /// with spaces so `link:x[Foo\nBar,role=hl]` reads as `Foo Bar`.
 ///
@@ -1583,17 +1582,18 @@ struct TextAttrlist<'src> {
 /// contiguous, single-line `'src` slice and deferred every other shape. It no
 /// longer does, by the same move the image family's own bracket made
 /// ([`bracket_attrlist`](super::image)): the list is parsed from the level's
-/// **match string** — which is exactly what the replacer parses, out of its own
-/// escaped, already-expanded haystack — and
+/// **match string** — the same escaped, already-expanded bytes Asciidoctor's
+/// own parse reads — and
 /// [`into_owned`](Attrlist::into_owned)ed onto the text's coarse source span
-/// (design §4.4, the fallback the node's `location` already takes). So a text
+/// (the same coarse whole-content-span fallback the node's `location`
+/// already takes). So a text
 /// crossing an escaped special (`link:index.html[a < b,role=hl]`), a restored
 /// entity (`mailto:a@b.com[Tom &copy; Jerry,Subject]`), an expanded attribute
 /// value (`link:index.html[{label},role=hl]`), or a line break
 /// (`link:index.html[Docs\nmore,role=hl]`) is now recognized.
 ///
 /// A **verbatim** text whose source slice *is* those same bytes keeps the
-/// `'src` parse, and with it the borrow (§4.5) — the shape every ordinary
+/// `'src` parse, and with it the borrow — the shape every ordinary
 /// `link:index.html[Docs,role=hl]` takes. Both halves of that test are load
 /// bearing. The range must be verbatim because bytes can coincide without the
 /// text being the source's: [`build_match_string`] gives a *restored* entity
@@ -1606,9 +1606,9 @@ struct TextAttrlist<'src> {
 ///
 /// A **masked** construct — a passthrough or a STEM expression — is admitted
 /// too, and restored the way the image family's own bracket is: the text is
-/// put into the string pipeline's own *shape* before the parse
-/// ([`tokened_bracket`], each masked piece rewritten to the
-/// `\u{96}`*n*`\u{97}` token whose shape the sentinel has), so the split sees
+/// put into that same tokened *shape* before the parse
+/// ([`tokened_bracket`], each masked piece rewritten to its own
+/// `\u{96}`*n*`\u{97}` token), so the split sees
 /// one opaque run carrying none of the `,`/`=`/`"` bytes it reads, and each
 /// body is spliced into the parsed values after it
 /// ([`Attrlist::into_owned_restoring`]). What the *display text* keeps is the
@@ -1620,22 +1620,20 @@ struct TextAttrlist<'src> {
 /// A **rendered** piece — a span the quotes step made, an
 /// earlier-recognized macro node — is admitted the same way, in every slot,
 /// and its token's body is the *build-time fold* with the parser's own
-/// renderer ([`MaskedPiece`](super::image::MaskedPiece)). Those are the bytes
-/// the string replacer reads out of its own already-rendered haystack there, so
-/// a slot `render_link` writes out reproduces the string pipeline's answer
-/// (`link:x[Docs,title=*Pause*]` keeps its `<strong>`), which is the whole
-/// point: a frozen body is what makes the markup an author wrote survive into
-/// the attribute. Freezing costs one thing — a *later* fold with some other
-/// renderer sees the parse-time renderer's markup in those slots — and that is
+/// renderer ([`MaskedPiece`](super::image::MaskedPiece)), so a slot
+/// `render_link` writes out carries the same markup Asciidoctor's own
+/// rendering does (`link:x[Docs,title=*Pause*]` keeps its `<strong>`), which
+/// is the whole point: a frozen body is what makes the markup an author wrote
+/// survive into the attribute. Freezing costs one thing — a *later* fold with
+/// some other renderer sees the parse-time renderer's markup in those slots —
+/// and that is
 /// the same trade the image family's bracket makes for every value it holds
 /// ([`bracket_attrlist`](super::image)), so the three
 /// [`Attrlist`]-bearing families now agree on it. It is safe because a value
 /// reaching an attribute is escaped for the `"` delimiter where it lands
 /// (`encode_attribute_value`, applied by `render_link` to every slot it
 /// writes), so markup carried into a `title`/`class`/`id`/`target` cannot
-/// close the attribute it sits in — the guarantee the string pipeline cannot
-/// make, since it splices a passthrough's body into the *finished* string
-/// after every escape has run (asciidoctor#2661).
+/// close the attribute it sits in (asciidoctor#2661).
 ///
 /// The **display text** is exempt from the freeze rather than from the escape:
 /// it becomes the node's children, so the fold renders each piece itself,
@@ -1645,19 +1643,20 @@ struct TextAttrlist<'src> {
 /// **before** that restore, and a token reaching one of them defers the whole
 /// match. There is exactly one such caller: a `mailto:`'s comma list, whose
 /// second and third positionals become the `?subject=`/`&amp;body=` query
-/// through [`encode_uri_component`]. The string pipeline percent-encodes its
-/// own sentinel there (`%C2%960%C2%97`), which
+/// through [`encode_uri_component`], which would percent-encode the
+/// placeholder token itself (`%C2%960%C2%97`) — bytes
 /// `Passthroughs::restore_to`
-/// then cannot find in the finished `href` — so its golden *leaks* the encoded
-/// sentinel, and no restore here can reproduce that. This is the same boundary
+/// can then no longer find in the finished `href`. The frozen golden
+/// recording for that shape captures exactly that leaked, still-encoded
+/// token, and no restore here can reproduce it. This is the same boundary
 /// the cross-reference family's own pre-restore target keeps, drawn per slot
 /// rather than per family so that a masked piece in the display text beside a
 /// plain subject still restores.
 ///
 /// Returns `None` for that one shape alone: a `pre_restore` slot holding a
 /// token. A list whose two parses disagree about the match's own extent used to
-/// return `None` here too; the tree's own split is what stands now (design
-/// §5.2's deferral divergence).
+/// return `None` here too; the tree's own split is what stands now — a
+/// documented divergence from a markup-based reading, not a deferral.
 fn text_attrlist<'src>(
     raw_text: &str,
     text_range: std::ops::Range<usize>,
@@ -1698,11 +1697,11 @@ fn text_attrlist<'src>(
     let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
 
     // One thing has to hold before a token may stand for a **rendered** piece:
-    // the *split* must land where the string replacer's own parse of the
-    // markup lands. A token carries none of the `,` / `=` / `"` the split
-    // reads, and the replacer's markup may (`link:x[a *b, c* d,role=hl]`), so
-    // the tree's own split is the one that stands (design §5.2's deferral
-    // divergence).
+    // the *split* must land where a parse of the rendered
+    // markup would land. A token carries none of the `,` / `=` / `"` the split
+    // reads, and the rendered markup may (`link:x[a *b, c* d,role=hl]`), so
+    // the tree's own split is the one that stands — a documented divergence
+    // from the markup-based reading.
     let _carried: Vec<InlineNode<'src>> = masked.iter().map(|piece| piece.node.clone()).collect();
 
     if masked.is_empty() {
@@ -1747,11 +1746,11 @@ fn text_attrlist<'src>(
 /// # Scope
 ///
 /// This is the **last** of the link family's spellings: a bare address written
-/// in the flow (`doc.writer@example.com`), which the string pipeline turns into
+/// in the flow (`doc.writer@example.com`), turned into
 /// a `mailto:` link whose display text is the address itself (no `bare` role,
-/// unlike an auto-linked URL — see [`build_email_node`]). It reuses the string
-/// pipeline's *exact* recognition, so only the recognition *sink* differs
-/// (design §4.1), including the pattern's own "prefix that causes a mismatch"
+/// unlike an auto-linked URL — see [`build_email_node`]). It reuses
+/// [`INLINE_EMAIL`]'s *exact* recognition pattern,
+/// including the pattern's own "prefix that causes a mismatch"
 /// group: a `\` escape drops its backslash and leaves the address literal,
 /// while a `>`, `:`, or `/` before the address means it is not a bare address
 /// at all (it is the tail of a URL, or a `mailto:` macro's own target) and the
@@ -1769,14 +1768,16 @@ fn text_attrlist<'src>(
 /// - An address **abutting an already-recognized construct**
 ///   (`**bold**doc@example.org`, `link:x[y]doc@example.org`,
 ///   `image:x.png[]doc@example.org`). The mismatch-prefix group reads the
-///   character immediately before the address; in the string pipeline that is
-///   the preceding construct's *rendered* last character (`</strong>`, `</a>`,
-///   and `<img …>` all end in `>`, a mismatch character, so the address stays
-///   literal there), while here [`build_match_string`] stands the construct in
+///   character immediately before the address; matching over the *rendered*
+///   markup, that would be the preceding construct's rendered last character
+///   (`</strong>`, `</a>`,
+///   and `<img …>` all end in `>`, a mismatch character, so the address would
+///   stay
+///   literal), while here [`build_match_string`] stands the construct in
 ///   as one opaque [`SPAN_PLACEHOLDER`] belonging to no mismatch class. A tree
 ///   whose markup exists only at fold time cannot reproduce that decision, so
-///   the address is left literal rather than recognized into a link the string
-///   pipeline does not build. The sibling auto-link family reaches the same
+///   the address is left literal rather than recognized into a link matching
+///   the rendered markup would not build. The sibling auto-link family reaches the same
 ///   outcome structurally — [`INLINE_LINK`]'s own boundary-prefix group is
 ///   *required*, so a placeholder simply fails its match
 ///   (`**bold**https://example.org` is already deferred for exactly this
@@ -1784,7 +1785,7 @@ fn text_attrlist<'src>(
 ///   unconditional rather than keyed on what the preceding node *would* render
 ///   to: a construct that renders to nothing (a concealed index term) or to
 ///   text not ending in a mismatch character (a STEM expression, a
-///   passthrough) is one the string pipeline *does* link, so those defer too —
+///   passthrough) is one matching the rendered markup *would* link, so those defer too —
 ///   reading that would mean invoking a renderer while building the tree.
 ///
 /// An address's bytes *may*, by contrast, come from a
@@ -1800,10 +1801,10 @@ fn text_attrlist<'src>(
 /// boundary, after the cross-reference, `link:`/`mailto:` macro, and
 /// auto-link/formal-URL families, and the last of the link family's own
 /// spellings to lift it. The match string carries such a leaf's canonical
-/// entity — the very bytes the string replacer's own escaped haystack holds
+/// entity — the same escaped bytes `apply_special_characters` always produces
 /// there — so the target this pass computes off that string
-/// (`mailto:a&amp;b@example.org`) *is* the one the replacer computed and
-/// registered, and no value on the node needs the source's own `&`. The
+/// (`mailto:a&amp;b@example.org`) is the correctly escaped one, and
+/// no value on the node needs the source's own `&`. The
 /// display text, which is the address itself, then becomes **structured
 /// children** rather than one baked `Text` (see [`macro_text_children`]), so
 /// the special folds back to its own entity instead of being escaped twice.
@@ -1885,8 +1886,7 @@ fn find_email_matches<'src>(
         if !prefix.is_empty() {
             if prefix == "\\" {
                 // The escape drops its single backslash and keeps the rest of
-                // the match literal, mirroring the string replacer's
-                // `caps[0][1..]`.
+                // the match literal.
                 matches.push(MacroMatch {
                     kind: MacroMatchKind::Unescape {
                         backslash: full.start,
@@ -1895,23 +1895,23 @@ fn find_email_matches<'src>(
                 });
             }
 
-            // Any other prefix (`>`, `:`, `/`) makes the string replacer emit
-            // the whole match unchanged — which is exactly what recording no
-            // match at all does here.
+            // Any other prefix (`>`, `:`, `/`) means this is not a bare
+            // address at all — which is exactly what recording no
+            // match at all leaves unchanged.
             continue;
         }
 
         // The mismatch-prefix group above read an *empty* prefix — but that
         // decision is only faithful when the tree can actually see the
-        // character the string pipeline reads there. When the address abuts an
+        // character a markup-based reading would see there. When the address abuts an
         // already-recognized construct (`**bold**doc@example.org`,
-        // `link:x[y]doc@example.org`), the string pipeline reads that
+        // `link:x[y]doc@example.org`), the
         // construct's *rendered* last character — `</strong>`, `</a>`, and
-        // `<img …>` all end in `>`, one of the three mismatch characters — and
-        // suppresses the address, while [`build_match_string`] stands the
+        // `<img …>` all end in `>`, one of the three mismatch characters — would
+        // suppress the address, while [`build_match_string`] stands the
         // construct in as one opaque [`SPAN_PLACEHOLDER`], which no mismatch
-        // class contains. Recognizing here would build a link the string
-        // pipeline does not, so this defers instead — leaving the address as
+        // class contains. Recognizing here would build a link a markup-based
+        // reading would not, so this defers instead — leaving the address as
         // literal text, never a wrong node, exactly as the sibling auto-link
         // family already behaves for the same input ([`INLINE_LINK`]'s own
         // boundary-prefix group is *required*, so a placeholder simply fails
@@ -1937,38 +1937,37 @@ fn find_email_matches<'src>(
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Link}` node from a bare e-mail match,
-/// computing the target and display text exactly as `InlineEmailReplacer` does
-/// so the fold reproduces the same bytes: the target is the address prefixed
+/// computing the target and display text so the fold reproduces the bytes
+/// Asciidoctor's own rendering does: the target is the address prefixed
 /// with `mailto:`, and the display text is the address as written. Unlike a
 /// bare *URL* auto-link, no `bare` role is added and `hide-uri-scheme` plays no
-/// part — the string replacer passes `extra_roles: vec![]` and the raw address
-/// as its `link_text`.
+/// part.
 ///
-/// The target is read straight off the level's **match string**, exactly as
-/// `InlineEmailReplacer` reads `caps[2]` off its own escaped haystack — the
+/// The target is read straight off the level's **match string** — the
 /// same bytes, whether the address is verbatim `'src`, comes from a
 /// [`synthesized`](Piece::synthesized) run (an attribute expansion), or
 /// carries an escaped special (`a&amp;b@example.org`). An e-mail node holds no
 /// `Span`-typed field (no [`Attrlist`] parsed out of `'src`), only plain text,
-/// so only the node's `location` needs design §4.4's coarse fallback.
+/// so only the node's `location` needs the coarse whole-content-span
+/// fallback.
 ///
 /// The display text is that same address, so it is a *slice* of the match's own
 /// range rather than a value this builder computes: [`macro_text_children`]
-/// recovers it, borrowing from `'src` in the common case (§4.5) and rebuilding
+/// recovers it, borrowing from `'src` in the common case and rebuilding
 /// it as structured children — each escaped special staying the
 /// [`CharRef`](InlineNode::CharRef) it already is — when it crosses one, rather
 /// than baking the already-escaped address into one `Text` node the fold would
-/// escape a second time (design §3.4). There is no `\]` bracket unescape: this
+/// escape a second time. There is no `\]` bracket unescape: this
 /// text comes from the address, which the pattern's own character classes never
 /// let a bracket into.
 ///
 /// This is **total**: what the family defers is decided entirely by the gate
 /// [`find_email_matches`] applies before calling it.
 ///
-/// As in the additive builder generally, this performs *no* recognition side
-/// effect: it does **not** `register_link` the target, which
-/// `InlineEmailReplacer` does. [`apply_link_side_effects`] is that deferred
-/// piece, staged for the cutover alongside the other link forms'.
+/// This performs *no* recognition side
+/// effect: it does **not** `register_link` the target itself.
+/// [`apply_link_side_effects`] does that separately, once per parse, after
+/// the tree is built and folded, alongside the other link forms'.
 fn build_email_node<'src>(
     caps: &regex::Captures<'_>,
     pieces: &[Piece],
@@ -2000,39 +1999,32 @@ fn build_email_node<'src>(
     })
 }
 
-/// Performs the recognition side effect the string pipeline's five link
-/// replacers (`InlineLinkReplacer`'s angle/formal/bare branches,
-/// `InlineLinkMacroReplacer`, and `InlineEmailReplacer`) attach to a matched
-/// link — registering the target in the document's asset catalog — by walking
-/// an already-built tree and reading each [`Ref`](InlineNode::Ref)`{Link}`
+/// Performs the recognition side effect a matched link needs —
+/// registering the target in the document's asset catalog — by walking
+/// the already-built tree and reading each [`Ref`](InlineNode::Ref)`{Link}`
 /// node's own stored `target` instead of a regex capture. `target` already
-/// holds exactly the string the string pipeline registers (see
+/// holds the fully computed string (see
 /// [`build_inline_link_node`], [`build_link_node`], and [`build_email_node`]),
 /// so no recomputation is needed.
 ///
-/// Every macro family this module recognizes defers exactly this kind of side
-/// effect (see
+/// Every macro family in this module recognizes its construct without
+/// performing this kind of side effect itself (see
 /// [`image::apply_image_side_effects`](super::image::apply_image_side_effects)'
-/// s own note): while the additive builder runs *alongside* the authoritative
-/// string pipeline — each against its own, independent [`Parser`] — performing
-/// it from every additive pass would risk double-counting a registration once
-/// the two paths ever share one `Parser`. This function is that deferred piece
-/// for the link family, staged as its own building block for the eventual
-/// cutover (design §5.2, Phase 4 step 6): re-attaching it for real means
-/// calling it exactly once per parse, after the single-pass builder replaces
-/// the recorder as `Content`'s tree source. That is now done: this runs once
-/// per content from the tree, and the string replacers' own `register_link`
-/// calls are suppressed for that content (see
-/// `Parser::suppress_macro_side_effects`).
+/// s own note) — recognition and registration are kept separate so each
+/// family's tests can build and inspect a tree without a full
+/// `Parser`/`Content` round trip. This function is the link family's own
+/// registration pass, called exactly once per parse, after the tree is built
+/// and folded, from [`apply_macro_side_effects`](super::apply_macro_side_effects).
 ///
 /// # Registration order across the three link forms
 ///
-/// The string pipeline registers a link's target *when its own replacer's
-/// regex pass matches it* — `InlineLinkReplacer` (auto-links and formal-URL
-/// links, `INLINE_LINK`'s non-angle branch) runs as one whole-string pass, then
-/// `InlineLinkMacroReplacer` (`link:`/`mailto:`, `INLINE_LINK_MACRO`) runs as a
-/// *second*, later pass, then `InlineEmailReplacer` (a bare address,
-/// `INLINE_EMAIL`) as a *third* — exactly the order [`inline_link_level`],
+/// The registration order follows Asciidoctor's own substitution passes,
+/// which run whole-string over the content one family at a time: auto-links
+/// and formal-URL
+/// links (`INLINE_LINK`'s non-angle branch) register first, then
+/// `link:`/`mailto:` macros (`INLINE_LINK_MACRO`) as a
+/// *second*, later pass, then a bare address
+/// (`INLINE_EMAIL`) as a *third* — exactly the order [`inline_link_level`],
 /// [`link_macro_level`], and [`email_level`] apply the three families in. So
 /// the catalog ends up in **family-pass order, not true source order**: every
 /// auto-link/formal-URL link in the content registers before every
@@ -2251,7 +2243,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -2297,7 +2289,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_hide_uri_scheme", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -2358,7 +2350,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -2400,7 +2392,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs_in("passthroughs_hide_uri_scheme", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -2461,7 +2453,7 @@ mod tests {
                 "the fold must not emit a live link: {folded:?}"
             );
 
-            // The string pipeline, by contrast, emits one.
+            // The frozen golden recording, by contrast, emits one.
             let golden = golden_passthroughs(source);
 
             assert!(
@@ -2528,7 +2520,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -2719,7 +2711,7 @@ mod tests {
     #[test]
     fn a_link_window_suffix_opens_blank() {
         // A trailing `^` in the text is stripped and selects the `_blank`
-        // window, exactly as the string replacer does.
+        // window, matching Asciidoctor's own behavior.
         let nodes = build_src(Span::new("link:index.html[Open^]"));
 
         let reference = assert_link(&nodes[0]);
@@ -2960,7 +2952,7 @@ mod tests {
         // A `link:` text carrying an `=` splits into an attribute list (here a
         // role): the first positional attribute becomes the display text, and
         // the parsed `Attrlist<'src>` rides on the node's own `attrs` field, so
-        // the fold reproduces the role exactly as the string replacer does.
+        // the fold reproduces the role matching Asciidoctor's own behavior.
         let source = "link:index.html[Docs,role=hl]";
         let nodes = build_src(Span::new(source));
 
@@ -3168,7 +3160,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3224,7 +3216,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_hide_uri_scheme", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3303,7 +3295,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3348,7 +3340,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs_in("passthroughs_hide_uri_scheme", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3488,7 +3480,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3669,7 +3661,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -3915,7 +3907,7 @@ mod tests {
     #[test]
     fn a_bare_auto_link_strips_trailing_punctuation() {
         // A trailing ';' is stripped off the target and kept as literal text
-        // after the link, exactly as the string replacer does.
+        // after the link, matching Asciidoctor's own behavior.
         let nodes = build_src(Span::new("https://example.org; done"));
 
         let reference = assert_link(&nodes[0]);
@@ -4055,7 +4047,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen golden recording for {source:?}"
             );
         }
     }
@@ -4173,7 +4165,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -4308,7 +4300,7 @@ mod tests {
             "an angle URL crossing a rendered span must stay literal: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, *does* build a link here.
+        // The frozen golden recording, by contrast, *does* build a link here.
         assert!(golden_macros(source).contains("<a href"));
     }
 
@@ -4384,7 +4376,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
 
@@ -4407,7 +4399,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_experimental", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -4468,7 +4460,7 @@ mod tests {
                 "a target crossing a rendered span must stay literal: {nodes:?}"
             );
 
-            // The string pipeline, by contrast, *does* build a link here.
+            // The frozen golden recording, by contrast, *does* build a link here.
             assert!(golden_macros(source).contains("<a href"));
         }
     }
@@ -4500,7 +4492,7 @@ mod tests {
             assert_ne!(
                 fold_html(&nodes, &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "{source:?} now agrees with the string pipeline; fold it into the parity corpus"
+                "{source:?} now agrees with the frozen golden recording; fold it into the parity corpus"
             );
 
             // The tree's own reading is the well-formed one: one link node
@@ -4679,7 +4671,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -4765,7 +4757,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -4823,7 +4815,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -5077,7 +5069,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -5133,7 +5125,7 @@ mod tests {
                 "a target crossing a rendered span must stay literal: {nodes:?}"
             );
 
-            // The string pipeline, by contrast, *does* build a link here.
+            // The frozen golden recording, by contrast, *does* build a link here.
             assert!(golden_macros(source).contains("<a href"));
         }
     }
@@ -5177,7 +5169,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -5215,7 +5207,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen golden recording for {source:?}"
             );
 
             // Not vacuous: each fixture really is a link now, and the slot
@@ -5328,7 +5320,7 @@ mod tests {
             assert_ne!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "{source:?} now agrees with the string pipeline; fold it into the parity corpus"
+                "{source:?} now agrees with the frozen golden recording; fold it into the parity corpus"
             );
 
             // The tree's own reading is the well-formed one: one link node
@@ -5729,7 +5721,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen golden recording for {source:?}"
             );
         }
     }
@@ -5804,7 +5796,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_passthroughs(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen golden recording for {source:?}"
             );
         }
     }
@@ -5915,7 +5907,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_macros(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen golden recording for {source:?}"
             );
         }
     }
@@ -6660,7 +6652,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_normal(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }
@@ -6721,7 +6713,7 @@ mod tests {
                     &HtmlInlineRenderer {}
                 ),
                 golden_normal(fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen golden recording for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -41,7 +41,7 @@ use crate::{
 /// branch** — an angle-bracketed URL (`<https://example.org>`) and the
 /// bracketed form that keeps its `&lt;` (`<https://example.org[text]`) — in
 /// their verbatim
-/// forms, reproducing the string replacer's boundary-prefix
+/// forms, matching Asciidoctor's own boundary-prefix
 /// preservation, bare-URL trailing-punctuation stripping, `^` new-window
 /// suffix, `hide-uri-scheme` display text, and `\` scheme escape. It
 /// deliberately leaves several forms **unrecognized** for a later increment,
@@ -73,7 +73,8 @@ use crate::{
 /// and the bracketed display text — is computed out of the level's match
 /// string, which carries a synthesized run's bytes exactly, so
 /// `https://{host}/path` and `{url}[Docs]` are recognized with only the node's
-/// `location` taking design §4.4's coarse fallback. A **formal text carrying
+/// `location` taking the coarse whole-content-span fallback (see this
+/// module's header). A **formal text carrying
 /// an attribute list** (an `=` selecting roles / id / title / window) is no
 /// exception any more: [`text_attrlist`] parses that list from the same match
 /// string when the text has no `'src` slice of its own, and owns the result
@@ -87,9 +88,9 @@ use crate::{
 /// [`range_has_no_opaque_piece`](super::image::range_has_no_opaque_piece),
 /// after the cross-reference and `link:`/`mailto:` macro families. The match
 /// string carries such a leaf's
-/// canonical entity — the very bytes the string replacer's own escaped haystack
-/// holds there — so the target this pass computes off that string
-/// (`https://example.org/?a=1&amp;b=2`) *is* the one the replacer computed, and
+/// canonical entity — the same escaped bytes `apply_special_characters`
+/// always produces there — so the target this pass computes off that string
+/// (`https://example.org/?a=1&amp;b=2`) *is* the correctly escaped one, and
 /// no value on the node needs the source's own `<`/`>`/`&`. The display text
 /// then becomes **structured children** rather than one baked `Text` (see
 /// [`macro_text_children`]), so the special folds back to its own entity
@@ -110,8 +111,8 @@ use crate::{
 /// children through [`macro_text_children`], whose
 /// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
 /// piece's own node whole into them — so the text is carried *structurally*,
-/// and the fold re-renders exactly the markup the string replacer captured
-/// there. Everything this pass *computes* stays gated: the **target**, and
+/// and the fold re-renders that markup exactly. Everything this pass
+/// *computes* stays gated: the **target**, and
 /// with it a **bare** link's shown text (a slice of the target's own range)
 /// and the `<url>` form's whole interior (see [`build_angle_link_node`]). An
 /// **attribute-list text** is computed too — its display text comes back from
@@ -124,24 +125,25 @@ use crate::{
 /// lift, after the cross-reference one (`xref::find_xref_matches`) and the
 /// `link:`/`mailto:` macro ([`find_link_macro_matches`]).
 ///
-/// What the admission cannot do is make the *recognition* agree in every case,
-/// because the string replacer matches over the markup itself where this
-/// matches over one placeholder standing in for it — and this pass cannot know
-/// what that markup carries without folding, which building a tree must never
-/// do. The two read the same extent unless the markup carries a character the
-/// pattern (or the replacer's own attribute-list probe) is sensitive to, which
-/// leaves two documented divergences of *extent*, each pinned by its own test
-/// and each one where the string pipeline's reading is the markup-perturbed one
-/// and the tree's the well-formed one — exactly as the quotes step's own
-/// crossed-delimiter divergence is:
+/// What the admission cannot do is make the *recognition* agree with matching
+/// over the fully rendered markup in every case, because this pass cannot know
+/// what a span's markup carries without folding it first, which building a
+/// tree must never do — so it matches over one placeholder standing in for the
+/// span instead. The two extents coincide unless the markup carries a
+/// character the pattern (or an attribute-list probe reading the rendered
+/// text) is sensitive to, which leaves two documented divergences of
+/// *extent*, each pinned by its own test and each one where matching the
+/// rendered markup gives the perturbed reading and the tree's is the
+/// well-formed one — exactly as the quotes step's own crossed-delimiter
+/// divergence is:
 ///
-/// - a `]` inside the span (`https://example.org[a *b ] c* d]`), which ends
-///   [`INLINE_LINK`]'s own lazy text capture early for the string replacer but
-///   not here;
+/// - a `]` inside the span (`https://example.org[a *b ] c* d]`), which would
+///   end [`INLINE_LINK`]'s own lazy text capture early if matched over the
+///   rendered markup, but not here;
 /// - markup carrying an `=` beside a comma elsewhere in the text
-///   (`…example.org[one, [.hl]#two#]`): the replacer's attribute-list probe
-///   fires on the markup's own `=`, and the parse then keeps only what precedes
-///   that comma.
+///   (`…example.org[one, [.hl]#two#]`): an attribute-list probe reading the
+///   rendered markup fires on its own `=`, keeping only what precedes that
+///   comma.
 ///
 /// # A masked construct in the target
 ///
@@ -854,7 +856,7 @@ fn build_angle_link_node<'src>(
 }
 
 /// The display text for a bare link, dropping the URI scheme under
-/// `hide-uri-scheme` exactly as the string replacer's `URI_SNIFF` strip does.
+/// `hide-uri-scheme` via the shared [`URI_SNIFF`] strip.
 /// Neither of the two callers can be left with nothing by the strip:
 /// [`INLINE_LINK`]'s bare branch rejects a bare scheme with no body upstream,
 /// and its ANGLE branch's `<url>` alternative requires at least one character

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -2579,10 +2579,10 @@ mod tests {
 
     #[test]
     fn registers_the_restored_target_for_a_link_over_a_stem_expression() {
-        // As for a passthrough target, the staged side effect registers the
-        // node's own — *restored* — target, for both the macro family and the
-        // auto-link one, where the string pipeline registers the sentinel it
-        // matched. The two come back in **family pass order**, not source
+        // As for a passthrough target, [`apply_link_side_effects`] registers
+        // the node's own — *restored* — target, for both the macro family
+        // and the
+        // auto-link one. The two come back in **family pass order**, not source
         // order (see
         // `registers_interleaved_forms_in_family_pass_order_not_source_order`),
         // so the auto-link precedes the macro written before it.
@@ -2640,13 +2640,11 @@ mod tests {
 
     #[test]
     fn registers_the_restored_target_for_a_link_macro_over_a_passthrough() {
-        // The staged side effect registers the node's own target — the
-        // *restored* bytes. The string pipeline registers the sentinel it
-        // matched (`"\u{96}0\u{97}"` verbatim, since its restore pass rewrites
-        // only the rendered string, never the catalog), which no consumer can
-        // read anything from; the cutover deliberately adopts the tree's
-        // honest answer rather than reproducing that wart, so this pins the
-        // policy with no golden-catalog comparison.
+        // [`apply_link_side_effects`] registers the node's own target — the
+        // *restored* bytes — rather than an unrestored placeholder no
+        // consumer could read anything from. This pins that policy with no
+        // golden-catalog comparison, since the frozen recordings never
+        // captured a restored catalog entry to compare against.
         let source =
             "link:++https://example.org/a__b++[] and link:pass:[My Documents/report.pdf][R]";
         let parser = Parser::default().with_catalog_assets(true);
@@ -2762,11 +2760,11 @@ mod tests {
 
     #[test]
     fn a_link_macro_target_crossing_an_escaped_special_is_recognized() {
-        // The string pipeline matches macros over *escaped* text, so a target
+        // Macros match over *escaped* text, so a target
         // containing `&` is matched as `a&amp;b.html` — and the level's match
-        // string carries those very bytes for the `CharRef::Special` the
-        // `SpecialCharacters` step made, so the node's target is exactly the
-        // one the string replacer computed. `target` is a computed value, not
+        // string carries those very bytes for the `CharRef::Special`
+        // `apply_special_characters` made, so the node's target is exactly
+        // the correctly escaped one. `target` is a computed value, not
         // an `'src` slice, so nothing here needs the source's own `&`.
         let source = "link:a&b.html[x]";
         let nodes = build_src(Span::new(source));
@@ -2870,8 +2868,8 @@ mod tests {
         // A display text crossing an escaped special is rebuilt out of the
         // nodes it covers rather than baked into one `Text` child: the special
         // stays the `CharRef` it already is — keeping its own precise `'src`
-        // span (#944) — and folds back to the same entity the string replacer's
-        // text carries, where a single `Text` holding `&lt;` would be escaped a
+        // span (#944) — and folds back to the same entity, where a single
+        // `Text` holding `&lt;` would be escaped a
         // second time.
         let source = "link:index.html[a < b]";
         let nodes = build_src(Span::new(source));
@@ -3049,8 +3047,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_inline_links() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the auto-link /
+        // reproduces the frozen golden recording byte-for-byte. This is the
+        // differential corpus that pins the auto-link /
         // formal-URL link increment. A fixture may cross an escaped
         // special anywhere but its own attribute-list text; the forms
         // still deferred (an attribute-list text crossing a special, a
@@ -3103,8 +3101,8 @@ mod tests {
             // An **attribute-list-bearing** text with no `'src` slice of its
             // own: one crossing an escaped special and one spanning two lines
             // (which the attrlist parse joins with a space). Each is parsed
-            // from the level's match string — the same bytes the string
-            // replacer parses — and owned off it. The incidental-`=` fallback
+            // from the level's match string — already-escaped bytes — and
+            // owned off it. The incidental-`=` fallback
             // reaches the same path.
             "https://example.org[a < b,role=hl]",
             "https://example.org[Tom & Jerry,role=hl^]",
@@ -3127,8 +3125,8 @@ mod tests {
             "*see https://example.org*",
             "_https://example.org in em_",
             // A URL crossing an *escaped special*: the target this pass reads
-            // off the level's match string is the escaped one the string
-            // replacer computed, and a bare link's shown text is recovered from
+            // off the level's match string is the correctly escaped one,
+            // and a bare link's shown text is recovered from
             // that same range as structured children rather than baked.
             "https://example.org/?a=1&b=2",
             "See https://example.org/?a=1&b=2, then stop.",
@@ -3229,14 +3227,13 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_an_auto_link_target_over_a_passthrough() {
         // The differential corpus for an auto-link / formal-URL target
         // crossing a masked **passthrough** — the last family of that class.
-        // The string pipeline swallows the `\u{96}`*n*`\u{97}` sentinel into
-        // the URL (both target classes admit it exactly as they admit the
-        // tree's placeholder, and the bare branch's own trailing character
-        // class admits the last byte of either spelling, so the two recognize
-        // the same extent) and the restore pass then splices the extracted
-        // body over every sentinel in the rendered string, so the tree's
+        // Both target classes admit the tree's own placeholder exactly as
+        // they would admit its restored bytes, and the bare branch's own
+        // trailing character class admits the last byte of either spelling,
+        // so this family needs no widening of its own to recognize the same
+        // extent, and the tree's
         // computed target substitutes the `Raw` node's value for its
-        // placeholder the same way (see [`restore_masked_passthroughs`]).
+        // placeholder directly (see [`restore_masked_passthroughs`]).
         use super::super::super::test_support::golden_passthroughs;
 
         let fixtures = [
@@ -3256,8 +3253,9 @@ mod tests {
             "https://example.org/++a++#frag",
             "https://++a++.++b++.org/x",
             // The trailing-punctuation strip keys off the target's final
-            // character in both pipelines — a placeholder is no more a `;`
-            // than the sentinel is, so a `;` *inside* the passthrough stays
+            // character — a placeholder is no more a `;`
+            // than the passthrough's own restored bytes are, so a `;`
+            // *inside* the passthrough stays
             // in the target while a literal one after it is stripped.
             "see https://example.org/++a++; now",
             "https://example.org/a++;++",
@@ -3385,15 +3383,16 @@ mod tests {
 
     #[test]
     fn a_quote_restored_into_an_auto_link_target_is_a_documented_divergence() {
-        // A `"` inside the passthrough body reaches the `href` through two
-        // different orders. The string pipeline renders its *sentinel* — which
-        // carries no quote for `encode_attribute_value` to escape — and the
-        // restore then splices the raw `"` into the finished attribute, which
-        // it closes; the fold renders the *restored* target, so the quote is
-        // escaped where it belongs. The tree's is the well-formed reading, and
+        // A `"` inside the passthrough body could reach the `href` two
+        // different ways: spliced raw into the finished attribute — which it
+        // would close, since the placeholder itself carries no quote for
+        // `encode_attribute_value` to escape — or escaped where it belongs,
+        // by rendering the *restored* target and letting the fold's own
+        // escape run over it. The fold takes the second, well-formed
+        // reading, and
         // it is the reading the two sibling families' own restores already
         // take (`link:++a"b++[]`, `image:++a"b.png++[]`), so this is pinned
-        // rather than corrected.
+        // as a documented divergence from the literal-splice reading.
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "https://example.org/++a\"b++";
@@ -3428,10 +3427,11 @@ mod tests {
         //
         // Recognition needs no widening here for the same reason the
         // passthrough increment found: [`INLINE_LINK`]'s three URL classes
-        // admit the sentinel and the one-character placeholder alike, and
+        // admit the placeholder the same way they would admit the restored
+        // bytes, and
         // both pre-restore decisions — rejecting a quoted URL, stripping a
-        // bare one's trailing punctuation — read a placeholder exactly as the
-        // sentinel-holding haystack reads its own sentinel.
+        // bare one's trailing punctuation — read the placeholder exactly as
+        // they would read the restored bytes.
         use super::super::super::test_support::golden_passthroughs;
 
         let fixtures = [
@@ -3442,8 +3442,8 @@ mod tests {
             "https://example.org/stem:[a]stem:[b]",
             "https://example.org/stem:[x]#frag",
             // The trailing-punctuation strip keys off the target's final
-            // character in both pipelines — a placeholder is no more a `;`
-            // or a `.` than the sentinel is.
+            // character — a placeholder is no more a `;`
+            // or a `.` than the passthrough's own restored bytes are.
             "https://example.org/stem:[x],",
             "(https://example.org/stem:[x])",
             "See https://example.org/stem:[x]. Then.",
@@ -3492,11 +3492,11 @@ mod tests {
     #[test]
     fn an_auto_link_target_over_a_stem_expression_is_recognized() {
         // The computed target is the restored bytes — the expression's
-        // *rendered* form, which is what the string pipeline's `href`
+        // *rendered* form, which is what the `href`
         // carries once `Passthroughs::restore_to` runs — while the bare
         // link's shown text keeps the [`Stem`](InlineNode::Stem) node itself
         // as a child, so the fold emits those same bytes without re-escaping
-        // them (design §3.4), exactly as a bare macro's `Raw` child does.
+        // them, exactly as a bare macro's `Raw` child does.
         let nodes = build_src(Span::new("https://example.org/stem:[x + y]"));
 
         let reference = assert_link(&nodes[0]);
@@ -3562,9 +3562,10 @@ mod tests {
         // formal-URL family (an `=`) — all three of which come back from the
         // one [`text_attrlist`] parse.
         //
-        // Reproducing the string pipeline means reproducing its *order*, as
+        // Reproducing Asciidoctor's own output means reproducing its
+        // *order*, as
         // the image family's own bracket increment found: its
-        // [`Attrlist::parse`] reads the `\u{96}`n`\u{97}` sentinel as one
+        // [`Attrlist::parse`] reads the `\u{96}`n`\u{97}` token as one
         // opaque run carrying none of the `,`/`=`/`"` bytes the split reads,
         // so the text is put into that same shape before the parse
         // ([`tokened_bracket`]) and restored after it — into the parsed
@@ -3588,8 +3589,8 @@ mod tests {
             "link:https://example.org[++a,b++]",
             // An `=` inside the body, with no real named attribute to split
             // off: `extract_attributes_from_text` hands the whole tokened text
-            // back unparsed, exactly as it hands the string replacer its own
-            // sentinel-bearing one.
+            // back unparsed, exactly as it would for any other text with no
+            // real attribute to split off.
             "link:https://example.org[++a=b++]",
             // A body inside a *named* value, a quoted one, and both halves of
             // one list at once.
@@ -3605,8 +3606,9 @@ mod tests {
             "link:https://example.org[T,role=hl,++a++]",
             "link:https://example.org[++a++,,role=hl]",
             // The shorthand items after a token: their offsets are shifted
-            // past the restore rather than re-derived, so the `#`/`.`/`%` the
-            // string pipeline found over its own sentinel are the same ones.
+            // past the restore rather than re-derived, so the `#`/`.`/`%`
+            // found over the token are the same ones the restored bytes
+            // would give.
             "link:https://example.org[++abc++#myid.myrole,role=hl]",
             "link:https://example.org[++a++%myopt,role=hl]",
             // The `^` window suffix past a token, and the `\]` unescape.
@@ -3673,11 +3675,12 @@ mod tests {
     #[test]
     fn a_mailto_subject_over_a_masked_construct_is_deferred() {
         // A `mailto:`'s second and third positionals are read **before** the
-        // restore: [`encode_uri_component`] folds them into the `href`, and
-        // the string pipeline encodes its own sentinel there
-        // (`%C2%960%C2%97`), which `Passthroughs::restore_to` then cannot
-        // find in the finished attribute — so its golden *leaks* the encoded
-        // sentinel and no restore here can reproduce it. Deferred with the
+        // restore: [`encode_uri_component`] would percent-encode the
+        // placeholder token itself there
+        // (`%C2%960%C2%97`), which `Passthroughs::restore_to` can then no
+        // longer find in the finished attribute — the frozen golden
+        // recording for this shape captures exactly that leaked,
+        // still-encoded token, and no restore here can reproduce it. Deferred with the
         // whole match left literal, the same boundary the cross-reference
         // family's own pre-restore target keeps, and drawn per *slot* so that
         // the sibling fixtures above (a masked display text beside a plain
@@ -3710,11 +3713,11 @@ mod tests {
     fn a_restored_quote_in_a_link_title_is_a_documented_divergence() {
         // The tree's is the **well-formed** reading, and the same one the
         // image family's own bracket already takes for its `alt`: the fold
-        // escapes the restored `"` through `encode_attribute_value`, where
-        // the string pipeline encoded its quote-free *sentinel* and then
-        // spliced the raw quote into the finished `title="…"`, closing the
-        // attribute early. (The `id` slot is emitted unescaped in both, so it
-        // stays byte-identical; only the encoded slots come apart.)
+        // escapes the restored `"` through `encode_attribute_value`, rather
+        // than splicing the raw quote straight into the finished
+        // `title="…"`, which would close the attribute early. (The `id`
+        // slot is emitted unescaped either way, so it stays byte-identical;
+        // only the encoded slots come apart from a literal-splice reading.)
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "link:https://example.org[T,title=++a\"b++]";
@@ -3736,8 +3739,8 @@ mod tests {
         // The other half of the same class the image family's `link=` check
         // named, and it runs the **safe** way here too: `window=` and
         // `opts=` are values the renderer makes a *decision* on rather than
-        // emits, and it now reads the restored bytes, where the string
-        // pipeline tested its own sentinel and found neither `_blank` nor
+        // emits, and it reads the restored bytes rather than the
+        // placeholder, which by itself would match neither `_blank` nor
         // `nofollow`. So the tree emits the `rel` hardening the golden omits.
         use super::super::super::test_support::golden_passthroughs;
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -6457,12 +6457,12 @@ mod tests {
 
     #[test]
     fn registers_the_recorded_links_for_a_broad_fixture_set() {
-        // Each fixture uses its own pair of *independent* parsers (design
-        // §5.3's two-independent-parsers discipline, already established by
-        // the image increment's own differential corpus): one that the
-        // additive builder builds against and this function then walks, one
-        // that the real string pipeline (`golden_macros_with`) runs against
-        // directly. Because neither path is wired into the other, comparing
+        // Each fixture uses its own pair of *independent* parsers, the
+        // discipline already established by
+        // the image increment's own differential corpus: one that the
+        // tree builder builds against and this function then walks, one
+        // that produces the frozen golden recording (`golden_macros_with`).
+        // Because neither path is wired into the other, comparing
         // their two catalogs after the fact is the whole test.
         //
         // The separators are plain spaces, not `{sp}` attribute references:
@@ -6509,7 +6509,7 @@ mod tests {
                 r#"["https://c.example", "b.html", "mailto:a@example.org", "mailto:d@example.org"]"#,
             ),
             // A macro whose target crosses an escaped special registers the
-            // *escaped* target, exactly as the string replacer does.
+            // *escaped* target, matching Asciidoctor's own behavior.
             ("link:a&b.html[x]", r#"["a&amp;b.html"]"#),
             (
                 "mailto:a&b@example.org[]",
@@ -6594,13 +6594,14 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_for_links_inside_expanded_values() {
         // A link whose target or display text crosses a synthesized run (an
-        // attribute expansion) is now recognized: every value these nodes hold
+        // attribute expansion) is recognized: every value these nodes hold
         // is computed out of the level's match string, which carries an
         // expanded value's bytes exactly, so only the node's `location` takes
-        // design §4.4's coarse fallback — an attribute-list-bearing display
+        // the coarse whole-content-span fallback — an attribute-list-bearing
+        // display
         // text included, which `text_attrlist` parses from that same match
-        // string and owns off it. The one shape that still defers, a wholly
-        // expanded `link:`/`mailto:` macro, has its own divergence test
+        // string and owns off it. A wholly
+        // expanded `link:`/`mailto:` macro is recognized too, its own test
         // below.
         let parser = expanding_parser();
 
@@ -6637,9 +6638,9 @@ mod tests {
             "\\https://{host}",
             // A display text carrying an **attribute list** over a spliced
             // value, in all three spellings: the list is parsed from the
-            // level's match string — which carries the expansion's own bytes,
-            // exactly as the string replacer's already-expanded haystack does
-            // — and owned onto design §4.4's coarse span.
+            // level's match string — which carries the expansion's own
+            // bytes, already escaped
+            // — and owned onto the coarse whole-content-span fallback.
             "link:index.html[{label},role=hl]",
             "https://example.org[{label},role=hl]",
             "mailto:hello@example.org[{label},Hi there]",
@@ -6668,7 +6669,8 @@ mod tests {
     fn a_link_inside_an_expanded_value_keeps_a_coarse_location() {
         // The target and display text are recovered *exactly* from the match
         // string, while the node's `location` falls back to the enclosing
-        // synthesized run's own span — design §4.4's documented split.
+        // synthesized run's own span — the coarse whole-content-span
+        // fallback documented at this module's header.
         let parser = expanding_parser();
         let source = "link:{url}[{label}]";
         let nodes = build(Span::new(source), &parser, None);
@@ -6691,8 +6693,8 @@ mod tests {
         // is recognized now that the node records which spelling built it
         // ([`Ref::link_form`]) instead of having it re-derived from
         // `location` — the signal `apply_link_side_effects` reads to replay
-        // the string pipeline's family-pass registration order. Only the
-        // node's `location` takes design §4.4's coarse span. This closes the
+        // the crate's own family-pass registration order. Only the
+        // node's `location` takes the coarse whole-content-span fallback. This closes the
         // divergence `a_wholly_expanded_link_macro_is_a_documented_divergence`
         // used to pin, per its own "if this boundary is ever lifted" note.
         let parser = expanding_parser();

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -5429,8 +5429,8 @@ mod tests {
             "link:index.html[Docs] then doc@example.com",
             "https://example.org then doc@example.com",
             // An address inside a footnote's own text (extracted after the
-            // e-mail pass has already recognized it, exactly as the string
-            // pipeline substitutes it before the footnote text is pulled out).
+            // e-mail pass has already recognized it, before the footnote
+            // text is pulled out).
             "A claim.footnote:[write to doc@example.com]",
             // An address inside an anchor's reference text and beside an
             // anchor (both later passes).
@@ -5917,8 +5917,8 @@ mod tests {
             "``code``[width=10]#doc@example.org#",
             // A transparent span read *as* a sibling presents its own body,
             // where every other variant presents its markup: the space `x `
-            // ends with is what the string pipeline's flat haystack holds
-            // beside the address, and neither pipeline reads a mismatch
+            // ends with is what matching over the rendered markup would find
+            // beside the address, and no reading finds a mismatch
             // character there.
             "[width=10]##x ##doc@example.org",
             "*x [width=10]##y ##doc@example.org*",
@@ -5928,7 +5928,7 @@ mod tests {
             "[width=10]##x/##doc@example.org",
             "[width=10]##x:##doc@example.org",
             // And the same addresses at the content's own top level, where a
-            // level's start is exactly what the string pipeline presents.
+            // level's start satisfies the same requirement.
             "doc@example.org",
             "write to doc@example.org now",
         ] {
@@ -5943,7 +5943,8 @@ mod tests {
     #[test]
     fn an_address_at_a_tag_rendered_spans_edge_builds_no_node() {
         // The parity above, read structurally: the address is left as literal
-        // text rather than recognized into a link the string pipeline does not
+        // text rather than recognized into a link a markup-based reading
+        // would not
         // build.
         let nodes = build_src(Span::new("*doc@example.org*"));
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -5961,8 +5962,8 @@ mod tests {
         // a role nor an id renders to its body and nothing else, so its
         // children read what stands beside the *span* rather than the
         // enclosing `<strong>`'s own `>` — a space here, which is no mismatch
-        // character, so the address links exactly as the string pipeline links
-        // it.
+        // character, so the address links, matching Asciidoctor's own
+        // behavior.
         let nodes = build_src(Span::new("*x [width=10]#doc@example.org#*"));
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
 
@@ -5994,8 +5995,8 @@ mod tests {
         // placeholder — so
         // [`LevelContext::child_contexts`](super::super::quotes::LevelContext)
         // hands the transparent span that `>`, one of the bare e-mail
-        // pattern's three mismatch characters, and the address stays literal
-        // exactly as the string pipeline leaves it.
+        // pattern's three mismatch characters, and the address stays
+        // literal, matching Asciidoctor's own behavior.
         let source = "*x*[width=10]#doc@example.org#";
         let nodes = build_src(Span::new(source));
 
@@ -6040,8 +6041,8 @@ mod tests {
         // The half the identity protects here, exactly as it protects the
         // tag-rendered one. `[width=10]++x ++` renders its body and nothing
         // else too — but it is the passthrough-extraction pass's own wrapper,
-        // and the string pipeline is holding it as its `\u{96}…\u{97}`
-        // sentinel for every step this module runs, so the space inside it is
+        // masked behind its own placeholder for every step this module
+        // runs, so the space inside it is
         // not what the boundary-prefix group reads there and the URL stays
         // literal. Classifying a transparent span by its *body* alone would
         // have made this the increment's own new divergence.
@@ -6066,7 +6067,7 @@ mod tests {
     fn a_bare_url_swallowing_a_transparent_spans_body_is_a_documented_divergence() {
         // What the *opening* half cannot reach. A bare URL's body class
         // (`[^\s\[\]<]*`) consumes greedily rather than reading one
-        // character, so where the string pipeline's flat haystack lets it
+        // character, so where matching over the rendered markup would let it
         // swallow the whole body of the span beside it — building a target out
         // of both — a level holding that span as one opaque piece can only
         // reject the match: a URL crossing a span is not this level's to
@@ -6222,7 +6223,7 @@ mod tests {
     fn a_real_documents_span_edge_addresses_fold_to_their_rendered_strings() {
         // End-to-end, through the real parse path, on the shapes that named
         // this increment: an address written against a span's own edge must
-        // stay literal (as the string pipeline leaves it) and one written
+        // stay literal and one written
         // against a smart quote's must link, so a tree that decided either the
         // other way would regress the moment `rendered_html()` becomes a fold
         // of this tree.
@@ -6266,11 +6267,11 @@ mod tests {
 
     #[test]
     fn an_email_crossing_an_escaped_special_shows_structured_children() {
-        // The pattern's local-part class admits `&amp;`, so the string
-        // pipeline matches an address carrying a literal `&` over its own
+        // The pattern's local-part class admits `&amp;`, so an address
+        // carrying a literal `&` is matched over its own
         // *escaped* text. The match string carries the same entity there, so
-        // the target this pass computes off it is the very one the replacer
-        // computed (and registers), and the shown text — which for this form
+        // the target this pass computes off it is the correctly escaped
+        // one, and the shown text — which for this form
         // *is* the address — is recovered from the match's own range as
         // structured children, so the `&` stays the `CharRef` it already is
         // rather than being escaped a second time.
@@ -6299,7 +6300,7 @@ mod tests {
         );
     }
 
-    // ---- `apply_link_side_effects` (staged for the eventual cutover) ------
+    // ---- `apply_link_side_effects` -----------------------------------------
 
     use super::apply_link_side_effects;
 
@@ -6335,15 +6336,13 @@ mod tests {
 
     #[test]
     fn registers_the_restored_target_for_an_auto_link_over_a_passthrough() {
-        // The staged side effect registers the node's own target — the
+        // [`apply_link_side_effects`] registers the node's own target — the
         // *restored* bytes — exactly as it does for the two sibling families
-        // (`registers_the_restored_target_for_a_link_macro_over_a_passthrough`).
-        // The string pipeline registers the sentinel it matched
-        // (`"\u{96}0\u{97}"` verbatim, since its restore pass rewrites only
-        // the rendered string, never the catalog), which no consumer can read
-        // anything from; the cutover deliberately adopts the tree's honest
-        // answer rather than reproducing that wart, so this pins the policy
-        // with no golden-catalog comparison.
+        // (`registers_the_restored_target_for_a_link_macro_over_a_passthrough`),
+        // rather than an unrestored placeholder no consumer could read
+        // anything from. This pins that policy with no golden-catalog
+        // comparison, since the frozen recordings never captured a restored
+        // catalog entry to compare against.
         let source = "https://++example.org/a__b++ and <https://++x.example.org/y++>";
         let parser = Parser::default().with_catalog_assets(true);
         let nodes = build_with(Span::new(source), &parser);
@@ -6751,7 +6750,7 @@ mod tests {
     fn a_wholly_expanded_link_macro_keeps_a_coarse_location_and_its_form() {
         // The shape behind that parity: the node is a `Macro`-form link — the
         // signal the registration walk reads — with the whole attribute
-        // reference as its `location`, design §4.4's coarse fallback.
+        // reference as its `location`, the coarse whole-content-span fallback.
         let parser = expanding_parser();
         let nodes = build(Span::new("see {link-src} now"), &parser, None);
 
@@ -6814,7 +6813,8 @@ mod tests {
         // location`: a display text with no `'src` slice is parsed from the
         // level's match string, so every value on the resulting `Attrlist`
         // is **owned** off that temporary, and the list's own location tag
-        // falls back to the bracketed text's coarse span (design §4.4).
+        // falls back to the bracketed text's coarse span (the coarse
+        // whole-content-span fallback).
         let parser = expanding_parser();
         let source = "link:index.html[{label},role=hl]";
         let nodes = build(Span::new(source), &parser, None);
@@ -6832,13 +6832,13 @@ mod tests {
         assert_eq!(attrs.nth_attribute(1).unwrap().value(), "Docs");
 
         // The list's location tag is the bracketed text as *written*, not the
-        // expansion it stands for (design §4.4's coarse fallback).
+        // expansion it stands for (the coarse whole-content-span fallback).
         assert_eq!(attrs.span().data(), "{label},role=hl");
     }
 
     #[test]
     fn registers_the_recorded_links_inside_expanded_values() {
-        // The staged `register_link` side effect classifies each node by the
+        // The `register_link` side effect classifies each node by the
         // pass that built it, from the node's own `location` — which is exactly
         // why `link_macro_level` still requires its `link:`/`mailto:` marker to
         // be verbatim. These fixtures interleave the two URL-link passes' forms

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3680,11 +3680,11 @@ mod tests {
         // (`%C2%960%C2%97`), which `Passthroughs::restore_to` can then no
         // longer find in the finished attribute — the frozen golden
         // recording for this shape captures exactly that leaked,
-        // still-encoded token, and no restore here can reproduce it. Deferred with the
-        // whole match left literal, the same boundary the cross-reference
-        // family's own pre-restore target keeps, and drawn per *slot* so that
-        // the sibling fixtures above (a masked display text beside a plain
-        // subject) still restore.
+        // still-encoded token, and no restore here can reproduce it. Deferred
+        // with the whole match left literal, the same boundary the
+        // cross-reference family's own pre-restore target keeps, and
+        // drawn per *slot* so that the sibling fixtures above (a masked
+        // display text beside a plain subject) still restore.
         use super::super::super::test_support::golden_passthroughs;
 
         for source in [
@@ -3766,11 +3766,11 @@ mod tests {
     #[test]
     fn an_authors_own_sentinel_shaped_bytes_in_a_display_text_are_a_documented_divergence() {
         // The wart the image family's own bracket already pins, reached from
-        // this side: the string pipeline restores by `replace_all` over the
-        // *finished* string, so an author's own `\u{96}`n`\u{97}` bytes are
-        // rewritten too (both copies become the body), while this restore
-        // splices at the token it placed. Neither reading is reachable by
-        // ordinary authoring — these are C1 control characters.
+        // this side: restoring by `replace_all` over the
+        // *finished* string would rewrite an author's own `\u{96}`n`\u{97}`
+        // bytes too (both copies would become the body), while this restore
+        // splices only at the token it placed. Neither reading is reachable
+        // by ordinary authoring — these are C1 control characters.
         use super::super::super::test_support::golden_passthroughs;
 
         let source = "link:https://example.org[\u{96}0\u{97}++a++,role=hl]";
@@ -4003,7 +4003,7 @@ mod tests {
     fn a_link_macro_url_target_is_left_for_the_link_macro_pass() {
         // `link:https://…[…]` is the pattern's LINK-MACRO branch; the auto-link
         // pass leaves it, and `link_macro_level` builds the identical node, so
-        // the fold still matches the string pipeline byte-for-byte.
+        // the fold still matches the frozen golden recording byte-for-byte.
         let source = "link:https://example.org[Example]";
         let nodes = build_src(Span::new(source));
 
@@ -4020,8 +4020,8 @@ mod tests {
     #[test]
     fn an_auto_link_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
         // `INLINE_LINK`'s non-angle branch requires a boundary prefix
-        // (`( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )`), which inside a span the
-        // string pipeline reads out of that span's own rendered markup. Every
+        // (`( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )`), which inside a span would
+        // be read out of that span's own rendered markup. Every
         // shape a [`LevelContext`](super::super::quotes::LevelContext) can
         // present — the `>` ending a tag and the `;` ending a smart quote's
         // entity — is in that class, so the URL is recognized on both sides of
@@ -4066,9 +4066,10 @@ mod tests {
         // [`LevelContext::shift`](super::super::quotes::LevelContext)).
         // A boundary class reads exactly one character, but a bare URL's own
         // body class (`[^\s\[\]<]*`) consumes greedily: it excludes a `<`, so
-        // a tag-rendered span's closing markup stops it in both pipelines, and
-        // it admits an `&`, so at a smart quote's closing `&#8220;…&#8221;` the
-        // string pipeline swallows the whole entity into the target and leaves
+        // a tag-rendered span's closing markup would stop it there too, and
+        // it admits an `&`, so at a smart quote's closing `&#8220;…&#8221;`
+        // matching over the rendered markup would swallow the whole entity
+        // into the target and leave
         // a stray `;` behind. Supplying the level one `&` would build a third,
         // differently wrong target, so the closing character is dropped rather
         // than half-supplied and the tree keeps the well-formed reading — the
@@ -4082,7 +4083,8 @@ mod tests {
             "expected the documented divergence to still reproduce"
         );
 
-        // The string pipeline's own reading is the markup-perturbed one.
+        // The frozen golden recording's own reading is the markup-perturbed
+        // one.
         assert!(golden_macros(source).contains("https://example.org&#8221"));
         assert!(folded.contains(r#"href="https://example.org""#));
     }
@@ -4179,7 +4181,8 @@ mod tests {
 
     #[test]
     fn an_angle_bracketed_url_becomes_a_bare_ref_node_consuming_its_delimiters() {
-        // The string replacer emits *only* the rendered link for the whole
+        // Asciidoctor's own angle-link rendering emits *only* the rendered
+        // link for the whole
         // match, so the node consumes its `&lt;`/`&gt;` delimiters rather than
         // keeping them as literal text: one node, whose location covers the
         // brackets too.
@@ -4241,7 +4244,7 @@ mod tests {
     #[test]
     fn an_unterminated_angle_bracketed_url_is_left_literal() {
         // The ANGLE branch's third alternative — no closing `&gt;` and no
-        // `[…]` — is emitted unchanged by the string replacer, so the builder
+        // `[…]` — is left unchanged, so the builder
         // builds no node for it either (and, because the branch's own match
         // consumed the URL, no *non-angle* auto-link is found inside it).
         let nodes = build_src(Span::new("<https://example.org"));
@@ -4256,8 +4259,8 @@ mod tests {
     fn an_angle_bracketed_url_crossing_an_escaped_special_shows_structured_children() {
         // The delimiters of an angle link are escaped specials the node
         // consumes; so, now, may the URL *between* them be crossed by one. The
-        // target is read off the level's match string (the escaped bytes the
-        // string replacer computed), and the shown text — which for this
+        // target is read off the level's match string (the correctly
+        // escaped bytes), and the shown text — which for this
         // always-`bare` form *is* the target — is recovered from the interior's
         // own range as structured children, so the `&` stays the `CharRef` it
         // already is rather than being escaped a second time.
@@ -4295,8 +4298,9 @@ mod tests {
     fn an_angle_bracketed_url_over_a_rendered_span_is_a_documented_divergence() {
         // The interior gate admits an escaped special but still rejects an
         // *opaque* piece: a quoted span inside the delimiters is a `Styled`
-        // node by macro time, standing in as one placeholder where the string
-        // pipeline's haystack holds its markup, so the angle link is left
+        // node by macro time, standing in as one placeholder rather than the
+        // rendered markup that exists only at fold time, so the angle link
+        // is left
         // literal — the `<url>` form's own half of the boundary its `[…]`
         // sibling keeps below.
         let source = "<https://example.org/*bold*>";
@@ -4317,11 +4321,11 @@ mod tests {
         // bracketed display text crosses an **opaque** piece — a rendered span,
         // an already-recognized macro node of another family, a masked
         // passthrough. The text is carried structurally (each opaque piece's
-        // own node becomes a child), so the fold re-renders exactly the markup
-        // the string replacer captured in its own text.
+        // own node becomes a child), so the fold reproduces that markup
+        // exactly.
         let fixtures = [
-            // (A masked passthrough is opaque here too — and in the string
-            // pipeline, which restores passthroughs only after every step — but
+            // (A masked passthrough is opaque here too — since it restores
+            // only after every substitution step has run — but
             // this oracle runs the steps directly, without the extraction the
             // real `SubstitutionGroup::apply` performs around them, so those
             // fixtures live in the whole-pipeline sweep instead; see
@@ -4334,8 +4338,9 @@ mod tests {
             "https://example.org[a *b* c]",
             "https://example.org[*bold*]",
             // Every quoted form the earlier step can have produced, including
-            // an attributed span (whose markup carries an `=` the string
-            // replacer's own attribute-list probe reads, and this one does not:
+            // an attributed span (whose markup carries an `=` an
+            // attribute-list probe reading the rendered markup would read,
+            // and this one does not:
             // with no comma to split on, the parse yields one positional value
             // equal to the whole text, so both take the plain-text path).
             "https://example.org[_em_ and `code` and #mark#]",
@@ -4417,8 +4422,7 @@ mod tests {
         // the span is one opaque placeholder in the match string, but
         // `macro_text_children` recovers the text with `emit_range`, which
         // clones the span's own node whole into the link's children. The fold
-        // then re-renders exactly the markup the string replacer captured in
-        // its own display text.
+        // then reproduces that markup exactly.
         let source = "https://example.org[a *bold* b]";
         let nodes = build_src(Span::new(source));
 
@@ -4476,22 +4480,26 @@ mod tests {
     #[test]
     fn a_span_whose_markup_perturbs_the_inline_link_pattern_is_a_documented_divergence() {
         // What the structural recovery cannot do is make the *recognition*
-        // agree in every case: the string replacer matches over the span's
-        // markup where this matches over the one placeholder standing in for
-        // it, so the two read the same extent only while that markup carries
-        // no character the pattern (or the replacer's own attribute-list
-        // probe) is sensitive to. These are the two shapes where it does — and
-        // in each the string pipeline's reading is the markup-perturbed one (a
+        // agree with matching over the span's
+        // rendered markup in every case: this matches over the one
+        // placeholder standing in for
+        // it, so the two extents coincide only while that markup carries
+        // no character the pattern (or an attribute-list probe reading it)
+        // is sensitive to. These are the two shapes where it does — and
+        // in each matching the rendered markup gives the perturbed reading
+        // (a
         // truncated text, a text the attribute-list parse cut in half) and the
-        // tree's the well-formed one, exactly as the quotes step's own
+        // tree's is the well-formed one, exactly as the quotes step's own
         // crossed-delimiter divergence is.
         for source in [
-            // A `]` inside the span ends `INLINE_LINK`'s own lazy text capture
-            // early for the string replacer, but not here.
+            // A `]` inside the span would end `INLINE_LINK`'s own lazy text
+            // capture early if matched over the rendered markup, but not
+            // here.
             "https://example.org[a *b ] c* d]",
             // Markup carrying an `=` (an attributed span) *and* a comma
-            // elsewhere in the text: the string replacer's attribute-list probe
-            // fires on the markup's own `=`, and the parse then splits the text
+            // elsewhere in the text: an attribute-list probe reading the
+            // rendered markup fires on its own `=`, and the parse then
+            // splits the text
             // at that comma, keeping only what precedes it.
             "https://example.org[one, [.hl]#two#]",
         ] {
@@ -4514,11 +4522,11 @@ mod tests {
 
     #[test]
     fn a_bare_auto_link_crossing_an_escaped_special_shows_structured_children() {
-        // A URL whose body contains `&` is matched by the string pipeline over
+        // A URL whose body contains `&` is matched over
         // the *escaped* text (`…?a=1&amp;b=2`) — and the level's match string
-        // carries exactly those bytes for the `CharRef::Special` the
-        // `SpecialCharacters` step made, so the target this pass computes is
-        // the one the replacer computed. A bare link's shown text *is* that
+        // carries exactly those bytes for the `CharRef::Special`
+        // `apply_special_characters` made, so the target this pass computes is
+        // the correctly escaped one. A bare link's shown text *is* that
         // target, so it is recovered from the URL's own range as structured
         // children (each special keeping its precise `'src` span, #944) rather
         // than baked, already escaped, into one `Text` the fold would escape
@@ -4636,9 +4644,9 @@ mod tests {
         // The trailing-punctuation strip keys off the target's *final
         // character*, over the escaped text — so a bare URL ending in a
         // literal `&` (whose match-string tail is `&amp;`) satisfies it on
-        // that entity's own `;`. The string replacer splits the entity there
-        // (target `…/a&amp`, a literal `;` after the link), and the tree now
-        // reproduces that split rather than deferring to it: the boundary
+        // that entity's own `;`. Splitting the entity there
+        // (target `…/a&amp`, a literal `;` after the link) is what the tree
+        // reproduces rather than deferring to it: the boundary
         // falls inside a `CharRef` leaf, which
         // [`emit_range`](super::super::quotes::emit_range) cuts into two
         // [`Raw`](InlineNode::Raw) halves — each folding to its own bytes, so
@@ -4687,9 +4695,9 @@ mod tests {
     #[test]
     fn a_bare_urls_trailing_strip_cuts_a_special_into_two_raw_halves() {
         // The parity above, read structurally: the target keeps the entity's
-        // leading bytes as the string replacer's own `href` does, the shown
+        // leading bytes, the shown
         // text carries them as a `Raw` leaf (a `Text` would have the fold
-        // escape the `&` a second time — design §3.4), and the `;` the strip
+        // escape the `&` a second time), and the `;` the strip
         // left behind is the leaf's own remaining byte, emitted beside the
         // link rather than duplicating the whole entity there.
         let nodes = build_src(Span::new("https://example.org/a&"));
@@ -4701,7 +4709,7 @@ mod tests {
 
         // Neither half has an honest `'src` slice of its own — the source
         // holds one `&` where the match string holds five bytes — so both keep
-        // the leaf's whole location (design §4.4's coarse fallback).
+        // the leaf's whole location (the coarse whole-content-span fallback).
         let head = assert_raw(&reference.children[1], "&amp");
         assert_eq!(head.data(), "&");
 
@@ -4715,8 +4723,8 @@ mod tests {
         // A *restored entity* (`&amp;copy;` written in the source, which the
         // character-replacements step turns back into a `CharRef::Entity`
         // whose value is `&copy;`) is admitted for the same reason an escaped
-        // special is: its match-string bytes are the string pipeline's own
-        // haystack bytes there, and the fold emits them verbatim. It is
+        // special is: its match-string bytes are the correctly escaped bytes
+        // there, and the fold emits them verbatim. It is
         // recovered as its own `CharRef` child rather than baked into a `Text`
         // the fold would escape a second time.
         let fixtures = [
@@ -5030,8 +5038,9 @@ mod tests {
             "link:index.html[a *b* c]",
             "link:index.html[*bold*]",
             // Every quoted form the earlier step can have produced, including
-            // an attributed span (whose markup carries an `=` the string
-            // replacer's own attribute-list probe reads, and this one does not:
+            // an attributed span (whose markup carries an `=` an
+            // attribute-list probe reading the rendered markup would read,
+            // and this one does not:
             // with no comma to split on, the parse yields one positional value
             // equal to the whole text, so both take the plain-text path).
             "link:index.html[_em_ and `code` and #mark#]",
@@ -5088,8 +5097,7 @@ mod tests {
         // the span is one opaque placeholder in the match string, but
         // `macro_text_children` recovers the text with `emit_range`, which
         // clones the span's own node whole into the link's children. The fold
-        // then re-renders exactly the markup the string replacer captured in
-        // its own display text.
+        // then reproduces that markup exactly.
         let source = "link:index.html[a *bold* b]";
         let nodes = build_src(Span::new(source));
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -102,8 +102,8 @@ use crate::{
 /// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, or an
 /// already-recognized macro node of another family — is *not* recoverable:
 /// [`build_match_string`] stands it in as one
-/// [`SPAN_PLACEHOLDER`] where the string pipeline's haystack holds its markup
-/// inline, and that markup exists only at fold time. It is nonetheless admitted
+/// [`SPAN_PLACEHOLDER`], since that markup exists only at fold time. It is
+/// nonetheless admitted
 /// **inside the bracketed display text** of a formal URL link
 /// (`https://example.org[a *b* c]`, and the angle spelling
 /// `<https://example.org[a *b* c]` that keeps its `&lt;`), because that text is
@@ -153,49 +153,43 @@ use crate::{
 /// third and last family to take [`range_is_restorable`]. (This family's
 /// target reaches the `href` as computed; the `image:`/`icon:` family's is
 /// re-processed by `web_path` at fold time, over its restored ranges masked —
-/// see [`Image::restored_target_ranges`](crate::inlines::Image).) the string
-/// replacer swallows the `\u{96}`*n*`\u{97}` sentinel into its own target (both
-/// target classes admit it exactly as they admit the tree's placeholder, and
-/// the bare branch's trailing-character class admits the last byte of either
-/// spelling, so the two recognize the same extent — this family needs no
-/// widening of its own, unlike the `image:`/`icon:` one), and
-/// `Passthroughs::restore_to`
-/// then splices the extracted body's substituted text over every sentinel in
-/// the rendered string. A `Raw` node's `value` **is** that text, known at build
+/// see [`Image::restored_target_ranges`](crate::inlines::Image).) Both target
+/// classes admit the tree's own placeholder exactly as they would admit its
+/// restored bytes, and the bare branch's trailing-character class admits the
+/// last byte of either spelling, so this family needs no widening of its own
+/// to recognize the same extent, unlike the `image:`/`icon:` one. A `Raw`
+/// node's `value` **is** the passthrough's already-substituted text, known at
+/// build
 /// time, so [`restore_masked_passthroughs`] substitutes it for the placeholder
 /// and the computed target finishes into exactly the restored string's bytes —
 /// `https://++example.org/now_this__link_works.html++` and
 /// `https://example.orgpass:[/a b]`, the two documented idioms, and every
 /// partial mask around them.
 ///
-/// Every *decision* stays on the bytes as matched, where the string
-/// replacer's own haystack answers identically: neither a placeholder nor a
-/// sentinel is the `"`/`'` an invalid quoted URL is rejected on, and neither
+/// Every *decision* stays on the bytes as matched: neither the placeholder
+/// nor a passthrough's restored bytes is the `"`/`'` an invalid quoted URL is
+/// rejected on, and neither
 /// is the `;` or `:` the trailing-punctuation strip keys off — so a `;`
-/// *inside* a passthrough stays in the target in both pipelines while a
-/// literal one after it is stripped in both. The `hide-uri-scheme` strip needs
+/// *inside* a passthrough stays in the target while a
+/// literal one after it is stripped. The `hide-uri-scheme` strip needs
 /// no such care here (see [`build_inline_link_node`]). A **bare** link's shown
 /// text, a slice of the target's own range, carries the `Raw` node itself
 /// through [`macro_text_children`], folding to the same restored bytes without
 /// re-escaping.
 ///
-/// Two readings are deliberately **not** faithful, each pinned by its own
-/// test. A `"` restored into the target is escaped by the fold's
-/// `encode_attribute_value` where the string pipeline encoded its
-/// quote-free sentinel and spliced the raw `"` into the finished `href` — the
-/// well-formed reading, and the one the two sibling families' restores
-/// already take. And the staged [`apply_link_side_effects`] registers the
-/// node's honest restored target where the string pipeline registers the
-/// sentinel bytes verbatim (its restore rewrites only the rendered string,
-/// never the catalog) — the same wart the cutover declines to reproduce
-/// there.
+/// Two readings are deliberately **not** literal restores, each pinned by its
+/// own test. A `"` restored into the target is escaped by the fold's
+/// `encode_attribute_value` — the well-formed reading, and the one the two
+/// sibling families' restores already take — rather than spliced raw into the
+/// finished `href`. And [`apply_link_side_effects`] registers the node's
+/// honest restored target in the catalog, rather than leaving unrestored
+/// placeholder bytes there.
 ///
 /// An invalid quoted bare URL (`"https://example.org`) and a bare scheme with no
-/// body (`http://;`) are left literal by the string step *and* the builder, so
-/// they render identically and are covered by the differential corpus rather
-/// than a divergence test. So is an ANGLE-branch URL with **no** closing `&gt;`
-/// and no `[…]` (`<https://example.org`), which the string replacer's own angle
-/// path emits unchanged.
+/// body (`http://;`) are left literal, so
+/// they render identically to source and are covered by the differential corpus
+/// rather than a divergence test. So is an ANGLE-branch URL with **no** closing
+/// `&gt;` and no `[…]` (`<https://example.org`), which is emitted unchanged.
 pub(super) fn inline_link_level<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -320,14 +314,13 @@ fn find_inline_link_matches<'src>(
 /// place where the strip's own arithmetic would cut *inside* an escaped
 /// special.
 ///
-/// Like every macro family in this additive builder, it deliberately performs
+/// Like every macro family here, it deliberately performs
 /// *no* recognition side effect: it does **not** `register_link` the target in
-/// the document's asset catalog, because the builder is not yet the
-/// authoritative recognition sink — the string pipeline still registers it, and
-/// registering it here too would double-count it. The cutover (design §5.2
-/// Phase 4, step 6) re-attaches this registration, so
-/// `Document::catalog().links()` stays populated by the string pipeline until
-/// then. (The same applies to the `link:`/`mailto:` macro node built by
+/// the document's asset catalog itself. That registration happens once per
+/// parse, after the tree is built and folded, via [`apply_link_side_effects`]
+/// — which keeps recognition and registration separate so each family's
+/// tests can build and inspect a tree without a full `Parser`/`Content`
+/// round trip. (The same applies to the `link:`/`mailto:` macro node built by
 /// [`build_link_node`].)
 ///
 /// [`InlineLinkReplacer`]: crate::content::macros
@@ -345,9 +338,9 @@ fn build_inline_link_node<'src>(
     let scheme_m = n.scheme_match()?;
     let scheme = scheme_m.as_str();
 
-    // The `<url>` form is a separate computation in the string replacer, taken
-    // on exactly this condition — and, as there, taken before anything else,
-    // including this branch's own escape check and gate.
+    // The `<url>` form is handled separately, on exactly this condition —
+    // checked before anything else, including this branch's own escape check
+    // and gate.
     if n.is_angle() && n.attrlist().is_none() {
         return build_angle_link_node(n, &scheme_m, full, nodes, pieces, root, parser);
     }
@@ -391,10 +384,10 @@ fn build_inline_link_node<'src>(
     //
     // An expanded attribute value and an escaped special are admitted
     // throughout, since every value read here comes off the match string —
-    // whose bytes are, for both, exactly the ones the string replacer's own
-    // haystack carries there. So is a **masked** construct — a passthrough or
-    // a STEM expression — whose bytes the string replacer's own haystack does
-    // *not* carry: the target finishes
+    // whose bytes are, for both, exactly the ones the match string carries
+    // there. So is a **masked** construct — a passthrough or
+    // a STEM expression — whose bytes the match string does
+    // *not* carry directly: the target finishes
     // into the restored ones below (see [`range_is_restorable`] and
     // [`restore_masked_passthroughs`]), while every decision made here —
     // the quoted-prefix rejection, the trailing-punctuation strip, the
@@ -452,8 +445,8 @@ fn build_inline_link_node<'src>(
         }
 
         // Strip a trailing ';' or ':' (and an adjacent ')') off a bare URL,
-        // keeping it as literal text after the link — mirroring the string
-        // replacer, which keys off the target's final character.
+        // keeping it as literal text after the link — keying off the target's
+        // final character, matching Asciidoctor's own behavior.
         let mut stripped = 0usize;
 
         if target.ends_with([';', ':']) {
@@ -501,10 +494,10 @@ fn build_inline_link_node<'src>(
     // bytes — the node's own rendered body ([`restorable_body`]) substituted
     // for its placeholder, the same rewrite `Passthroughs::restore_to`
     // performs on the emitted `href` — and only the node's values take them.
-    // Every *decision* the string replacer makes over the bytes as matched
+    // Every *decision* over the bytes as matched
     // is already behind us (the quoted-prefix rejection and the
-    // trailing-punctuation strip above), each reading a placeholder exactly
-    // as the sentinel-holding haystack reads its own sentinel: neither
+    // trailing-punctuation strip above), each reading the placeholder exactly
+    // as it would read the passthrough's own restored bytes: neither
     // spelling is a quote, and neither ends in the `;` or `:` the strip
     // keys off.
     //
@@ -612,13 +605,13 @@ fn build_inline_link_node<'src>(
         // URL range rather than a value this builder computes, and takes the
         // same structured recovery a bare `link:`/`mailto:` macro's does (see
         // [`build_link_node`]): baking the already-escaped target into one
-        // `Text` would have the fold escape it a second time (design §3.4).
+        // `Text` would have the fold escape it a second time.
         // There is no `\]` unescape here — this text comes from the URL groups,
         // whose own character classes never admit a bracket. A URL crossing a
         // **masked** construct takes that same structured path, carrying the
         // [`Raw`](InlineNode::Raw) or [`Stem`](InlineNode::Stem) node itself —
-        // which folds to the very bytes the restore splices into the string
-        // pipeline's own shown text.
+        // which folds to the very bytes the restore splices into the
+        // shown text.
         //
         // The scheme-hiding offset indexes the match string even when
         // `target` is the restored value, because [`URI_SNIFF`] is
@@ -645,11 +638,12 @@ fn build_inline_link_node<'src>(
         if escaped_computed_text {
             // Parsed out of the level's match string, so it holds an escaped
             // special's canonical entity (and a restored entity's own bytes)
-            // where a node holds logical text: rebuild design §3.4's
-            // trichotomy from those bytes, exactly as the cross-reference
-            // family's own attribute-list value is rebuilt — and each masked
-            // construct the value still holds a token for as the node itself,
-            // whose fold emits the bytes `restore_to` splices there.
+            // where a node holds logical text: rebuild the escaped/entity/
+            // replacement trichotomy from those bytes, exactly as the
+            // cross-reference family's own attribute-list value is
+            // rebuilt — and each masked construct the value still
+            // holds a token for as the node itself, whose fold
+            // emits the bytes `restore_to` splices there.
             restored_value_children(&link_text, &restores, text_location, specials)
         } else {
             // Parsed out of the source's own bytes, which are already logical
@@ -661,7 +655,7 @@ fn build_inline_link_node<'src>(
         }
     } else {
         // A text sliced straight out of the bracket. `macro_text_children`
-        // borrows it from `'src` in the common verbatim case (§4.5), owns it
+        // borrows it from `'src` in the common verbatim case, owns it
         // when it crosses an expanded attribute value, and rebuilds it as
         // structured children — each escaped special staying the `CharRef` it
         // already is, each **opaque** piece staying its own node — when it
@@ -743,10 +737,10 @@ fn build_inline_link_node<'src>(
 /// general path — admits an opaque piece inside its text. The two escape checks
 /// above run ahead of the gate, for the same reason the general path's does.
 ///
-/// Like the rest of this additive builder it performs no `register_link` side
-/// effect; [`apply_link_side_effects`] stages that for the cutover, and needs
-/// no angle-specific case — an angle node is `InlineLinkReplacer`'s own pass,
-/// so it records the same [`AutoOrFormal`](LinkForm::AutoOrFormal)
+/// Like the rest of this builder it performs no `register_link` side
+/// effect itself; [`apply_link_side_effects`] handles that afterward and needs
+/// no angle-specific case, since an angle node records the same
+/// [`AutoOrFormal`](LinkForm::AutoOrFormal)
 /// [`link_form`](crate::inlines::Ref::link_form) its non-angle sibling does.
 ///
 /// [`InlineLinkReplacer`]: crate::content::macros
@@ -798,8 +792,8 @@ fn build_angle_link_node<'src>(
     );
 
     // As in the general path: a **masked** construct in the interior
-    // finishes into the restored bytes, which are what the string pipeline's
-    // own `href` and shown text carry once `Passthroughs::restore_to` runs.
+    // finishes into the restored bytes, which are what the emitted
+    // `href` and shown text carry once `Passthroughs::restore_to` runs.
     // This form makes no decision off the bytes as matched at all — it has
     // neither a quoted-prefix rejection nor a trailing-punctuation strip —
     // and the interior *is* the target's own range, so the restore covers it
@@ -894,22 +888,23 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// macro's own `link:`/`mailto:` **marker** included: the target and display
 /// text are read out of the level's match string, which carries an expanded
 /// value's bytes exactly, and only the node's `location` falls back to the
-/// expansion's coarse span (design §4.4). A *wholly* expanded macro
-/// (`:m: link:index.html[Docs]`, then `{m}`) used to defer for that location
-/// alone — it was the signal that told this pass's nodes from the other two
-/// link passes' when [`apply_link_side_effects`] replays the string
-/// pipeline's family-pass registration order — and no longer does: the node
-/// records the spelling itself, on
-/// [`Ref::link_form`](crate::inlines::Ref::link_form).
+/// expansion's coarse span. The node records which of the three link
+/// spellings built it directly, on
+/// [`Ref::link_form`](crate::inlines::Ref::link_form) — the fact
+/// [`apply_link_side_effects`] reads to tell this pass's nodes from the other
+/// two link passes' when it replays the crate's own family-pass registration
+/// order — so a *wholly* expanded macro (`:m: link:index.html[Docs]`, then
+/// `{m}`) is recognized too, with no need to re-derive the spelling from
+/// `location`.
 ///
 /// An **escaped special** ([`CharRef`](InlineNode::CharRef)`::Special`) is
 /// admitted too, in an attribute-list text as much as anywhere else
 /// (`link:a&b.html[]`,
 /// `link:index.html[a < b]`, `link:index.html[a < b,role=hl]`). The match
 /// string carries such a leaf's canonical
-/// entity — the very bytes the string replacer's own escaped haystack holds
+/// entity — the same escaped bytes `apply_special_characters` always produces
 /// there — so the target this pass computes off that string (`a&amp;b.html`)
-/// *is* the one the replacer computed, and no value on the node needs the
+/// is the correctly escaped one, and no value on the node needs the
 /// source's own `<`/`>`/`&`. The display text then becomes **structured
 /// children** rather than one baked `Text` (see [`macro_text_children`]), so
 /// the special folds back to its own entity instead of being escaped twice —
@@ -921,15 +916,15 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, or an
 /// already-recognized macro node of another family — is *not* recoverable:
 /// [`build_match_string`] stands it in as one
-/// [`SPAN_PLACEHOLDER`] where the string pipeline's haystack holds its markup
-/// inline, and that markup exists only at fold time. It is nonetheless admitted
+/// [`SPAN_PLACEHOLDER`], since that markup exists only at fold time. It is
+/// nonetheless admitted
 /// **inside the bracketed display text**, because that text is the one capture
 /// this family never reads as bytes: it becomes the node's children through
 /// [`macro_text_children`], whose
 /// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
 /// piece's own node whole into them — so the text is carried *structurally*,
-/// and the fold re-renders exactly the markup the string replacer captured
-/// there. The **target** stays gated, since it is a value this pass computes
+/// and the fold re-renders that markup exactly. The **target** stays gated,
+/// since it is a value this pass computes
 /// off the match string. An **attribute-list text** takes a different route
 /// again: its display text comes back from an [`Attrlist`] parse rather than
 /// from a range, so [`text_attrlist`] gives every opaque piece there an
@@ -939,24 +934,24 @@ fn hide_uri_scheme_text(target: &str, parser: &Parser) -> String {
 /// renderer writes out. This is the second family to take that lift, after the
 /// cross-reference one (see `xref::find_xref_matches`).
 ///
-/// What the admission cannot do is make the *recognition* agree in every case,
-/// because the string replacer matches over the markup itself where this
-/// matches over one placeholder standing in for it — and this pass cannot know
-/// what that markup carries without folding, which building a tree must never
-/// do. The two read the same extent unless the markup carries a character the
-/// pattern (or the replacer's own probe) is sensitive to, which leaves three
-/// documented divergences of *extent*, each pinned by its own test and each one
-/// where the string pipeline's reading is the markup-perturbed one and the
-/// tree's the well-formed one — exactly as the quotes step's own
-/// crossed-delimiter divergence is:
+/// What the admission cannot do is make the *recognition* agree with matching
+/// over the fully rendered markup in every case, because this pass cannot know
+/// what a span's markup carries without folding it first, which building a
+/// tree must never do — so it matches over one placeholder standing in for
+/// the span instead. The two extents coincide unless the markup carries a
+/// character the pattern (or an attribute-list probe reading the rendered
+/// text) is sensitive to, which leaves three documented divergences of
+/// *extent*, each pinned by its own test and each one where matching the
+/// rendered markup gives the perturbed reading and the tree's is the
+/// well-formed one — exactly as the quotes step's own crossed-delimiter
+/// divergence is:
 ///
-/// - a `]` inside the span (`link:x[a *b ] c* d]`), which ends
-///   [`INLINE_LINK_MACRO`]'s own lazy text capture early for the string
-///   replacer but not here;
+/// - a `]` inside the span (`link:x[a *b ] c* d]`), which would end
+///   [`INLINE_LINK_MACRO`]'s own lazy text capture early if matched over the
+///   rendered markup, but not here;
 /// - markup carrying an `=` beside a comma elsewhere in a `link:` text
-///   (`link:x[one, [.hl]#two#]`): the replacer's attribute-list probe fires on
-///   the markup's own `=`, and the parse then keeps only what precedes that
-///   comma;
+///   (`link:x[one, [.hl]#two#]`): an attribute-list probe reading the rendered
+///   markup fires on its own `=`, keeping only what precedes that comma;
 /// - a comma inside the span of a `mailto:` text (`mailto:a@x.org[a *b, c*
 ///   d]`), which is that spelling's own attribute-list probe, read the same
 ///   way.
@@ -1064,7 +1059,7 @@ fn find_link_macro_matches<'src>(
         // one value this family computes off the match string is its **target**
         // (group 3; group 2 is the empty-target alternative, which has no bytes
         // to gate), so only that range needs a match string whose bytes the
-        // builder can finish into the string replacer's own — which for this
+        // builder can finish honestly — which for this
         // family includes a **masked** construct (a passthrough or a STEM
         // expression), restored into the computed
         // target exactly as `Passthroughs::restore_to` rewrites the emitted
@@ -1081,7 +1076,7 @@ fn find_link_macro_matches<'src>(
         // ([`Ref::link_form`](crate::inlines::Ref::link_form)) rather than
         // having it re-derived from `location` — so a *wholly* expanded macro
         // (`:m: link:index.html[Docs]`, then `{m}`) is recognized, with only
-        // its `location` taking design §4.4's coarse span. A text carrying an
+        // its `location` taking the coarse whole-content-span fallback. A text carrying an
         // attribute list is handled inside `text_attrlist`, since its display
         // text comes back from a *parse*: every opaque piece is tokened
         // through that parse and restored after it.
@@ -1119,11 +1114,7 @@ fn find_link_macro_matches<'src>(
 /// already has).
 ///
 /// This is `Passthroughs::restore_to`'s own
-/// rewrite, applied to a *computed value* instead of the rendered string: the
-/// string pipeline's replacer reads the `\u{96}`*n*`\u{97}` sentinel into the
-/// value (a `link:` macro's target, and with it the emitted `href` and a bare
-/// macro's shown text), and the restore pass then splices the extracted
-/// body's text over every sentinel in the rendered string.
+/// rewrite, applied to a *computed value* instead of the rendered string.
 /// [`restorable_body`] is the build-time counterpart of that splice, for both
 /// kinds the one extraction pass masks: a
 /// [`Raw`](InlineNode::Raw) node's `value` **is** the substituted text
@@ -1132,8 +1123,7 @@ fn find_link_macro_matches<'src>(
 /// `render_styled` call `PassthroughRestoreReplacer` makes for a
 /// STEM entry — so substituting either for the placeholder here finishes the
 /// value into exactly the restored string's bytes. Every other byte is kept
-/// as matched, which is what restore does too — it rewrites the sentinels and
-/// nothing else.
+/// as matched — only the masked placeholders change, nothing else.
 pub(super) fn restore_masked_passthroughs(
     masked: &str,
     range: &std::ops::Range<usize>,
@@ -1199,8 +1189,8 @@ pub(super) fn restore_masked_passthroughs(
 
 /// Builds one [`Ref`](InlineNode::Ref) link node from a recognized
 /// `link:`/`mailto:` match, computing the target, display text, window, and
-/// roles exactly as the string replacer does so the fold reproduces the same
-/// bytes. Returns `None` for a form this increment defers (see
+/// roles so the fold reproduces the bytes Asciidoctor's own rendering does.
+/// Returns `None` for a form this increment defers (see
 /// [`link_macro_level`]): a rejected dangerous `link:` scheme, a link text
 /// that carries an attribute list *and* crosses an opaque piece, or a
 /// `mailto:` whose subject or body carries a masked construct (see
@@ -1209,7 +1199,7 @@ pub(super) fn restore_masked_passthroughs(
 /// The display text becomes the node's children, so the fold recovers
 /// `link_text` by folding them and needs no build-time state
 /// (bare-vs-labeled, `hide-uri-scheme`, `mailto:`) at fold time; the `bare`
-/// role, when the string step would add one, rides on the node's `roles`.
+/// role, when one applies, rides on the node's `roles`.
 /// Which shape those children take follows what the text *is*:
 ///
 /// - a **bracketed text** is sliced out of the bracket by
@@ -1221,23 +1211,23 @@ pub(super) fn restore_masked_passthroughs(
 ///   the whole target group, or (under `hide-uri-scheme`) its scheme-stripped
 ///   tail, always a *suffix* since [`URI_SNIFF`] is `^`-anchored — so it takes
 ///   the same treatment rather than baking the already-escaped target into one
-///   `Text` the fold would escape a second time (design §3.4);
+///   `Text` the fold would escape a second time;
 /// - an **attribute list's positional value** is the one text this builder
 ///   *computes*, out of an [`Attrlist`] parse (see [`text_attrlist`]). A parse
 ///   of the bracket's own verbatim `'src` slice yields logical text, so it
 ///   stays a single synthesized `Text` (that slice carries no entity to undo);
-///   a parse of the level's **match string** yields the bytes the string
-///   replacer parsed instead, so it is rebuilt through
-///   [`computed_value_children`] — design §3.4's trichotomy under an order that
-///   has already escaped, and §3.4.1's literal reading under one that has not —
+///   a parse of the level's **match string** yields already-escaped bytes
+///   instead, so it is rebuilt through
+///   [`computed_value_children`] — the escaped/entity/replacement trichotomy under an order that
+///   has already escaped, and the literal reading under one that has not —
 ///   exactly as the cross-reference family's own attribute-list value is, with
 ///   each **masked** construct that value still holds a token for spliced back
 ///   in as its own node ([`restored_value_children`]).
 ///
-/// As in the additive builder generally, this performs *no* recognition side
+/// This performs *no* recognition side
 /// effect — notably it does **not** `register_link` the target in the asset
-/// catalog, which the string replacer does; the cutover (design §5.2 Phase 4,
-/// step 6) re-attaches that (see [`build_inline_link_node`]).
+/// catalog itself; [`apply_link_side_effects`] does that separately, once per
+/// parse, after the tree is built and folded (see [`build_inline_link_node`]).
 pub(super) fn build_link_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
@@ -1258,10 +1248,10 @@ pub(super) fn build_link_node<'src>(
     // expression — finishes into the restored bytes: the node's own rendered
     // body substituted for its placeholder, the same rewrite
     // `Passthroughs::restore_to` performs on the emitted `href`, and only the
-    // node's computed values take them. Every *decision* the string replacer
-    // makes over the bytes as matched (the `URI_SNIFF` strip below) stays on
-    // `target_str`, whose placeholder the sentinel-holding haystack answers
-    // the same way.
+    // node's computed values take them. Every *decision* over the bytes as
+    // matched (the `URI_SNIFF` strip below) stays on
+    // `target_str`, reading the placeholder the same way it would read the
+    // passthrough's own restored bytes.
     let restored = caps.get(3).and_then(|m| {
         restore_masked_passthroughs(
             m.as_str(),
@@ -1491,11 +1481,12 @@ pub(super) fn build_link_node<'src>(
         if escaped_computed_text {
             // Parsed out of the level's match string, so it holds an escaped
             // special's canonical entity (and a restored entity's own bytes)
-            // where a node holds logical text: rebuild design §3.4's
-            // trichotomy from those bytes, exactly as the cross-reference
-            // family's own attribute-list value is rebuilt — and each masked
-            // construct the value still holds a token for as the node itself,
-            // whose fold emits the bytes `restore_to` splices there.
+            // where a node holds logical text: rebuild the escaped/entity/
+            // replacement trichotomy from those bytes, exactly as the
+            // cross-reference family's own attribute-list value is
+            // rebuilt — and each masked construct the value still
+            // holds a token for as the node itself, whose fold
+            // emits the bytes `restore_to` splices there.
             restored_value_children(&link_text, &restores, text_location, specials)
         } else {
             // Parsed out of the source's own bytes, which are already logical
@@ -1507,7 +1498,7 @@ pub(super) fn build_link_node<'src>(
         }
     } else {
         // A text sliced straight out of the bracket. `macro_text_children`
-        // borrows it from `'src` in the common verbatim case (§4.5), owns it
+        // borrows it from `'src` in the common verbatim case, owns it
         // when it crosses an expanded attribute value, and rebuilds it as
         // structured children — each escaped special staying the `CharRef` it
         // already is, each **opaque** piece staying its own node — when it

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -4784,8 +4784,9 @@ mod tests {
         // character-replacements step turns into `CharRef::Replacement`
         // leaves) is admitted for the same reason the two other `CharRef`
         // leaves are: its match-string bytes — the entity the built-in backend
-        // renders it as (`&#169;`, `&#8217;`) — are the string pipeline's own
-        // haystack bytes there, and the fold routes the leaf back through the
+        // renders it as (`&#169;`, `&#8217;`) — are the same bytes the match
+        // string always carries there, and the fold routes the leaf back
+        // through the
         // renderer to those same bytes. A display text carrying one keeps it
         // as its own child rather than baking the entity into a `Text` the
         // fold would escape.
@@ -4801,8 +4802,8 @@ mod tests {
             "link:a(C)b.html[Text]",
             "https://example.org/?a=(C)b",
             // A bare e-mail address abutting one — the `;` a replacement's
-            // entity ends in is no mismatch character, so the string pipeline
-            // links the address that follows it, and now so does the tree.
+            // entity ends in is no mismatch character, so the address that
+            // follows it is linked.
             "a(C)b@example.com",
             // A target crossing a replacement, an escaped special, and a
             // restored entity at once.
@@ -4904,7 +4905,8 @@ mod tests {
         // `CharRef::Entity` leaf — which the fold emits verbatim — where one
         // `Text` holding the whole value would escape its `&` a second time.
         // Every part of the value shares the bracketed text's coarse span
-        // (design §4.4): a parsed value has no `'src` slice of its own.
+        // (the coarse whole-content-span fallback): a parsed value has no
+        // `'src` slice of its own.
         let source = "https://example.org[a &copy; b,role=hl]";
         let nodes = build_src(Span::new(source));
 
@@ -4962,8 +4964,8 @@ mod tests {
         let attrs = &reference.attrs;
         assert_eq!(attrs.roles().into_iter().next(), Some("hl"));
 
-        // The parsed positional value is the *escaped* text the string
-        // replacer's own attrlist carries, and the list's location tag is the
+        // The parsed positional value is the *escaped* text, and the
+        // list's location tag is the
         // bracketed text as written.
         assert_eq!(attrs.nth_attribute(1).unwrap().value(), "a &lt; b");
         assert_eq!(attrs.span().data(), "a < b,role=hl");
@@ -4979,8 +4981,8 @@ mod tests {
         // A formal URL text carrying an `=` splits into an attribute list
         // (here a role): the first positional attribute becomes the display
         // text, and the parsed `Attrlist<'src>` rides on the node's own
-        // `attrs` field, so the fold reproduces the role exactly as the
-        // string replacer does.
+        // `attrs` field, so the fold reproduces the role Asciidoctor's own
+        // rendering does.
         let source = "https://example.org[Example,role=hl]";
         let nodes = build_src(Span::new(source));
 
@@ -5021,11 +5023,11 @@ mod tests {
         // macro whose bracketed display text crosses an **opaque** piece — a
         // rendered span, an already-recognized macro node of another family, a
         // masked passthrough. The text is carried structurally (each opaque
-        // piece's own node becomes a child), so the fold re-renders exactly the
-        // markup the string replacer captured in its own text.
+        // piece's own node becomes a child), so the fold reproduces that
+        // markup exactly.
         let fixtures = [
-            // (A masked passthrough is opaque here too — and in the string
-            // pipeline, which restores passthroughs only after every step — but
+            // (A masked passthrough is opaque here too — since it restores
+            // only after every substitution step has run — but
             // this oracle runs the steps directly, without the extraction the
             // real `SubstitutionGroup::apply` performs around them, so those
             // fixtures live in the whole-pipeline sweep instead; see
@@ -5195,9 +5197,8 @@ mod tests {
     fn a_span_in_a_rendered_attribute_keeps_its_markup() {
         // The boundary this family used to draw per **slot**, now gone. A
         // rendered piece's body is the build-time fold with the parser's own
-        // renderer — the very bytes the string replacer reads out of its own
-        // already-rendered haystack — so a slot `render_link` writes out
-        // reproduces the string pipeline's answer rather than deferring the
+        // renderer, so a slot `render_link` writes out carries the same
+        // markup Asciidoctor's own rendering does, rather than deferring the
         // whole macro to literal text. This is the image family's own bracket
         // rule (`bracket_attrlist`), which the three `Attrlist`-bearing
         // families now share.
@@ -5242,11 +5243,11 @@ mod tests {
     fn a_rendered_slot_cannot_break_out_of_its_attribute() {
         // What makes carrying fold-time markup into a slot safe: the value is
         // escaped for the `"` delimiter where it lands, so a span whose own
-        // markup carries a quote cannot close the attribute it sits in. The
-        // string pipeline reaches the same bytes here because it renders from
-        // the same values; what it cannot make inert is a *passthrough*, whose
-        // body it splices into the finished string after every escape has run
-        // (asciidoctor#2661) — the deliberate divergence its own test pins.
+        // markup carries a quote cannot close the attribute it sits in. A
+        // *passthrough* is different: its body is spliced into the finished
+        // string after every escape has run
+        // (asciidoctor#2661), so it cannot be made inert the same way — the
+        // deliberate divergence its own test pins.
         for (source, expected) in [
             (
                 r#"link:index.html[x,title=[.r"z]#b#]"#,
@@ -5266,8 +5267,8 @@ mod tests {
 
     #[test]
     fn a_span_whose_markup_splits_the_attribute_list_is_the_trees_to_read() {
-        // The link family's half of the deferral divergence (design §5.2's
-        // step 6) — the same decision the xref family's own test records, for
+        // The link family's half of the deferral divergence — the same
+        // decision the xref family's own test records, for
         // the same reason and by the same mechanism.
         //
         // A span whose markup carries a character the split reads used to make
@@ -5309,26 +5310,30 @@ mod tests {
     #[test]
     fn a_span_whose_markup_perturbs_the_string_pipeline_is_a_documented_divergence() {
         // What the structural recovery cannot do is make the *recognition*
-        // agree in every case: the string replacer matches over the span's
-        // markup where this matches over the one placeholder standing in for
-        // it, so the two read the same extent only while that markup carries
-        // no character the pattern (or the replacer's own attribute-list
-        // probe) is sensitive to. These are the three shapes where it does —
-        // and in each the string pipeline's reading is the markup-perturbed
-        // one (a truncated text, a text the attribute-list parse cut in half)
-        // and the tree's the well-formed one, exactly as the quotes step's own
+        // agree with matching over the span's rendered markup in every case:
+        // this matches over the one placeholder standing in for
+        // it, so the two extents coincide only while that markup carries
+        // no character the pattern (or an attribute-list probe reading it)
+        // is sensitive to. These are the three shapes where it does —
+        // and in each matching the rendered markup gives the perturbed
+        // reading (a truncated text, a text the attribute-list parse cut in
+        // half)
+        // and the tree's is the well-formed one, exactly as the quotes step's own
         // crossed-delimiter divergence is.
         for source in [
-            // A `]` inside the span ends `INLINE_LINK_MACRO`'s own lazy text
-            // capture early for the string replacer, but not here.
+            // A `]` inside the span would end `INLINE_LINK_MACRO`'s own lazy
+            // text capture early if matched over the rendered markup, but
+            // not here.
             "link:index.html[a *b ] c* d]",
             // Markup carrying an `=` (an attributed span) *and* a comma
-            // elsewhere in the text: the string replacer's attribute-list
-            // probe fires on the markup's own `=`, and the parse then splits
+            // elsewhere in the text: an attribute-list
+            // probe reading the rendered markup fires on its own `=`, and
+            // the parse then splits
             // the text at that comma, keeping only what precedes it.
             "link:index.html[one, [.hl]#two#]",
             // The `mailto:` spelling's own probe is a `,`, so a comma the span
-            // itself carries sends the string replacer down the subject branch
+            // itself carries sends a markup-based match down the subject
+            // branch
             // where this one stays plain.
             "mailto:a@example.org[a *b, c* d]",
         ] {
@@ -5354,8 +5359,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_bare_emails() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the bare e-mail
+        // reproduces the frozen golden recording byte-for-byte. This is the
+        // differential corpus that pins the bare e-mail
         // increment: the address forms the pattern claims, the prefixes it
         // treats as mismatches, and the escape.
         let fixtures = [
@@ -5482,8 +5487,7 @@ mod tests {
     #[test]
     fn an_escaped_email_stays_literal() {
         // `\doc@example.com` drops the single backslash and leaves the address
-        // as literal text — no link node — mirroring the string replacer's
-        // `caps[0][1..]`.
+        // as literal text — no link node.
         let source = "\\doc@example.com";
         let nodes = build_src(Span::new(source));
 
@@ -5502,10 +5506,10 @@ mod tests {
     #[test]
     fn a_mailto_macro_target_is_not_re_recognized_as_a_bare_email() {
         // The e-mail pass runs *after* the `link:`/`mailto:` macro pass, so by
-        // then the macro is one opaque node here (already-rendered `<a …>`
-        // markup in the string pipeline, whose `mailto:` prefix the pattern's
-        // own `:` mismatch group rejects). Either way exactly one link node
-        // results, and it is the macro's.
+        // then the macro is already a `Ref` node here — one opaque
+        // placeholder in the match string, whose `mailto:` prefix the
+        // pattern's own `:` mismatch group rejects anyway. Exactly one link
+        // node results, and it is the macro's.
         let source = "mailto:hello@example.org[Email us]";
         let nodes = build_src(Span::new(source));
 
@@ -5546,8 +5550,7 @@ mod tests {
     fn an_email_inside_an_expanded_attribute_value_is_recognized() {
         // An address whose bytes come from a *synthesized* run (an attribute
         // reference's resolved value) — recovered exactly by `text_slice`,
-        // since an e-mail node carries only plain text (design §3.4.1's "a
-        // macro inside an expanded value" boundary). The two URL-link passes
+        // since an e-mail node carries only plain text. The two URL-link passes
         // now make the same lift for their own targets and display texts —
         // an attribute-list-bearing one included, since `text_attrlist` parses
         // a text with no `'src` slice from the level's match string and owns
@@ -5578,20 +5581,21 @@ mod tests {
         assert_eq!(link_text_of(reference), "doc@example.com");
 
         // The address has no honest `'src` slice of its own, so its location
-        // falls back to the enclosing synthesized run's coarse span (design
-        // §4.4) while its text stays exact.
+        // falls back to the enclosing synthesized run's coarse span (the
+        // coarse whole-content-span fallback) while its text stays exact.
         assert_eq!(reference.location.data(), "{contact}");
     }
 
     #[test]
     fn an_email_abutting_a_rendered_construct_stays_literal() {
         // The mismatch-prefix group reads the character immediately before the
-        // address. The string pipeline reads it out of already-rendered markup
-        // — `</strong>`, `</a>`, and `<img …>` all end in `>`, a mismatch
-        // character — and so leaves the address literal. The tree stands the
+        // address. Matching over already-rendered markup would read
+        // `</strong>`, `</a>`, and `<img …>` — all ending in `>`, a mismatch
+        // character — and so would leave the address literal. The tree stands
+        // the
         // construct in as one opaque placeholder, which belongs to no mismatch
         // class, so `find_email_matches` defers explicitly instead of building
-        // a link the string pipeline does not: parity, not a divergence, for
+        // a link a markup-based reading would not: parity, not a divergence, for
         // every construct whose rendering ends in one of `\`, `>`, `:`, `/`.
         for source in [
             "**bold**doc@example.com",
@@ -5621,10 +5625,11 @@ mod tests {
     #[test]
     fn an_email_abutting_a_construct_that_hides_its_boundary_is_a_documented_divergence() {
         // What the unconditional deferral above costs, pinned exactly. In each
-        // of these the string pipeline's mismatch-prefix group does *not* see a
-        // mismatch character before the address, so it links it — a concealed
-        // index term renders to nothing, and a passthrough or STEM expression
-        // is still masked by its own sentinel when the macros step runs (it is
+        // of these, matching over the rendered markup would find *no*
+        // mismatch character before the address and so would link it — a
+        // concealed index term renders to nothing, and a passthrough or STEM
+        // expression is still masked behind its own placeholder when the
+        // macros step runs (it is
         // restored afterwards), so neither presents rendered markup there. The
         // tree cannot tell those apart from a construct that *did* render
         // markup without folding the preceding node while building, so all of
@@ -5666,15 +5671,17 @@ mod tests {
         // The mirror image of the boundary above, in the sibling auto-link
         // family, which predates the e-mail pass: `INLINE_LINK`'s own
         // boundary-prefix group *requires* one of `^`, a blank, or
-        // `[>()\[\];"\']`. The string pipeline reads `</strong>`'s own `>`
-        // there and builds a link, where the bare placeholder standing in for
+        // `[>()\[\];"\']`. Matching over the rendered markup would read
+        // `</strong>`'s own `>`
+        // there and build a link, where the bare placeholder standing in for
         // the span belongs to no such class — so this is the one boundary a
         // `>` and a placeholder read *differently*, and the reason the identity
         // that tells a rendered span from an extraction-pass wrapper has to
         // reach recognition at all.
         for source in [
-            // A bare URL against each tag-rendered variant's closing edge. The
-            // string pipeline reads the `>` that ends the tag and links; so
+            // A bare URL against each tag-rendered variant's closing edge.
+            // Matching over the rendered markup would read the `>` that ends
+            // the tag and link; so
             // does the tree, now that the placeholder carries it.
             "**bold**https://example.org",
             "__em__https://example.org",
@@ -5693,22 +5700,23 @@ mod tests {
             // One character further out, where a space intervenes and both
             // pipelines match on the space itself.
             "**bold** https://example.org",
-            // And with no span at all, where the level's own start anchor is
-            // what the string pipeline presents too.
+            // And with no span at all, where the level's own start anchor
+            // satisfies the same requirement.
             "https://example.org",
             "see https://example.org now",
             // The reverse direction: a span written against a bare URL's own
             // tail. The `<` that opens the tag is what ends the URL body
-            // (`[^\s\[\]<]*` excludes it) in the string pipeline, and now
-            // here as well.
+            // (`[^\s\[\]<]*` excludes it), matching over the rendered markup
+            // or over the tree alike.
             "https://example.org**bold**",
             "https://example.org\"`q`\"",
             // A formal-URL link's own boundary-prefix group is the same one.
             "**bold**https://example.org[Site]",
             // A **transparent** span read *as* a sibling: rendering to its
-            // body and nothing else, what it presents is that body — so the
-            // string pipeline's flat haystack holds the space `x ` ends with
-            // where the tree stood one placeholder, and both link.
+            // body and nothing else, what it presents is that body — so
+            // matching over the rendered markup would find the space `x `
+            // ends with, where the tree stands one placeholder in its place,
+            // and both link.
             "[width=10]##x ##https://example.org",
             "*[width=10]##x ##https://example.org*",
             "x [width=10]##y ##https://example.org",
@@ -5761,8 +5769,8 @@ mod tests {
     fn an_auto_link_abutting_a_passthrough_wrapper_stays_literal() {
         // The half the identity exists to protect. An attribute-list-prefixed
         // passthrough builds a [`Styled`](crate::inlines::Styled) wrapper that
-        // renders `<span class="quotes">…</span>` — but the string pipeline is
-        // holding it as its own `\u{96}…\u{97}` sentinel for every step this
+        // renders `<span class="quotes">…</span>` — but it is masked behind
+        // its own placeholder for every step this
         // module runs, so the boundary-prefix group sees no `>` and the URL
         // stays literal. Classifying it by its *rendering* would have made this
         // the increment's own new divergence.
@@ -5791,8 +5799,8 @@ mod tests {
         // nested `Normal` build — so a wrapper *that* build extracts is
         // invisible to this content's list. Consulting the list there would
         // find no entry and call the wrapper a rendered span, handing the URL
-        // beside it a `>` the string pipeline never presents (it is holding
-        // the wrapper as its own `\u{96}…\u{97}` sentinel, exactly as at the
+        // beside it a `>` that is never actually there (the
+        // wrapper is masked behind its own placeholder, exactly as at the
         // top level).
         //
         // Nothing consults it, because no family descends into a wrapper at
@@ -5822,8 +5830,8 @@ mod tests {
     fn a_url_in_a_nested_builds_body_is_linked_once() {
         // The same body, one step on: what the nested build *does* recognize
         // it recognizes with its own identity in hand, so a URL written
-        // against a tag-rendered span there links exactly as the string
-        // pipeline links it — and links **once**, since the outer step does
+        // against a tag-rendered span there links, matching Asciidoctor's
+        // own behavior — and links **once**, since the outer step does
         // not descend to match over the result a second time.
         use super::super::super::test_support::golden_passthroughs;
 
@@ -5841,13 +5849,15 @@ mod tests {
     #[test]
     fn an_address_at_a_spans_own_edge_reads_that_spans_boundary_characters() {
         // The mismatch-prefix group reads the character immediately before the
-        // address, and inside a span the string pipeline reads that span's own
-        // *rendered* markup there: `<strong>` ends in `>`, one of the group's
+        // address, and inside a span, matching over that span's own
+        // *rendered* markup would read: `<strong>` ends in `>`, one of the
+        // group's
         // three mismatch characters, so `*doc@example.org*` keeps the address
         // literal where a level matched in isolation sees a start anchor and
         // links it. The macros step takes the same
         // [`LevelContext`](super::super::quotes::LevelContext) the quotes and
-        // character-replacements steps do, so the two pipelines agree again.
+        // character-replacements steps do, so recognition agrees with the
+        // rendered-markup reading again.
         for source in [
             // Against a span's opening edge, in each variant's own rendering
             // shape. Every tag-rendered variant ends its opening markup in `>`
@@ -5898,8 +5908,9 @@ mod tests {
             // boundary-prefix group.
             "*x [width=10]#https://example.org#*",
             // A **tag-rendered** span beside the transparent one presents the
-            // `>` its own closing markup ends in, which the string pipeline
-            // reads there too — a mismatch character for the e-mail family and
+            // `>` its own closing markup ends in, which matching over the
+            // rendered markup would read there too — a mismatch character
+            // for the e-mail family and
             // an accepted prefix for the auto-link one.
             "*x*[width=10]#doc@example.org#",
             "*x*[width=10]#https://example.org#",

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1076,10 +1076,11 @@ fn find_link_macro_matches<'src>(
         // ([`Ref::link_form`](crate::inlines::Ref::link_form)) rather than
         // having it re-derived from `location` — so a *wholly* expanded macro
         // (`:m: link:index.html[Docs]`, then `{m}`) is recognized, with only
-        // its `location` taking the coarse whole-content-span fallback. A text carrying an
-        // attribute list is handled inside `text_attrlist`, since its display
-        // text comes back from a *parse*: every opaque piece is tokened
-        // through that parse and restored after it.
+        // its `location` taking the coarse whole-content-span fallback. A text
+        // carrying an attribute list is handled inside `text_attrlist`,
+        // since its display text comes back from a *parse*: every
+        // opaque piece is tokened through that parse and restored after
+        // it.
         if let Some(target) = caps.get(3)
             && !range_is_restorable(nodes, pieces, &(target.start()..target.end()))
         {
@@ -1217,12 +1218,12 @@ pub(super) fn restore_masked_passthroughs(
 ///   of the bracket's own verbatim `'src` slice yields logical text, so it
 ///   stays a single synthesized `Text` (that slice carries no entity to undo);
 ///   a parse of the level's **match string** yields already-escaped bytes
-///   instead, so it is rebuilt through
-///   [`computed_value_children`] — the escaped/entity/replacement trichotomy under an order that
-///   has already escaped, and the literal reading under one that has not —
-///   exactly as the cross-reference family's own attribute-list value is, with
-///   each **masked** construct that value still holds a token for spliced back
-///   in as its own node ([`restored_value_children`]).
+///   instead, so it is rebuilt through [`computed_value_children`] — the
+///   escaped/entity/replacement trichotomy under an order that has already
+///   escaped, and the literal reading under one that has not — exactly as the
+///   cross-reference family's own attribute-list value is, with each **masked**
+///   construct that value still holds a token for spliced back in as its own
+///   node ([`restored_value_children`]).
 ///
 /// This performs *no* recognition side
 /// effect — notably it does **not** `register_link` the target in the asset
@@ -1903,18 +1904,19 @@ fn find_email_matches<'src>(
 
         // The mismatch-prefix group above read an *empty* prefix — but that
         // decision is only faithful when the tree can actually see the
-        // character a markup-based reading would see there. When the address abuts an
-        // already-recognized construct (`**bold**doc@example.org`,
-        // `link:x[y]doc@example.org`), the
+        // character a markup-based reading would see there. When the address
+        // abuts an already-recognized construct
+        // (`**bold**doc@example.org`, `link:x[y]doc@example.org`), the
         // construct's *rendered* last character — `</strong>`, `</a>`, and
-        // `<img …>` all end in `>`, one of the three mismatch characters — would
-        // suppress the address, while [`build_match_string`] stands the
-        // construct in as one opaque [`SPAN_PLACEHOLDER`], which no mismatch
-        // class contains. Recognizing here would build a link a markup-based
-        // reading would not, so this defers instead — leaving the address as
-        // literal text, never a wrong node, exactly as the sibling auto-link
-        // family already behaves for the same input ([`INLINE_LINK`]'s own
-        // boundary-prefix group is *required*, so a placeholder simply fails
+        // `<img …>` all end in `>`, one of the three mismatch characters —
+        // would suppress the address, while [`build_match_string`]
+        // stands the construct in as one opaque [`SPAN_PLACEHOLDER`],
+        // which no mismatch class contains. Recognizing here would
+        // build a link a markup-based reading would not, so this defers
+        // instead — leaving the address as literal text, never a wrong
+        // node, exactly as the sibling auto-link family already behaves
+        // for the same input ([`INLINE_LINK`]'s own boundary-prefix
+        // group is *required*, so a placeholder simply fails
         // its match). See [`email_level`]'s own scope note.
         if s.get(..full.start)
             .is_some_and(|before| before.ends_with(SPAN_PLACEHOLDER))
@@ -2014,7 +2016,8 @@ fn build_email_node<'src>(
 /// family's tests can build and inspect a tree without a full
 /// `Parser`/`Content` round trip. This function is the link family's own
 /// registration pass, called exactly once per parse, after the tree is built
-/// and folded, from [`apply_macro_side_effects`](super::apply_macro_side_effects).
+/// and folded, from
+/// [`apply_macro_side_effects`](super::apply_macro_side_effects).
 ///
 /// # Registration order across the three link forms
 ///
@@ -2142,8 +2145,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_link_macros() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the `link:`/`mailto:`
+        // reproduces the frozen golden recording byte-for-byte. This is the
+        // differential corpus that pins the `link:`/`mailto:`
         // macro increment. What is still deferred — a URL target (the
         // `INLINE_LINK` pass's own territory), a display text crossing a
         // rendered span, and a *wholly* expanded macro — lives in a divergence
@@ -2197,8 +2200,8 @@ mod tests {
             "_link:y.html[Y] in em_",
             // An escaped special (a `CharRef` by macro time) in the target, in
             // the display text, and in both — the match string carries its
-            // canonical entity, which is exactly what the string replacer's own
-            // haystack holds there.
+            // canonical entity, the same escaped bytes `apply_special_characters`
+            // always produces.
             "link:a&b.html[x]",
             "link:a&b.html[]",
             "mailto:a&b@example.org[]",
@@ -2216,7 +2219,7 @@ mod tests {
             // own: one crossing an escaped special, one crossing a restored
             // entity, and one spanning two lines (which the attrlist parse
             // joins with a space). Each is parsed from the level's match
-            // string — the same bytes the string replacer parses — and owned
+            // string — already-escaped bytes — and owned
             // off it, in both the `link:` (`=`) and `mailto:` (`,`) spellings.
             "link:index.html[a < b,role=hl]",
             "link:index.html[Tom & Jerry,role=hl^]",
@@ -2254,7 +2257,7 @@ mod tests {
         // scheme; the builder reproduces the string step's `URI_SNIFF`
         // stripping, including the fall-back to the whole target when
         // the strip leaves nothing. Every fixture is a non-`://`
-        // `link:` target, so the string pipeline routes it through the
+        // `link:` target, so it is routed through the
         // same `INLINE_LINK_MACRO` the builder uses (a `://` target is
         // `INLINE_LINK`'s territory, a later increment).
         use crate::parser::ModificationContext;
@@ -2297,12 +2300,11 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_for_a_link_macro_target_over_a_passthrough() {
         // The differential corpus for a `link:`/`mailto:` target crossing a
-        // masked **passthrough** — the string pipeline swallows the
-        // `\u{96}`*n*`\u{97}` sentinel into the target (its class admits it as
-        // it admits the placeholder) and the restore pass then splices the
-        // extracted body over every sentinel in the rendered string, so the
-        // tree's computed target substitutes the `Raw` node's value for its
-        // placeholder the same way (see [`restore_masked_passthroughs`]).
+        // masked **passthrough**: `INLINE_LINK_MACRO`'s target class admits
+        // the placeholder the same way it would admit the passthrough's own
+        // restored bytes, so the tree's computed target substitutes the
+        // `Raw` node's value for its
+        // placeholder directly (see [`restore_masked_passthroughs`]).
         // These are the documented idioms: `++…++` to keep a target's
         // formatting characters literal, and `pass:[…]` to admit characters
         // the target class itself rejects (a space).
@@ -2314,7 +2316,8 @@ mod tests {
             "link:++https://example.org/now_this__link_works.html++[]",
             "link:++https://example.org/a__b__c.html++[the docs]",
             // A `pass:[…]` target carrying a space — a byte the target class
-            // itself excludes, which only the sentinel lets through.
+            // itself excludes, which only the passthrough's placeholder lets
+            // through.
             "link:pass:[My Documents/report.pdf][Get Report]",
             // A `pass:c[…]` target, and an attribute list on the (empty)
             // display text beside it.
@@ -2357,8 +2360,7 @@ mod tests {
 
     #[test]
     fn hide_uri_scheme_reads_the_target_as_matched_over_a_passthrough() {
-        // The `URI_SNIFF` strip runs over the bytes as *matched*, exactly as
-        // the string replacer sniffs its own sentinel-holding haystack: a
+        // The `URI_SNIFF` strip runs over the bytes as *matched*: a
         // scheme hidden inside the passthrough is invisible to the strip (the
         // shown text keeps it), while a verbatim scheme prefix ahead of the
         // passthrough is stripped — and the offset, a match of literal ASCII
@@ -2425,14 +2427,15 @@ mod tests {
     #[test]
     fn a_dangerous_scheme_inside_a_passthrough_is_a_documented_divergence() {
         // The one place this increment chooses the safe reading over byte
-        // parity. The string replacer's dangerous-scheme check reads its own
-        // masked haystack, where the sentinel hides the scheme — so
-        // `link:++javascript:...++[]` passes its check and the restore then
-        // completes a live `javascript:` link in the golden output. The
+        // parity. Checking the masked haystack directly would hide the
+        // scheme behind its placeholder — so
+        // `link:++javascript:...++[]` would pass that check and the restore
+        // would then complete a live `javascript:` link, which is what the
+        // frozen golden recording shows. The
         // builder checks the *restored* target instead and defers, leaving
         // the text literal (the passthrough's own restore still applies to
-        // it), exactly as both pipelines treat the unmasked
-        // `link:javascript:...[x]` spelling.
+        // it), exactly as the unmasked
+        // `link:javascript:...[x]` spelling is treated.
         use super::super::super::test_support::golden_passthroughs;
 
         for source in [
@@ -2469,8 +2472,9 @@ mod tests {
         // masked **STEM** expression — the same restore-the-value move this
         // family's passthrough corpus above pins, over the other node kind
         // the one extraction pass masks. `INLINE_LINK_MACRO`'s `[^\s\[\]]+`
-        // target class swallows the sentinel and the placeholder alike, so
-        // recognition agrees with no widening, and the `URI_SNIFF` strip
+        // target class admits the placeholder the same way it would admit
+        // the restored bytes, so
+        // recognition needs no widening, and the `URI_SNIFF` strip
         // still runs over the bytes as matched.
         use super::super::super::test_support::golden_passthroughs;
 
@@ -2536,7 +2540,7 @@ mod tests {
         // platform separator. These two families never route a target through
         // `web_path` — it reaches the `href` as computed — so a restored STEM
         // target must be byte-identical under either separator, and must
-        // match the string pipeline under both.
+        // match the frozen golden recording under both.
         //
         // Without this, the difference is invisible on a Posix runner and
         // only surfaces on Windows CI.
@@ -4460,7 +4464,8 @@ mod tests {
                 "a target crossing a rendered span must stay literal: {nodes:?}"
             );
 
-            // The frozen golden recording, by contrast, *does* build a link here.
+            // The frozen golden recording, by contrast, *does* build a link
+            // here.
             assert!(golden_macros(source).contains("<a href"));
         }
     }
@@ -5125,7 +5130,8 @@ mod tests {
                 "a target crossing a rendered span must stay literal: {nodes:?}"
             );
 
-            // The frozen golden recording, by contrast, *does* build a link here.
+            // The frozen golden recording, by contrast, *does* build a link
+            // here.
             assert!(golden_macros(source).contains("<a href"));
         }
     }
@@ -6686,8 +6692,9 @@ mod tests {
         // ([`Ref::link_form`]) instead of having it re-derived from
         // `location` — the signal `apply_link_side_effects` reads to replay
         // the crate's own family-pass registration order. Only the
-        // node's `location` takes the coarse whole-content-span fallback. This closes the
-        // divergence `a_wholly_expanded_link_macro_is_a_documented_divergence`
+        // node's `location` takes the coarse whole-content-span fallback. This
+        // closes the divergence
+        // `a_wholly_expanded_link_macro_is_a_documented_divergence`
         // used to pin, per its own "if this boundary is ever lifted" note.
         let parser = expanding_parser();
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -5318,8 +5318,8 @@ mod tests {
         // and in each matching the rendered markup gives the perturbed
         // reading (a truncated text, a text the attribute-list parse cut in
         // half)
-        // and the tree's is the well-formed one, exactly as the quotes step's own
-        // crossed-delimiter divergence is.
+        // and the tree's is the well-formed one, exactly as the quotes step's
+        // own crossed-delimiter divergence is.
         for source in [
             // A `]` inside the span would end `INLINE_LINK_MACRO`'s own lazy
             // text capture early if matched over the rendered markup, but
@@ -5595,8 +5595,9 @@ mod tests {
         // the
         // construct in as one opaque placeholder, which belongs to no mismatch
         // class, so `find_email_matches` defers explicitly instead of building
-        // a link a markup-based reading would not: parity, not a divergence, for
-        // every construct whose rendering ends in one of `\`, `>`, `:`, `/`.
+        // a link a markup-based reading would not: parity, not a divergence,
+        // for every construct whose rendering ends in one of `\`, `>`,
+        // `:`, `/`.
         for source in [
             "**bold**doc@example.com",
             "__em__doc@example.com",

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -47,16 +47,16 @@ use crate::{
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ComputedSpecials {
     /// `SpecialCharacters` sits **before** `Macros` in this order, so a
-    /// computed value holds the already-escaped bytes the string replacer
-    /// parsed out of its own escaped haystack: `&lt;` is an escaped special
+    /// computed value holds already-escaped bytes read out of the level's own
+    /// escaped match string: `&lt;` is an escaped special
     /// standing for a logical `<`, which [`escaped_value_children`] unwinds one
-    /// level so the fold escapes it back exactly once (§3.4).
+    /// level so the fold escapes it back exactly once.
     Escaped,
 
     /// No `SpecialCharacters` step has run yet — either the order has none at
     /// all (`subs=attributes,macros`) or it runs *after* `Macros`
     /// (`subs=macros,specialcharacters`) — so a computed value holds the
-    /// author's own bytes, which the string replacer splices in verbatim:
+    /// author's own bytes, spliced in verbatim:
     /// `&lt;` is six literal characters, not an escaped `<`, and
     /// [`unescaped_value_children`] classifies it as such.
     Verbatim,
@@ -64,26 +64,30 @@ pub(super) enum ComputedSpecials {
 
 /// The macros substitution, as a node transducer.
 ///
-/// This increment recognizes **image and icon macros** (`image:target[…]`,
+/// This recognizes **image and icon macros** (`image:target[…]`,
 /// `icon:target[…]`), the **UI macros** (`kbd:[…]`, `btn:[…]`, `menu:…[…]`),
-/// the **`link:`/`mailto:` macro** (`link:target[…]`, `mailto:addr[…]`),
-/// **auto-links and formal-URL links** (`https://example.org`,
-/// `https://example.org[text]`), and **bare e-mail addresses**
-/// (`doc@example.org`), replacing each with an
-/// [`Image`](InlineNode::Image), [`Ui`](InlineNode::Ui), or
-/// [`Ref`](InlineNode::Ref) node. An image node carries its own owned
+/// **index terms** (`((term))`, `(((primary, secondary)))`,
+/// `indexterm:[…]`, `indexterm2:[…]`), **auto-links and formal-URL links**
+/// (`https://example.org`, `https://example.org[text]`), the
+/// **`link:`/`mailto:` macro** (`link:target[…]`, `mailto:addr[…]`), **bare
+/// e-mail addresses** (`doc@example.org`), **inline anchors** (`[[id]]`,
+/// `anchor:id[…]`), and **cross-references** (`xref:id[…]`, `<<id>>`),
+/// replacing each with an [`Image`](InlineNode::Image), [`Ui`](InlineNode::Ui),
+/// [`IndexTerm`](crate::inlines::IndexTerm), or [`Ref`](InlineNode::Ref) node.
+/// An image node carries its own owned
 /// [`Attrlist`](crate::attributes::Attrlist) — the step that makes a macro node
 /// *self-describing*, so the fold reconstructs the render parameters and calls
-/// the same `render_image`/`render_icon` the string step calls; a UI node
-/// carries the keys / label / menu path the string replacer computed, so its
+/// the same `render_image`/`render_icon`; a UI node
+/// carries the computed keys / label / menu path, so its
 /// fold calls the same `render_keyboard`/`render_button`/`render_menu`; a link
 /// node (whether a `link:`/`mailto:` macro, an auto-link, or a bare e-mail
 /// address) carries the
 /// computed target, display text (as [`Text`](InlineNode::Text) children), and
-/// roles/window, so its fold calls the same `render_link`. The remaining macro
-/// families (cross-references, footnotes, index terms, anchors, STEM) are later
-/// increments (see [`link_macro_level`], [`inline_link_level`], and
-/// [`email_level`] for the link forms this increment defers).
+/// roles/window, so its fold calls the same `render_link`. Footnotes and STEM
+/// macros are recognized by their own separate transducers elsewhere in
+/// [`build`](super::build) rather than here (see
+/// [`link_macro_level`], [`inline_link_level`], and
+/// [`email_level`] for the three link forms).
 ///
 /// It also recognizes the **bibliography anchor** (`[[[label]]]`) that prefixes
 /// a bibliography list item, as an [`Anchor`](InlineNode::Anchor) node whose
@@ -91,36 +95,34 @@ pub(super) enum ComputedSpecials {
 /// its pattern is `^`-anchored to the whole content (see
 /// [`biblio_anchor_level`]).
 ///
-/// Each family is applied at each level in the **same order the string step
-/// applies them** — keyboard/button, then menu, then image/icon, then
+/// Each family is applied at each level in a fixed order — keyboard/button,
+/// then menu, then image/icon, then index terms, then
 /// auto-links (`INLINE_LINK`), then the `link:`/`mailto:` macro
-/// (`INLINE_LINK_MACRO`), then a bare e-mail address (`INLINE_EMAIL`) — so a
+/// (`INLINE_LINK_MACRO`), then a bare e-mail address (`INLINE_EMAIL`), then
+/// inline anchors, then cross-references — so a
 /// level's overlapping constructs resolve
-/// identically. Like the other steps it descends
+/// consistently. Like the other steps it descends
 /// into the [`Styled`](crate::inlines::Styled)/[`Ref`](InlineNode::Ref)
 /// children earlier steps created — a macro can appear inside a rendered span
-/// (`*image:x[]*`), just as the string pipeline matches one inside a rendered
-/// `<strong>` tag — then matches at each level.
+/// (`*image:x[]*`) — then matches at each level.
 ///
 /// # The UI macros are gated on `experimental`
 ///
-/// The string step recognizes `kbd:`/`btn:`/`menu:` only when the
+/// `kbd:`/`btn:`/`menu:` are recognized only when the
 /// `experimental` document attribute is set (an optimization that skips the
-/// work in the common case); this transducer mirrors that gate exactly, so with
-/// `experimental` off a `kbd:[…]` stays literal here just as it does in the
-/// string output.
+/// work in the common case), so with
+/// `experimental` off a `kbd:[…]` stays literal.
 ///
 /// # Scope: verbatim macros only
 ///
 /// A recognized macro is built into an `'src`-borrowing node only when its
 /// whole match is **verbatim source** — no special character (`< > &`, an
 /// atomic [`CharRef`](InlineNode::CharRef)) and no rendered
-/// [`Styled`](crate::inlines::Styled) span falls inside it. The string pipeline
-/// matches macros over *escaped, already-rendered* text, so a macro containing
-/// (say) a `&` sees `&amp;` in its target/attrlist, and a self-describing node
+/// [`Styled`](crate::inlines::Styled) span falls inside it. A macro
+/// containing (say) a `&` sees `&amp;` in its target/attrlist once
+/// `specialcharacters` has escaped it, and a self-describing node
 /// cannot carry that escaped text as an `'src` slice. Such a macro is therefore
-/// **left unrecognized** here for a later increment (the attribute-references
-/// step and the cutover), mirroring how the quotes step documents its own
+/// **left unrecognized** here, mirroring how the quotes step documents its own
 /// cross-span boundary (crossed delimiters). A family relaxes that gate where
 /// the escaped piece is a delimiter *it consumes and never slices* — the
 /// angle-bracketed URL's own `&lt;`/`&gt;` (see
@@ -130,8 +132,8 @@ pub(super) enum ComputedSpecials {
 /// formal-URL**, the **bare e-mail**, the **image/icon**, and the **UI**
 /// families), wherever the escaped text need not
 /// ride on the node as an `'src` slice at all: none of those families' targets
-/// is `Span`-typed, so each reads its values out of the match string (whose
-/// entity bytes *are* the string pipeline's own) and rebuilds its display text
+/// is `Span`-typed, so each reads its values out of the match string
+/// and rebuilds its display text
 /// as structured children through [`macro_text_children`], keeping each special
 /// as its own `CharRef` (see `xref::find_xref_matches`,
 /// `links::find_link_macro_matches`, `links::build_inline_link_node`,
@@ -188,7 +190,7 @@ pub(super) fn apply_macros<'src>(
 }
 
 /// Applies each macro family at this level — and, first, at every level nested
-/// inside it — in the string step's own family order. See
+/// inside it — in a fixed family order. See
 /// [`apply_macros`], which wraps this with the once-per-content
 /// bibliography-anchor pass.
 ///
@@ -196,12 +198,12 @@ pub(super) fn apply_macros<'src>(
 ///
 /// `ctx` is the [`LevelContext`] this level sits in — the character an
 /// enclosing construct's own rendering presents immediately before it, which
-/// the string pipeline's flat haystack holds there and a level matched in
-/// isolation does not. Two of this step's families read exactly that
+/// a fully rendered flat string holds there but a level matched in
+/// isolation does not have on its own. Two of this step's families read exactly that
 /// character: `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s
 /// "prefix that causes a mismatch" group (see
 /// [`links::inline_link_level`] and [`links::email_level`]). Without it,
-/// `*doc@example.org*` links here while the string pipeline — reading the `>`
+/// `*doc@example.org*` links here while a flat-string reading — seeing the `>`
 /// that ends `<strong>`, one of that group's own mismatch characters — leaves
 /// the address literal.
 ///
@@ -232,14 +234,14 @@ pub(super) fn apply_macros<'src>(
 /// [`build_match_string`](super::quotes::build_match_string) writes around
 /// that span's own placeholder — the two outer characters of its markup, or,
 /// for a span rendering to its **body** and nothing else, that body's own two
-/// outer characters. Either one it can write only for a span the string
-/// pipeline has really rendered, not for the passthrough-extraction pass's own
-/// wrapper (see [`Masked`]), whose body the pipeline is holding inside its own
-/// sentinel whatever that body renders as. This step is where `masked` is
+/// outer characters. Either one it can write only for a span really
+/// rendered here, not for the passthrough-extraction pass's own
+/// wrapper (see [`Masked`]), whose body stands in as an opaque placeholder
+/// regardless of what that body itself renders as. This step is where `masked` is
 /// carried, and only here, because these two prefix groups are the only
 /// classes in the whole module that read a tag's `>` differently from the
-/// bare placeholder: `**bold**https://example.org` links in the string
-/// pipeline, reading the `>` that ends `</strong>`, where a quote sub's own
+/// bare placeholder: `**bold**https://example.org` links against a
+/// fully rendered reading, which sees the `>` that ends `</strong>`, where a quote sub's own
 /// `(^|[^\w&;:}])` accepts the two alike. Every other step goes on passing
 /// [`Masked::UNKNOWN`](super::special_chars::Masked::UNKNOWN), which is not a
 /// shortcut but the same answer stated once.
@@ -251,8 +253,8 @@ fn apply_macro_families<'src>(
     masked: Masked<'_>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
-    // Recurse into spans/refs first, matching the string pipeline's
-    // whole-string pass. Each nested level is matched in the context its own
+    // Recurse into spans/refs first, so every level is matched, inside out.
+    // Each nested level is matched in the context its own
     // enclosing construct's rendering presents (see this function's own doc
     // comment); a span the built-in backend renders with no markup of its own
     // is transparent, so `child_contexts` hands its children the character its
@@ -272,7 +274,7 @@ fn apply_macro_families<'src>(
             .zip(contexts)
             .map(|(node, inner)| match node {
                 // An extraction wrapper's body is **not** this content's to
-                // substitute. The string pipeline holds it as a sentinel for
+                // substitute. It is an opaque placeholder for
                 // every step from here on, and the body was already
                 // substituted once — by the separate, nested `Normal` build
                 // the `x-` compatibility form (`[x-]++text++`) runs it
@@ -330,19 +332,17 @@ fn apply_macro_families<'src>(
     let nodes = image_macros_level(nodes, root, parser, ctx, masked);
 
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
-    // `indexterm2:[…]`) run after image/icon and before the link families,
-    // mirroring the string step's order.
+    // `indexterm2:[…]`) run after image/icon and before the link families.
     let nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
 
     // A **visible** term's shown text is not a boundary the later families
-    // stop at. The string replacer puts that text back into the one flat
-    // haystack every later pass scans — `((a term with a link:t.html[T]))`
-    // links exactly as if the parentheses were not there — so the families
+    // stop at — it is ordinary flow content, and
+    // `((a term with a link:t.html[T]))` links exactly as if the parentheses
+    // were not there. So the families
     // below descend into the term's own
     // [`children`](crate::inlines::IndexTerm::children), which is where this
-    // pass has just put that text. (A *concealed* term shows nothing, so the
-    // replacer leaves no text behind for them to scan and its `children` are
-    // empty.)
+    // pass has just put that text. (A *concealed* term shows nothing, so its
+    // `children` are empty and there is nothing for them to scan.)
     //
     // Their own level, rather than one flat scan across the term and its
     // neighbours: a term renders its shown text with no markup of its own, so
@@ -397,12 +397,12 @@ fn apply_macro_families<'src>(
 }
 
 /// The macro families that run **after** the index-term pass — the three link
-/// spellings, inline anchors, and cross-references — in the string step's own
+/// spellings, inline anchors, and cross-references — in their fixed
 /// order.
 ///
 /// Split out of [`apply_macro_families`] because it has two callers rather
-/// than one: this level, and a visible index term's shown text, which the
-/// string replacer hands back to exactly these passes. See the call site for
+/// than one: this level, and a visible index term's shown text, which is
+/// ordinary flow content reaching exactly these passes. See the call site for
 /// why the term's children are their own level.
 fn apply_reference_families<'src>(
     nodes: Vec<InlineNode<'src>>,
@@ -413,63 +413,59 @@ fn apply_reference_families<'src>(
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
-    // pass and before the `link:`/`mailto:` macro, mirroring the string step's
-    // order (`INLINE_LINK` precedes `INLINE_LINK_MACRO`).
+    // pass and before the `link:`/`mailto:` macro.
     let nodes = inline_link_level(nodes, root, parser, ctx, masked, specials);
 
-    // The `link:`/`mailto:` macro runs after the auto-link pass, mirroring the
-    // string step's order.
+    // The `link:`/`mailto:` macro runs after the auto-link pass.
     let nodes = link_macro_level(nodes, root, parser, ctx, masked, specials);
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
-    // families and before the anchor pass, exactly where the string step runs
-    // `InlineEmailReplacer` — so an address that is really the tail of a URL,
-    // or a `mailto:` macro's own target, is already inside an opaque node
-    // (there, already-rendered `<a …>` markup) and is not re-recognized.
+    // families and before the anchor pass — so an address that is really the
+    // tail of a URL, or a `mailto:` macro's own target, is already inside an
+    // opaque node and is not re-recognized.
     let nodes = email_level(nodes, root, ctx, masked);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
-    // before cross-references, mirroring the string step's order. (The
-    // bibliography-anchor pass the string step runs *first* — a `^`-anchored
-    // `[[[id]]]`, recognized only inside a bibliography list item — runs in
-    // [`apply_macros`], outside this recursion.)
+    // before cross-references. (The bibliography-anchor pass — a `^`-anchored
+    // `[[[id]]]`, recognized only inside a bibliography list item — runs
+    // first, in [`apply_macros`], outside this recursion.)
     let nodes = anchor_macros_level(nodes, root, ctx, masked);
 
-    // Cross-references (`xref:id[…]`) run after the anchor pass, mirroring the
-    // string step's order.
+    // Cross-references (`xref:id[…]`) run after the anchor pass.
     xref_macros_level(nodes, root, parser, ctx, masked, specials)
 }
 
-/// The eventual cutover's single entry point (design §5.2, Phase 4 step 6) for
+/// The single entry point for
 /// **every** recognition side effect the macro families above defer —
 /// composing [`anchors::apply_biblio_side_effects`],
 /// [`image::apply_image_side_effects`], [`links::apply_link_side_effects`], and
-/// [`anchors::apply_ref_side_effects`], each staged and tested as its own
-/// standalone building block, into the one call the cutover makes exactly once
-/// per parse.
+/// [`anchors::apply_ref_side_effects`], each its own reviewable
+/// building block, into the one call
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) makes
+/// exactly once per parse.
 ///
 /// # Ordering
 ///
-/// The four are called in the same relative order the string pipeline's own
-/// macro passes run in (the bibliography anchor, then image/icon, …, links, …,
-/// anchors, … — see [`apply_macros`]'s own doc comment): bibliography anchor,
+/// The four are called in the crate's own macro-family order (the
+/// bibliography anchor, then image/icon, …, links, …, anchors, … — see
+/// [`apply_macros`]'s own doc comment): bibliography anchor,
 /// then image, then link, then anchor/ref.
-/// This is not cosmetic — it is what keeps this function's output identical to
-/// the golden pipeline's whenever more than one family's side effect touches
+/// This is not cosmetic — it is what keeps output identical to
+/// the recorded golden output whenever more than one family's side effect touches
 /// the *same* shared list. Concretely, [`Parser::record_substitution_warning`]
 /// appends to one shared warnings list, and both
 /// [`image::apply_image_side_effects`]'s dangerous-link-scheme warning and
 /// [`anchors::apply_ref_side_effects`]'s duplicate-id warning write to it — a
 /// content whose image triggers the first and whose anchor triggers the
-/// second must see the image warning recorded first, exactly as it would from
-/// the string pipeline's own image-then-anchor pass order. The same holds one
+/// second must see the image warning recorded first, matching the
+/// image-then-anchor family order. The same holds one
 /// step earlier for [`anchors::apply_biblio_side_effects`]'s own duplicate-id
-/// warning, which the string pipeline's first pass records ahead of both. (The
+/// warning, recorded ahead of both. (The
 /// asset/ref catalogs the three write to are otherwise disjoint from one
 /// another — images, links, and refs are three separate lists — so this
 /// ordering does not, by itself, need to hold *within* a single catalog; see
 /// [`links::apply_link_side_effects`]'s own doc comment for the finer-grained
-/// ordering *within* the link family that the golden pipeline also requires.)
+/// ordering *within* the link family that the golden recordings also require.)
 ///
 /// Index terms, cross-references, and footnotes are not part of this
 /// function: index terms and cross-references perform no recognition side
@@ -479,18 +475,13 @@ fn apply_reference_families<'src>(
 /// place (see [`apply_footnotes`](super::footnotes::apply_footnotes)'s own doc
 /// comment); it already runs during [`build`](super::build), not here.
 ///
-/// This is the **production** entry point for all four side effects:
-/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) calls it
-/// once per content, from the tree it just built, while the string pipeline's
-/// own copies are suppressed for that content (see
-/// `Parser::suppress_macro_side_effects`). Design §5.2's step 6 asks for
-/// exactly that — "re-attach the recognition side effects ... at the cutover
-/// ... which is what avoids double-counting each registration".
+/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) calls this
+/// once per content, from the tree it just built.
 ///
-/// It runs *after* the whole string pass rather than during its macros step.
-/// Across contents that preserves document order, and within one content the
-/// composition below preserves the string pipeline's own pass order, which is
-/// what the two orderings above require. `source` and
+/// It runs *after* the whole tree is built rather than during the macros step
+/// itself. Across contents that preserves document order, and within one
+/// content the composition below preserves the crate's own macro-family
+/// order, which is what the two orderings above require. `source` and
 /// `leading_anchor_registered` are threaded straight through to
 /// [`anchors::apply_ref_side_effects`] — see its own doc comment for both.
 pub(crate) fn apply_macro_side_effects(
@@ -519,8 +510,7 @@ pub(super) struct MacroMatch<'src> {
 pub(super) enum MacroMatchKind<'src> {
     /// An escaped macro (`\image:…`, `\kbd:[…]`, `\https://…`): drop the single
     /// backslash at `backslash` and keep the rest of the match as literal
-    /// nodes, replacing nothing — mirroring the string replacer's
-    /// `caps[0][1..]`. The backslash is at the match start for the
+    /// nodes, replacing nothing. The backslash is at the match start for the
     /// prefix-less macros, and at the scheme for an escaped auto-link whose
     /// match carries a boundary prefix.
     Unescape { backslash: usize },
@@ -598,20 +588,19 @@ pub(super) fn rebuild_macro_level<'src>(
 /// `raw_text` is the match string's own bytes for `text_range`, and
 /// `unescape_bracket` selects the one behavior the callers do *not* share: the
 /// `xref:` and `link:`/`mailto:` macro forms unescape an escaped closing
-/// bracket (`\]`) in their bracketed text, mirroring their replacers' own
-/// `replace("\\]", "]")`, while the `<<id,text>>` shorthand — which has no
-/// bracket to escape, and whose own branch of `InlineXrefReplacer` performs no
-/// such replace — keeps the pair literal.
+/// bracket (`\]`) in their bracketed text, while the `<<id,text>>` shorthand —
+/// which has no
+/// bracket to escape — keeps the pair literal.
 ///
 /// The common case is one [`Text`](InlineNode::Text) child: an unescaped
 /// bracket makes its logical value a computed (owned) one — a *synthesized*
 /// `Text` whose value need not coincide with its source — while otherwise
 /// [`text_slice`] recovers the range's own bytes, borrowing a single verbatim
-/// run (the builder's `'src`-borrowing goal, §4.5) and, for a text crossing a
+/// run (the builder's `'src`-borrowing goal) and, for a text crossing a
 /// [`synthesized`](Piece::synthesized) run, taking the match string's bytes —
-/// the expanded value exactly, and the very text the string replacer matched
-/// over — as an owned value, with only its location falling back to the
-/// enclosing run's coarse span (design §4.4).
+/// the expanded value exactly —
+/// as an owned value, with only its location falling back to the
+/// enclosing run's coarse span.
 ///
 /// [`text_slice`] rather than `text_location.data()`, because a verbatim range
 /// is **not always contiguous in the source**: an earlier step can drop a byte
@@ -621,7 +610,7 @@ pub(super) fn rebuild_macro_level<'src>(
 /// whose backslash
 /// [`apply_attribute_references`](super::attribute_refs::apply_attribute_references)
 /// drops as a *gap* in the ranges it emits), and re-reading the enclosing
-/// source span would put the backslash back — a text the string pipeline no
+/// source span would put the backslash back — a byte the tree no
 /// longer carries. Slicing the pieces themselves, as [`emit_range`] already
 /// does for the structured path below, cannot reintroduce it.
 ///
@@ -631,10 +620,10 @@ pub(super) fn rebuild_macro_level<'src>(
 /// [`text_slice`] declines to recover — instead becomes
 /// **structured children**, recovered with [`emit_range`]: the
 /// leaf is its own [`CharRef`] child that folds
-/// back to the same bytes the string replacer's text carries, where one `Text`
+/// back to the same bytes, where one `Text`
 /// child holding the match string's `&lt;` (or `&copy;`) would be escaped a
 /// second time by
-/// the fold (design §3.4).
+/// the fold.
 ///
 /// A text crossing an **opaque** piece (a rendered span, an
 /// earlier-recognized macro node, a masked passthrough) takes that same
@@ -695,8 +684,8 @@ pub(super) fn macro_text_children<'src>(
 /// each **escaped closing bracket**'s backslash dropped — the `\]` unescape
 /// every bracket-bearing macro form performs, expressed structurally.
 ///
-/// `raw_text` is the level's own match-string slice for `range` (the bytes the
-/// string replacer's `replace("\\]", "]")` runs over), so the two agree on
+/// `raw_text` is the level's own match-string slice for `range`, so this
+/// agrees with a plain `replace("\\]", "]")` over the same bytes on
 /// which backslashes pair off: [`str::match_indices`] scans non-overlapping and
 /// left to right, exactly as [`str::replace`] does, so a run of backslashes
 /// resolves identically on both sides.
@@ -709,7 +698,7 @@ pub(super) fn macro_text_children<'src>(
 /// ending in a backslash followed by a literal `]` (`:t: b\`, then
 /// `xref:foo[a<{t}]x]`) puts the two characters in different runs. Skipping the
 /// backslash by range is boundary-agnostic, and leaves every surviving fragment
-/// borrowing `'src` (§4.5) where a rebuilt value would have had to own its
+/// borrowing `'src` where a rebuilt value would have had to own its
 /// bytes.
 ///
 /// Shared with the footnote family — whose content is *always* structured
@@ -751,8 +740,8 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
 /// back through [`restored_value_children`].
 ///
 /// Why tokening at all, when the placeholder is already one opaque character:
-/// so the split sees the string pipeline's own **shape** there. The
-/// replacer parses an attribute list over the piece's *markup*, which carries
+/// so the split sees the same **shape** an attribute-list parse over the
+/// piece's *rendered markup* would, which carries
 /// no `,`/`=`/`"` the split could read differently than it reads a token —
 /// and a bare placeholder, being a single `Co` character, would be
 /// indistinguishable from one *inside* a value once the parse hands that value
@@ -793,9 +782,8 @@ pub(super) fn tokened_text<'src>(
         // The pieces that become a token are the **opaque** ones — atomic, and
         // not one of the three [`CharRef`](InlineNode::CharRef) leaves
         // [`build_match_string`](super::quotes::build_match_string) gives real
-        // bytes to. Every other piece contributes its own bytes as it stands:
-        // those are the string replacer's bytes there, so the split reads them
-        // identically and the caller's own rebuild
+        // bytes to. Every other piece contributes its own bytes as it stands,
+        // and the caller's own rebuild
         // ([`computed_value_children`]) already knows how to unwind them.
         let opaque = piece
             .atomic
@@ -829,9 +817,9 @@ pub(super) fn tokened_text<'src>(
 /// text of the node it stands for.
 ///
 /// A string slot has nowhere to put a node, so the alternative to this is
-/// refusing the whole match (which is what the gate used to do) or spelling the
-/// token into the output (which is what the string pipeline does, emitting
-/// either rendered markup or a raw `\u{96}0\u{97}` sentinel). Neither is what
+/// refusing the whole match, or spelling the
+/// token into the output as either rendered markup or a raw `\u{96}0\u{97}`
+/// placeholder. Neither is what
 /// the author wrote. What they wrote is the source, so that is what the slot
 /// takes.
 ///
@@ -888,19 +876,17 @@ pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> Stri
 ///
 /// Splicing the node rather than its bytes is what keeps the fold honest. A
 /// [`Raw`](InlineNode::Raw) leaf's body is emitted verbatim and a
-/// [`Stem`](InlineNode::Stem) leaf's is rendered at fold time — which is
-/// exactly what `Passthroughs::restore_to` splices into the string pipeline's
-/// own display text — where those same bytes spliced into a
-/// [`Text`](InlineNode::Text) would be escaped a second time (design §3.4):
+/// [`Stem`](InlineNode::Stem) leaf's is rendered at fold time — where those
+/// same bytes spliced into a
+/// [`Text`](InlineNode::Text) would be escaped a second time:
 /// `link:x[++<b>a</b>++,role=hl]` would show `&amp;lt;b&amp;gt;` against the
 /// golden's `&lt;b&gt;`. A rendered
 /// [`Styled`](crate::inlines::Styled) span has no bytes to splice at all —
 /// its markup exists only at fold time — so for it the node *is* the only
 /// honest reading.
 ///
-/// The walk is index-keyed and left to right, like
-/// `Passthroughs::restore_to`'s
-/// own: each token is sought only in the bytes after the previous one, and a
+/// The walk is index-keyed and left to right: each token is sought only in
+/// the bytes after the previous one, and a
 /// token the parse dropped (a value the split discarded) is simply not found,
 /// leaving the ones after it to splice by their own index.
 pub(super) fn restored_value_children<'src>(
@@ -933,7 +919,7 @@ pub(super) fn restored_value_children<'src>(
 }
 
 /// Rebuilds a value the macros step **computed** off the level's match string
-/// as the children a node shows, taking whichever half of design §3.4.1
+/// as the children a node shows, taking whichever half
 /// `specials` names.
 ///
 /// A computed value is the one thing this step reads as *bytes* rather than
@@ -958,10 +944,10 @@ pub(super) fn computed_value_children<'src>(
 /// the level's own match string rather than out of the tree, here a reference-
 /// or link-family attribute list's positional value — as the nodes that fold
 /// back to exactly those bytes, all sharing `location` (the value has no `'src`
-/// slice of its own, so design §4.4's coarse fallback is the only honest span
+/// slice of its own, so the coarse fallback is the only honest span
 /// for any part of it).
 ///
-/// The rebuild is design §3.4's trichotomy applied to a string:
+/// The rebuild applies the same trichotomy to a string:
 /// [`build_match_string`](super::quotes::build_match_string) gives an escaped
 /// special its canonical entity and a *restored* entity its own bytes, while a
 /// [`Text`](InlineNode::Text) node holds **logical** text the fold escapes. So
@@ -982,7 +968,7 @@ pub(super) fn computed_value_children<'src>(
 /// a verbatim run holds no special at all (the `SpecialCharacters` step split
 /// every one into its own leaf) and a synthesized run's own specials are
 /// [`Raw`](InlineNode::Raw) leaves, which are opaque and so rejected by the
-/// caller's gate. Under an effective order that never escapes (§3.4.1) a
+/// caller's gate. Under an effective order that never escapes a
 /// literal `&` *does* survive into a verbatim run, and is left exactly as it
 /// is here, since neither class matches it.
 ///
@@ -1114,7 +1100,7 @@ mod tests {
         // step drops an escaped reference's backslash as a gap in the ranges it
         // emits, leaving two adjacent verbatim runs whose match-string bytes
         // run on while their source spans skip one. Re-reading the span would
-        // put the backslash back — a text the string pipeline no longer
+        // put the backslash back — a byte the tree no longer
         // carries — so this pins all three families that build a display text
         // through the shared helper.
         let parser = Parser::default();
@@ -1156,16 +1142,16 @@ mod tests {
     fn a_computed_value_is_classified_by_where_the_escaping_step_sits() {
         // [`escaped_value_children`] reads its input as the *escaped* text a
         // family took off the level's match string, so it unwinds one level of
-        // §3.4's trichotomy: `&lt;` becomes the logical `<` a `Text` node
+        // the trichotomy: `&lt;` becomes the logical `<` a `Text` node
         // holds, which the fold escapes back. That is exact under an order
         // that runs `SpecialCharacters` **before** `Macros` — every built-in
         // group — and exactly wrong under one that does not, where the same
-        // six bytes are the author's own and the string replacer splices them
-        // in untouched.
+        // six bytes are the author's own and get spliced in
+        // untouched.
         //
         // An attribute list is parsed under *any* order that runs `Macros`, so
         // both readings are reachable, and which one a value takes is decided
-        // the way §3.4.1 decides every other classification: by where the
+        // the way every other classification is: by where the
         // escaping step actually sits in the group's effective order. This
         // pins that decision from both sides over one fixture per family — the
         // three that compute an attribute-list value — so neither half can
@@ -1262,11 +1248,10 @@ mod tests {
         // The `Verbatim` half is *not* "the order has no escaping step" but
         // "none has run yet", so it covers an order that escapes **after**
         // `Macros` too. Only the cross-reference family can be pinned to
-        // parity there, because it is the one family whose node the string
-        // pipeline is still holding as a deferred placeholder when the
-        // escaping step runs — so `flatten_prior_markup` leaves it alone,
-        // where a link's already-emitted `<a …>` markup is escaped by the
-        // string pipeline and is the separate divergence
+        // parity there, because it is the one family whose node stays an
+        // unresolved placeholder in the tree
+        // when the escaping step runs — so `flatten_prior_markup` leaves it alone,
+        // where a link's already-emitted `<a …>` markup is escaped, which is the separate divergence
         // `a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence`
         // pins. Both spellings reach parity; the bare `<` did not before the
         // decision became position-aware.
@@ -1307,8 +1292,8 @@ mod tests {
         // the level's match string is a `CharRef` leaf's own entity, while a
         // literal one is a `Raw` leaf the match string stands in as an opaque
         // placeholder. So it is pinned directly, on the classification it
-        // makes: one logical `Text` run, which the fold escapes back to the
-        // `&amp;` the string pipeline would have emitted.
+        // makes: one logical `Text` run, which the fold escapes back to
+        // `&amp;`.
         let src = Span::new("x");
         let children = escaped_value_children("a & b &copy; c &lt; d", src);
 
@@ -1402,9 +1387,7 @@ mod tests {
         //
         // - The **UI** family (`kbd:`/`btn:`/`menu:`) swapped its own gate for
         //   the shared opaque-piece one. Every value a `Ui` node holds is
-        //   already-substituted text read out of the match string, which is
-        //   exactly what the string replacer computes from its own escaped
-        //   haystack.
+        //   already-substituted text read out of the match string.
         //
         // - A **footnote's text** needed no code change at all: its content is
         //   structured children (`emit_range` keeps a `CharRef` leaf as its own
@@ -1526,13 +1509,14 @@ mod tests {
         // finer: not a later **step** reading an earlier step's tags, but a
         // later **family of this same step** reading an earlier family's.
         //
-        // The string pipeline runs its macro families as passes over one flat
-        // string, so by the time the cross-reference and footnote passes run,
-        // that string already holds the `</a>` the link pass wrote. Their
-        // patterns match straight through it, and the bracket a family reads
-        // as its own can begin inside one link's display text and end outside
-        // it: `link:t.html[pre xref:tgt[T] post]` renders an `<a>` nested
-        // inside an `<a>`, because the cross-reference's own bracketed text is
+        // The crate's old string-substitution implementation ran its macro
+        // families as passes over one flat
+        // string, so by the time the cross-reference and footnote passes ran,
+        // that string already held the `</a>` the link pass had written. Their
+        // patterns matched straight through it, and the bracket a family read
+        // as its own could begin inside one link's display text and end outside
+        // it: `link:t.html[pre xref:tgt[T] post]` rendered an `<a>` nested
+        // inside an `<a>`, because the cross-reference's own bracketed text was
         // `T</a> post`.
         //
         // A tree has no tags to match through. The link's display text is a
@@ -1541,9 +1525,9 @@ mod tests {
         // where it was written, and the link keeps the text it was given.
         //
         // This is a **keep**: the tree's answer is the well-formed one, and
-        // the string pipeline's is markup no backend would choose to emit.
+        // the old implementation's was markup no backend would choose to emit.
 
-        // `golden_html` is what the string pipeline rendered — kept in the
+        // `golden_html` is what the old pipeline rendered — kept in the
         // fixture as the recorded half of the divergence now that the
         // pipeline itself is gone, exactly as the divergence corpora keep
         // theirs in `snapshots/`.
@@ -1644,11 +1628,11 @@ mod tests {
 
     #[test]
     fn a_bibliography_entry_registers_before_every_other_family() {
-        // The string pipeline runs its bibliography-anchor pass *first*, ahead
+        // The bibliography-anchor pass runs *first*, ahead
         // of every other macro family, so a duplicate bibliography id must be
         // warned about before an image's dangerous-link-scheme warning in the
         // one shared warnings list — the same ordering this function's own doc
-        // comment records for image-before-anchor, one step earlier. Each side
+        // comment records for image-before-anchor, one place earlier. Each side
         // uses its own independent parser.
         let source = "[[[dup]]] image:x.png[alt,link=javascript:alert(1)] entry";
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -199,8 +199,8 @@ pub(super) fn apply_macros<'src>(
 /// `ctx` is the [`LevelContext`] this level sits in — the character an
 /// enclosing construct's own rendering presents immediately before it, which
 /// a fully rendered flat string holds there but a level matched in
-/// isolation does not have on its own. Two of this step's families read exactly that
-/// character: `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s
+/// isolation does not have on its own. Two of this step's families read exactly
+/// that character: `INLINE_LINK`'s boundary-prefix group and `INLINE_EMAIL`'s
 /// "prefix that causes a mismatch" group (see
 /// [`links::inline_link_level`] and [`links::email_level`]). Without it,
 /// `*doc@example.org*` links here while a flat-string reading — seeing the `>`
@@ -237,14 +237,14 @@ pub(super) fn apply_macros<'src>(
 /// outer characters. Either one it can write only for a span really
 /// rendered here, not for the passthrough-extraction pass's own
 /// wrapper (see [`Masked`]), whose body stands in as an opaque placeholder
-/// regardless of what that body itself renders as. This step is where `masked` is
-/// carried, and only here, because these two prefix groups are the only
+/// regardless of what that body itself renders as. This step is where `masked`
+/// is carried, and only here, because these two prefix groups are the only
 /// classes in the whole module that read a tag's `>` differently from the
 /// bare placeholder: `**bold**https://example.org` links against a
-/// fully rendered reading, which sees the `>` that ends `</strong>`, where a quote sub's own
-/// `(^|[^\w&;:}])` accepts the two alike. Every other step goes on passing
-/// [`Masked::UNKNOWN`](super::special_chars::Masked::UNKNOWN), which is not a
-/// shortcut but the same answer stated once.
+/// fully rendered reading, which sees the `>` that ends `</strong>`, where a
+/// quote sub's own `(^|[^\w&;:}])` accepts the two alike. Every other step goes
+/// on passing [`Masked::UNKNOWN`](super::special_chars::Masked::UNKNOWN), which
+/// is not a shortcut but the same answer stated once.
 fn apply_macro_families<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
@@ -451,12 +451,12 @@ fn apply_reference_families<'src>(
 /// [`apply_macros`]'s own doc comment): bibliography anchor,
 /// then image, then link, then anchor/ref.
 /// This is not cosmetic — it is what keeps output identical to
-/// the recorded golden output whenever more than one family's side effect touches
-/// the *same* shared list. Concretely, [`Parser::record_substitution_warning`]
-/// appends to one shared warnings list, and both
-/// [`image::apply_image_side_effects`]'s dangerous-link-scheme warning and
-/// [`anchors::apply_ref_side_effects`]'s duplicate-id warning write to it — a
-/// content whose image triggers the first and whose anchor triggers the
+/// the recorded golden output whenever more than one family's side effect
+/// touches the *same* shared list. Concretely,
+/// [`Parser::record_substitution_warning`] appends to one shared warnings list,
+/// and both [`image::apply_image_side_effects`]'s dangerous-link-scheme warning
+/// and [`anchors::apply_ref_side_effects`]'s duplicate-id warning write to it —
+/// a content whose image triggers the first and whose anchor triggers the
 /// second must see the image warning recorded first, matching the
 /// image-then-anchor family order. The same holds one
 /// step earlier for [`anchors::apply_biblio_side_effects`]'s own duplicate-id
@@ -1250,8 +1250,9 @@ mod tests {
         // `Macros` too. Only the cross-reference family can be pinned to
         // parity there, because it is the one family whose node stays an
         // unresolved placeholder in the tree
-        // when the escaping step runs — so `flatten_prior_markup` leaves it alone,
-        // where a link's already-emitted `<a …>` markup is escaped, which is the separate divergence
+        // when the escaping step runs — so `flatten_prior_markup` leaves it
+        // alone, where a link's already-emitted `<a …>` markup is
+        // escaped, which is the separate divergence
         // `a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence`
         // pins. Both spellings reach parity; the bare `<` did not before the
         // decision became position-aware.
@@ -1587,12 +1588,11 @@ mod tests {
         // A content that exercises every family this function composes in one
         // go: an image whose `link=` targets a dangerous scheme (a warning
         // from the image family) *before* a duplicate anchor id (a warning
-        // from the anchor family) — the golden pipeline's own image-then-
+        // from the anchor family) — the crate's own image-then-
         // anchor pass order (`apply_macros`'s own doc comment) must land the
         // two warnings in that order, not the reverse. Each side uses its own
-        // *independent* parser (design §5.3's two-independent-parsers
-        // discipline, established by the image increment's own differential
-        // corpus).
+        // *independent* parser — the two-independent-parsers
+        // discipline every warning-ordering test in this module uses.
         let source = "image:x.png[alt,link=javascript:alert(1)] then [[dup]] and [[dup]]";
 
         let builder_parser = Parser::default().with_catalog_assets(true);

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 /// Whether the escaping step has already run by the time the macros step reads
 /// a value off the level's match string.
 ///
-/// Design §3.4.1 decides what a fragment is worth by *where the steps sit* in
+/// What a fragment is worth is decided by *where the steps sit* in
 /// the group's effective order, not by where the fragment came from. The
 /// attribute-references step already makes that decision for the value it
 /// splices in

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1374,7 +1374,7 @@ mod tests {
                     "build_for_group_restored_entity",
                     source
                 ),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
         }
     }
@@ -1430,7 +1430,7 @@ mod tests {
                     "build_for_group_recoverable_piece",
                     source
                 ),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
         };
 

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -273,8 +273,8 @@ pub(super) fn menu_macros_level<'src>(
 /// No boundary can split such a leaf, either: the match is delimited by
 /// `menu:`, `[`, and `]`, and its item list by `&gt;` or `,` — none of which
 /// occurs in `&lt;`, `&amp;`, or a restored entity's own `&name;`, while a
-/// `&gt;` *is* the delimiter the item list itself splits on — so every atomic overlap
-/// is either wholly contained or consumed as the delimiter itself.
+/// `&gt;` *is* the delimiter the item list itself splits on — so every atomic
+/// overlap is either wholly contained or consumed as the delimiter itself.
 fn find_menu_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -295,8 +295,8 @@ fn find_menu_matches<'src>(
         // own — because dropping the backslash keeps the rest of the match as
         // its own original nodes (an escaped special or a rendered span among
         // them), which fold back to exactly the
-        // original bytes minus the backslash. Mirrors the same hoist the `footnoteref:`
-        // family makes for the identical reason.
+        // original bytes minus the backslash. Mirrors the same hoist the
+        // `footnoteref:` family makes for the identical reason.
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -340,9 +340,9 @@ fn find_menu_matches<'src>(
 /// [`text_slice`]), and — when it crosses an escaped special or a restored
 /// entity, which [`text_slice`] declines because it cannot slice one — comes
 /// from the **match string**, i.e. in the already-substituted form
-/// `render_menu` receives from the string pipeline and emits verbatim
+/// `render_menu` receives and emits verbatim
 /// (`menu:F&le[Save]`'s name is `F&amp;le` on both sides). The submenu path
-/// and trailing item are split exactly as the string replacer splits them, out
+/// and trailing item are split out
 /// of that same match string (owned, because a split part is trimmed).
 fn build_menu_node<'src>(
     caps: &regex::Captures<'_>,
@@ -373,18 +373,17 @@ fn build_menu_node<'src>(
     })
 }
 
-/// Splits a menu macro's item list into its submenu path and trailing item,
-/// reproducing the string replacer's delimiter handling: a
+/// Splits a menu macro's item list into its submenu path and trailing item: a
 /// [`SUBMENU_DELIMITER`] (from a source `>`) takes precedence over a comma,
 /// the last part is the menu item, and any earlier parts are submenus. With no
 /// delimiter the whole (right-trimmed) list is a single item, and an absent
 /// list (an empty `[]`) is a bare menu reference.
 ///
-/// The list it splits is the *match string* text — the same escaped text the
-/// string replacer splits — so the caret branch keys off `&gt;` here exactly as
-/// it does there, and so does every other part: an item carrying an escaped
+/// The list it splits is the *match string* text — its own escaped text —
+/// so the caret branch keys off `&gt;`, and so does every other part: an item
+/// carrying an escaped
 /// special or a restored entity keeps that leaf's own entity bytes, which is
-/// precisely the text `render_menu` receives from the string pipeline and
+/// precisely the text `render_menu` receives and
 /// emits verbatim.
 fn split_menu_items<'src>(items: Option<&str>) -> (Vec<CowStr<'src>>, Option<CowStr<'src>>) {
     let Some(items) = items else {
@@ -432,8 +431,7 @@ mod tests {
     };
 
     /// A parser with the `experimental` attribute set, so the UI macros are
-    /// recognized (the string step gates them on it, and the builder mirrors
-    /// that gate).
+    /// recognized.
     fn experimental_parser() -> Parser {
         use crate::parser::ModificationContext;
 
@@ -452,11 +450,11 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_ui_macros() {
         // For each fixture, folding the single-pass tree (all five steps, under
-        // `experimental`) reproduces the string pipeline's output
-        // byte-for-byte. This is the differential corpus (design §5.3)
-        // that pins the UI-macro increment. Every fixture is
+        // `experimental`) reproduces the golden output
+        // byte-for-byte. This is the differential corpus
+        // that pins the UI-macro family. Every fixture is
         // deliberately *verbatim* (no `<`/`>`/`&` inside a macro), the
-        // boundary this increment claims.
+        // boundary that family claims.
         let fixtures = [
             // No UI macro despite macro-ish characters.
             "kbd is a word, not a macro",
@@ -500,8 +498,7 @@ mod tests {
             "\\menu:View[Zoom > Reset]",
             // An escaped macro the gate would *reject* (its item list crosses
             // an escaped `&`): the escape is honored ahead of the gate, so the
-            // backslash is dropped here exactly as the string replacer drops
-            // it.
+            // backslash is simply dropped.
             "\\menu:File[A & B]",
             // Several UI macros together, and next to another macro family.
             "See kbd:[F1] for help and btn:[Go] to run.",
@@ -535,8 +532,8 @@ mod tests {
 
     #[test]
     fn ui_macros_are_literal_without_experimental() {
-        // Without `experimental`, the string step does not recognize the UI
-        // macros, and neither does the builder: the fold reproduces the literal
+        // Without `experimental`, the UI
+        // macros are not recognized: the fold reproduces the literal
         // (default-parser) output byte-for-byte.
         let fixtures = ["kbd:[Ctrl+T]", "btn:[Save]", "menu:File[Save]"];
 
@@ -589,7 +586,7 @@ mod tests {
     #[test]
     fn a_kbd_sequence_splits_into_keys() {
         // The `+`/`,` delimiter selects how the sequence is split into keys,
-        // exactly as the string replacer's `split_kbd_keys` does.
+        // via the shared `split_kbd_keys`.
         let nodes = build_ui(Span::new("kbd:[Ctrl+Shift+N]"));
 
         match &assert_ui(&nodes[0]).kind {
@@ -608,8 +605,8 @@ mod tests {
 
     #[test]
     fn a_btn_macro_becomes_a_ui_node() {
-        // The label is normalized (surrounding whitespace folded) like the
-        // string replacer's `normalize_index_text`.
+        // The label is normalized (surrounding whitespace folded) via the
+        // shared `normalize_index_text`.
         let nodes = build_ui(Span::new("btn:[ Save ]"));
 
         match &assert_ui(&nodes[0]).kind {
@@ -744,16 +741,11 @@ mod tests {
         // **escaped special** (`&`, `<`, `>`), a **restored entity**
         // (`&copy;`, `&#8942;`), or a **typographic replacement** (`(C)`, a
         // smart apostrophe) is recognized: all three are atomic pieces
-        // `build_match_string` gives *real bytes* to — the very bytes the
-        // string replacer's own escaped haystack carries there — and every
+        // `build_match_string` gives *real bytes* to, and every
         // value a `Ui` node holds is read out of that match string and emitted
         // verbatim by `render_keyboard`/`render_button`/`render_menu`. So the
-        // fold reproduces the string pipeline's output byte-for-byte, which is
-        // what these fixtures pin. (This closes the boundary the
-        // `a_menu_over_a_special_character_is_a_documented_divergence` and
-        // `a_kbd_macro_over_a_special_character_is_a_documented_divergence`
-        // tests used to pin, per their own "fold this into a parity corpus"
-        // convention.)
+        // fold reproduces the golden output byte-for-byte, which is
+        // what these fixtures pin.
         let parser = experimental_parser();
         let renderer = HtmlInlineRenderer {};
 
@@ -839,7 +831,7 @@ mod tests {
         // The structural counterpart of the parity corpus above: a `Ui` node's
         // values are *already-substituted* text (the contract an `IndexTerm`'s
         // `terms` already uses), because that is what `render_keyboard` and
-        // friends receive from the string pipeline and emit verbatim. So a key
+        // friends receive and emit verbatim. So a key
         // crossing an escaped special carries the entity, not the source's own
         // `&` — while the node's `location` still covers the macro in *source*
         // terms (the entity is one byte there, five in the match string).
@@ -865,8 +857,8 @@ mod tests {
         // `'src` (through `text_slice`). When it crosses a recoverable atomic
         // piece — here a restored entity, which `text_slice` declines because
         // it cannot slice one — the name comes from the match string instead,
-        // in the same already-substituted form the string replacer's own
-        // params carry. The item list, split from that same string, is
+        // in the same already-substituted form `render_menu` receives. The
+        // item list, split from that same string, is
         // unaffected.
         let nodes = build_ui(Span::new("menu:&#8942;[More Tools, Extensions]"));
 
@@ -896,9 +888,9 @@ mod tests {
         // macro family keeps: a match crossing an **opaque** piece — a
         // rendered span, an already-recognized macro node — is left
         // unrecognized. `build_match_string` stands each in as a single
-        // placeholder where the string pipeline's own haystack holds the
-        // markup it will fold to, so a value read out of the match string
-        // would not be the replacer's, and reading the markup would mean
+        // placeholder whose markup exists only at fold time, so a value read
+        // out of the match string would not be the true rendered text, and
+        // reading the markup would mean
         // folding while building the tree (which this module never does).
         for source in [
             // A rendered span inside a keyboard, button, and menu macro.
@@ -913,8 +905,8 @@ mod tests {
                 "a UI macro crossing an opaque piece must be left unrecognized: {nodes:?}"
             );
 
-            // The string pipeline, by contrast, *does* build a UI macro here —
-            // the divergence this test documents. (If a later increment lifts
+            // The golden recording, by contrast, *does* hold a UI macro here —
+            // the divergence this test documents. (If a later change lifts
             // it, fold these fixtures into the parity corpus above.)
             let golden = golden_macros_in("macros_experimental", source, &experimental_parser());
 
@@ -994,7 +986,7 @@ mod tests {
     #[test]
     fn a_menu_inside_an_expanded_value_keeps_a_coarse_location() {
         // The values are exact; only the node's `location` falls back to the
-        // enclosing synthesized run's coarse span (design §4.4), since an
+        // enclosing synthesized run's coarse span, since an
         // expanded value's bytes have no `'src` counterpart of their own. The
         // menu name recovered from such a run is necessarily owned.
         let parser = expanding_parser();

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -19,10 +19,9 @@ use crate::{
 };
 
 /// The delimiter a menu macro's item list is split on: the *escaped* form of
-/// the source `>` submenu caret, which is what the string replacer sees (the
-/// special-characters step runs long before macros) and therefore what this
-/// module's own match string presents too — as an atomic
-/// [`CharRef`](InlineNode::CharRef) piece.
+/// the source `>` submenu caret — the special-characters step runs long
+/// before macros, so this module's own match string presents it too — as an
+/// atomic [`CharRef`](InlineNode::CharRef) piece.
 const SUBMENU_DELIMITER: &str = "&gt;";
 
 /// The keyboard/button UI macro pass at a level: matches
@@ -31,9 +30,8 @@ const SUBMENU_DELIMITER: &str = "&gt;";
 ///
 /// The caller runs this only under the `experimental` document attribute (see
 /// [`apply_macros`](super::apply_macros)); a cheap prefilter still skips the
-/// pattern sweep when no `kbd:`/`btn:` prefix with a `:[` is present, mirroring
-/// the string step's `found_macroish_short` guard.
-/// Mirrors the string step's `found_macroish_short` guard: a `kbd:`/`btn:`
+/// pattern sweep when no `kbd:`/`btn:` prefix with a `:[` is present: a
+/// `kbd:`/`btn:`
 /// macro needs its name prefix and a `:[`. Shared between
 /// [`kbd_btn_macros_level`]'s pre-build sniff and its post-build one, so the
 /// two answers cannot drift apart.
@@ -95,11 +93,11 @@ fn find_kbd_btn_matches<'src>(
         // Group 1 is the (optional) escape backslash. It is honored *before*
         // the gate below — and needs no gate of its own — because dropping
         // the backslash keeps the rest of the match as its own original nodes
-        // (a rendered span among them), which fold back to exactly the bytes
-        // the string replacer's `caps[0][1..]` emits. Mirrors that replacer's
-        // own escape-first check order, and closes the same latent gap the
-        // `footnoteref:`, menu, cross-reference, link, and image increments
-        // each closed for their own families.
+        // (a rendered span among them), which fold back to exactly the
+        // original bytes minus the backslash. This is the same escape-first
+        // check order, and closes the same latent gap, the
+        // `footnoteref:`, menu, cross-reference, link, and image families
+        // each close for their own escaped spellings.
         if caps.get(1).is_some() {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -112,11 +110,11 @@ fn find_kbd_btn_matches<'src>(
         }
 
         // A match crossing an **opaque** piece — a rendered span, an
-        // earlier-recognized macro node, a masked passthrough — is left for a
-        // later increment: `build_match_string` stands each in as one
-        // placeholder where the string pipeline's own haystack holds the
-        // markup it will fold to, so the keys or label read out of the match
-        // string would not be the replacer's.
+        // earlier-recognized macro node, a masked passthrough — is left
+        // unrecognized: `build_match_string` stands each in as one
+        // placeholder whose markup exists only at fold time, so the keys or
+        // label read out of the match string would not be the true rendered
+        // text.
         //
         // Every *recoverable* piece is admitted: a
         // [`synthesized`](Piece::synthesized) run (an attribute expansion,
@@ -126,7 +124,7 @@ fn find_kbd_btn_matches<'src>(
         // (`kbd:[a(C)b]`). This family never slices `'src` for a value at all
         // — its keys and label come straight from the match string, which
         // carries every one of those pieces' bytes exactly — so only the
-        // node's `location` takes design §4.4's coarse fallback (see
+        // node's `location` takes the coarse fallback (see
         // [`build_kbd_btn_node`]). Nor can a boundary split such a leaf: the
         // match is delimited by `kbd:`/`btn:`, `[`, and `]`, and its keys by
         // `,`/`+` — none of which occurs in `&lt;`, `&gt;`, `&amp;`, or a
@@ -152,20 +150,20 @@ fn find_kbd_btn_matches<'src>(
 }
 
 /// Builds one [`Ui`](InlineNode::Ui) node from a keyboard/button match,
-/// splitting the keys / normalizing the label exactly as the string replacer
-/// does so the fold reproduces the same bytes.
+/// splitting the keys / normalizing the label so the fold reproduces the
+/// golden bytes.
 ///
 /// Every value it computes comes from the **match string**, never from an
 /// `'src` slice: on a verbatim match those bytes *are* the source text; on a
-/// [`synthesized`](Piece::synthesized) one they are the expanded value the
-/// string pipeline itself matched over; and across an escaped special or a
+/// [`synthesized`](Piece::synthesized) one they are the expanded value
+/// itself; and across an escaped special or a
 /// restored entity they are that leaf's own entity bytes (`&amp;`, `&copy;`) —
-/// which is what the string replacer's own escaped haystack holds there, and
-/// what `render_keyboard`/`render_button` then emit *verbatim*. That is
+/// exactly what
+/// `render_keyboard`/`render_button` then emit *verbatim*. That is
 /// precisely what lets this family recognize a macro inside an expanded
 /// attribute value, or across an entity, where a family carrying an
 /// [`Attrlist`](crate::attributes::Attrlist)`<'src>` cannot. Only the node's
-/// `location` falls back to the enclosing run's coarse span (design §4.4) in
+/// `location` falls back to the enclosing run's coarse span in
 /// the synthesized case.
 fn build_kbd_btn_node<'src>(
     caps: &regex::Captures<'_>,
@@ -208,8 +206,8 @@ fn build_kbd_btn_node<'src>(
 /// text crossing any *other* escaped special (`menu:File[Save & Exit]`) or a
 /// restored entity (`menu:&#8942;[More Tools, Extensions]`) is recognized too:
 /// like a keyboard macro's keys, every value a menu node holds is read out of
-/// the match string, whose bytes at such a leaf are exactly the ones the
-/// string replacer's own escaped haystack carries and `render_menu` emits
+/// the match string, whose bytes at such a leaf are exactly the ones
+/// `render_menu` emits
 /// verbatim (see [`find_menu_matches`]). What is still deferred is a name or
 /// item text crossing an **opaque** piece — a rendered
 /// [`Styled`](crate::inlines::Styled) span, an earlier-recognized macro node,
@@ -267,16 +265,15 @@ pub(super) fn menu_macros_level<'src>(
 /// caret-only check; it is now the general one, because *every* value a menu
 /// node holds comes from the match string, whose bytes at such a leaf — a
 /// special's canonical entity, a restored entity's own text — are exactly the
-/// ones the string replacer's own escaped haystack carries and `render_menu`
+/// ones `render_menu`
 /// emits verbatim. So a name or item text crossing any escaped special
 /// (`menu:File[Save & Exit]`, `menu:a>b[Save]`) or restored entity
-/// (`menu:&#8942;[More Tools, Extensions]`) is recognized, exactly as the
-/// string pipeline recognizes it.
+/// (`menu:&#8942;[More Tools, Extensions]`) is recognized.
 ///
 /// No boundary can split such a leaf, either: the match is delimited by
 /// `menu:`, `[`, and `]`, and its item list by `&gt;` or `,` — none of which
 /// occurs in `&lt;`, `&amp;`, or a restored entity's own `&name;`, while a
-/// `&gt;` *is* the delimiter both pipelines split on — so every atomic overlap
+/// `&gt;` *is* the delimiter the item list itself splits on — so every atomic overlap
 /// is either wholly contained or consumed as the delimiter itself.
 fn find_menu_matches<'src>(
     nodes: &[InlineNode<'src>],
@@ -297,9 +294,9 @@ fn find_menu_matches<'src>(
         // checked *before* the sliceability gate — and needs no gate of its
         // own — because dropping the backslash keeps the rest of the match as
         // its own original nodes (an escaped special or a rendered span among
-        // them), which fold back to exactly the bytes the string replacer's
-        // `caps[0][1..]` emits. Mirrors the same hoist the `footnoteref:`
-        // increment made for the identical reason.
+        // them), which fold back to exactly the
+        // original bytes minus the backslash. Mirrors the same hoist the `footnoteref:`
+        // family makes for the identical reason.
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -525,7 +525,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_experimental", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -550,7 +550,7 @@ mod tests {
             assert_eq!(
                 fold_html(&nodes, &renderer),
                 golden_macros(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -821,7 +821,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_macros_in("macros_experimental", fixture, &parser),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden output for {fixture:?}"
             );
         }
     }
@@ -914,7 +914,7 @@ mod tests {
                 golden.contains("<kbd>")
                     || golden.contains(r#"class="button"#)
                     || golden.contains(r#"class="menu"#),
-                "expected the golden pipeline to build a UI macro for {source:?}"
+                "expected the golden recording to hold a UI macro for {source:?}"
             );
         }
     }
@@ -978,7 +978,7 @@ mod tests {
                     &parser.render_context()
                 ),
                 golden_normal(source, &parser),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden output for {source:?}"
             );
         }
     }
@@ -1074,7 +1074,7 @@ mod tests {
                     &parser.render_context()
                 ),
                 golden_normal(filtered, &parser),
-                "fold diverged from the string pipeline for {filtered:?}"
+                "fold diverged from the golden output for {filtered:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -232,11 +232,11 @@ fn restored_range<'a>(
 /// value this family computes off that string (the target, the
 /// `raw_text.contains('=')` attribute-list probe, the attrlist parse itself,
 /// the shorthand's `split_once(',')`) sees the construct's fully-escaped
-/// bytes directly. The reference *text* is then rebuilt as structured children rather
-/// than one sliced [`Text`](InlineNode::Text) (see [`macro_text_children`]), so
-/// the leaf folds back to its own bytes instead of being escaped
-/// twice — and the attribute-list branch, whose value comes back from a parse
-/// rather than from a range, re-derives the same split with
+/// bytes directly. The reference *text* is then rebuilt as structured children
+/// rather than one sliced [`Text`](InlineNode::Text) (see
+/// [`macro_text_children`]), so the leaf folds back to its own bytes instead of
+/// being escaped twice — and the attribute-list branch, whose value comes back
+/// from a parse rather than from a range, re-derives the same split with
 /// [`computed_value_children`].
 ///
 /// # A rendered span inside the reference text
@@ -278,10 +278,10 @@ fn restored_range<'a>(
 /// string; matching over rendered markup instead would read it off the markup
 /// itself, so a span whose markup carries an `=` (an attributed span, a link,
 /// an image) would take the attribute-list branch where this one stays plain.
-/// That costs nothing wherever the parse finds the `=` incidental (an attribute list
-/// with no comma to split on yields one positional value equal to the whole
-/// text, which is every unattributed markup shape) and is a third documented
-/// divergence otherwise.
+/// That costs nothing wherever the parse finds the `=` incidental (an attribute
+/// list with no comma to split on yields one positional value equal to the
+/// whole text, which is every unattributed markup shape) and is a third
+/// documented divergence otherwise.
 fn find_xref_matches<'src>(
     nodes: &[InlineNode<'src>],
     s: &str,
@@ -358,14 +358,15 @@ fn find_xref_matches<'src>(
 
         // An escape (`\xref:` / `\<<`) is honored by dropping the backslash and
         // keeping the rest literal. That check is made *before* looking at
-        // anything else, so the escape needs no gate of its own here either: dropping
-        // the backslash keeps the rest of the match as its **own original
-        // nodes** (a rendered span or an escaped special among them), which
-        // fold back to exactly the bytes the replacer's `caps[0][1..]` emits.
-        // (This is the same check-order fix the `footnoteref:` and menu
-        // increments made for their own families; before it, an escaped
-        // `\xref:sec[*bold*]` whose match the gate rejected was left
-        // unrecognized, backslash and all.)
+        // anything else, so the escape needs no gate of its own here either:
+        // dropping the backslash keeps the rest of the match as its
+        // **own original nodes** (a rendered span or an escaped special
+        // among them), which fold back to exactly the bytes the
+        // replacer's `caps[0][1..]` emits. (This is the same
+        // check-order fix the `footnoteref:` and menu increments made
+        // for their own families; before it, an escaped `\xref:sec[*
+        // bold*]` whose match the gate rejected was left unrecognized,
+        // backslash and all.)
         if whole.as_str().starts_with('\\') {
             matches.push(MacroMatch {
                 kind: MacroMatchKind::Unescape {
@@ -478,21 +479,21 @@ fn attrlist_text_carries_its_opaque_pieces(
 /// author's `\u{96}0\u{97}` from the one this pass emitted: it would splice a
 /// node's source into the author's text and leave the real token standing.
 /// (`Passthroughs::restore_to` has the same blind spot — the wart the image
-/// bracket's own sibling test pins — but the string pipeline reaches it over
-/// the *finished* string, where a `role=` it never restores into simply keeps
-/// the author's bytes.)
+/// bracket's own sibling test pins — reached there over the *finished*
+/// string, where a `role=` it never restores into simply keeps the author's
+/// bytes.)
 ///
 /// So a text carrying one defers, which is what the per-slot check this
 /// replaced did for the same bytes. It is a deferral, not a rewrite: the tree
-/// claims no construct, and the string pipeline's own reading stands.
+/// claims no construct, and Asciidoctor's own reading stands.
 fn text_carries_author_written_token_bytes(raw_text: &str) -> bool {
     raw_text.contains('\u{96}') || raw_text.contains('\u{97}')
 }
 
 /// The match-string range of a `<<…>>` shorthand's **id half**: its inner up to
 /// the first `,`, or the whole inner when it carries none — the very split
-/// [`build_xref_shorthand_node`] then makes on the same bytes, and the string
-/// replacer's own `inner.split_once(',')`.
+/// [`build_xref_shorthand_node`] then makes on the same bytes, matching
+/// Asciidoctor's own `inner.split_once(',')`.
 ///
 /// This is the half [`find_xref_matches`] gates, since the id is the one value
 /// the shorthand *reads* off the match string; the reference text after the
@@ -507,8 +508,8 @@ fn shorthand_id_range(s: &str, inner: &std::ops::Range<usize>) -> std::ops::Rang
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a verbatim `xref:`
-/// macro match, computing the target and display text exactly as the string
-/// replacer does so the fold reproduces the same bytes.
+/// macro match, computing the target and display text to match Asciidoctor's
+/// own rendering byte-for-byte.
 ///
 /// The scope this builder claims is every macro-form target, including a text
 /// carrying an attribute list; the `<<id>>` shorthand is built by
@@ -518,8 +519,7 @@ fn shorthand_id_range(s: &str, inner: &std::ops::Range<usize>) -> std::ops::Rang
 /// None`); the empty target (`xref:#[]`), a target naming another document
 /// (`xref:other.adoc#frag[]`), and a target naming this document (or a file
 /// included into it in full) all carry a destination *derived* from the
-/// target itself, computed by [`xref_target_and_derived`] exactly as the
-/// string replacer computes it.
+/// target itself, computed by [`xref_target_and_derived`].
 ///
 /// The display text becomes the node's children as a single
 /// [`Text`](InlineNode::Text), so the fold recovers the provided text by
@@ -529,9 +529,9 @@ fn shorthand_id_range(s: &str, inner: &std::ops::Range<usize>) -> std::ops::Rang
 /// list (an `=`) is interpreted.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
-/// effect — notably it does **not** register the reference for resolution,
-/// which the string replacer does by recording a deferred `XrefSegment`; the
-/// cutover (design §5.2 Phase 4, step 6) wires resolution to the tree.
+/// effect — notably it does **not** register the reference for resolution
+/// itself; that happens once per parse, at fold time, via
+/// `xref_segment_from_node`.
 fn build_xref_node<'src>(
     caps: &regex::Captures<'_>,
     full: &std::ops::Range<usize>,
@@ -548,12 +548,12 @@ fn build_xref_node<'src>(
     #[allow(clippy::unwrap_used)]
     let target_match = caps.get(3).unwrap();
 
-    // The target's bytes as the string replacer reads them. A leaf the match
+    // The target's fully-resolved bytes. A leaf the match
     // string stands in as a placeholder — an expanded attribute value's `&`,
     // say (`xref:{cpp}[…]`, where `{cpp}` is `C&#43;&#43;`) — contributes its
     // own bytes here. The gate admits only such leaves, so the splice always
-    // finishes the value into bytes the replacer's own haystack held; a
-    // *masked* construct, whose bytes it would not have held yet, keeps the
+    // finishes the value into bytes already fully resolved; a
+    // *masked* construct, whose bytes are not yet resolved, keeps the
     // match deferred instead.
     let restored_target = restored_range(
         target_match.as_str(),
@@ -584,9 +584,8 @@ fn build_xref_node<'src>(
         // The *effective* style, not the macro's override: an
         // `xrefstyle=` on the macro wins, and otherwise the document-wide
         // `xrefstyle` **in effect at this point in the document** is resolved
-        // into the node here — the same reading, at the same moment, the string
-        // replacer makes (design §3.3.1 point 1: every order-dependent fact is
-        // resolved into node values at build time, so the fold is pure).
+        // into the node here — every order-dependent fact is resolved into
+        // node values at build time, so the fold stays pure.
         xrefstyle: xrefstyle.or_else(|| document_xrefstyle(parser)),
         attrs: Attrlist::empty(location.slice(0..0)),
         location,
@@ -597,7 +596,7 @@ fn build_xref_node<'src>(
 /// [`InlineXrefReplacer::replace_append`](crate::content::macros)'s own text
 /// interpretation exactly so the fold reproduces the same bytes: a text
 /// carrying an `=` is parsed — from a newline-normalized copy, since the parse
-/// is not necessarily verbatim (mirroring the string replacer, which parses
+/// is not necessarily verbatim (matching Asciidoctor, which parses
 /// the same normalized copy rather than a source slice) — as an
 /// [`Attrlist`], whose first positional attribute becomes the display text
 /// and whose `window`/`role`/`xrefstyle` named attributes are honored. If the
@@ -631,9 +630,9 @@ fn xref_macro_text<'src>(
 
     if raw_text.contains('=') {
         // Tokened before the parse, so an opaque piece the text encloses reads
-        // to the split as the one indivisible run the string replacer's own
-        // markup is there (see [`tokened_text`]). A text enclosing none comes
-        // back byte-identical, which is every list that was already at parity.
+        // to the split as one indivisible run standing in for its rendered
+        // markup (see [`tokened_text`]). A text enclosing none comes
+        // back byte-identical.
         #[allow(clippy::unwrap_used)]
         let text_range = text_span.unwrap();
 
@@ -678,9 +677,8 @@ fn xref_macro_text<'src>(
                     // with no `'src` slice of its own (it comes from the
                     // normalized, attrlist-parsed copy, not the source
                     // directly); it falls back to the bracketed text's own
-                    // span (design §4.4), mirroring the synthesized-value
-                    // location policy `apply_attribute_references` already
-                    // establishes.
+                    // span, the same synthesized-value location policy
+                    // `apply_attribute_references` already establishes.
                     let location = source_slice(pieces, text_range.start()..text_range.end(), root);
 
                     // Each token this value still holds becomes the node it
@@ -706,7 +704,7 @@ fn xref_macro_text<'src>(
 }
 
 /// Builds the display-text children for a text with no attribute list (or one
-/// whose `=` was incidental), mirroring the string replacer's own
+/// whose `=` was incidental), matching Asciidoctor's own
 /// `raw_text.replace("\\]", "]")` unescape.
 fn plain_xref_text<'src>(
     raw_text: &str,
@@ -724,12 +722,12 @@ fn plain_xref_text<'src>(
 }
 
 /// Builds one [`Ref`](InlineNode::Ref)`{Xref}` node from a `<<id>>` shorthand
-/// cross-reference, computing the target and display text exactly as the string
-/// replacer's shorthand branch does so the fold reproduces the same bytes.
+/// cross-reference, computing the target and display text to match
+/// Asciidoctor's own shorthand handling byte-for-byte.
 ///
 /// `inner` is the shorthand's inner text (`INLINE_XREF` group 2) in
 /// match-string coordinates. It is split on the first `,` into an id and an
-/// optional reference text, each trimmed — mirroring the string replacer's
+/// optional reference text, each trimmed — matching Asciidoctor's
 /// `inner.split_once(',')` with `id.trim()` / `text.trim()`, which runs over
 /// the very same bytes.
 ///
@@ -741,14 +739,14 @@ fn plain_xref_text<'src>(
 /// comma that split them. The reference text after that comma carries no such
 /// guarantee: it becomes the node's children through [`macro_text_children`] —
 /// a single [`Text`](InlineNode::Text) borrowed from `'src` in the common
-/// verbatim case (§4.5), owned when it crosses a synthesized run, structured
+/// verbatim case, owned when it crosses a synthesized run, structured
 /// when it crosses an escaped special or an opaque piece (whose own node the
 /// children then carry). The whole `<<…>>` — its `CharRef` delimiters
 /// included — is the node's `location` (a synthesized run's coarse enclosing
-/// span, per design §4.4).
+/// span, for a construct with no `Span`-typed field of its own).
 ///
-/// **A comma is what makes a text *present*, not what it contains.** The
-/// string replacer's own split records `<<id,>>` (and `<<id,   >>`) as a
+/// **A comma is what makes a text *present*, not what it contains.**
+/// Asciidoctor's own split records `<<id,>>` (and `<<id,   >>`) as a
 /// *present-but-empty* text — `Some("")`, which renders an empty `<a>…</a>`
 /// rather than the bracketed `[id]` fallback `None` renders — so a shorthand
 /// carrying a comma always builds at least one child, empty value and
@@ -768,17 +766,17 @@ fn plain_xref_text<'src>(
 /// [`xref_target_and_derived`] exactly as the macro form's.
 ///
 /// A shorthand whose id already carries a rendered `<` (an earlier-substituted
-/// macro, e.g. `<<link:https://example.com[], Example>>`) — which the string
-/// replacer's own `id.contains('<')` guard leaves untouched — cannot reach here
+/// macro, e.g. `<<link:https://example.com[], Example>>`) — which Asciidoctor's
+/// own `id.contains('<')` guard leaves untouched — cannot reach here
 /// at all: rendered markup is an *opaque* piece, so the caller never calls this
-/// builder. That is why no counterpart to the guard is needed: an id carrying a
-/// merely *escaped* `<`, which the gate does admit, is an entity by macro time
-/// in both pipelines, so neither the guard nor this builder ever sees a bare
-/// `<` there.
+/// builder. That is why no counterpart to the guard is needed here: an id
+/// carrying a merely *escaped* `<`, which the gate does admit, is an entity
+/// by macro time, so this builder never sees a bare `<` there.
 ///
 /// As in the additive builder generally, this performs *no* recognition side
-/// effect — notably it does **not** register the reference for resolution; the
-/// cutover (design §5.2 Phase 4, step 6) wires resolution to the tree.
+/// effect — notably it does **not** register the reference for resolution
+/// itself; that happens once per parse, at fold time, via
+/// `xref_segment_from_node`.
 fn build_xref_shorthand_node<'src>(
     inner: std::ops::Range<usize>,
     full: &std::ops::Range<usize>,
@@ -789,8 +787,8 @@ fn build_xref_shorthand_node<'src>(
     parser: &Parser,
 ) -> InlineNode<'src> {
     // The inner crosses no atomic piece (the caller checked), so the match
-    // string carries its logical bytes exactly — which is what the string
-    // replacer's own `inner.split_once(',')` sees. Reading them here rather
+    // string carries its logical bytes exactly — which is what
+    // Asciidoctor's own `inner.split_once(',')` sees. Reading them here rather
     // than through the inner's source slice is what lets a shorthand inside an
     // expanded attribute value be recognized: a synthesized run has no `'src`
     // slice of its own. A byte offset within `inner_data` maps to a
@@ -814,9 +812,9 @@ fn build_xref_shorthand_node<'src>(
         None => inner_data,
     };
 
-    // The id's bytes as the string replacer reads them — see
+    // The id's fully-resolved bytes — see
     // [`restored_range`]. The `trim` is applied after, on the restored value,
-    // exactly as the replacer trims its own `id`.
+    // matching Asciidoctor's own trim of its `id`.
     let id_range = inner.start..inner.start + raw_id.len();
     let restored_id = restored_range(raw_id, id_range, nodes, pieces, parser);
 
@@ -836,7 +834,7 @@ fn build_xref_shorthand_node<'src>(
             // when the text is empty (or whitespace-only), which is the
             // present-but-empty text the doc comment describes — while a
             // synthesized one keeps its exact expanded bytes against the
-            // enclosing run's coarse location (design §4.4).
+            // enclosing run's coarse location.
             let lead = raw_text.len() - raw_text.trim_start().len();
 
             let text_start = inner.start + index + 1 + lead;
@@ -844,9 +842,9 @@ fn build_xref_shorthand_node<'src>(
 
             // The same one-child-or-structured-children split the macro form
             // makes, reached through the shared helper — but with **no** `\]`
-            // unescape: the shorthand has no bracket to escape, and the string
-            // replacer's own shorthand branch performs no such replace, so a
-            // `\]` written here stays literal in both pipelines. An empty (or
+            // unescape: the shorthand has no bracket to escape, and
+            // Asciidoctor's own shorthand branch performs no such replace, so a
+            // `\]` written here stays literal. An empty (or
             // whitespace-only) text crosses nothing, so it takes the helper's
             // single-child path and keeps the zero-length child the fold keys
             // `provided_text` on.
@@ -891,9 +889,9 @@ mod tests {
         parser::{HtmlInlineRenderer, XrefStyle},
     };
 
-    /// The string pipeline's output through the **whole** `Normal` group —
-    /// the attributes step included — with any deferred cross-reference
-    /// finalized to its unresolved fallback.
+    /// The frozen recording of `source`'s rendered output through the
+    /// **whole** `Normal` group — the attributes step included — with any
+    /// deferred cross-reference finalized to its unresolved fallback.
     ///
     /// [`golden_xref`] deliberately drives the macro-family steps only, which
     /// is right for a verbatim fixture and wrong for one whose target is
@@ -904,13 +902,13 @@ mod tests {
         crate::content::inline_builder::snapshot::recorded("xref_whole_pipeline", source)
     }
 
-    /// The string pipeline's output through the **macros** step for `source`,
-    /// with any deferred cross-references finalized to their unresolved
-    /// fallback. Unlike [`golden_macros`], the macros step defers a
-    /// cross-reference to a placeholder rather than rendering it, so the
-    /// placeholder must be finalized — no catalog resolution runs, so the
-    /// result is the unresolved-fallback rendering the additive builder's
-    /// fold (always unresolved) must reproduce.
+    /// The frozen recording of `source`'s rendered output through the
+    /// **macros** step, with any deferred cross-references finalized to their
+    /// unresolved fallback. Unlike [`golden_macros`], the macros step
+    /// defers a cross-reference to a placeholder rather than rendering it,
+    /// so the placeholder must be finalized — no catalog resolution runs,
+    /// so the result is the unresolved-fallback rendering the additive
+    /// builder's fold (always unresolved) must reproduce.
     fn golden_xref_with(source: &str, _parser: &Parser) -> String {
         crate::content::inline_builder::snapshot::recorded("xref_macros", source)
     }
@@ -933,12 +931,12 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_xrefs() {
         // For each fixture, folding the single-pass tree (all five steps)
-        // reproduces the string pipeline's output byte-for-byte. This is the
-        // differential corpus (design §5.3) that pins the cross-reference
-        // increment. Every fixture is a *verbatim* cross-reference in either
+        // reproduces the frozen recording byte-for-byte. This is the
+        // differential corpus that pins cross-reference behavior. Every
+        // fixture is a *verbatim* cross-reference in either
         // spelling, whether it resolves through the catalog (same-document) or
         // through a target-derived destination (inter-document, or the
-        // document-as-a-whole form) — the boundary this increment claims (an
+        // document-as-a-whole form) — the boundary this family claims (an
         // attribute-list text, and a shorthand crossing a special/span, are
         // deferred and live in divergence tests below).
         let fixtures = [
@@ -1020,7 +1018,7 @@ mod tests {
             "*see <<x>>*",
             "_<<y,Y>> in em_",
             // A reference text crossing an *escaped special*: the match string
-            // carries the entity the string replacer's own haystack carries, so
+            // carries the entity itself, so
             // both spellings are recognized, the text becoming structured
             // children (a `CharRef` between two `Text` runs) that fold back to
             // the same entity.
@@ -1041,10 +1039,10 @@ mod tests {
             "xref:install[Tom & Jerry,role=hl]",
             "xref:install[a<b,window=_blank]",
             "xref:install[a > b,role=hl]",
-            // A *target* crossing one. The macro form reads it exactly as the
-            // string replacer does (an id of `foo&amp;bar`); the shorthand
+            // A *target* crossing one. The macro form reads it the same way
+            // Asciidoctor does (an id of `foo&amp;bar`); the shorthand
             // form's own `id.contains('<')` guard never fires, since an escaped
-            // special is an entity by macro time in both pipelines.
+            // special is an entity by macro time.
             "xref:foo&bar[Ampersand]",
             "<<foo&bar,Ampersand>>",
             // Escaped, crossing one: the backslash is dropped and the rest
@@ -1121,17 +1119,16 @@ mod tests {
         // `xref:#install[]` uses the explicit-`#` same-document form. The
         // node's `target` is the *interpreted* id (`install`), not the
         // raw `#install`: it is the value the renderer builds the
-        // `href` from and resolution keys on, matching the string
-        // pipeline and the recorder tree (see the `Ref::target` field
+        // `href` from and resolution keys on (see the `Ref::target` field
         // docs). Storing `#install` would fold to `href="##install"`
-        // and break parity.
+        // instead.
         let nodes = build_src(Span::new("xref:#install[Install]"));
 
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.target.as_ref(), "install");
         assert_eq!(link_text_of(reference), "Install");
 
-        // The fold reproduces the string pipeline's `href="#install"` exactly.
+        // The fold produces `href="#install"` exactly.
         let folded = fold_html(&nodes, &HtmlInlineRenderer {});
         assert!(folded.contains(r##"href="#install""##), "folded: {folded}");
         assert_eq!(folded, golden_xref("xref:#install[Install]"));
@@ -1155,8 +1152,7 @@ mod tests {
     #[test]
     fn an_escaped_xref_stays_literal() {
         // `\xref:…` drops the backslash and keeps the macro as literal text —
-        // no reference node — exactly as the string replacer's escape
-        // branch does.
+        // no reference node.
         let source = "\\xref:install[Installation]";
         let nodes = build_src(Span::new(source));
 
@@ -1173,8 +1169,7 @@ mod tests {
 
     #[test]
     fn an_escaped_xref_the_gate_rejects_still_drops_its_backslash() {
-        // The escape check runs *ahead* of the gate, mirroring the string
-        // replacer's own `caps.get(1)`-first order: a macro the gate rejects
+        // The escape check runs *ahead* of the gate: a macro the gate rejects
         // (here, an *attribute-list* display text crossing a rendered span,
         // the one text shape that still needs its own bytes) still drops its
         // backslash and keeps the rest — the rendered span included — as its
@@ -1232,8 +1227,7 @@ mod tests {
     fn an_xref_shorthand_display_text_is_located_at_its_trimmed_source() {
         // The reference text's `Text` child locates at the *trimmed* text
         // within the shorthand, not at the whole shorthand and not
-        // including the surrounding whitespace the string replacer
-        // trims.
+        // including the surrounding whitespace that gets trimmed.
         let nodes = build_src(Span::new("<<install, Install Now >>"));
 
         let reference = assert_xref(&nodes[0]);
@@ -1262,8 +1256,7 @@ mod tests {
     #[test]
     fn an_escaped_xref_shorthand_stays_literal() {
         // `\<<id>>` drops the backslash and keeps the shorthand as literal text
-        // — no reference node — exactly as the string replacer's escape
-        // branch does. Its delimiters are non-verbatim `CharRef`s, so
+        // — no reference node. Its delimiters are non-verbatim `CharRef`s, so
         // this also exercises the escape path that does not require a
         // verbatim inner.
         let source = "\\<<install,Install Now>>";
@@ -1336,8 +1329,8 @@ mod tests {
 
     #[test]
     fn an_xref_shorthand_with_an_empty_text_keeps_it_present() {
-        // `<<id,>>` records a *present-but-empty* reference text: the string
-        // replacer renders an empty `<a href="#install"></a>`, not the
+        // `<<id,>>` records a *present-but-empty* reference text: it
+        // renders an empty `<a href="#install"></a>`, not the
         // bracketed `[install]` fallback a comma-less shorthand renders. The
         // node keeps the distinction structurally — the text is present as one
         // empty `Text` child — so the fold reproduces the same bytes.
@@ -1379,14 +1372,14 @@ mod tests {
     fn a_real_documents_empty_shorthand_text_reaches_its_tree() {
         // End-to-end, through the real parse path, and with the reference
         // *resolved*: this is the shape that makes the form a blocker for the
-        // authoritative fold rather than an unclaimed one — a golden test
+        // fold rather than an unclaimed one — a golden test
         // already exercises it (`xref_should_use_title_of_target_as_link_text_
         // when_explicit_link_text_is_empty` in `tests/asciidoctor_rb/
-        // links_test.rs`, design §5.3's oracle). Resolution reaches the node
-        // too: the positional mirror skips a list whose node count diverges
-        // from the string pipeline's deferred segments, so leaving the
-        // shorthand unrecognized used to cost the whole content its resolved
-        // destinations.
+        // links_test.rs`, part of the ported `asciidoctor` test suite).
+        // Resolution reaches the node too: the positional mirror skips a list
+        // whose node count diverges from the number of deferred segments the
+        // tree produces, so leaving the shorthand unrecognized would cost the
+        // whole content its resolved destinations.
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = Parser::default().parse("<<tigers,>>\n\n[#tigers]\n== Tigers");
@@ -1416,7 +1409,7 @@ mod tests {
 
     #[test]
     fn a_whitespace_only_xref_shorthand_text_trims_to_an_empty_present_text() {
-        // The reference text is trimmed exactly as the string replacer trims
+        // The reference text is trimmed the same way Asciidoctor trims
         // it, so a whitespace-only text is the same present-but-empty text —
         // its zero-length span sitting where the trim left it, after the
         // leading whitespace.
@@ -1439,8 +1432,7 @@ mod tests {
         // the span is one opaque placeholder in the match string, but
         // `macro_text_children` recovers the text with `emit_range`, which
         // clones the span's own node whole into the reference's children. The
-        // fold then re-renders exactly the markup the string replacer captured
-        // in its own reference text.
+        // fold then re-renders exactly that markup.
         let source = "<<x,a *bold* b>>";
         let nodes = build_src(Span::new(source));
 
@@ -1471,8 +1463,7 @@ mod tests {
     fn an_inter_document_xref_becomes_a_ref_node() {
         // An inter-document target (`other.adoc#frag`) carries a *derived*
         // destination computed from the target itself — the AsciiDoc extension
-        // stripped, the output suffix substituted in — mirroring the string
-        // replacer's own target interpretation exactly.
+        // stripped, the output suffix substituted in.
         let source = "xref:other.adoc#frag[Elsewhere]";
         let nodes = build_src(Span::new(source));
 
@@ -1502,8 +1493,8 @@ mod tests {
 
     #[test]
     fn an_xref_text_over_a_special_character_becomes_structured_children() {
-        // A cross-reference whose text contains `<` is matched by the string
-        // pipeline over the *escaped* text (`xref:foo[a&lt;b]`), which is
+        // A cross-reference whose text contains `<` is matched over the
+        // *escaped* text (`xref:foo[a&lt;b]`), which is
         // exactly what the level's match string carries too. The text becomes
         // structured children rather than one sliced `Text`, so the escaped
         // special stays the `CharRef` it already is — folding back to the same
@@ -1543,7 +1534,7 @@ mod tests {
     fn an_xref_shorthand_text_over_a_special_character_becomes_structured_children() {
         // The shorthand's own version of the case directly above: the id is
         // read from the match string (where an escaped special is its entity,
-        // so the string replacer's `id.contains('<')` guard never fires there
+        // so the `id.contains('<')` guard never fires there
         // either) and the trimmed reference text becomes structured children.
         let source = "<< spaced , Tom & Jerry >>";
         let nodes = build_src(Span::new(source));
@@ -1572,8 +1563,8 @@ mod tests {
     fn an_xref_attribute_list_text_over_a_special_character_holds_logical_text() {
         // The attribute-list branch computes its display text by *parsing* the
         // already-escaped match-string text, so the positional value comes back
-        // holding `&amp;`. A `Text` node holds logical text the fold escapes
-        // (design §3.4), so the entity is put back to its character here and
+        // holding `&amp;`. A `Text` node holds logical text the fold escapes,
+        // so the entity is put back to its character here and
         // re-escaped at fold time — one round trip, not two escapes.
         let source = "xref:install[Tom & Jerry,role=hl]";
         let nodes = build_src(Span::new(source));
@@ -1594,8 +1585,8 @@ mod tests {
     fn fold_matches_the_string_pipeline_for_a_cross_reference_crossing_a_restored_entity() {
         // A restored entity (`&copy;`, `&#8217;`) is admitted for the same
         // reason an escaped special is: the level's match string carries its
-        // own bytes — the string pipeline's haystack bytes from the
-        // replacements step onward — and the fold emits them verbatim.
+        // own bytes — the fully-resolved bytes from the character-replacements
+        // step onward — and the fold emits them verbatim.
         let fixtures = [
             // A reference text crossing one, in both spellings.
             "xref:sec[Tom &copy; Jerry]",
@@ -1643,7 +1634,7 @@ mod tests {
         // A typographic replacement is the third recoverable piece, admitted
         // for the same reason the two entity leaves are: the level's match
         // string carries the entity the built-in backend renders it as — the
-        // string pipeline's own haystack bytes from the replacements step
+        // same fully-resolved bytes from the character-replacements step
         // onward — and the fold routes the leaf back through the renderer to
         // those same bytes.
         let fixtures = [

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1704,7 +1704,7 @@ mod tests {
         // `escaped_value_children` re-derives the same split from the value's
         // own bytes: the escaped special becomes the character a `Text` holds
         // logically, and the restored entity its own `CharRef` leaf. Both fold
-        // back to one escape level, as the string replacer's own text does.
+        // back to one escape level, as Asciidoctor's own text does.
         let source = "xref:sec[Tom &copy; & Jerry,role=hl]";
         let nodes = build_src(Span::new(source));
 
@@ -1713,7 +1713,7 @@ mod tests {
         assert_eq!(reference.children.len(), 3);
 
         // Every part of a parsed positional value shares the bracketed text's
-        // own coarse span (design §4.4) — it has no `'src` slice of its own.
+        // own coarse span — it has no `'src` slice of its own.
         let text_span = reference.children[0].span();
         assert_eq!(text_span.data(), "Tom &copy; & Jerry,role=hl");
 
@@ -1817,15 +1817,15 @@ mod tests {
 
     #[test]
     fn fold_matches_the_string_pipeline_for_a_text_crossing_a_rendered_span() {
-        // The differential corpus for this increment: a display or reference
+        // The differential corpus for cross-reference text: a display or
+        // reference
         // text crossing an **opaque** piece — a rendered span, an
         // already-recognized macro node, a masked passthrough — in both
         // spellings. The text is carried structurally (each opaque piece's own
-        // node becomes a child), so the fold re-renders exactly the markup the
-        // string replacer captured in its own text.
+        // node becomes a child), so the fold re-renders exactly that markup.
         let fixtures = [
-            // (A masked passthrough is opaque here too — and in the string
-            // pipeline, which restores passthroughs only after every step — but
+            // (A masked passthrough is opaque here too, and restored only
+            // after every step, but
             // this oracle runs the steps directly, without the extraction the
             // real `SubstitutionGroup::apply` performs around them, so those
             // fixtures live in the whole-pipeline sweep instead; see
@@ -1961,8 +1961,7 @@ mod tests {
 
                 // The bytes around the token take the same rebuild every
                 // attribute-list value takes: an owned run off the parse,
-                // whose location is the bracketed text's own coarse span
-                // (design §4.4).
+                // whose location is the bracketed text's own coarse span.
                 assert_eq!(value.as_ref(), " here");
             }
 
@@ -1972,12 +1971,13 @@ mod tests {
 
     #[test]
     fn an_attribute_list_delimiter_inside_a_span_is_the_trees_to_read() {
-        // The deferral divergence (design §5.2's step 6), decided in favor of
+        // The deferral divergence, decided in favor of
         // the tree.
         //
         // A token carries none of the `,` / `=` / `"` a bracket split reads, so
         // the tree's split sees `a ␖ d,role=hl` — a display text and a role.
-        // The string replacer splits over the piece's own **markup**: `a *b, c*
+        // Splitting over the piece's own rendered **markup** instead gives a
+        // different answer: `a *b, c*
         // d` renders `a <strong>b, c</strong> d`, whose list splits at the
         // comma *inside the tag*, ending the anchor at `a <strong>b` and
         // leaving it unbalanced. Asciidoctor does the same.
@@ -1985,9 +1985,9 @@ mod tests {
         // This used to defer where the two readings disagreed, which made the
         // presence of a comma inside a span decide whether the macro was
         // recognized **at all** — the fixtures below came out as literal text.
-        // Emitting the replacer's split is the wrong answer and reproducing it
-        // was never on the table, so the tree's reading stands and this crate
-        // diverges from both the replacer and Asciidoctor here.
+        // Splitting over rendered markup is the wrong answer, and reproducing
+        // it was never on the table, so the tree's reading stands and this
+        // crate diverges from Asciidoctor here.
         for (source, expected) in [
             (
                 "xref:sec[a *b, c* d,role=hl]",
@@ -2005,7 +2005,8 @@ mod tests {
             };
 
             // The role landed as a role rather than being swallowed into the
-            // display text, which is the half the replacer's split loses.
+            // display text, which is the half a split over rendered markup
+            // would lose.
             assert_eq!(
                 ref_.roles.iter().map(|r| r.as_ref()).collect::<Vec<_>>(),
                 ["hl"],
@@ -2027,8 +2028,8 @@ mod tests {
                 "for {source:?}"
             );
 
-            // The divergence, stated as bytes: the replacer cuts the anchor
-            // short inside the tag it just wrote.
+            // The divergence, stated as bytes: the frozen recording cuts the
+            // anchor short inside the tag it just wrote.
             assert_ne!(golden_xref(source), expected, "for {source:?}");
         }
 
@@ -2068,15 +2069,15 @@ mod tests {
                 "an author-written token byte must defer the match: {nodes:?}"
             );
 
-            // The string pipeline builds one, keeping the author's bytes: it
-            // reaches its own restore over the *finished* string, which never
-            // rewrites a `role=` it did not extract into.
+            // The frozen recording builds one, keeping the author's bytes:
+            // passthrough restoration ran over the *finished* string, which
+            // never rewrote a `role=` it did not extract into.
             assert!(golden_whole_pipeline(source).contains("<a href"));
         }
 
         // A text with **no** opaque piece never reaches that gate, and needs
         // not to: there is no token to confuse, so the author's bytes pass
-        // through to the slot exactly as the string pipeline passes them.
+        // through to the slot unchanged.
         let source = "xref:sec[a,role=\u{96}0\u{97}hl]";
         assert_eq!(
             fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
@@ -2103,9 +2104,9 @@ mod tests {
 
         // A masked passthrough contributes its **body**, not its source span:
         // the `+++` delimiters are syntax saying *do not substitute this*, so
-        // the body is exactly the literal text asked for — here a value the
-        // string pipeline cannot express at all (`full` reaches the slot as a
-        // sentinel, so it never selects a style).
+        // the body is exactly the literal text asked for — a value that used
+        // to reach this slot only as its passthrough-placeholder token, never
+        // as `full` itself, so it could never select a style.
         let nodes = build_src(Span::new("xref:sec[a,xrefstyle=+++full+++]"));
         let reference = assert_xref(&nodes[0]);
         assert_eq!(reference.xrefstyle, Some(XrefStyle::Full));
@@ -2131,11 +2132,11 @@ mod tests {
     fn an_untranslated_string_attribute_is_escaped_by_the_renderer() {
         // What the slot holds is *text*, and the renderer escapes it for the
         // attribute it is building — so a body carrying a `"` or an `&` lands
-        // inert rather than breaking out of the tag. The string pipeline
-        // cannot make this guarantee (a passthrough is restored into the
-        // rendered string after every escape has run), which is the whole
-        // reason the values differ; here it does not even reach the value,
-        // leaking the sentinel that stood for it instead.
+        // inert rather than breaking out of the tag. The frozen recording
+        // cannot make this guarantee: a passthrough there is restored into
+        // the rendered string only after every escape has run, so it never
+        // reaches the value at all — leaking the sentinel that stood for it
+        // instead.
         for (source, expected) in [
             (
                 "xref:sec[a,role=+++x&y\"z+++]",
@@ -2169,25 +2170,27 @@ mod tests {
     #[test]
     fn a_span_whose_markup_perturbs_the_string_pipeline_is_a_documented_divergence() {
         // What the structural recovery cannot do is make the *recognition*
-        // agree in every case: the string replacer matches over the span's
-        // markup where this matches over the one placeholder standing in for
-        // it, so the two read the same extent only while that markup carries
-        // no character the pattern is sensitive to. These are the three shapes
-        // where it does — and in each the string pipeline's reading is the
-        // markup-perturbed one (a truncated text, a text the attribute-list
-        // parse cut in half) and the tree's the well-formed one, exactly as
+        // agree in every case: matching over the span's rendered markup
+        // instead of the one placeholder standing in for it reads a different
+        // extent whenever that markup carries a character the pattern is
+        // sensitive to. These are the three shapes
+        // where it does — and in each the well-formed reading is the tree's,
+        // not the markup-perturbed one a match over raw text would give
+        // (a truncated text, a text the attribute-list
+        // parse cut in half) — exactly as
         // the quotes step's own crossed-delimiter divergence is.
         for source in [
-            // A `]` inside the span ends the macro form's lazy text capture
-            // early for the string replacer, but not here.
+            // A `]` inside the span would end the macro form's lazy text
+            // capture early if matched over raw markup, but not here.
             "xref:sec[a *b ] c* d]",
-            // A `>>` inside the span is the shorthand's own terminator, seen
-            // as `&gt;&gt;` in the string pipeline's haystack.
+            // A `>>` inside the span is the shorthand's own terminator, which
+            // a match over raw markup would see as `&gt;&gt;`.
             "<<x,a *b >> c* d>>",
             // Markup carrying an `=` (an attributed span) *and* a comma
-            // elsewhere in the text: the string replacer's attribute-list
-            // probe fires on the markup's own `=`, and the parse then splits
-            // the text at that comma, keeping only what precedes it.
+            // elsewhere in the text: matching over raw markup would have its
+            // attribute-list probe fire on the markup's own `=`, and the
+            // parse then split the text at that comma, keeping only what
+            // precedes it.
             "xref:sec[one, [.hl]#two#]",
         ] {
             let nodes = build_src(Span::new(source));
@@ -2205,17 +2208,17 @@ mod tests {
         // The cross-reference family keeps the opaque-piece gate over a
         // masked passthrough — unlike the `link:`/`mailto:` family, which
         // restores one into its target — because a deferred cross-reference's
-        // target is used *before* the restore pass can reach it: the string
-        // pipeline captures it into the deferred segment while the haystack
-        // still holds the `\u{96}`*n*`\u{97}` sentinel, and the restore pass
-        // rewrites only the rendered string, so the sentinel bytes leak into
-        // the golden output's own `href` and fallback text. The tree defers
+        // target used to be captured into the deferred segment while the
+        // haystack still held the `\u{96}`*n*`\u{97}` passthrough sentinel,
+        // before the restore pass — which rewrote only the rendered string —
+        // could reach it, so the sentinel bytes leaked into the recorded
+        // output's own `href` and fallback text. The tree defers
         // instead and folds the restored literal — the well-formed reading
-        // against the string pipeline's leaked one.
+        // against that recorded, leaked one.
         let source = "xref:++someid++[]";
 
         // Recorded, so the leaked bytes this divergence is *about* outlive the
-        // string pipeline that leaked them (see [`snapshot`]).
+        // retired mechanism that produced them (see [`snapshot`]).
         let golden = crate::content::inline_builder::snapshot::recorded(
             "xref_passthrough_divergence",
             source,
@@ -2363,8 +2366,8 @@ mod tests {
     fn fold_matches_the_string_pipeline_under_a_document_wide_xrefstyle() {
         // The differential corpus for the reading above: with the style
         // resolved into the node rather than read at fold time, the fold still
-        // reproduces the string pipeline's bytes — the string replacer making
-        // the very same `document_xrefstyle` call in the very same pass.
+        // reproduces the frozen recording's bytes — `document_xrefstyle` is
+        // called at build time, in the very same pass the recording reflects.
         //
         // These fold to the *unresolved* fallback (a bare `Content` has no
         // catalog), which is the shape both sides agree on here; the resolved
@@ -2534,11 +2537,12 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_for_xrefs_inside_expanded_values() {
         // A cross-reference whose target or reference text crosses a
-        // *synthesized* run (an attribute expansion) is now recognized:
+        // *synthesized* run (an attribute expansion) is recognized:
         // nothing on a `Ref{Xref}` node is `Span`-typed — its target and text
         // come from the match string, which carries a synthesized run's bytes
         // exactly — so only the node's `location` takes
-        // design §4.4's coarse fallback. This is the same lift the anchor,
+        // the coarse fallback span used when a construct has no `Span`-typed
+        // field of its own. This is the same lift the anchor,
         // bare-e-mail, UI, and index-term families already made.
         let parser = expanding_parser();
 
@@ -2598,8 +2602,8 @@ mod tests {
     #[test]
     fn an_xref_inside_an_expanded_value_keeps_a_coarse_location() {
         // The values are exact; only the node's `location` (and its children's)
-        // falls back to the enclosing synthesized run's coarse span (design
-        // §4.4), since an expanded value's bytes have no `'src` counterpart of
+        // falls back to the enclosing synthesized run's coarse span,
+        // since an expanded value's bytes have no `'src` counterpart of
         // their own. A reference text recovered from such a run is necessarily
         // owned rather than borrowed.
         use crate::strings::CowStr;
@@ -2663,16 +2667,19 @@ mod tests {
 
     #[test]
     fn an_xref_target_may_be_attribute_expanded() {
-        // The point of this increment. `{cpp}` is `C&#43;&#43;`, and §3.4.1
-        // leaves an expanded value's `&` unescaped — so the target crosses two
+        // `{cpp}` is `C&#43;&#43;`, and an expanded attribute value's `&` is
+        // left unescaped, since the attributes step runs after
+        // `specialcharacters` — so the target crosses two
         // `Raw` leaves, which the match string stands in as placeholders.
         //
         // Those leaves are `RawOrigin::Substitution`: nothing extracted them
-        // and nothing restores them, so the string replacer's own haystack held
-        // exactly these bytes. Filling the placeholders in therefore reaches
-        // parity rather than departing from it — where a *masked* passthrough,
-        // which the replacer would not have restored yet, keeps its match
-        // deferred (`a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`).
+        // and nothing restores them, so these are exactly the bytes a
+        // rendered value holds. Filling the placeholders in therefore
+        // reproduces that value rather than departing from it — where a
+        // *masked* passthrough, not yet restored at this point, keeps its
+        // match deferred
+        // (`a_deferred_xref_target_over_a_passthrough_is_a_documented_divergence`).
+        //
         let renderer = HtmlInlineRenderer {};
 
         for fixture in [
@@ -2702,10 +2709,10 @@ mod tests {
     fn an_xref_over_a_rendered_span_in_an_expanded_value_is_still_deferred() {
         // Lifting the boundary admits a *synthesized* run, not an
         // [`atomic`](Piece::atomic) one: an expanded value whose own `<` became
-        // a `Raw` leaf (design §3.4.1 — the attributes step runs after
+        // a `Raw` leaf (the attributes step runs after
         // `specialcharacters`, so a literal special in a value is emitted
-        // unescaped) is opaque, so the shorthand around it still defers. The
-        // string pipeline leaves it literal too, for its own reason: its
+        // unescaped) is opaque, so the shorthand around it still defers.
+        // Asciidoctor leaves it literal too, for its own reason: its
         // `id.contains('<')` guard.
         use crate::parser::ModificationContext;
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -2155,7 +2155,7 @@ mod tests {
 
             assert!(
                 golden_whole_pipeline(source).contains('\u{96}'),
-                "the string pipeline is expected to leak its sentinel for {source:?}"
+                "the frozen recording is expected to leak its sentinel for {source:?}"
             );
         }
 
@@ -2198,7 +2198,7 @@ mod tests {
             assert_ne!(
                 fold_html(&nodes, &HtmlInlineRenderer {}),
                 golden_xref(source),
-                "{source:?} now agrees with the string pipeline; fold it into the parity corpus"
+                "{source:?} now agrees with the frozen recording; fold it into the parity corpus"
             );
         }
     }
@@ -2226,7 +2226,7 @@ mod tests {
 
         assert!(
             golden.contains('\u{96}'),
-            "expected the string pipeline's sentinel leak to still reproduce: {golden:?}"
+            "expected the frozen recording's sentinel leak to still reproduce: {golden:?}"
         );
 
         let nodes = build_src(Span::new(source));

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -142,9 +142,10 @@ pub(super) fn xref_macros_level<'src>(
     rebuild_macro_level(&nodes, &pieces, &s, matches)
 }
 
-/// Mirrors the string replacer's own `id.contains('<')` refusal: a shorthand
-/// whose id holds rendered inline markup is not a valid reference, and
-/// Asciidoctor leaves it untouched (`<<link:https://example.com[], Example>>`).
+/// A shorthand whose id holds rendered inline markup is not a valid
+/// reference — Asciidoctor leaves it untouched
+/// (`<<link:https://example.com[], Example>>`) — so this refuses it the same
+/// way, via `id.contains('<')`.
 ///
 /// This became reachable only with
 /// [`range_is_substitution_restorable`].
@@ -170,7 +171,8 @@ fn shorthand_id_has_no_rendered_markup(
 
 /// The bytes a range of the level's match string holds once every placeholder
 /// standing in for a **substitution-produced** [`Raw`](InlineNode::Raw) leaf is
-/// filled in — which is what the string replacer's own haystack held there.
+/// filled in — the fully-resolved bytes the construct's rendered value is
+/// computed from.
 ///
 /// Borrowed unchanged when the range crosses no such leaf, which is every
 /// ordinary cross-reference.
@@ -202,8 +204,8 @@ fn restored_range<'a>(
 /// cross-reference computes two values from the level's match string — its
 /// **target** (the `xref:` macro's group 3, the shorthand's own id half) and,
 /// when the text carries an attribute list, that list's parsed positional value
-/// — and each needs a match string whose bytes are the string replacer's own.
-/// A **reference text**, by contrast, becomes *structured children*
+/// — and each needs a match string whose bytes are already fully resolved and
+/// escaped. A **reference text**, by contrast, becomes *structured children*
 /// ([`macro_text_children`]), so it needs no recoverable bytes at all; see the
 /// rendered-span section below.
 ///
@@ -216,7 +218,8 @@ fn restored_range<'a>(
 /// run's bytes exactly — and its own attribute list is parsed from a normalized
 /// *copy* rather than a source slice (see
 /// [`xref_macro_text`]), so `attrs` is always `None` here. Only the node's
-/// `location` (and its children's) takes design §4.4's coarse fallback. This
+/// `location` (and its children's) takes the coarse fallback span used when a
+/// construct has no `Span`-typed field of its own. This
 /// is the same lift the anchor, bare-e-mail, UI, and index-term families
 /// already made, and for the same reason; the families that hold a real
 /// [`Attrlist`]`<'src>` (image, link) still cannot make it.
@@ -225,12 +228,11 @@ fn restored_range<'a>(
 /// **restored entity** (`xref:sec[Tom &copy; Jerry]`) are admitted for the same
 /// reason: the level's match string carries the
 /// [`CharRef`](InlineNode::CharRef) leaf's own bytes — a `Special`'s canonical
-/// entity, an `Entity`'s entity itself — the very bytes the string replacer's
-/// own escaped haystack holds there — so every
+/// entity, an `Entity`'s entity itself — so every
 /// value this family computes off that string (the target, the
 /// `raw_text.contains('=')` attribute-list probe, the attrlist parse itself,
-/// the shorthand's `split_once(',')`) sees exactly what the string replacer
-/// sees. The reference *text* is then rebuilt as structured children rather
+/// the shorthand's `split_once(',')`) sees the construct's fully-escaped
+/// bytes directly. The reference *text* is then rebuilt as structured children rather
 /// than one sliced [`Text`](InlineNode::Text) (see [`macro_text_children`]), so
 /// the leaf folds back to its own bytes instead of being escaped
 /// twice — and the attribute-list branch, whose value comes back from a parse
@@ -241,28 +243,28 @@ fn restored_range<'a>(
 ///
 /// A **rendered span** — a [`Styled`](crate::inlines::Styled) span, an
 /// already-recognized macro node, a masked passthrough — is *not* recoverable:
-/// it is one opaque placeholder here where the string pipeline's haystack holds
-/// its markup (or its own passthrough mask) inline, and that markup exists only
-/// at fold time. It is nonetheless admitted **inside a reference text**,
+/// it is one opaque placeholder here, standing in for markup (or a passthrough
+/// mask) that exists only at fold time. It is nonetheless admitted **inside a
+/// reference text**,
 /// because a reference text is the one capture this family never reads as
 /// bytes: it becomes the node's children through [`macro_text_children`], whose
 /// [`emit_range`](super::super::quotes::emit_range) path clones the opaque
 /// piece's own node whole into them — so the text is carried *structurally*,
-/// and the fold re-renders exactly the markup the string replacer captured
-/// there. This is the same "nesting is the point" recovery a footnote's own
-/// content has always used, applied to the display text of a reference.
+/// and the fold re-renders exactly that markup. This is the same "nesting is
+/// the point" recovery a footnote's own content has always used, applied to
+/// the display text of a reference.
 ///
-/// What that admission cannot do is make the *recognition* agree in every case,
-/// because the string replacer matches over the markup itself where this
-/// matches over one placeholder standing in for it. The two read the same
-/// extent unless the markup carries a character the pattern is sensitive to,
-/// which leaves two documented divergences of *extent* (each pinned by its own
-/// test), both of them cases where the string pipeline's own reading is the
-/// markup-perturbed one and the tree's is the well-formed one — exactly as the
-/// quotes step's crossed-delimiter divergence is:
+/// What that admission cannot do is make the *recognition* agree in every case:
+/// matching over one placeholder instead of the markup itself reads a
+/// different extent whenever that markup carries a character the pattern is
+/// sensitive to, which leaves two documented divergences of *extent* (each
+/// pinned by its own test); in both, the well-formed reading is the tree's,
+/// not the one a match over the raw, markup-perturbed text would give —
+/// exactly as the quotes step's crossed-delimiter divergence is:
 ///
-/// - a `]` inside the span (`xref:sec[*a ] b*]`), which ends the macro form's
-///   own lazy text capture early for the string replacer but not here;
+/// - a `]` inside the span (`xref:sec[*a ] b*]`), which would end the macro
+///   form's own lazy text capture early if matched over raw markup, but not
+///   here;
 /// - a `&gt;&gt;` inside the span (`<<sec,*a >> b*>>`), the shorthand's own
 ///   terminator, for the same reason.
 ///
@@ -273,10 +275,10 @@ fn restored_range<'a>(
 /// value cannot be mapped back to the node it stands in for — the same reason
 /// the image and link families defer their own `Attrlist`-bearing captures. The
 /// probe for that branch is `raw_text.contains('=')`, read here off the match
-/// string; the string replacer reads it off the markup, so a span whose markup
-/// carries an `=` (an attributed span, a link, an image) sends the string
-/// pipeline down its attribute-list branch where this one stays plain. That
-/// costs nothing wherever the parse finds the `=` incidental (an attribute list
+/// string; matching over rendered markup instead would read it off the markup
+/// itself, so a span whose markup carries an `=` (an attributed span, a link,
+/// an image) would take the attribute-list branch where this one stays plain.
+/// That costs nothing wherever the parse finds the `=` incidental (an attribute list
 /// with no comma to split on yields one positional value equal to the whole
 /// text, which is every unattributed markup shape) and is a third documented
 /// divergence otherwise.
@@ -309,8 +311,7 @@ fn find_xref_matches<'src>(
         let recoverable = match &shorthand_inner {
             Some(inner) => {
                 // The shorthand's id is its inner up to the first `,` — the
-                // very split `build_xref_shorthand_node` (and
-                // the string replacer) makes. A comma the
+                // very split `build_xref_shorthand_node` makes. A comma the
                 // *markup* of an opaque piece contributes
                 // cannot move that split unnoticed: such a piece would have to
                 // sit in the id half, which this gate then rejects.
@@ -356,9 +357,8 @@ fn find_xref_matches<'src>(
         };
 
         // An escape (`\xref:` / `\<<`) is honored by dropping the backslash and
-        // keeping the rest literal, mirroring the string replacer's leading
-        // `caps.get(1)` check — which it makes *before* looking at anything
-        // else, so the escape needs no gate of its own here either: dropping
+        // keeping the rest literal. That check is made *before* looking at
+        // anything else, so the escape needs no gate of its own here either: dropping
         // the backslash keeps the rest of the match as its **own original
         // nodes** (a rendered span or an escaped special among them), which
         // fold back to exactly the bytes the replacer's `caps[0][1..]` emits.
@@ -457,12 +457,11 @@ fn attrlist_text_carries_its_opaque_pieces(
     }
 
     // A token reaching one of the three values this family reads as a
-    // **string** — `window`, `xrefstyle`, a role — used to refuse the whole
-    // match here, because a node has no bytes to put in a string slot. It no
-    // longer does: `untranslated_value` gives the slot the author's *source*
-    // for the piece the token stands for, which is a value a string can hold.
-    // See its doc comment for the rules and for the divergence from the string
-    // pipeline that follows.
+    // **string** — `window`, `xrefstyle`, a role — would have no bytes to put
+    // in a string slot on its own: `untranslated_value` gives the slot the
+    // author's *source* for the piece the token stands for instead, which is
+    // a value a string can hold. See its doc comment for the rules and for
+    // the deliberate divergence from Asciidoctor that follows.
     true
 }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -1063,7 +1063,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_xref(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -1624,7 +1624,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_xref(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -1670,7 +1670,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_xref(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -1878,7 +1878,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_xref(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -1936,7 +1936,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_xref(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
     }
@@ -2042,7 +2042,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(source)), &HtmlInlineRenderer {}),
                 golden_xref(source),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen recording for {source:?}"
             );
         }
     }
@@ -2391,7 +2391,7 @@ mod tests {
                 assert_eq!(
                     folded,
                     golden_xref_with(fixture, &parser),
-                    "fold diverged from the string pipeline for {fixture:?} under xrefstyle={style:?}"
+                    "fold diverged from the frozen recording for {fixture:?} under xrefstyle={style:?}"
                 );
             }
         }
@@ -2594,7 +2594,7 @@ mod tests {
                     &parser.render_context()
                 ),
                 golden_normal(source, &parser),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the frozen recording for {source:?}"
             );
         }
     }
@@ -2693,7 +2693,7 @@ mod tests {
             assert_eq!(
                 fold_html(&nodes, &renderer),
                 golden_whole_pipeline(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the frozen recording for {fixture:?}"
             );
         }
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -177,9 +177,9 @@
 //!   `https://example.org[*bold*]`) is admitted for every
 //!   **reference-bearing** family — the cross-reference one, the
 //!   `link:`/`mailto:` macro, and the auto-link / formal-URL family — each of
-//!   which carries it *structurally*: a span really is unrecoverable — it is
-//!   one opaque placeholder here where the string pipeline's haystack holds
-//!   markup that only exists at fold time — but a display text is never read as
+//!   which carries it *structurally*: a span really is unrecoverable — it
+//!   exists only as rendered markup produced at fold time, with no source
+//!   bytes to read back — but a display text is never read as
 //!   bytes, and
 //!   [`macro_text_children`](macros::macro_text_children)'s
 //!   [`emit_range`](quotes::emit_range) path clones the piece's own **node**
@@ -187,10 +187,10 @@
 //!   family *computes* off the match string — a target, an attribute list's
 //!   parsed value, a bare link's shown text (a slice of its own target) —
 //!   keeps the gate, and so does the recognition's own
-//!   agreement: the string replacer matches over the markup where this matches
-//!   over one placeholder, which leaves a handful of documented divergences of
-//!   extent (a `]` or a `&gt;&gt;` inside the span, markup carrying the
-//!   replacer's own attribute-list `=`/`,` probe beside a comma), each the
+//!   agreement: matching over one placeholder rather than over rendered markup
+//!   leaves a handful of documented divergences from a markup-based reading —
+//!   cases where markup would carry a `]` or `&gt;&gt;` inside the span, or its
+//!   own attribute-list `=`/`,` probe beside a comma — each the
 //!   markup-perturbed reading against the tree's well-formed one. A
 //!   **cross-reference** carries it through its *attribute-list* text too
 //!   (`xref:sec[*bold*,role=hl]`): the value that parse hands back becomes the
@@ -201,17 +201,17 @@
 //!   reaching the `window=` / `role=` / `xrefstyle=` this family reads as a
 //!   *string* has no bytes to be read as, and that shape alone defers. The
 //!   token is what makes the *split* reproducible — a bracket's `,` / `=` / `"`
-//!   are the only bytes it reads, and a placeholder carries none of them. The
-//!   replacer, by contrast, splits over the piece's own **markup**, which may
-//!   carry them: `xref:sec[a *b, c* d,role=hl]` renders
-//!   `a <strong>b, c</strong> d`, whose list splits at the comma inside the tag
-//!   and leaves the anchor's text as `a <strong>b`, unbalanced. The two
-//!   readings therefore disagree about the match's own extent, and this used to
-//!   defer the match — which made a comma inside a span decide whether the
-//!   macro was recognized **at all**. Emitting the replacer's split is the
-//!   wrong answer, so **the tree's split is the one that stands** and this
-//!   crate diverges from both the replacer and Asciidoctor for that shape
-//!   (design §5.2's deferral divergence). The principle it rests on: a bracket
+//!   are the only bytes it reads, and a placeholder carries none of them.
+//!   Splitting over the piece's own rendered **markup** would carry them
+//!   instead: `xref:sec[a *b, c* d,role=hl]` renders
+//!   `a <strong>b, c</strong> d`, whose list would split at the comma inside the
+//!   tag and leave the anchor's text as `a <strong>b`, unbalanced — disagreeing
+//!   with the tree's own reading about the match's extent, which would let a
+//!   comma inside a span decide whether the
+//!   macro was recognized **at all**. That is the wrong answer, so **the tree's
+//!   split is the one that stands** and this
+//!   crate diverges from Asciidoctor for that shape.
+//!   The principle it rests on: a bracket
 //!   split must not read bytes that a markup-producing step introduced, and the
 //!   tokened side is exactly the side that holds to it. The two **link**
 //!   families take the same move through
@@ -230,7 +230,7 @@
 //!   or — reached at a tree's root — a filtered multi-line block's own joined
 //!   seed): [`text_slice`](quotes::text_slice) recovers the id's exact text
 //!   there, with only the node's `location` falling back to the coarse
-//!   enclosing span (design §4.4). A non-verbatim reference text — which does
+//!   enclosing span. A non-verbatim reference text — which does
 //!   not reach the flow — still just leaves the node's `reftext` unpopulated
 //!   without deferring the whole anchor.
 //!   Likewise a *concealed* index term (`indexterm:[…]`, `(((…)))`) renders
@@ -245,15 +245,15 @@
 //!   a plain attribute list is not deferred, since the list only decides which
 //!   of that argument's own bytes are shown and is consumed rather than
 //!   carried. An escaped shorthand keeps its match literal
-//!   minus the backslash, *except* the paren-wrapped `\(((x)))`, which the
-//!   string replacer still renders as the flow term nested inside it: that one
+//!   minus the backslash, *except* the paren-wrapped `\(((x)))`, which
+//!   Asciidoctor still renders as the flow term nested inside it: that one
 //!   becomes a **pair** of matches (the backslash's own, then the term's,
 //!   keeping a literal paren at each end). The **UI**, **index-term**, and
 //!   **cross-reference** families share the anchor's synthesized-run lift, and
 //!   for the same reason — none of those nodes carries a `Span`-typed field, so
 //!   a `kbd:`/`btn:`/`menu:` macro, an index term, or a cross-reference inside
 //!   an expanded attribute value is recognized with its exact text (only the
-//!   node's `location` taking design §4.4's coarse fallback).
+//!   node's `location` taking the coarse fallback).
 //! - [`apply_footnotes`] recognizes **footnotes** (`footnote:[…]`,
 //!   `footnote:id[…]`, `footnote:id[]`), replacing each with a
 //!   [`Footnote`](InlineNode::Footnote) node, folding through the shared
@@ -267,8 +267,9 @@
 //!   numbering must follow true left-to-right source order regardless of
 //!   nesting depth, which [`apply_macros`]'s depth-first child recursion does
 //!   not guarantee (see [`apply_footnotes`]'s doc comment). Registering the
-//!   number cannot be deferred to the cutover the way every other family's
-//!   catalog/warning side effect is, without breaking output parity (see
+//!   number cannot be deferred to the post-fold side-effect pass the way every
+//!   other family's catalog/warning side effect is, without breaking output
+//!   parity (see
 //!   `build_footnote_node`). Its content becomes structured children via
 //!   [`emit_range`](quotes::emit_range) rather than a literal attribute value,
 //!   so — unlike the other families — a content crossing an already-recognized
@@ -277,13 +278,14 @@
 //!   dropped as a *gap* in the emitted ranges by the reference-bearing
 //!   families' own
 //!   [`emit_range_unescaping_brackets`](macros::emit_range_unescaping_brackets),
-//!   so the subtree carries the literal `]` the string replacer's
-//!   `normalize_footnote_text` produces. The deprecated `footnoteref:[id,text]`
+//!   so the subtree carries the literal `]`, matching Asciidoctor's own
+//!   footnote-text normalization. The deprecated `footnoteref:[id,text]`
 //!   / `footnoteref:[id]` form (`build_footnoteref_node`) is recognized too,
 //!   splitting its one bracket on the first comma rather than taking an id from
-//!   the macro target (an id, the one half the string replacer never
-//!   normalizes, keeps its own `\]`); only its own deprecation warning (a
-//!   diagnostic, deferred to the cutover like every other family's) remains
+//!   the macro target (an id, unlike the text half, keeps its own literal
+//!   `\]`); only its own deprecation warning (a
+//!   diagnostic, deferred to that post-fold side-effect pass like every other
+//!   family's) remains
 //!   deferred. The bibliography-anchor form is a later increment.
 //! - [`apply_stem`] recognizes **inline STEM macros** (`stem:[…]`,
 //!   `asciimath:[…]`, `latexmath:[…]`), replacing each with a
@@ -452,8 +454,8 @@ pub(crate) fn build<'src>(
 /// (see [`Content::from_filtered`](crate::content::Content::from_filtered) /
 /// [`Content::from_filtered_lines`](crate::content::Content::from_filtered_lines)).
 ///
-/// `location` seeds every downstream construct's coarse-fallback span (design
-/// §4.4) and is threaded through as each step's own `root`/`source`
+/// `location` seeds every downstream construct's coarse-fallback span
+/// and is threaded through as each step's own `root`/`source`
 /// parameter, so it must be a `Span` that contains — and is used consistently
 /// with — the source bytes `value` was ultimately derived from.
 ///
@@ -680,8 +682,9 @@ pub(crate) fn build_for_group<'src>(
 /// apply`](crate::content::SubstitutionGroup::apply) runs in production —
 /// passthrough/STEM extraction, every step in true order, passthrough restore,
 /// and deferred-reference finalization, all against one `Content` — which is
-/// exactly what [`build`] (this module's own single call) must reproduce once
-/// the cutover (design §5.2, Phase 4 step 6) wires it in. This closes that gap:
+/// exactly what [`build`] (this module's own single call) reproduces, since
+/// `SubstitutionGroup::apply` calls it for every parse in production. This
+/// closes that gap:
 /// each fixture below mixes constructs that were previously verified only in
 /// separate, single-family corpora (quotes nested around an attribute
 /// reference, a footnote whose text itself carries an attribute reference, a
@@ -711,7 +714,8 @@ mod tests {
     fn a_raw_leafs_origin_says_who_produced_it() {
         // `RawOrigin` is a property of the *node*, not of the pass that happens
         // to be looking at it. That is the point: a recognition gate can ask
-        // "would the string replacer have seen these bytes, or a sentinel?"
+        // "was this text extracted as a passthrough, or is it a literal byte
+        // sequence?"
         // without knowing whether the extraction pass's identity is in hand —
         // which is what an earlier attempt at this got wrong, by inferring
         // provenance from a `Masked` list that is empty on some call paths.
@@ -781,10 +785,10 @@ mod tests {
             ]
         );
 
-        // An expanded attribute value's literal `&`, which §3.4.1 leaves
-        // unescaped because the value expands *after* `specialcharacters` ran.
-        // Nothing extracted it and nothing restores it — the string replacer
-        // reads these very bytes. `{cpp}` is `C&#43;&#43;`, so the expansion
+        // An expanded attribute value's literal `&`, unescaped because the
+        // value expands *after* `specialcharacters` already ran.
+        // Nothing extracted it and nothing restores it — it flows into the
+        // tree as a literal byte. `{cpp}` is `C&#43;&#43;`, so the expansion
         // leaves one `Raw` per `&`.
         //
         // Deliberately in plain flow rather than inside a macro: a construct
@@ -808,12 +812,13 @@ mod tests {
     }
 
     /// Asserts that the single-pass builder's fold of `source` matches the
-    /// frozen recording of what the string pipeline rendered it as, under a
+    /// frozen recording of the known-good output for it, under a
     /// document configured by `configure`.
     ///
     /// `configure` builds the parser here rather than the caller passing one
-    /// in — a signature kept from when this assertion also ran the string
-    /// pipeline and each side needed its own identically-configured document
+    /// in — a signature kept from when this assertion also ran the crate's
+    /// retired string-substitution implementation (see this module's
+    /// `README.md`) and each side needed its own identically-configured document
     /// (both sides advanced footnote numbers and `{counter:...}` values for
     /// real, so sharing one parser would have doubled them). Only [`built`]'s
     /// side runs today, but every call site passes a constructor, so the
@@ -825,11 +830,12 @@ mod tests {
     /// [`assert_parity_with`], reading a named corpus.
     ///
     /// The fold is handed to [`snapshot::assert_recorded`], which checks it
-    /// against a checked-in recording of the known-good bytes the string
-    /// pipeline produced while it existed. The fold is never what a recording
-    /// is written from, which is what keeps this corpus honest once
-    /// `rendered_html()` becomes a fold of the tree (design §5.2 Phase 4,
-    /// step 6 — see [`snapshot`](super::snapshot)).
+    /// against a checked-in recording of the known-good bytes, originally
+    /// produced by the crate's retired string-substitution implementation.
+    /// The fold is never what a recording
+    /// is written from, which is what keeps this corpus honest now that
+    /// `rendered_html()` is itself a fold of the tree
+    /// (see [`snapshot`](super::snapshot)).
     fn assert_parity_in(corpus: &str, source: &str, configure: impl Fn() -> Parser) {
         super::snapshot::assert_recorded(corpus, source, &built(source, &configure()));
     }
@@ -845,7 +851,7 @@ mod tests {
     /// thought to write down. This one is a **cross-product**, generated from
     /// two lists, and it exists because the shapes that turned out to be
     /// broken were the ones nobody thought to write down. Three separate
-    /// increments of step 6 closed a walk that failed to descend into a
+    /// fixes closed a walk that failed to descend into a
     /// container (a visible index term's shown text, an anchor's reference
     /// text, a footnote nested in a child), and in each case the reason no
     /// corpus caught it was the same: the construct and the container were
@@ -908,20 +914,21 @@ mod tests {
     /// pair joining it — or leaving it, which a fix does — fails the sweep.
     const DIVERGING_PAIRS: &[(&str, &str)] = &[
         // A later macro family matching **across** the markup an earlier
-        // family of the same step already emitted: the string pipeline's
-        // cross-reference and footnote passes scan a flat string that by then
-        // holds the link pass's own `</a>`, and match through it. See
+        // family of the same step already emitted: Asciidoctor's own
+        // regex-driven substitution scans a flat string that by then
+        // holds the link pass's own `</a>`, and matches through it. See
         // `a_family_matching_across_an_earlier_familys_markup_is_a_documented_divergence`
         // in `macros/mod.rs`.
         ("link text", "xref"),
         ("link text", "footnote"),
-        // A post-replacement inside a **cross-reference's** display text. The
-        // string pipeline never scans that text: a deferred cross-reference
-        // holds it in a template, not in the flat string the post-replacement
+        // A post-replacement inside a **cross-reference's** display text.
+        // Asciidoctor's own substitution order never scans that text: a
+        // deferred cross-reference is resolved through a template outside the
+        // flat string the post-replacement
         // step runs over — where a *link's* display text, in the same
         // position, is scanned and does get its `<br>`. The tree treats the
-        // two alike, which is what §4.2's retirement of the
-        // deferred-cross-reference sentinel makes true for real. See
+        // two alike now that a cross-reference is resolved in place rather
+        // than deferred through a template. See
         // `a_post_replacement_in_a_cross_reference_text_is_a_documented_divergence`
         // in `post_replacements.rs`.
         ("xref text", "line break"),

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -966,8 +966,8 @@ mod tests {
         );
     }
 
-    /// A broad, general-purpose sweep of inline fixtures, run against `build`
-    /// + `fold_html`. Unlike
+    /// A broad, general-purpose sweep of inline fixtures, run against
+    /// `build` and `fold_html`. Unlike
     /// the hand-picked combined-constructs corpus above, this one is not
     /// curated to stay inside `build`'s claimed vocabulary, so it is exactly
     /// the kind of audit that finds real gaps (it once caught a `hardbreaks`
@@ -2410,8 +2410,9 @@ mod tests {
         }
 
         /// The complement of the corpus above, for the *other* order case the
-        /// escaping-order rule has to answer for: not a group that never escapes, but one that
-        /// escapes **after** expanding an attribute reference.
+        /// escaping-order rule has to answer for: not a group that never
+        /// escapes, but one that escapes **after** expanding an
+        /// attribute reference.
         ///
         /// Every built-in group that runs both steps escapes first and expands
         /// later, which is why a spliced value's literal `<`/`>`/`&` has always
@@ -2820,10 +2821,10 @@ mod tests {
         /// records its own spelling
         /// ([`Ref::link_form`](crate::inlines::Ref::link_form)), which is what
         /// [`apply_link_side_effects`](macros::links::apply_link_side_effects)
-        /// reads to replay the string pipeline's family-pass registration
+        /// reads to replay the crate's own family-pass registration
         /// order. So this reads like every other family — which computes what
         /// it needs from the level's match string and is recognized in
-        /// flattened text just as the string pipeline recognizes it in the
+        /// flattened text just as it is recognized in Asciidoctor's own
         /// escaped tags; the corpus above pins an auto-link, an image macro,
         /// and a footnote doing the same.
         #[test]
@@ -2834,8 +2835,8 @@ mod tests {
             // sits in a wholly-synthesized run. That used to defer, because
             // this family required its own marker to be verbatim source; the
             // node now records its spelling instead (`Ref::link_form`), so the
-            // macro is recognized and the fold reproduces the string
-            // pipeline's own bytes.
+            // macro is recognized and the fold reproduces the same bytes
+            // Asciidoctor's own substitution would produce.
             let (group, invalid) =
                 SubstitutionGroup::from_custom_string(None, "quotes,specialcharacters,macros");
             assert!(invalid.is_empty());
@@ -2879,7 +2880,7 @@ mod tests {
     /// wholly-synthesized seed guarantees. That marker used to be what told
     /// this pass's nodes from the other link passes' when
     /// [`apply_link_side_effects`](macros::links::apply_link_side_effects)
-    /// replays the string pipeline's registration order; the node now records
+    /// replays each family's own registration order; the node now records
     /// its own spelling ([`Ref::link_form`](crate::inlines::Ref::link_form))
     /// instead, so the macro is recognized here too.
     ///
@@ -2899,7 +2900,7 @@ mod tests {
         // was the last one holding that rule, and it no longer needs it: the
         // node records which spelling built it (`Ref::link_form`) rather than
         // having it re-derived from `location`. So the macro is recognized
-        // here too, with only its `location` taking design §4.4's coarse span.
+        // here too, with only its `location` taking the coarse span fallback.
         let filtered = "see link:https://example.org[Example] here";
         let source = "  see link:https://example.org[Example] here";
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -2649,8 +2649,9 @@ mod tests {
             }
 
             // Orders that run a step *after* the escaping one, so the
-            // flattened text is what that later step reads — exactly as the
-            // string pipeline's later steps read the escaped tags. The
+            // flattened text is what that later step reads — matching the
+            // escaped tags Asciidoctor's own substitution would hand that
+            // later step. The
             // extraction pass runs for each of these (they name `macros`), so
             // they also exercise the masked/unmasked split
             // `flatten_prior_markup` draws.
@@ -2679,15 +2680,15 @@ mod tests {
         /// escaped: the tree a late-escaping order produces carries no
         /// [`Styled`](crate::inlines::Styled) node at all, and the tags are
         /// ordinary [`Text`](InlineNode::Text) runs and
-        /// [`CharRef`](InlineNode::CharRef) leaves the fold escapes once
-        /// (§3.4). That is what the document genuinely says under such an
+        /// [`CharRef`](InlineNode::CharRef) leaves the fold escapes once.
+        /// That is what the document genuinely says under such an
         /// order — the content is no longer a strong span, it is text that
         /// reads like a tag.
         ///
         /// The whole node list is asserted rather than only the text it folds
         /// to, so it pins the spans as well: a flattened node's value is the
         /// fold, which has no `'src` slice of its own, so every fragment the
-        /// escaping step splits it into takes design §4.4's coarse
+        /// escaping step splits it into takes the coarse
         /// enclosing-span fallback — here the `*bold*` the quotes step
         /// consumed, which is this fixture's whole source.
         #[test]
@@ -2724,22 +2725,24 @@ mod tests {
             );
         }
 
-        /// A documented divergence, not a bug: a construct the string
-        /// pipeline is holding as a **placeholder** at escaping time, nested
+        /// A documented divergence, not a bug: a construct held as a
+        /// **placeholder** at escaping time, nested
         /// *inside* a node an earlier step turned into markup.
         ///
         /// There are two such constructs, and the fixtures pin one of each: a
         /// passthrough (or inline-STEM) body, extracted ahead of every step
         /// and restored after the last one, and a deferred cross-reference,
-        /// recorded by the macros step and rendered by
-        /// [`Content::finalize_deferred`](crate::content::Content) once every
-        /// step has run. The string pipeline's escaping step acts on neither,
+        /// recorded by the macros step as an
+        /// [`XrefSegment`](crate::content::XrefSegment) and resolved once
+        /// every
+        /// step has run. The escaping step acts on neither,
         /// so it escapes *around* the placeholder and the construct comes back
         /// unescaped: `&lt;strong&gt;a <x> b&lt;/strong&gt;`.
         ///
         /// Folding the enclosing span whole would inline the construct into
         /// the escaped text instead. Splitting one node's fold back around its
-        /// placeholder descendants is the sentinel mechanism itself, which
+        /// placeholder descendants would need its own placeholder-aware
+        /// mechanism, which
         /// this module deliberately does not have — so such a node is left
         /// alone, exactly as an unrecognized construct is elsewhere here.
         ///

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -37,32 +37,30 @@
 //!   [`quote_subs`] patterns the crate uses for quoted text everywhere. An
 //!   attributed span's own attribute list (`['a<b']*bold*`) is parsed from the
 //!   level's **match string** — the escaped bytes recovered from the level's
-//!   own haystack, since `specialcharacters` has already run — so
-//!   the entity, not the author's raw `<`, reaches the rendered `class`/`id`
-//!   (see [`quote_attributes`](quotes)).
+//!   own haystack, since `specialcharacters` has already run — so the entity,
+//!   not the author's raw `<`, reaches the rendered `class`/`id` (see
+//!   [`quote_attributes`](quotes)).
 //! - [`apply_attribute_references`] recognizes attribute references (`{name}`),
 //!   splicing a set attribute's resolved value into the node stream, classified
 //!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs — a
-//!   literal `<`/`>`/`&` in the value is *not* re-escaped,
-//!   since [`apply_special_characters`] has already run, unless the group's
-//!   effective order puts that step *after* this one (only a `subs=` list can,
-//!   and `subs=attributes+` does), in which case the value is spliced as one
+//!   literal `<`/`>`/`&` in the value is *not* re-escaped, since
+//!   [`apply_special_characters`] has already run, unless the group's effective
+//!   order puts that step *after* this one (only a `subs=` list can, and
+//!   `subs=attributes+` does), in which case the value is spliced as one
 //!   ordinary `Text` run for it to escape (see [`SplicedSpecials`]). It uses
 //!   the shared [`ATTRIBUTE_REFERENCE`](crate::content::ATTRIBUTE_REFERENCE)
-//!   pattern. A `counter`/`counter2`
-//!   directive resolves *and advances* the named counter via
-//!   [`Parser::counter`], the same required side effect [`apply_footnotes`]
-//!   performs for footnote numbering. A missing-attribute reference under
-//!   `AttributeMissing::Drop` / `::DropLine` is deferred (see
+//!   pattern. A `counter`/`counter2` directive resolves *and advances* the
+//!   named counter via [`Parser::counter`], the same required side effect
+//!   [`apply_footnotes`] performs for footnote numbering. A missing-attribute
+//!   reference under `AttributeMissing::Drop` / `::DropLine` is deferred (see
 //!   [`apply_attribute_references`] for why). A character replacement *inside*
 //!   an expanded value ((C) → ©, `--`, …) is recognized too:
-//!   [`build_match_string`](quotes::build_match_string) looks
-//!   inside a [`synthesized`](quotes::Piece::synthesized) run rather than
-//!   treating it as opaque, and no **macro** family defers there. An
-//!   [`Attrlist`] a node carries needs no `'src` slice of its own — an image's
-//!   bracket, both link families' attribute-list-bearing display texts, and an
-//!   attributed span's own list are parsed from the level's own match string
-//!   and
+//!   [`build_match_string`](quotes::build_match_string) looks inside a
+//!   [`synthesized`](quotes::Piece::synthesized) run rather than treating it as
+//!   opaque, and no **macro** family defers there. An [`Attrlist`] a node
+//!   carries needs no `'src` slice of its own — an image's bracket, both link
+//!   families' attribute-list-bearing display texts, and an attributed span's
+//!   own list are parsed from the level's own match string and
 //!   [`into_owned`](Attrlist::into_owned)ed off it — so
 //!   [`range_is_verbatim`](macros::image::range_is_verbatim) survives only
 //!   where a *borrow* is still preferred, not as a boundary. And a macro
@@ -269,24 +267,22 @@
 //!   not guarantee (see [`apply_footnotes`]'s doc comment). Registering the
 //!   number cannot be deferred to the post-fold side-effect pass the way every
 //!   other family's catalog/warning side effect is, without breaking output
-//!   parity (see
-//!   `build_footnote_node`). Its content becomes structured children via
-//!   [`emit_range`](quotes::emit_range) rather than a literal attribute value,
-//!   so — unlike the other families — a content crossing an already-recognized
-//!   construct is not deferred: nesting is the point. A content carrying an
-//!   **escaped closing bracket** (`\]`) is recognized too, the backslash
-//!   dropped as a *gap* in the emitted ranges by the reference-bearing
-//!   families' own
+//!   parity (see `build_footnote_node`). Its content becomes structured
+//!   children via [`emit_range`](quotes::emit_range) rather than a literal
+//!   attribute value, so — unlike the other families — a content crossing an
+//!   already-recognized construct is not deferred: nesting is the point. A
+//!   content carrying an **escaped closing bracket** (`\]`) is recognized too,
+//!   the backslash dropped as a *gap* in the emitted ranges by the
+//!   reference-bearing families' own
 //!   [`emit_range_unescaping_brackets`](macros::emit_range_unescaping_brackets),
 //!   so the subtree carries the literal `]`, matching Asciidoctor's own
-//!   footnote-text normalization. The deprecated `footnoteref:[id,text]`
-//!   / `footnoteref:[id]` form (`build_footnoteref_node`) is recognized too,
+//!   footnote-text normalization. The deprecated `footnoteref:[id,text]` /
+//!   `footnoteref:[id]` form (`build_footnoteref_node`) is recognized too,
 //!   splitting its one bracket on the first comma rather than taking an id from
 //!   the macro target (an id, unlike the text half, keeps its own literal
-//!   `\]`); only its own deprecation warning (a
-//!   diagnostic, deferred to that post-fold side-effect pass like every other
-//!   family's) remains
-//!   deferred. The bibliography-anchor form is a later increment.
+//!   `\]`); only its own deprecation warning (a diagnostic, deferred to that
+//!   post-fold side-effect pass like every other family's) remains deferred.
+//!   The bibliography-anchor form is a later increment.
 //! - [`apply_stem`] recognizes **inline STEM macros** (`stem:[…]`,
 //!   `asciimath:[…]`, `latexmath:[…]`), replacing each with a
 //!   [`Stem`](InlineNode::Stem) leaf. Like [`apply_passthroughs`], it is an
@@ -473,14 +469,13 @@ pub(crate) fn build<'src>(
 /// - **`value` differs from `location.data()`** (a multi-line block whose
 ///   surviving lines were joined with `\n`, or any other filtered value with no
 ///   single contiguous `'src` slice of its own): the seed is *synthesized* —
-///   every node the builder produces from it still gets a real `InlineNode`, but
-///   one whose `location` coarsely falls back to the whole of `location`,
-///   the same fallback an
-///   attribute-reference expansion or a `counter` directive's resolved value
-///   already receives. This is what lets the single-pass builder process a
-///   real, multi-line, filtered block's content — not just a single contiguous
-///   source span — while every already-landed step's shared
-///   [`build_match_string`](quotes::build_match_string) /
+///   every node the builder produces from it still gets a real `InlineNode`,
+///   but one whose `location` coarsely falls back to the whole of `location`,
+///   the same fallback an attribute-reference expansion or a `counter`
+///   directive's resolved value already receives. This is what lets the
+///   single-pass builder process a real, multi-line, filtered block's content —
+///   not just a single contiguous source span — while every already-landed
+///   step's shared [`build_match_string`](quotes::build_match_string) /
 ///   [`source_slice`](quotes::source_slice) machinery handles the fallback with
 ///   no further change: it already treats *any* non-verbatim `Text` node this
 ///   way, regardless of where in the tree — or how early — that node was
@@ -513,9 +508,9 @@ pub(crate) fn build_from_value<'src>(
 ///   group's own order, each recast as its node transducer. The
 ///   [`Macros`](SubstitutionStep::Macros) step runs [`apply_macros`] and then
 ///   [`apply_footnotes`] — footnotes are recognized as part of the macros
-///   family in AsciiDoc's own substitution model, but are their own
-///   transducer here so numbering follows true source
-///   order (see [`apply_footnotes`]'s doc comment).
+///   family in AsciiDoc's own substitution model, but are their own transducer
+///   here so numbering follows true source order (see [`apply_footnotes`]'s doc
+///   comment).
 ///
 /// A group whose steps are empty ([`Pass`](SubstitutionGroup::Pass) /
 /// [`None`](SubstitutionGroup::None), or an empty custom list) yields the
@@ -818,11 +813,11 @@ mod tests {
     /// `configure` builds the parser here rather than the caller passing one
     /// in — a signature kept from when this assertion also ran the crate's
     /// retired string-substitution implementation (see this module's
-    /// `README.md`) and each side needed its own identically-configured document
-    /// (both sides advanced footnote numbers and `{counter:...}` values for
-    /// real, so sharing one parser would have doubled them). Only [`built`]'s
-    /// side runs today, but every call site passes a constructor, so the
-    /// shape stays.
+    /// `README.md`) and each side needed its own identically-configured
+    /// document (both sides advanced footnote numbers and `{counter:...}`
+    /// values for real, so sharing one parser would have doubled them).
+    /// Only [`built`]'s side runs today, but every call site passes a
+    /// constructor, so the shape stays.
     fn assert_parity_with(source: &str, configure: impl Fn() -> Parser) {
         assert_parity_in("whole_pipeline", source, configure);
     }
@@ -971,14 +966,12 @@ mod tests {
         );
     }
 
-    /// A broad, general-purpose sweep of inline fixtures — originally reusing
-    /// the shape of the Phase 1 byte-parity corpus (`NORMAL_CORPUS`, retired
-    /// with the Strategy-A recorder it pinned) — run against `build` +
-    /// `fold_html`. Unlike
+    /// A broad, general-purpose sweep of inline fixtures, run against `build`
+    /// + `fold_html`. Unlike
     /// the hand-picked combined-constructs corpus above, this one is not
     /// curated to stay inside `build`'s claimed vocabulary, so it is exactly
-    /// the kind of audit that caught the `hardbreaks` cutover blocker (see the
-    /// design doc's own "step 6 prep" note on that increment): a fixture here
+    /// the kind of audit that finds real gaps (it once caught a `hardbreaks`
+    /// handling bug this way): a fixture here
     /// that turns out to diverge is either a real, previously-unknown blocker
     /// (fix it) or a form some other increment already documents as deferred
     /// (drop it from this sweep and make sure it has its own divergence test
@@ -1124,9 +1117,9 @@ mod tests {
             "https://example.org[a *bold* label] auto-link",
             "<https://example.org[an _angle_ label] auto-link",
             "https://example.org[the image:logo.png[Logo] one] auto-link",
-            // A construct written against an enclosing span's own edge, where
-            // the string pipeline's haystack holds that span's rendered markup
-            // and the tree holds the level's own start or end.
+            // A construct written against an enclosing span's own edge — a
+            // markup-based match would see that span's rendered markup
+            // there, while the tree holds the level's own start or end.
             r#""``end points``""#,
             r#""`_e_`""#,
             r#""`x `code` y`""#,
@@ -1136,8 +1129,8 @@ mod tests {
             r#""`x --`""#,
             "*a -- b*",
             // The same seam one level *out*: a construct written **beside** an
-            // entity-rendered span, where the string pipeline's haystack holds
-            // that span's own closing `&#8221;` and the tree holds one
+            // entity-rendered span — a markup-based match would see
+            // that span's own closing `&#8221;` there, while the tree holds one
             // placeholder.
             r#""`a`"`code`"#,
             r#"'`a`'`code`"#,
@@ -1146,8 +1139,9 @@ mod tests {
             r#""`a`" `code`"#,
             // And the **tag**-rendered half of the same seam, told from the
             // passthrough-extraction pass's own wrapper by the identity the
-            // macros step now carries: the string pipeline reads the `>` that
-            // ends `</strong>` where the tree used to hold a bare placeholder.
+            // macros step now carries: a markup-based match would read the `>`
+            // that ends `</strong>` where the tree used to hold a bare
+            // placeholder.
             "**bold**https://example.org",
             "__em__https://example.org",
             "``code``https://example.org",
@@ -1180,7 +1174,7 @@ mod tests {
             "*x[width=10]###c# d##*",
             // And the same transparent span read *as* a sibling, where what
             // it presents is its own body rather than any markup: the space
-            // `x ` ends with, which the string pipeline's flat haystack holds
+            // `x ` ends with, which a flat markup-based reading would hold
             // beside the construct.
             "[width=10]##x ##https://example.org",
             "[width=10]##x ##doc@example.org",
@@ -1245,8 +1239,8 @@ mod tests {
 
         // The bare unconstrained form whose body encloses a construct this
         // step's *first* pass already extracted: the verbatim substitution
-        // runs over the placeholder and the inner body is spliced after, the
-        // string pipeline's own restore-last order.
+        // runs over the placeholder and the inner body is spliced after —
+        // restore-last order.
         assert_parity("+Sometimes you feel pass:q[`mono`].+ Sometimes you +$$don't$$+ and *bold*.");
 
         // Inline STEM beside a quoted span and a character replacement.
@@ -1311,7 +1305,8 @@ mod tests {
         // live around it: a keyboard macro whose key crosses an escaped
         // special, a menu whose name crosses a restored entity, and a button
         // label crossing one — each read out of the match string, whose bytes
-        // there are the string replacer's own.
+        // there are the same escaped/canonical bytes Asciidoctor's own
+        // substitution produces.
         assert_parity_with(
             "Press kbd:[Ctrl&C] then menu:&#8942;[More Tools, Extensions] in *bold* text.",
             with_experimental,
@@ -1603,10 +1598,10 @@ mod tests {
         // `Attrlist<'src>`. Their targets and display texts come from the
         // match string like every other family's values, and so now does
         // every attribute list they carry: a capture with no `'src` slice is
-        // parsed from that same match string — the bytes the string replacer
-        // parses — and owned off it. What still defers is a wholly expanded
-        // `link:` macro (pinned by its own divergence test in
-        // `macros/links.rs`).
+        // parsed from that same match string — the same escaped bytes
+        // Asciidoctor's own substitution reads — and owned off it. What still
+        // defers is a wholly expanded `link:` macro (pinned by its own
+        // divergence test in `macros/links.rs`).
         let with_link_attributes = || {
             Parser::default()
                 .with_intrinsic_attribute("url", "index.html", ModificationContext::Anywhere)
@@ -1652,7 +1647,8 @@ mod tests {
         // A cross-reference whose reference text crosses a *rendered span*, in
         // both spellings and beside the other families: the text is carried
         // structurally (the span's own node becomes a child), so the fold
-        // re-renders exactly the markup the string replacer captured.
+        // re-renders exactly the markup Asciidoctor's own substitution
+        // would produce.
         assert_parity_with(
             "See xref:{id}[the *bold* steps] and <<{id},a _slanted_ label>> about {product}.",
             with_xref_attributes,
@@ -1667,10 +1663,10 @@ mod tests {
             with_xref_attributes,
         );
 
-        // A **masked** construct in such a text: the string replacer's own
-        // haystack holds a sentinel there too, so the split-agreement check
+        // A **masked** construct in such a text: the passthrough sits behind
+        // an opaque placeholder there too, so the split-agreement check
         // leaves its token alone rather than comparing the tokened split
-        // against a body the replacer only splices at the very end. Driven
+        // against a body only spliced back in at the very end. Driven
         // through the whole pipeline, which is the only harness that runs the
         // passthrough-extraction pass on both sides.
         assert_parity(
@@ -1678,8 +1674,8 @@ mod tests {
         );
 
         // The same lift where the opaque piece is a **masked passthrough** —
-        // the one opaque class the string pipeline also holds as a placeholder
-        // of its own, since it restores passthroughs only after every step.
+        // the one construct every substitution order holds as a placeholder
+        // of its own, since passthroughs are restored only after every step.
         // These need the real `SubstitutionGroup::apply` (which brackets the
         // steps with that extraction), so they cannot live in the family's own
         // step-driven corpus.
@@ -1720,9 +1716,9 @@ mod tests {
         // restore that happens *inside* a parsed attribute-list value, run
         // here through the whole assembled pipeline. The two fixtures that
         // matter are a body carrying the split's own delimiters (which must
-        // stay one value, as it does where the string pipeline's parse reads
-        // its sentinel) and one sitting ahead of a shorthand item (whose
-        // offsets shift with the restore).
+        // stay one value, as it does wherever a passthrough placeholder is
+        // read as a single opaque token) and one sitting ahead of a shorthand
+        // item (whose offsets shift with the restore).
         assert_parity("See image:chart.png[++a, b = c++] and image:x.png[++A & B++].");
         assert_parity("An image:y.png[++abc++.myrole] beside *bold* text.");
 
@@ -1732,8 +1728,8 @@ mod tests {
         assert_parity("image:x.png[title=$$<b>$$ and *c*]");
         assert_parity("image:x.png[title=pass:[<b>] and *c*]");
 
-        // A construct written against an enclosing span's own edge, where the
-        // string pipeline's haystack holds that span's rendered markup and a
+        // A construct written against an enclosing span's own edge, where a
+        // markup-based match would see that span's rendered markup and a
         // level matched in isolation holds its own start or end — the quotes
         // and character-replacements steps' own boundary context, here running
         // through the whole assembled pipeline (so the *other* steps see the
@@ -1748,18 +1744,18 @@ mod tests {
 
         // The same seam one level out, where the construct sits **beside** the
         // span rather than inside it: the monospace and mark subs read the
-        // `;` ending that span's own `&#8221;`, so both pipelines leave them
+        // `;` ending that span's own `&#8221;`, so they leave them
         // literal, and the surrounding constructs still resolve normally.
         assert_parity(r##"He said "`hello`"`code` and then "`bye`"#mark# alone."##);
         assert_parity(r#"Quoting "`one`"'`two`' back to back, plus a *bold* run."#);
 
         // The **tag**-rendered half of that seam, in the one family that can
         // tell a `>` from the placeholder: `INLINE_LINK`'s boundary-prefix
-        // group accepts the `>` a closing tag ends with, so both pipelines
-        // link a URL written straight against a span's outer edge — while the
-        // extraction pass's own wrapper, which the string pipeline is still
-        // holding as a sentinel, presents no such character and leaves it
-        // literal in both.
+        // group accepts the `>` a closing tag ends with, so a URL written
+        // straight against a span's outer edge is linked — while the
+        // extraction pass's own wrapper, which represents a passthrough as an
+        // opaque placeholder, presents no such character and leaves it
+        // literal.
         assert_parity("A **bold**https://example.org run and __em__https://example.org too.");
         assert_parity("Then [quotes]++x++https://example.org stays literal.");
 
@@ -1865,7 +1861,7 @@ mod tests {
             // A construct crossing a *typographic replacement* at a
             // synthesized tree's root: the leaf carries the entity the
             // built-in backend renders it as, so a value read off the match
-            // string is the string replacer's own.
+            // string matches what Asciidoctor's own substitution would read.
             (
                 "  a ((Coffee (C) Beans)) term\n  and <<s(C)c,Tom (C) Jerry>>",
                 "a ((Coffee (C) Beans)) term\nand <<s(C)c,Tom (C) Jerry>>",
@@ -2075,7 +2071,7 @@ mod tests {
             // the fold emits, not about the node kinds: because no
             // `SpecialCharacters` step ever acted on it, a literal `<`/`>`/`&`
             // is a `Raw` leaf the fold emits verbatim, not a `Text` run the
-            // fold would escape (design §3.4.1). Everything between the
+            // fold would escape. Everything between the
             // specials is one borrowed `Text` run, and nothing else is
             // recognized.
             let source = "<b>raw</b> *not bold* {product}";
@@ -2100,7 +2096,7 @@ mod tests {
 
                 // That the leaves rejoin to the *untouched* seed is what the
                 // parity assertion itself pins: neither group runs a step, so
-                // the string pipeline's own output for this content is the
+                // this content's known-good output is the
                 // source verbatim, and the fold must reproduce it.
                 assert_eq!(
                     golden_for_group(&group, source),
@@ -2136,7 +2132,7 @@ mod tests {
         #[test]
         fn a_custom_list_runs_exactly_the_named_steps_in_order() {
             // `subs=quotes` alone: `*bold*` is recognized, `<` is emitted
-            // unescaped (a `Raw` leaf, not a `CharRef` — design §3.4.1, since
+            // unescaped (a `Raw` leaf, not a `CharRef`, since
             // no `SpecialCharacters` step acts on it), and `{product}` stays
             // unexpanded.
             let (group, invalid) = SubstitutionGroup::from_custom_string(None, "quotes");
@@ -2199,14 +2195,14 @@ mod tests {
             assert_group_parity(&group, source);
         }
 
-        /// A differential corpus for the §3.4.1 classification the group-aware
+        /// A differential corpus for the classification the group-aware
         /// entry point applies last: under an effective order whose steps
-        /// **never include** `SpecialCharacters`, a literal `<`/`>`/`&` is
-        /// emitted verbatim by the string pipeline, so it must fold verbatim
-        /// here too.
+        /// **never include** `SpecialCharacters`, a literal `<`/`>`/`&` must
+        /// fold verbatim here too — matching Asciidoctor's own output when
+        /// `specialcharacters` is skipped.
         ///
         /// This is the case a `Text` node cannot express on its own — `Text`
-        /// is logical text the fold *escapes* (design §3.4) — so every fixture
+        /// is logical text the fold *escapes* — so every fixture
         /// below folded to escaped entities before the classification landed,
         /// diverging from the real pipeline. The corpus crosses a set of
         /// specials-bearing fixtures with every real group that takes this
@@ -2256,8 +2252,9 @@ mod tests {
                 "<<tigers>> stays literal",
                 // The converse: a source-written `&lt;&lt;…&gt;&gt;` *is* the
                 // shorthand's escaped spelling, so the group that runs
-                // `macros` recognizes it (the string pipeline matches the very
-                // bytes the author wrote). Its present-but-empty reference
+                // `macros` recognizes it (matching the very
+                // bytes the author wrote, the same way Asciidoctor's own
+                // substitution does). Its present-but-empty reference
                 // text is one empty `Text` child, which the classification
                 // must carry through rather than split away — splitting emits
                 // no empty run, and the fold reads an absent child as "no text
@@ -2412,8 +2409,8 @@ mod tests {
             }
         }
 
-        /// The complement of the corpus above, for the *other* order §3.4.1
-        /// has to answer for: not a group that never escapes, but one that
+        /// The complement of the corpus above, for the *other* order case the
+        /// escaping-order rule has to answer for: not a group that never escapes, but one that
         /// escapes **after** expanding an attribute reference.
         ///
         /// Every built-in group that runs both steps escapes first and expands
@@ -2422,7 +2419,8 @@ mod tests {
         /// list can reverse the two — and `subs=attributes+`, which *prepends*
         /// the step, is the documented AsciiDoc idiom for inspecting what a
         /// `pass:quotes[…]` attribute entry actually stores, so the reversed
-        /// order is a real one. Under it the string pipeline escapes the
+        /// order is a real one. Under it, Asciidoctor's own substitution
+        /// escapes the
         /// spliced value like any other text (`MyApp<sup>2</sup>` renders as
         /// `MyApp&lt;sup&gt;2&lt;/sup&gt;`), which every fixture below folded
         /// verbatim — and so diverged — before `SplicedSpecials` landed.
@@ -2433,8 +2431,9 @@ mod tests {
         /// `Verbatim`), and the explicit `subs=` lists that name the two steps
         /// in that order. Each list keeps `specialcharacters` ahead of every
         /// *markup-producing* step, because a step that emits markup before
-        /// the escaping one is a different question — the string pipeline
-        /// escapes the tags that step already wrote, while a tree's markup
+        /// the escaping one is a different question — escaping the tags that
+        /// step already wrote is what a flat-string reading would do, while a
+        /// tree's markup
         /// exists only at fold time — and is pinned as its own divergence by
         /// [`a_markup_producing_step_before_the_escaping_one_is_a_documented_divergence`].
         #[test]
@@ -2499,8 +2498,8 @@ mod tests {
                 // splicing one here would have hidden the `&` from the macros
                 // step that runs later in the order; a `Text` run the escaping
                 // step turns into a `CharRef` is exactly what that step's own
-                // gate admits, matching the string pipeline (whose macros pass
-                // likewise runs over the already-escaped `a&amp;b.example.org`).
+                // gate admits, matching Asciidoctor's own macros pass, which
+                // likewise runs over the already-escaped `a&amp;b.example.org`.
                 "link:{host}/x[go]",
                 "https://{host}/docs auto-link",
                 // The same, for the two steps that read a spliced run's own
@@ -2520,9 +2519,10 @@ mod tests {
         /// [`flatten_prior_markup`](super::super::special_chars::flatten_prior_markup):
         /// a step that produces **markup** ahead of the escaping one.
         ///
-        /// `subs=quotes,specialcharacters` runs the quotes step first, so the
-        /// string pipeline holds `<strong>bold</strong>` by the time
-        /// `specialcharacters` runs — and escapes those very tags, emitting
+        /// `subs=quotes,specialcharacters` runs the quotes step first, so a
+        /// flat-string reading holds `<strong>bold</strong>` by the time
+        /// `specialcharacters` runs — and Asciidoctor's own substitution
+        /// escapes those very tags, emitting
         /// `&lt;strong&gt;bold&lt;/strong&gt;`. A tree has no rendered tags at
         /// that point: a [`Styled`](crate::inlines::Styled) span's markup
         /// exists only at fold time. The policy is to reach fold time for that

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -2101,7 +2101,7 @@ mod tests {
                 assert_eq!(
                     golden_for_group(&group, source),
                     source,
-                    "the string pipeline must leave this content untouched under {group:?}"
+                    "this content must render untouched under {group:?}"
                 );
 
                 assert_group_parity(&group, source);

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -1,11 +1,15 @@
 //! Builds the inline AST **directly from source in a single forward pass**.
 //!
-//! This is the first brick of "Strategy B" (design §4.1): rather than recover
-//! the tree from a post-substitution *marked string* — the
-//! `inline_tree` recorder's "Strategy A", now test-only — each
-//! substitution step is recast as a **transducer** over a node list,
+//! See this module's own `README.md` for the background this doc comment
+//! assumes — how the crate's inline-substitution implementation moved from
+//! string rewriting to this tree, the escaping-order rule several steps
+//! below refer to, and how a construct with no `Span`-typed field recovers
+//! its text from a level's match string.
+//!
+//! Each substitution step is recast as a **transducer** over a node list,
 //! `Vec<InlineNode<'src>> -> Vec<InlineNode<'src>>`, that refines the tree in
-//! place. Two properties fall out that Strategy A cannot offer:
+//! place. Building the tree directly gives two properties that recovering it
+//! after the fact from a rendered string cannot:
 //!
 //! 1. **Honest per-node spans.** A node is sliced straight from the source
 //!    [`Span`], so its `location` reports the real `line`/`col`/`offset` of the
@@ -15,11 +19,7 @@
 //!    borrows the very bytes its `location` covers, so the common case does not
 //!    allocate.
 //!
-//! # Status
-//!
-//! Strategy B "touches every step," so it lands incrementally under the
-//! golden-HTML oracle. This module currently implements the **foundation** plus
-//! these refinements:
+//! # What each step does
 //!
 //! - [`build`] seeds a single borrowed whole-source [`Text`](InlineNode::Text)
 //!   node and threads it through the steps; [`build_from_value`] generalizes
@@ -27,43 +27,42 @@
 //!   [`Content`](crate::content::Content) itself is built from, so a genuinely
 //!   multi-line, filtered block — whose joined text has no single contiguous
 //!   `'src` slice — can be processed too, with every node it produces falling
-//!   back to `location` as its coarse span (design §4.4).
+//!   back to `location` as its coarse span.
 //! - [`apply_special_characters`] splits each `Text` run on `<`/`>`/`&` into
 //!   precise-span [`Text`](InlineNode::Text) and
 //!   [`CharRef`](InlineNode::CharRef) nodes.
 //! - [`apply_quotes`] recognizes [quoted text] and wraps each matched run in a
 //!   [`Styled`](crate::inlines::Styled) span, **introducing nesting** — `*a _b_
-//!   c*` becomes a tree, not a flat run. It reuses the *exact* [`quote_subs`]
-//!   the string pipeline matches with (changing the recognition *sink*, not the
-//!   recognition), so its fold is byte-identical to the string step. An
+//!   c*` becomes a tree, not a flat run. It matches with the *exact*
+//!   [`quote_subs`] patterns the crate uses for quoted text everywhere. An
 //!   attributed span's own attribute list (`['a<b']*bold*`) is parsed from the
-//!   level's **match string** — the escaped bytes the string replacer parses
-//!   out of its own haystack, since `specialcharacters` has already run — so
+//!   level's **match string** — the escaped bytes recovered from the level's
+//!   own haystack, since `specialcharacters` has already run — so
 //!   the entity, not the author's raw `<`, reaches the rendered `class`/`id`
 //!   (see [`quote_attributes`](quotes)).
 //! - [`apply_attribute_references`] recognizes attribute references (`{name}`),
 //!   splicing a set attribute's resolved value into the node stream, classified
-//!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs per
-//!   design §3.4.1 — a literal `<`/`>`/`&` in the value is *not* re-escaped,
+//!   into [`Text`](InlineNode::Text) and [`Raw`](InlineNode::Raw) runs — a
+//!   literal `<`/`>`/`&` in the value is *not* re-escaped,
 //!   since [`apply_special_characters`] has already run, unless the group's
 //!   effective order puts that step *after* this one (only a `subs=` list can,
 //!   and `subs=attributes+` does), in which case the value is spliced as one
-//!   ordinary `Text` run for it to escape (see [`SplicedSpecials`]). It reuses
+//!   ordinary `Text` run for it to escape (see [`SplicedSpecials`]). It uses
 //!   the shared [`ATTRIBUTE_REFERENCE`](crate::content::ATTRIBUTE_REFERENCE)
-//!   pattern, so only the recognition *sink* differs. A `counter`/`counter2`
+//!   pattern. A `counter`/`counter2`
 //!   directive resolves *and advances* the named counter via
 //!   [`Parser::counter`], the same required side effect [`apply_footnotes`]
 //!   performs for footnote numbering. A missing-attribute reference under
 //!   `AttributeMissing::Drop` / `::DropLine` is deferred (see
 //!   [`apply_attribute_references`] for why). A character replacement *inside*
-//!   an expanded value ((C) → ©, `--`, …) is recognized, a follow-up increment
-//!   having taught [`build_match_string`](quotes::build_match_string) to look
-//!   inside a [`synthesized`](quotes::Piece::synthesized) run instead of
-//!   treating it as opaque; and no **macro** family defers there any more. An
+//!   an expanded value ((C) → ©, `--`, …) is recognized too:
+//!   [`build_match_string`](quotes::build_match_string) looks
+//!   inside a [`synthesized`](quotes::Piece::synthesized) run rather than
+//!   treating it as opaque, and no **macro** family defers there. An
 //!   [`Attrlist`] a node carries needs no `'src` slice of its own — an image's
 //!   bracket, both link families' attribute-list-bearing display texts, and an
 //!   attributed span's own list are parsed from the level's own match string
-//!   (the bytes the string replacer parses too) and
+//!   and
 //!   [`into_owned`](Attrlist::into_owned)ed off it — so
 //!   [`range_is_verbatim`](macros::image::range_is_verbatim) survives only
 //!   where a *borrow* is still preferred, not as a boundary. And a macro
@@ -152,9 +151,8 @@
 //!   in both of `INLINE_LINK`'s branches (`https://example.org/?a=1&b=2`,
 //!   `https://example.org[a < b]`, `<https://example.org/a&b>`): the
 //!   level's match string carries a
-//!   [`CharRef`](InlineNode::CharRef)`::Special`'s canonical entity, the very
-//!   bytes the string replacer's own escaped haystack holds there, so every
-//!   value these families read off that string is what the string replacer read.
+//!   [`CharRef`](InlineNode::CharRef)`::Special`'s canonical entity — the same
+//!   escaped bytes every value these families read off that string reads.
 //!   The display text then becomes **structured children** rather than one
 //!   sliced or baked `Text` — the special stays the `CharRef` it already is,
 //!   folding back to the same entity instead of being escaped twice — which for
@@ -165,8 +163,7 @@
 //!   family at once, since recoverability is a property of the piece rather
 //!   than of the family reading across it: the match string carries the
 //!   entity's own bytes, and a replacement's built-in rendering
-//!   ([`replacement_entity`](quotes::replacement_entity)), which are the
-//!   string pipeline's own haystack bytes there. The
+//!   ([`replacement_entity`](quotes::replacement_entity)). The
 //!   one capture still holding that boundary in the two **link** families is a
 //!   display text carrying an attribute list, parsed as a real
 //!   [`Attrlist`]`<'src>` from the source's own
@@ -317,80 +314,65 @@
 //! also needs the **footnote-free** reading its cross-reference text and its
 //! auto-generated id are derived from, which
 //! [`fold_reference_text`] gives by skipping each
-//! [`Footnote`](InlineNode::Footnote) node wherever it sits. That is the
-//! tree's answer to the first of the three sentinel systems design §4.2 names:
-//! the string pipeline renders the title **once** with the footnote renderer
-//! bracketing each marker in a sentinel pair, cuts the bracketed regions out,
-//! and then removes the spent sentinels — one render yielding two strings,
-//! where a tree simply folds twice. Deleting the sentinels is the cutover's
-//! own job; this is staged and unwired like every other piece of that step.
+//! [`Footnote`](InlineNode::Footnote) node wherever it sits — the two are
+//! independent folds of the same tree, rather than one rendering with the
+//! footnote-bracketed regions cut back out of it after the fact (see
+//! `parser/snapshots/README.md` for how the crate used to do the latter).
 //!
 //! - [`apply_post_replacements`] turns a trailing ` +` at the end of a line
 //!   into a [`LineBreak`](InlineNode::LineBreak) leaf. Under the block-wide
 //!   `hardbreaks` option — the enclosing block's own `attrlist`, or the
 //!   document's `hardbreaks-option` attribute — it instead turns *every* line
 //!   ending into a break, stripping a redundant trailing ` +` rather than
-//!   doubling it, mirroring [`apply_post_replacements`]'s own string-pipeline
-//!   counterpart exactly.
+//!   doubling it.
 //! - [`fold_html`] folds the resulting leaves and spans back to output bytes
-//!   through an [`InlineRenderer`](crate::parser::InlineRenderer) — the first
-//!   fold over the *public* [`InlineNode`] tree (the recorder's `fold_into`
-//!   folds an intermediate representation, not the public tree).
+//!   through an [`InlineRenderer`](crate::parser::InlineRenderer) — the sole
+//!   fold over the *public* [`InlineNode`] tree.
 //!
 //! [quoted text]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
 //! [character replacements]:
 //!     https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
 //!
-//! This module is now **the production tree source**, for every parse:
+//! This module is **the production tree source** for every parse:
 //! `SubstitutionGroup::apply` calls [`build_for_group`] — the group-aware
-//! entry point mirroring its own `run_pipeline` step selection — over the
-//! pre-substitution content value, against a counter-safe clone of the
-//! parser, and stores the result on
-//! [`Content::inlines`](crate::content::Content::inlines). This replaced the
-//! Strategy-A recorder (`content::inline_tree`, now test-only oracle
-//! machinery) as the design's step 6 tree-source swap. The authoritative
-//! rendered string is still produced by the string pipeline; making
-//! `rendered_html()` a fold of this tree — and deleting the three production
-//! sentinel systems — is the remaining half of the cutover. A form documented
-//! as deferred elsewhere in this module is left as literal text in the tree
+//! entry point mirroring the step selection for the content's substitution
+//! group — over the pre-substitution content value, against a counter-safe
+//! clone of the parser, and stores the result on
+//! [`Content::inlines`](crate::content::Content::inlines).
+//! [`Content::rendered_html`](crate::content::Content::rendered_html) is
+//! itself a fold of that tree, through [`fold_html`]. A form documented as
+//! deferred elsewhere in this module is left as literal text in the tree
 //! (never a wrong node), so the fold-parity guarantee is scoped to the
 //! claimed vocabulary.
 //!
-//! # Staging the cutover's recognition side effects
+//! # Recognition side effects
 //!
-//! Every macro family above deliberately skips a **recognition side effect**
-//! the string pipeline performs at the same point — registering an id, link,
-//! or image target in the document catalog, or recording a warning — because
-//! the builder still runs *alongside* the authoritative string pipeline
-//! (against a counter-safe clone of the parser, whose mutations are
-//! discarded), so performing one here today would double-count the
-//! registration the string pipeline already performs. Each family's own
-//! deferred side effects are staged as their own reviewable building block —
+//! Every macro family above recognizes its construct without performing the
+//! **recognition side effect** that goes with it — registering an id, link,
+//! or image target in the document catalog, or recording a warning. Each
+//! family's own side effect is instead its own reviewable building block —
 //! `register_image` and the `link=` dangerous-scheme/self-href warning for
 //! `image:`/`icon:`, `register_link` for the five link forms, and the
 //! `register_ref` pair for anchors and id-carrying attributed spans — and
-//! [`apply_macro_side_effects`] composes all three, in the string pipeline's
-//! own family-pass order, into the single call the cutover's remaining half
-//! makes exactly once per parse (design §5.2, Phase 4 step 6): once
-//! `rendered_html()` is a fold of this tree, the string pipeline no longer
-//! performs the registrations and this call takes over. Until then it is
-//! exercised only by its own tests (and its constituents' own), against
-//! their own `Parser`.
+//! [`apply_macro_side_effects`] composes all three, in the crate's own
+//! family-pass order, into the single call
+//! [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup::apply)
+//! makes exactly once per parse, after the tree is built and folded.
+//! Callouts are a sibling of that call rather than
+//! one of the three, registered by [`apply_callout_side_effects`] instead,
+//! since callouts are recognized in verbatim content, where the macros step
+//! does not run at all.
 //!
 //! # A note on quote nesting
 //!
-//! The string pipeline realizes nesting by running the ordered [`quote_subs`]
-//! over one growing string: an earlier sub renders `<strong>…</strong>` and a
-//! later sub matches around (or inside) it. [`apply_quotes`] reproduces that by
-//! applying each sub to the node tree in turn and, before matching at a level,
-//! descending into the [`Styled`](crate::inlines::Styled) spans earlier subs
-//! created — so `*a `b` c*` (strong containing a later-recognized monospace)
-//! and `*a _b_ c*` nest correctly. A [`Styled`](crate::inlines::Styled) span an
-//! earlier sub produced is otherwise **opaque** to a later sub at the same
-//! level (represented by a single placeholder while matching), which is where
-//! this single-pass recognition can, in principle, diverge from the string
-//! pipeline's match-through-rendered-tags behavior for pathological cross-span
-//! inputs; the differential corpus (§5.3) pins the cases this increment claims.
+//! [`apply_quotes`] applies each of the ordered [`quote_subs`] to the node
+//! tree in turn and, before matching at a level, descends into the
+//! [`Styled`](crate::inlines::Styled) spans an earlier sub created — so `*a
+//! `b` c*` (strong containing a later-recognized monospace) and `*a _b_ c*`
+//! nest correctly. A [`Styled`](crate::inlines::Styled) span an earlier sub
+//! produced is otherwise **opaque** to a later sub at the same level
+//! (represented by a single placeholder while matching); the differential
+//! corpus pins the cases this covers.
 //!
 //! [`Text`]: InlineNode::Text
 //! [`quote_subs`]: crate::content::quote_subs
@@ -414,17 +396,9 @@ pub(crate) mod snapshot;
 mod test_support;
 
 use attribute_refs::{SplicedSpecials, apply_attribute_references};
-// Staged for the eventual authoritative-fold half of the cutover (see this
-// module's own doc comment); not yet called from any real parse path, so —
-// unlike the step re-exports below — reachable only via `cfg(test)` callers
-// and future external callers today.
-#[allow(unused_imports)]
 pub(crate) use callouts::apply_callout_side_effects;
 use callouts::apply_callouts;
 use char_replacements::apply_character_replacements;
-// Consumed only by `cfg(test)` callers and future external callers until the
-// authoritative-fold half of the cutover wires it into `Content`.
-#[allow(unused_imports)]
 pub(crate) use fold::{fold_deferring_xrefs, fold_html, fold_reference_text};
 use footnotes::apply_footnotes;
 pub(crate) use macros::apply_macro_side_effects;
@@ -497,9 +471,9 @@ pub(crate) fn build<'src>(
 /// - **`value` differs from `location.data()`** (a multi-line block whose
 ///   surviving lines were joined with `\n`, or any other filtered value with no
 ///   single contiguous `'src` slice of its own): the seed is *synthesized* —
-///   every node the pipeline builds from it still gets a real `InlineNode`, but
-///   one whose `location` coarsely falls back to the whole of `location`
-///   (design §4.4's documented migration-stage policy), the same fallback an
+///   every node the builder produces from it still gets a real `InlineNode`, but
+///   one whose `location` coarsely falls back to the whole of `location`,
+///   the same fallback an
 ///   attribute-reference expansion or a `counter` directive's resolved value
 ///   already receives. This is what lets the single-pass builder process a
 ///   real, multi-line, filtered block's content — not just a single contiguous
@@ -526,28 +500,25 @@ pub(crate) fn build_from_value<'src>(
 
 /// Builds the inline tree from an already-computed content **value** under the
 /// substitution group that governs the content — the group-aware counterpart
-/// of [`build_from_value`], mirroring the step selection
-/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup)'s own
-/// `run_pipeline` makes for the string.
-///
-/// The mapping reproduces `run_pipeline` exactly:
+/// of [`build_from_value`], selecting steps by the content's own
+/// [`SubstitutionGroup`].
 ///
 /// - Passthrough (and, with it, inline-STEM) extraction runs first, ahead of
 ///   every step, **iff** the group's steps include
 ///   [`Macros`](SubstitutionStep::Macros) or the group is
-///   [`Header`](SubstitutionGroup::Header) — the same condition `run_pipeline`
-///   gates `Passthroughs::extract_from` on.
+///   [`Header`](SubstitutionGroup::Header).
 /// - Each of the group's [`steps()`](SubstitutionGroup::steps) then runs in the
 ///   group's own order, each recast as its node transducer. The
 ///   [`Macros`](SubstitutionStep::Macros) step runs [`apply_macros`] and then
-///   [`apply_footnotes`] — footnotes are part of the string pipeline's macros
-///   step, but are their own transducer here so numbering follows true source
+///   [`apply_footnotes`] — footnotes are recognized as part of the macros
+///   family in AsciiDoc's own substitution model, but are their own
+///   transducer here so numbering follows true source
 ///   order (see [`apply_footnotes`]'s doc comment).
 ///
 /// A group whose steps are empty ([`Pass`](SubstitutionGroup::Pass) /
 /// [`None`](SubstitutionGroup::None), or an empty custom list) yields the
 /// untouched seed: a single [`Text`](InlineNode::Text) node holding `value`,
-/// exactly as the string pipeline leaves such content's text unchanged. Empty
+/// with its text left unchanged. Empty
 /// content is seeded with **no** node at all rather than an empty one: a leaf
 /// carrying nothing is not something a consumer should have to skip, and the
 /// steps would have nothing to do with it anyway. (The distinction matters
@@ -570,8 +541,7 @@ pub(crate) fn build_for_group<'src>(
     let mut nodes = vec![InlineNode::Text { value, location }];
 
     // Passthroughs are extracted before every other step (mirroring
-    // `Passthroughs::extract_from`, which the string pipeline runs ahead of
-    // its own step loop, under the same group condition), so their content is
+    // `Passthroughs::extract_from`'s own gate), so their content is
     // never touched by specialcharacters, quotes, replacements, or macros.
     if steps.contains(&SubstitutionStep::Macros) || group == &SubstitutionGroup::Header {
         nodes = apply_passthroughs(nodes, location, parser);
@@ -588,20 +558,19 @@ pub(crate) fn build_for_group<'src>(
     // rather than only for the order that needs the first:
     //
     //   - `flatten_prior_markup`, for a `subs=` list that puts the escaping
-    //     step *after* a step that already produced markup: the string pipeline
-    //     escapes the tags that step wrote, and this is what tells those from a
-    //     passthrough body the escaping step never touches.
+    //     step *after* a step that already produced markup: escaping needs to
+    //     see the tags that step wrote as logical text, and this is what tells
+    //     those from a passthrough body the escaping step never touches.
     //
     //   - recognition itself (`build_match_string`, via `Masked`), for every
-    //     order: a sibling reads a rendered span's own markup, and a wrapper —
-    //     which the string pipeline is still holding as a `\u{96}…\u{97}`
-    //     placeholder — presents no markup to read.
+    //     order: a sibling reads a rendered span's own markup, and a wrapper
+    //     presents no markup to read.
     let masked = masked_locations(&nodes);
 
     for (position, step) in steps.iter().enumerate() {
         nodes = match step {
             SubstitutionStep::SpecialCharacters => {
-                // Design §3.4.1, applied to this step's own *position*:
+                // Applied to this step's own *position* in the order:
                 // anything an earlier step of this order already turned into
                 // markup is logical text by the time the escaping step reaches
                 // it (see `flatten_prior_markup`). A no-op when this step runs
@@ -619,14 +588,14 @@ pub(crate) fn build_for_group<'src>(
             SubstitutionStep::Quotes => apply_quotes(nodes, location, parser),
 
             // In the *normal* effective order (specialcharacters → quotes →
-            // attributes → replacements → macros, design §3.4.1), by this
+            // attributes → replacements → macros), by this
             // point `<`/`>`/`&` are already `CharRef` leaves and quoted spans
             // are already `Styled` nodes, and whatever this step splices in
             // is exactly what the steps still ahead see and refine.
             //
             // A `Custom` order can put `SpecialCharacters` *after* this step
-            // instead — `subs=attributes+` prepends it — and then the string
-            // pipeline escapes the spliced value like any other text. That is
+            // instead — `subs=attributes+` prepends it — and then the spliced
+            // value is escaped like any other text. That is
             // the one thing a spliced value's classification turns on, so it
             // is decided here, where the order is in hand, and carried down as
             // `SplicedSpecials`.
@@ -654,8 +623,8 @@ pub(crate) fn build_for_group<'src>(
                 // nodes to rebuild it from and its classification has to be
                 // re-derived from the bytes. Whether those bytes are already
                 // escaped is decided by where the escaping step sits in this
-                // order — design §3.4.1 applied to the step's *position*,
-                // exactly as `SplicedSpecials` decides it for the step above —
+                // order, exactly as `SplicedSpecials` decides it for the step
+                // above —
                 // so it is decided here, where the order is in hand, and
                 // carried down as `ComputedSpecials`.
                 let specials = if steps
@@ -684,12 +653,11 @@ pub(crate) fn build_for_group<'src>(
         };
     }
 
-    // Design §3.4.1: a literal `<`/`>`/`&` that no `SpecialCharacters` step
-    // ever acted on is emitted verbatim by the string pipeline, so it is a
+    // A literal `<`/`>`/`&` that no `SpecialCharacters` step
+    // ever acted on is emitted verbatim, so it is a
     // `Raw` leaf here rather than the `Text` run the fold would escape. This
     // runs last, after the group's own steps, so every transducer still sees
-    // the specials as ordinary text — exactly as the string pipeline's steps
-    // do under such an order.
+    // the specials as ordinary text.
     if !steps.contains(&SubstitutionStep::SpecialCharacters) {
         nodes = classify_unescaped_specials(nodes);
     }

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -102,13 +102,13 @@ use crate::{
 ///
 /// A **prohibited prefix** ahead of either attribute-list-prefixed bare form
 /// (`index:[attrs]+text+`, `` \[x-]`text` ``) is answered the way
-/// Asciidoctor's own regex answers it, for want of a lookbehind: the match's first character
-/// — always its `[` — is written back verbatim and the *rest of that same
-/// match* is scanned again ([`collect_bare_pass_matches`], recursively). The
-/// second scan routinely recognizes a different, shorter construct the
-/// bracket was hiding — for the plus form, the bare unconstrained form over
-/// the same body, so the attribute list ends up a literal prefix and the body
-/// an *ordinary* passthrough rather than a `Styled` span — and for the
+/// Asciidoctor's own regex answers it, for want of a lookbehind: the match's
+/// first character — always its `[` — is written back verbatim and the *rest of
+/// that same match* is scanned again ([`collect_bare_pass_matches`],
+/// recursively). The second scan routinely recognizes a different, shorter
+/// construct the bracket was hiding — for the plus form, the bare unconstrained
+/// form over the same body, so the attribute list ends up a literal prefix and
+/// the body an *ordinary* passthrough rather than a `Styled` span — and for the
 /// backtick form it finds nothing, leaving the construct to the later quotes
 /// step. Writing both of this pass's escapes at once
 /// (`\[attrs]\++text++`) lands here as well: the delimiter escape wins the
@@ -910,9 +910,9 @@ fn build_passthrough_node<'src>(
     // producing an already-final HTML string
     // that this arm wraps in a single `Raw` leaf. A `Raw` leaf is *opaque* to
     // every later step in this module (never descended into, never re-matched —
-    // this module's own passthrough-as-leaf convention), so it is immune to both
-    // failure modes above: nothing in `build`'s own remaining steps can touch
-    // it, whether or not the author's list included that step.
+    // this module's own passthrough-as-leaf convention), so it is immune to
+    // both failure modes above: nothing in `build`'s own remaining steps
+    // can touch it, whether or not the author's list included that step.
     //
     // That opacity is also why the explicit-list form is the one place `value`
     // is not the author's own bytes, and so the one place the node records a
@@ -1207,8 +1207,8 @@ fn split_old_behavior_attrlist(attrlist: Span<'_>) -> (Span<'_>, bool) {
 /// marker's `Normal`-group passthrough body (see
 /// [`split_old_behavior_attrlist`]).
 ///
-/// This mirrors `PassthroughRestoreReplacer`'s own `pass.subs.apply(…)` call
-/// for that case. That call is *not* just the six named steps
+/// This matches Asciidoctor's own handling for that case. It is *not* just
+/// the six named steps
 /// (`SpecialCharacters`, `Quotes`, `AttributeReferences`,
 /// `CharacterReplacements`, `Macros`, `PostReplacement`): `SubstitutionGroup`'s
 /// `run_pipeline` extracts passthroughs (and, as part of that same extraction,
@@ -1218,10 +1218,10 @@ fn split_old_behavior_attrlist(attrlist: Span<'_>) -> (Span<'_>, bool) {
 /// and restored, not left for `Macros` to walk over as plain text.
 /// [`build`](super::build)
 /// already threads a span through exactly that full sequence — passthroughs,
-/// STEM, then the six steps, footnotes included (the string pipeline's
-/// `Macros` step recognizes footnote macros too, so `Normal`'s semantics
+/// STEM, then the six steps, footnotes included (Asciidoctor's own `Macros`
+/// step recognizes footnote macros too, so `Normal`'s semantics
 /// cover them; `build` only splits that recognition into its own step for
-/// numbering-order reasons, design §5.2 step 4b(ii) part 4c) — so this
+/// numbering-order reasons) — so this
 /// delegates to it directly rather than re-deriving a subset.
 fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<'src>> {
     super::build(text, parser, None)
@@ -1235,22 +1235,19 @@ fn apply_normal_subs<'src>(text: Span<'src>, parser: &Parser) -> Vec<InlineNode<
 /// [`InlineRenderer`](crate::parser::InlineRenderer)
 /// `parser` carries rather than a hand-rolled, always-default escaping.
 ///
-/// **This is the authoritative-pass closure** (design §5.2's step 6). Until
-/// now this ran `subs.apply`, which re-entered
-/// [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup) for the
-/// body; that re-entry took no tree seed (a reentrancy guard on the `Parser`,
-/// since retired along with the re-entry), so its *string* pipeline was the
-/// body's authoritative pass. It was the last thing
-/// in production keeping `run_pipeline` alive — the survey named it the
-/// only non-test-side blocker to the deletion, which has since landed.
+/// This function builds the body's own tree directly, rather than
+/// re-entering [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup)
+/// for a second, string-based substitution pass over it — the reentrant call
+/// this used to make (guarded against recursion on the `Parser`) is retired
+/// along with the call itself.
 ///
-/// It closes because [`build_for_group`](super::build_for_group) already runs
-/// **an arbitrary group's steps in that group's own order** — including a
-/// `Custom` order that puts the escaping step after a step that produced
-/// markup, which is what `flatten_prior_markup` and `SplicedSpecials` are for.
-/// So the body needs no string pipeline of its own: it is built as a tree and
-/// folded, exactly as every other content is, and the enclosing level goes on
-/// wrapping the result in one opaque `Raw` leaf.
+/// This works because [`build_for_group`](super::build_for_group) already
+/// runs **an arbitrary group's steps in that group's own order** — including
+/// a `Custom` order that puts the escaping step after a step that produced
+/// markup, which is what `flatten_prior_markup` and `SplicedSpecials` are
+/// for. So the body needs no string-based substitution of its own: it is
+/// built as a tree and folded, exactly as every other content is, and the
+/// enclosing level goes on wrapping the result in one opaque `Raw` leaf.
 ///
 /// *The obvious objection does not apply here, which is why this works.* A
 /// passthrough's body cannot be built as *nodes spliced into the enclosing
@@ -1424,7 +1421,7 @@ mod tests {
 
     #[test]
     fn a_pass_macro_unescapes_an_escaped_closing_bracket() {
-        // Mirrors the string replacer's `text.replace("\\]", "]")`, the same
+        // Matches Asciidoctor's own unescape of `\]` to `]`, the same
         // treatment every other macro family's bracket content gets. The
         // unescape makes the value owned, unlike the no-escape case above.
         let nodes = build_src(Span::new(r"pass:[a\]b]"));
@@ -1449,7 +1446,7 @@ mod tests {
         // that same de-escaped text and consumes its leading `+++` as a bare
         // passthrough wrapping a single `+` (the outer `+` is the delimiter,
         // the middle `+` is the body), leaving the third `+` as literal text
-        // in front of `text+++` — exactly what the string pipeline's own
+        // in front of `text+++` — exactly what Asciidoctor's own
         // second regex pass does over its own once-substituted text, so this
         // is parity, not a divergence.
         let source = r"\+++text+++";
@@ -1846,8 +1843,8 @@ mod tests {
             // attributed *quote's* — parsed from the escaped text, since the
             // escaping step runs before the quotes step (see
             // [`quote_attributes`](super::quotes)) — this extraction pass runs
-            // *ahead* of every step, so the string pipeline parses the
-            // author's raw bytes here and `attributes_of` matches it by
+            // *ahead* of every step, so it parses the
+            // author's raw bytes here directly, and `attributes_of` matches it by
             // parsing the source slice.
             "[.a<b]++text++",
             "[#a&b]++text++",
@@ -1892,7 +1889,7 @@ mod tests {
             // A delimiter escape after an attribute list drops one backslash
             // and leaves the rest literal — which the bare-form second pass
             // then legitimately re-recognizes as its own (different) match,
-            // exactly as the string pipeline's own second regex pass does.
+            // exactly as Asciidoctor's own second regex pass does.
             r"[.role]\++text++",
             // The bare-plus form's own delimiter escape: dropped backslash,
             // literal remainder, no further pass to re-scan a residue.
@@ -1903,7 +1900,7 @@ mod tests {
             // `++`, no `x-` monospace either. Every boundary, in flow,
             // beside its unescaped twin, with a special character and with
             // quote syntax in the kept prefix (both substituted normally
-            // there, exactly as the string pipeline substitutes its own
+            // there, exactly as Asciidoctor substitutes its own
             // literal `[attrs]`), and spanning a newline.
             r"\[attrs]++text++",
             r"abc \[attrs]++text++",
@@ -1939,8 +1936,8 @@ mod tests {
             r"see \+text+ end",
             r"\+text+",
             // A prefix the pattern's own consuming boundary group excludes
-            // (`\`, `:`, `;`) leaves the match unrecognized by both
-            // pipelines, so the source stays entirely literal.
+            // (`\`, `:`, `;`) leaves the match unrecognized, matching
+            // Asciidoctor's own behavior, so the source stays entirely literal.
             r"a\+text+ b",
             "a:+text+ b",
             "a;+text+ b",
@@ -1949,7 +1946,7 @@ mod tests {
             "a copyright (C) then +text+",
             // The two *attribute-list-prefixed* options behind that same
             // prohibited prefix, which their own pattern does not exclude
-            // and which the string replacer answers with a retry over the
+            // and which Asciidoctor answers with a retry over the
             // match minus its leading `[`. For the plus option that retry
             // routinely finds the bare unconstrained form the bracket was
             // hiding — a literal `[attrs]` prefix and an *ordinary*
@@ -2126,7 +2123,7 @@ mod tests {
 
     #[test]
     fn the_x_dash_marker_normal_subs_numbers_a_nested_footnote() {
-        // `[x-]++footnote:[…]++`: the string pipeline's `Macros` step
+        // `[x-]++footnote:[…]++`: Asciidoctor's own `Macros` step
         // recognizes footnote macros too, so `Normal`'s semantics cover them;
         // `build` splits that recognition into its own `apply_footnotes` step
         // (for numbering-order reasons), which delegating to `build` picks up
@@ -2303,7 +2300,7 @@ mod tests {
 
     #[test]
     fn a_prohibited_prefix_before_a_bare_attrlisted_form_retries_over_the_rest() {
-        // The string pipeline's own `InlinePassReplacer` retries around a
+        // This family's own retry, reproducing Asciidoctor's behavior around a
         // match immediately preceded by `\`, `:`, or `;` (no lookbehind in
         // Rust's regex engine): it writes the match's first character back
         // verbatim and re-scans the rest. That retry is not a no-op — here it
@@ -2503,8 +2500,8 @@ mod tests {
         // `a_bare_attrlisted_match_whose_content_crosses_an_already_built_node_is_deferred`'s
         // guard, rather than a hand-built level.
         //
-        // The string pipeline instead reconciles this via a recursive
-        // sentinel-restoration step (`PassthroughRestoreReplacer` re-resolves
+        // Asciidoctor instead reconciles this via a recursive
+        // placeholder-restoration step (re-resolving
         // a leftover placeholder against the *outer* passthrough list when a
         // nested `Normal`-group substitution doesn't consume it) that has no
         // counterpart in this tree-based, single-pass builder.
@@ -2527,11 +2524,11 @@ mod tests {
     fn a_bare_plus_attrlisted_delimiter_escape_stays_literal() {
         // `[attrs]\+text+`: honors the escape of the formatting mark — one
         // backslash drops, the rest (attrlist brackets included) stays
-        // literal, mirroring `InlinePassReplacer`'s own `escape_count > 0`
-        // branch. Unlike the delimited form's own escape
+        // literal, matching Asciidoctor's own handling of this escape.
+        // Unlike the delimited form's own escape
         // (`[.role]\++text++`), there is no further pass to re-scan the
         // residue here — this second pass already is the last one — so the
-        // result is simple parity with the golden string pipeline.
+        // result is simple parity with the golden recording.
         let source = r"[attrs]\+text+";
         let nodes = build_src(Span::new(source));
 

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1782,9 +1782,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_passthroughs() {
         // For each fixture, folding the single-pass tree (all six steps,
-        // passthroughs included) reproduces the string pipeline's output
-        // byte-for-byte. This is the differential corpus (design §5.3) that
-        // pins the passthrough increment.
+        // passthroughs included) reproduces the frozen golden recording
+        // byte-for-byte. This is the differential corpus that pins
+        // passthrough recognition.
         let fixtures = [
             // No passthrough despite passthrough-ish characters.
             "plain text",
@@ -2688,8 +2688,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_for_a_bare_form_over_an_extracted_passthrough() {
         // The bare `+…+` form runs in this step's *second* pass, so its body
-        // can enclose a construct the first pass already replaced. The string
-        // pipeline sees its own sentinel there and treats it as ordinary body
+        // can enclose a construct the first pass already replaced. Asciidoctor
+        // treats its own placeholder there as ordinary body
         // text — substituting over it and letting the final restore splice the
         // inner body in afterwards — and this reproduces that order exactly.
         for fixture in [
@@ -2842,7 +2842,7 @@ mod tests {
         // the bare unconstrained form's own pattern already excludes a `\`,
         // `:`, or `;` prefix in its consuming boundary group, so this is
         // parity, not a divergence: the passthrough is correctly left
-        // unrecognized *and* the golden string pipeline agrees.
+        // unrecognized *and* the golden recording agrees.
         for source in [r"a\+text+ b", "a:+text+ b", "a;+text+ b"] {
             let nodes = build_src(Span::new(source));
 

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -22,20 +22,18 @@ use crate::{
 /// for [`apply_special_characters`](super::special_chars::apply_special_characters)
 /// and the later steps to refine.
 ///
-/// This is the **first** step [`build`](super::build) runs — mirroring
-/// `Passthroughs::extract_from`,
-/// which the string pipeline runs *before* its own step loop — so a
-/// passthrough's content is never touched by specialcharacters, quotes,
-/// replacements, or macros: it is a leaf, and every later step's
-/// [`build_match_string`] already treats a node it does not specifically
-/// handle (an already-built [`Styled`] span, and now a
-/// [`Raw`](InlineNode::Raw) leaf) as a
-/// single opaque placeholder.
+/// This is the **first** step [`build`](super::build) runs, matching
+/// Asciidoctor's own order, which extracts passthroughs before any other
+/// substitution runs — so a passthrough's content is never touched by
+/// specialcharacters, quotes, replacements, or macros: it is a leaf, and
+/// every later step's [`build_match_string`] already treats a node it does
+/// not specifically handle (an already-built [`Styled`] span, and now a
+/// [`Raw`](InlineNode::Raw) leaf) as a single opaque placeholder.
 ///
-/// It reuses the string pipeline's *exact* recognition —
-/// [`INLINE_PASS_MACRO`] is now shared `pub(crate)` — so only the recognition
-/// *sink* differs (§4.1). Two forms fold through a [`Raw`](InlineNode::Raw)
-/// node whose `value`
+/// Recognition uses the same [`INLINE_PASS_MACRO`] pattern this construct
+/// has always been matched with, now shared as `pub(crate)`, so only the
+/// recognition *sink* (a tree node instead of a rendered string) differs.
+/// Two forms fold through a [`Raw`](InlineNode::Raw) node whose `value`
 /// is the *content itself*, since their substitution list applies nothing:
 /// the triple-plus (`+++text+++`) and bare `pass:[…]` macro (with no
 /// substitution list) both resolve to [`SubstitutionGroup::None`], and the
@@ -47,10 +45,9 @@ use crate::{
 /// run through the real substitution pipeline
 /// ([`passthrough_text`]) so a custom
 /// [`InlineRenderer`](crate::parser::InlineRenderer)'s
-/// escaping is honored, exactly as it would be for the string pipeline's own
-/// restore step — the cost is an owned [`Raw`](InlineNode::Raw) value rather
-/// than a `'src` borrow, since the pipeline's output is not guaranteed to
-/// coincide with the source.
+/// escaping is honored — the cost is an owned [`Raw`](InlineNode::Raw) value
+/// rather than a `'src` borrow, since the pipeline's output is not
+/// guaranteed to coincide with the source.
 ///
 /// An **attribute-list-prefixed** passthrough (`[quotes]++text++`,
 /// `` [x-]`text` ``, `[attrs]+text+`) folds through a [`Styled`] node instead:
@@ -59,11 +56,11 @@ use crate::{
 /// an attributed quote does ([`attributes_of`]) and wrap the body — itself a
 /// `Raw` leaf under `SubstitutionGroup::None`/`Verbatim`, unless the legacy
 /// `x-` compatibility marker switches it to a full `Normal`-order subtree
-/// ([`apply_normal_subs`]) — in `Code` (monospace) or `Unquoted`, mirroring
-/// `PassthroughRestoreReplacer`'s own `render_styled` call for a
-/// stored passthrough whose `type_` is `Some`. This runs as a **second pass**
+/// ([`apply_normal_subs`]) — in `Code` (monospace) or `Unquoted`, matching
+/// how Asciidoctor itself renders a passthrough carrying a stored type. This
+/// runs as a **second pass**
 /// ([`apply_bare_attrlisted_pass_level`]) after the delimited forms above,
-/// mirroring `Passthroughs::extract_from`'s own order (`INLINE_PASS_MACRO`
+/// matching Asciidoctor's own recognition order (`INLINE_PASS_MACRO`
 /// before [`INLINE_PASS`]).
 ///
 /// Running as a genuine second pass has one consequence worth calling out: a
@@ -83,8 +80,9 @@ use crate::{
 /// The **bare unconstrained form** (`+text+`, no attribute list) folds
 /// through a plain [`Raw`](InlineNode::Raw) leaf — like the double-plus/
 /// double-dollar forms, an absent attrlist means no stored `type_`, so
-/// `PassthroughRestoreReplacer` never wraps the restored text in a rendered
-/// span. Unlike the two attribute-list-prefixed bare forms above (matched via
+/// the restored text is never wrapped in a rendered span, matching
+/// Asciidoctor's own passthrough-restore behavior. Unlike the two
+/// attribute-list-prefixed bare forms above (matched via
 /// `\b{start-half}`, which does not by itself exclude a `\`/`:`/`;` prefix and
 /// so needs the retry below), this form's own pattern already excludes that
 /// "prohibited prefix" — and the word-boundary rule the doc comment on
@@ -97,14 +95,14 @@ use crate::{
 /// sub-range the auto-link increment introduced. Because it runs in the
 /// *second* pass, its body may enclose a construct the first pass already
 /// replaced (`+a $$b$$ c+`, `` +you feel pass:q[`mono`].+ ``): the verbatim
-/// substitution runs over the placeholder as the string pipeline runs it over
-/// its own sentinel, and the inner body is spliced in **after** — see
+/// substitution runs over the node's own opaque placeholder text, and the
+/// inner body is spliced in **after** — see
 /// [`build_bare_unconstrained_match`]. The attribute-list-prefixed forms keep
 /// their verbatim gate, so `[method x-]+pass:[<b>]+` stays deferred.
 ///
 /// A **prohibited prefix** ahead of either attribute-list-prefixed bare form
-/// (`index:[attrs]+text+`, `` \[x-]`text` ``) is answered the way the string
-/// replacer answers it, for want of a lookbehind: the match's first character
+/// (`index:[attrs]+text+`, `` \[x-]`text` ``) is answered the way
+/// Asciidoctor's own regex answers it, for want of a lookbehind: the match's first character
 /// — always its `[` — is written back verbatim and the *rest of that same
 /// match* is scanned again ([`collect_bare_pass_matches`], recursively). The
 /// second scan routinely recognizes a different, shorter construct the
@@ -155,7 +153,7 @@ use crate::{
 /// *second* pass ([`INLINE_PASS`]) legitimately re-scans that same de-escaped
 /// text and consumes its leading `+++`/`++` as a bare passthrough wrapping a
 /// shorter run (`+text` / `text`, one `+` left over as trailing literal
-/// text), exactly as the string pipeline's own second regex pass does over
+/// text), exactly as Asciidoctor's own second regex pass does over
 /// its own once-substituted text: parity, not a divergence
 /// (`an_escaped_triple_plus_reveals_a_nested_bare_passthrough`,
 /// `an_escaped_double_plus_reveals_a_nested_bare_passthrough`). An escaped
@@ -176,13 +174,12 @@ pub(super) fn apply_passthroughs<'src>(
 ) -> Vec<InlineNode<'src>> {
     let nodes = apply_pass_macro_level(nodes, root, parser);
 
-    // The bare-form pass runs second, mirroring `Passthroughs::extract_from`'s
-    // own order: the string pipeline runs `INLINE_PASS_MACRO` first, then
-    // `INLINE_PASS` over what it left behind, so a construct the macro pass
-    // already replaced (now an opaque placeholder in the rebuilt match
-    // string) is untouched by this second pass. A bare `+…+` may still
-    // *enclose* one, which the string pipeline reads as ordinary body text
-    // around its own sentinel and restores last; see
+    // The bare-form pass runs second, so a construct the macro pass already
+    // replaced (now an opaque placeholder in the rebuilt match string) is
+    // untouched by this second pass, matching Asciidoctor's own two-pass
+    // recognition order (`INLINE_PASS_MACRO` before `INLINE_PASS`). A bare
+    // `+…+` may still *enclose* one, in which case its content is treated as
+    // ordinary body text around that placeholder and restored last; see
     // [`build_bare_unconstrained_match`] for how that order is reproduced.
     apply_bare_attrlisted_pass_level(nodes, root, parser)
 }
@@ -276,7 +273,7 @@ fn apply_bare_attrlisted_pass_level<'src>(
 /// unattrlisted delimiter escape. A *bracket* escape (`\[attrs]++text++`)
 /// becomes a **pair**: an [`Unescape`](MacroMatchKind::Unescape) over the
 /// bracket, then a [`Node`](MacroMatchKind::Node) over the delimited
-/// remainder, which the string replacer stores without its attribute list.
+/// remainder, which Asciidoctor stores without its attribute list.
 fn find_passthrough_matches<'src>(
     s: &str,
     pieces: &[Piece],
@@ -426,7 +423,7 @@ fn find_passthrough_matches<'src>(
 /// [`build_bare_unconstrained_match`]).
 ///
 /// The scan is [`collect_bare_pass_matches`], which is recursive so that the
-/// two attribute-list-prefixed options can reproduce the string replacer's
+/// two attribute-list-prefixed options can reproduce Asciidoctor's
 /// own **prohibited-prefix retry**; see its doc comment.
 fn find_bare_attrlisted_matches<'src>(
     s: &str,
@@ -622,16 +619,16 @@ fn collect_bare_pass_matches<'src>(
 /// This pass runs second, over what the [`INLINE_PASS_MACRO`] pass left
 /// behind, so a `+…+` body can enclose a construct that pass already replaced
 /// — `+a $$b$$ c+`, `+you feel pass:q[`mono`].+`, both documented AsciiDoc
-/// idioms. The string pipeline sees its own **sentinel** there and treats it
-/// as ordinary body text: it applies the verbatim substitution to the body
-/// *with the sentinel still in it*, stores the result as this passthrough's
-/// own entry, and lets the final restore splice the inner body in afterwards.
+/// idioms. Matching Asciidoctor's own output requires the same *restore-last*
+/// order: the verbatim substitution runs over the body with the inner
+/// construct still an opaque placeholder in it, producing this passthrough's
+/// own stored value, and only then is the inner body's own restored text
+/// spliced back in.
 ///
 /// The tree reproduces that order exactly. The body is read from the level's
 /// **match string** — where an already-built [`Raw`](InlineNode::Raw) or
 /// [`Stem`](crate::inlines::Stem) leaf stands as one
-/// [`SPAN_PLACEHOLDER`](super::quotes::SPAN_PLACEHOLDER), the same shape the
-/// sentinel has —
+/// [`SPAN_PLACEHOLDER`](super::quotes::SPAN_PLACEHOLDER) —
 /// [`passthrough_text`] runs over those bytes as written, and each placeholder
 /// in the *result* is then replaced by what the fold of that node emits
 /// ([`restorable_body`]). Substituting first and splicing after is what keeps
@@ -642,7 +639,7 @@ fn collect_bare_pass_matches<'src>(
 /// The gate is correspondingly [`range_is_restorable`]: a masked construct is
 /// admitted, and so is a [`synthesized`](Piece::synthesized) run (the match
 /// string carries its bytes exactly, and this no longer slices `'src` for the
-/// body). Only the node's `location` keeps design §4.4's coarse span. Nothing
+/// body). Only the node's `location` falls back to a coarse span. Nothing
 /// else can reach this pass — it runs before the escaping, quotes, and macros
 /// steps, so a [`CharRef`](InlineNode::CharRef) leaf or a rendered span does
 /// not exist yet.
@@ -694,8 +691,8 @@ fn build_bare_unconstrained_match<'src>(
                 // siblings; `substitute_and_restore` has already applied it,
                 // so `value` is the author's body (or, for a body enclosing an
                 // already-extracted construct, that body with each inner
-                // node's own fold bytes spliced in — which is what the string
-                // pipeline's own restore produces there too).
+                // node's own fold bytes spliced in — matching what
+                // Asciidoctor's own restore produces there too).
                 origin: RawOrigin::Passthrough {
                     subs: SubstitutionGroup::Verbatim,
                     source_text: None,
@@ -708,9 +705,9 @@ fn build_bare_unconstrained_match<'src>(
 }
 
 /// Applies the verbatim substitution to a bare `+…+` body and splices each
-/// already-extracted node's own fold bytes back in — the restore-last order
-/// the string pipeline itself performs, where the sentinel it holds for such a
-/// node is ordinary body text until the final restore.
+/// already-extracted node's own fold bytes back in — the same restore-last
+/// order Asciidoctor performs, where its own placeholder for such a node is
+/// ordinary body text until the final restore.
 ///
 /// `body_text` is the body as it stands in the level's **match string** and
 /// `range` is where that body sits in it, so the overlapping [`Piece`]s say
@@ -855,8 +852,7 @@ fn build_passthrough_node<'src>(
         // ([`RawForm::Escaped`]). Rendering it here instead would freeze it
         // against whichever renderer the parse carried, which is a different
         // renderer from the one a later `render_with` fold is handed, and
-        // (while the string pipeline still runs) invokes that renderer a
-        // second time for a value nothing reads.
+        // would invoke that renderer a second time for a value nothing reads.
         let content = source_slice(pieces, m.start()..m.end(), root);
 
         return InlineNode::Raw {
@@ -877,8 +873,7 @@ fn build_passthrough_node<'src>(
     // not a richer node subtree) is the safe shape for this increment.
     // Without one (the bare `pass:[…]` form), `SubstitutionGroup::None`
     // applies nothing. Either way, an escaped closing bracket (`\]`)
-    // unescapes first, mirroring the string replacer's
-    // `text.replace("\\]", "]")` — the same treatment every other macro
+    // unescapes first — the same treatment every other macro
     // family's bracket content gets.
     #[allow(clippy::unwrap_used)]
     let m = caps.get(15).unwrap();
@@ -911,12 +906,11 @@ fn build_passthrough_node<'src>(
     //
     // `passthrough_text` — already used for `++…++`/`$$…$$`/the bare
     // unconstrained form — sidesteps both failure modes: it renders `text`
-    // through the **real, string-based** substitution pipeline
-    // (`SubstitutionGroup::apply`, the same call `PassthroughRestoreReplacer`
-    // makes for a stored `Passthrough`), producing an already-final HTML string
+    // through the **real** substitution pipeline (`SubstitutionGroup::apply`),
+    // producing an already-final HTML string
     // that this arm wraps in a single `Raw` leaf. A `Raw` leaf is *opaque* to
     // every later step in this module (never descended into, never re-matched —
-    // design §4.2's passthrough-as-leaf convention), so it is immune to both
+    // this module's own passthrough-as-leaf convention), so it is immune to both
     // failure modes above: nothing in `build`'s own remaining steps can touch
     // it, whether or not the author's list included that step.
     //
@@ -931,8 +925,8 @@ fn build_passthrough_node<'src>(
         let (subs, invalid) = SubstitutionGroup::from_custom_string(None, subs_list.as_str());
 
         // An unrecognized name in the list (`pass:bogus[…]`) is skipped while
-        // the recognized ones are still honored — and reported, exactly as
-        // `InlinePassMacroReplacer` reports it, against the content's own span.
+        // the recognized ones are still honored — and reported, against the
+        // content's own span, matching Asciidoctor's own reporting.
         // Recorded here rather than replayed from the tree because the node
         // carries no trace of it: an invalid name leaves the value it produces
         // indistinguishable from a valid list's.
@@ -1191,8 +1185,8 @@ fn build_bare_attrlisted_passthrough_node<'src>(
 }
 
 /// Splits an old-behavior-eligible attrlist span into its final attrlist body
-/// and whether the legacy `x-` compatibility marker was present — mirroring
-/// the string replacer's own check (`handle_quoted_text` and
+/// and whether the legacy `x-` compatibility marker was present — matching
+/// Asciidoctor's own check (`handle_quoted_text` and
 /// `InlinePassReplacer` both apply it identically): an attrlist of exactly
 /// `x-` clears entirely; one *ending* in ` x-` drops that suffix; anything
 /// else is kept as written and is not old-behavior.

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -2747,7 +2747,7 @@ mod tests {
             assert_eq!(
                 fold_html(&build_src(Span::new(fixture)), &HtmlInlineRenderer {}),
                 golden_passthroughs(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -27,17 +27,17 @@ pub(super) fn apply_post_replacements<'src>(
 
 /// A break needs a `+`, and — off the root level, where an end-of-level
 /// match is discarded (see [`apply_level`]) — a `\n` for the pattern's `$` to
-/// anchor against. The string pipeline's own pre-check is the root form of
-/// this: it guards on a `+` alone, since its haystack is the whole rendered
-/// string. Shared between [`apply_level`]'s pre-build sniff and its
-/// post-build one, so the two answers cannot drift apart.
+/// anchor against. At the root, the guard is on a `+` alone, since the whole
+/// content's own haystack is checked there. Shared between [`apply_level`]'s
+/// pre-build sniff and its post-build one, so the two answers cannot drift
+/// apart.
 fn level_prefilter(s: &str, is_root: bool) -> bool {
     s.contains('+') && (is_root || s.contains('\n'))
 }
 
 /// One level of the post-replacement pass. `is_root` marks the content's own
 /// top level, which is the only level whose end coincides with the end of the
-/// string pipeline's haystack — see the match filter below for why that
+/// content's own match string — see the match filter below for why that
 /// decides whether a ` +` ending the level is a break.
 fn apply_level<'src>(
     nodes: Vec<InlineNode<'src>>,
@@ -46,8 +46,9 @@ fn apply_level<'src>(
     attrlist: Option<&Attrlist<'src>>,
     is_root: bool,
 ) -> Vec<InlineNode<'src>> {
-    // Descend into spans/refs first, matching the string pipeline's
-    // whole-string pass. A nested level is never the root. A level with
+    // Descend into spans/refs first, recognizing a break inside a nested
+    // span before this level's own pass runs. A nested level is never the
+    // root. A level with
     // neither — the common leaf-only case — has nothing to descend into, so
     // it skips the rebuild of its node vector entirely.
     let nodes: Vec<InlineNode<'src>> = if nodes
@@ -92,8 +93,8 @@ fn apply_level<'src>(
 
     // A break needs a `+`, and — off the root level, where an end-of-level
     // match is discarded below — a `\n` for the pattern's `$` to anchor
-    // against. The string pipeline's own pre-check is the root form of this: it
-    // guards on a `+` alone, since its haystack is the whole rendered string.
+    // against. At the root, the guard is on a `+` alone, since the whole
+    // content's own haystack is checked there.
     if !level_prefilter(&s, is_root) {
         return nodes;
     }
@@ -103,14 +104,12 @@ fn apply_level<'src>(
     // and group 1 (the `(.*)` line content) always participate in this pattern.
     //
     // The pattern's `$` (multiline) matches before each `\n` *and* at the end
-    // of the haystack. The string pipeline's haystack is the whole rendered
-    // string, so its end-of-haystack match can only fire at the very end of the
-    // content; this transducer matches over one level at a time, where end of
-    // level and end of haystack coincide only at the root. A nested `Styled` or
-    // `Ref` level is always followed by its own closing markup (`</strong>`,
-    // `</a>`, …) in the string pipeline's haystack, so a ` +` ending a span is
-    // not at a line end there and stays literal: `*bold +*` renders
-    // `<strong>bold +</strong>`, not `<strong>bold<br></strong>`. Dropping the
+    // of the haystack. This transducer matches over one level at a time,
+    // where end of level and end of content coincide only at the root: a
+    // nested `Styled` or `Ref` level is always followed by its own closing
+    // markup (`</strong>`, `</a>`, …), so a ` +` ending a span is not at a
+    // line end and stays literal — `*bold +*` renders `<strong>bold
+    // +</strong>`, not `<strong>bold<br></strong>`. Dropping the
     // end-of-level match off the root reproduces that, while a ` +` before a
     // `\n` is unaffected at every level.
     let breaks: Vec<std::ops::Range<usize>> = hard_line_break_pattern()
@@ -138,12 +137,9 @@ fn apply_level<'src>(
 }
 
 /// The `hardbreaks` form of the post-replacement substitution: every line
-/// ending (`\n`) in the level's match string becomes a break, mirroring the
-/// string pipeline's own `line.ends_with(" +")`-stripping, line-by-line
-/// rejoin exactly — a trailing ` +` is stripped rather than kept *and*
-/// doubled, and the level's *last* line (nothing follows its own `\n`, since
-/// there is none) never gets one, matching the string pipeline leaving the
-/// popped last line unbroken.
+/// ending (`\n`) in the level's match string becomes a break — a trailing
+/// ` +` is stripped rather than kept *and* doubled, and the level's *last*
+/// line (nothing follows its own `\n`, since there is none) never gets one.
 fn apply_hardbreaks<'src>(nodes: Vec<InlineNode<'src>>, root: Span<'src>) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: see
     // `apply_level`'s own copy of this comment.
@@ -222,31 +218,20 @@ mod tests {
 
     #[test]
     fn a_post_replacement_in_a_cross_reference_text_is_now_at_parity() {
-        // Once a documented divergence, and **closed by the retirement of the
-        // deferred-cross-reference sentinel system** (design §4.2's second) —
-        // exactly where this test's own note said it would close.
+        // Once a documented divergence (see this module's README for the
+        // retired deferred-cross-reference mechanism that caused it): a
+        // link's display text and a cross-reference's sit in the same
+        // position in the source, and this step treats them alike — a
+        // display text is a subtree either way, and this step walks
+        // subtrees regardless of which macro family built it. So all three
+        // rows below are at parity, and the cross-reference's `<br>` is no
+        // longer conditional on how it was resolved.
         //
-        // The asymmetry was the sentinel system showing through. A link's
-        // display text and a cross-reference's sit in the same position in the
-        // source, and this step treats them alike. The string pipeline could
-        // not: by the time it ran, a *link* had been rendered inline into the
-        // one flat string this step scans, so its display text got its `<br>`
-        // — while a deferred cross-reference had been replaced by a sentinel
-        // pair whose text lived in a **template**, which this step never saw at
-        // all. The same bytes in the same place got a line break in one and not
-        // the other, decided by nothing the author wrote.
-        //
-        // A tree has one answer for both, because a display text is a subtree
-        // either way and this step walks subtrees. Now that a deferred content
-        // is *folded* after resolution rather than rebuilt from its template,
-        // that one answer is the one a caller reads: all three rows below are
-        // at parity, and the cross-reference's `<br>` is no longer conditional
-        // on which pipeline produced it.
-        //
-        // Driven through a real document, where the cross-reference resolves —
-        // a bare `Content` has no catalog, so *every* cross-reference is left
-        // as the sentinel there and the two would differ for a second,
-        // unrelated reason.
+        // Driven through a real document, where the cross-reference
+        // resolves — a bare `Content` has no catalog, so every
+        // cross-reference falls back to its unresolved rendering there,
+        // which would make the two folds differ for a second, unrelated
+        // reason.
         use crate::blocks::{FindBlocks, IsBlock};
 
         let doc = crate::Parser::default().parse(concat!(
@@ -355,7 +340,7 @@ mod tests {
         );
     }
 
-    /// Runs `source` through the string pipeline (the golden oracle) and
+    /// Runs `source` through the frozen recording (the golden oracle) and
     /// through [`super::super::build`] + [`fold_html`], asserting byte
     /// parity.
     fn assert_parity(source: &str) {

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -3972,8 +3972,8 @@ mod tests {
     fn a_restored_entity_contributes_its_own_bytes_to_the_match_string() {
         // The two `CharRef` leaves are the atomic pieces `build_match_string`
         // gives real bytes to: a `Special` its canonical entity, and an
-        // `Entity` the entity itself. Both are what the string pipeline's own
-        // haystack holds at that position, which is what lets a family read a
+        // `Entity` the entity itself. Both are the bytes this position holds,
+        // which is what lets a family read a
         // value across one; both stay `atomic`, since a leaf is one
         // indivisible node.
         let nodes = vec![
@@ -4011,9 +4011,11 @@ mod tests {
     #[test]
     fn crossed_delimiters_are_a_documented_divergence() {
         // `` `a *b` c* `` interleaves a monospace and a strong span so their
-        // ranges *overlap* rather than nest. The string pipeline, rewriting a
-        // flat string, emits crossed — malformed — HTML tags (`<code>…<strong>…
-        // </code>…</strong>`) that no tree can represent. The single-pass
+        // ranges *overlap* rather than nest. The old string-substitution
+        // implementation, rewriting a flat string, emitted crossed —
+        // malformed — HTML tags (`<code>…<strong>…</code>…</strong>`) that no
+        // tree can represent, and that recording is still this test's golden
+        // oracle. The single-pass
         // builder instead treats an earlier span as opaque, so it produces a
         // well-formed tree (here, monospace wrapping a strong span). This is
         // the documented boundary of the single-pass recognition (see
@@ -4027,7 +4029,7 @@ mod tests {
         );
         let golden = golden_quotes(source);
 
-        // The string pipeline's crossed tags: monospace matched *through* the
+        // The golden recording's crossed tags: monospace matched *through* the
         // rendered `<strong>` tag, so `</code>` closes before `</strong>`.
         assert_eq!(golden, "<code>a <strong>b</code> c</strong>");
 
@@ -4114,8 +4116,8 @@ mod tests {
     #[test]
     fn a_char_ref_inside_a_span_is_preserved_as_a_child() {
         // The special character splits into a `CharRef` child of the span; the
-        // fold re-escapes it, matching the string pipeline (covered by the
-        // corpus) while the structure exposes the entity.
+        // fold re-escapes it, matching Asciidoctor's own output (covered by
+        // the corpus) while the structure exposes the entity.
         let nodes = build_src(Span::new("*a<b*"));
 
         let children = assert_styled(&nodes[0], StyleVariant::Strong, SpanForm::Constrained);
@@ -4178,7 +4180,7 @@ mod tests {
         match &nodes[0] {
             InlineNode::Styled(styled) => {
                 // `#…#` with an attribute list downgrades from mark to an
-                // unquoted span, exactly as the string pipeline does.
+                // unquoted span, matching Asciidoctor's own behavior.
                 assert_eq!(styled.variant, StyleVariant::Unquoted);
                 assert_eq!(styled.roles, vec![CowStr::from("lead")]);
                 assert_ne!(
@@ -4189,7 +4191,7 @@ mod tests {
 
                 // A wholly verbatim attribute list is parsed from its own
                 // `'src` slice, so the node's list is located exactly there
-                // (its values borrow, per §4.5) rather than falling back to
+                // (its values borrow) rather than falling back to
                 // the coarse span an owned one takes.
                 let attrs = &styled.attrs;
                 assert_eq!(attrs.span().data(), ".lead");
@@ -4205,9 +4207,9 @@ mod tests {
     fn an_attributed_spans_attribute_list_is_parsed_from_the_escaped_text() {
         // The structural counterpart of the corpus fixtures above: the role
         // and id a special-carrying attribute list yields are the *escaped*
-        // bytes — the ones the string pipeline's quote replacer parses out of
-        // its own (already-escaped) haystack and renders verbatim into the
-        // `class`/`id` attribute — not the author's raw `<`/`&`.
+        // bytes — parsed out of the level's own (already-escaped) match
+        // string and rendered verbatim into the `class`/`id` attribute — not
+        // the author's raw `<`/`&`.
         let source = "[#a&b.c<d]*bold*";
         let nodes = build_src(Span::new(source));
 
@@ -4217,8 +4219,8 @@ mod tests {
                 assert_eq!(styled.roles, vec![CowStr::from("c&lt;d")]);
 
                 // Those bytes have no `'src` slice of their own, so the list
-                // is owned and takes the bracket's coarse source span (design
-                // §4.4) as its location tag — the same fallback an image's
+                // is owned and takes the bracket's coarse source span as its
+                // location tag — the same fallback an image's
                 // bracket and a link's display-text list already take.
                 let attrs = &styled.attrs;
                 assert_eq!(attrs.span().data(), "#a&b.c<d");
@@ -4239,17 +4241,14 @@ mod tests {
         // An *opaque* piece inside an attribute list — a masked passthrough
         // (`[.a+++x+++b]#y#`) or a span an earlier sub already rendered
         // (`[.a**b**c]#y#`) — is the one shape `attrlist_is_readable` rejects.
-        // The string pipeline parses its attribute list out of a haystack that
-        // holds the passthrough's own *placeholder* (one atomic character no
-        // comma can hide behind), or the earlier sub's rendered tags, and
-        // restores the passthrough's text into the rendered `class`
-        // afterwards. A tree cannot reproduce either: splicing a passthrough's
-        // text in at parse time would let a comma inside it split the list
-        // where the placeholder never can, and a span's markup exists at fold
-        // time alone. So the construct is left unrecognized — literal text,
-        // never a *wrong* node (which is what the raw source slice used to
-        // yield here: a `class` of `a**b**c`) — exactly as every macro family
-        // leaves its own opaque-piece boundary.
+        // Splicing a passthrough's real text back in at parse time would let
+        // a comma inside it split the attribute list, where the placeholder —
+        // one atomic character no comma can hide behind — never can; a
+        // rendered span's markup, likewise, exists only at fold time and has
+        // no source bytes to parse a list from. So the construct is left
+        // unrecognized — literal text, never a *wrong* node (which is what
+        // the raw source slice used to yield here: a `class` of `a**b**c`) —
+        // exactly as every macro family leaves its own opaque-piece boundary.
         //
         // If that boundary is ever lifted, fold these fixtures into the
         // parity corpus above.
@@ -4279,7 +4278,7 @@ mod tests {
             assert_ne!(folded, golden, "expected a divergence for {source:?}");
 
             // The attributed construct itself is gone from the tree: what the
-            // string pipeline renders as an attributed `<span>` is left as
+            // golden recording renders as an attributed `<span>` is left as
             // literal text (an earlier sub's own span, or the passthrough's
             // `Raw` leaf, still sits inside it).
             assert!(
@@ -4304,9 +4303,9 @@ mod tests {
         // Every family that parses an attribute list therefore agrees on a
         // quoted role, whichever step recognized it: the quotes step, whose
         // list is a slice of the buffer (`['{myrole}']*bold*`), and the
-        // passthrough-extraction step, whose list the string pipeline
-        // substitutes at *restore* time instead (`['{myrole}']++text++`, see
-        // `PassthroughRestoreReplacer`). The unquoted spellings — a bare
+        // passthrough-extraction step, whose list is substituted at
+        // *restore* time instead (`['{myrole}']++text++`, see
+        // `substitute_and_restore`). The unquoted spellings — a bare
         // positional, a shorthand role, an id — never took this path at all,
         // and are here to pin that they still do not.
         let parser = crate::Parser::default().with_intrinsic_attribute(
@@ -4369,7 +4368,7 @@ mod tests {
                 "<strong class=\"highlight\">bold</strong>",
             ),
         ] {
-            // `golden_html` is the string pipeline's recorded rendering,
+            // `golden_html` is the golden recording's rendering,
             // frozen in the fixture at the last differentially-verified
             // parity.
             let folded = super::super::fold_html(
@@ -4386,18 +4385,18 @@ mod tests {
     fn an_attribute_list_rewritten_by_a_later_step_is_a_documented_divergence() {
         // The complement of the boundary above, and not one this step can
         // draw: under the *normal* order the steps that run **after** quotes
-        // (character replacements) go on matching over the string pipeline's
-        // whole rendered string — the markup the quotes step just wrote
-        // included — so they rewrite bytes that live only inside a rendered
-        // `class`/`id` attribute. A later *sub* of this same step does it too
+        // (character replacements) used to go on matching over the whole
+        // rendered string — the markup the quotes step just wrote
+        // included — so they rewrote bytes that live only inside a rendered
+        // `class`/`id` attribute. A later *sub* of this same step did it too
         // (`[.a~b~c]#y#`, whose subscript sub runs after the unquoted one that
         // consumed the attribute list). A tree's markup exists at fold time
         // alone, and its later transducers see the nodes, not the tags, so an
         // attribute list is whatever the sub that recognized it parsed, and
         // nothing rewrites it afterwards.
         //
-        // This is the same class as `flatten_prior_markup`'s own (design
-        // §5.2, Phase 4 step 6's late-escaping increment) — a step acting on
+        // This is the same class as `flatten_prior_markup`'s own case
+        // — a step acting on
         // another step's emitted markup — seen from the other side, and it
         // costs three shapes: a typographic replacement, a *restored* entity
         // (whose escaped `&amp;amp;` the replacements step unwinds one level
@@ -4420,9 +4419,9 @@ mod tests {
             ),
             ("[.a~b~c]#y#", "<span class=\"a<sub>b</sub>c\">y</span>"),
         ] {
-            // `golden_html` is what the string pipeline rendered — the
-            // recorded half of the divergence, frozen in the fixture now that
-            // the pipeline is gone.
+            // `golden_html` is what the old string-substitution
+            // implementation rendered — the recorded half of the divergence,
+            // frozen in the fixture now that it is gone.
             let folded = super::super::fold_html(
                 &super::super::build(Span::new(source), &parser, None),
                 &HtmlInlineRenderer {},

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -423,21 +423,21 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 /// either way: the extraction pass builds neither smart-quote variant, so a
 /// [`DoubleQuote`](StyleVariant::DoubleQuote) or
 /// [`SingleQuote`](StyleVariant::SingleQuote) node can only have come from the
-/// quotes step, where the string pipeline really does hold `&#8220;…&#8221;`.
+/// quotes step, which really does render `&#8220;…&#8221;`.
 ///
 /// # A transparent span presents its own body
 ///
 /// A span the built-in backend renders with **no markup of its own** — an
 /// unquoted span whose attribute list resolves to neither a role nor an id —
 /// wraps its body in nothing, so what a sibling reads there is that *body*:
-/// the string pipeline's flat haystack holds `x ` where
-/// `[width=10]##x ##https://example.org` stands one opaque placeholder, and
-/// links on the space the body ends with.
+/// rendering `[width=10]##x ##https://example.org` holds `x ` where the span
+/// stands as one opaque placeholder, and links on the space the body ends
+/// with.
 /// [`transparent_sibling_boundaries`] answers that pair from the span's own
 /// children, and the identity gates it for exactly the reason it gates a tag:
 /// `[width=10]++x ++` is an extraction wrapper that renders its body and
-/// nothing else, and what the string pipeline holds *there* is the sentinel a
-/// bare placeholder already reads as.
+/// nothing else, and what a sibling reads *there* is the same placeholder a
+/// bare, unclassified span already reads as.
 ///
 /// # Two halves, answered independently
 ///
@@ -524,8 +524,8 @@ fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> 
 }
 
 /// The character a level's own match string `s` holds immediately before byte
-/// offset `at`, or `None` where this module cannot say what the string pipeline
-/// holds there — because nothing precedes that offset, or because what does is
+/// offset `at`, or `None` where this module cannot say what character is
+/// there — because nothing precedes that offset, or because what does is
 /// an unclassified opaque node.
 ///
 /// This is how a **transparent** span's children learn what precedes the span
@@ -544,8 +544,9 @@ fn probe_styled_sibling_boundaries(styled: &Styled<'_>) -> Option<(char, char)> 
 /// entity-rendered ones. Reporting it here would *manufacture* a
 /// character where the level previously read its own start anchor, which is a
 /// different answer rather than a better one — and for a wrapper it would be
-/// the wrong one, since the string pipeline holds a `\u{97}` sentinel there
-/// that the auto-link's own prefix group rejects exactly as `^` is accepted.
+/// the wrong one, since a sibling there reads the wrapper's own placeholder
+/// character, which the auto-link's own prefix group rejects exactly as `^`
+/// is accepted.
 /// So an unclassified neighbour reports nothing and the span goes on
 /// inheriting, leaving that shape exactly as it already was — the same line
 /// [`styled_sibling_boundaries`] draws, for the same reason.
@@ -638,7 +639,7 @@ pub(super) fn apply_quotes<'src>(
 /// presents — or, for a span that renders no markup of its own, the one its
 /// **siblings** present ([`LevelContext::child_contexts`]) — which is what
 /// keeps a sub matching *inside* an earlier sub's span reading the same
-/// characters the string pipeline's flat haystack holds there.
+/// characters a whole-content match would see there.
 fn apply_quote_sub<'src>(
     sub: &QuoteSub,
     nodes: Vec<InlineNode<'src>>,
@@ -648,7 +649,7 @@ fn apply_quote_sub<'src>(
 ) -> Vec<InlineNode<'src>> {
     // Recurse into the spans produced by earlier subs *before* matching at this
     // level. A span this sub itself creates below is therefore never revisited
-    // by the same sub, matching the string pipeline (a sub runs once). A level
+    // by the same sub (a sub runs once per level). A level
     // with no such span — the common leaf-only case, visited once per sub —
     // has nothing to descend into, so it skips the context derivation and the
     // rebuild of its node vector entirely.
@@ -705,11 +706,11 @@ pub(super) struct Piece {
     /// its `value` differs from `location.data()`, so unlike a verbatim run
     /// its match-string bytes do **not** correspond one-to-one with source
     /// bytes. It contributes its `value` to the match string so a later step
-    /// (design §3.4.1: character replacements, macros) can still recognize a
+    /// (character replacements, macros) can still recognize a
     /// construct inside it, but a match landing here has no honest `'src`
     /// slice: [`emit_range`] slices the node's *value* instead of its
     /// location, and [`s_to_src`] falls back to the piece's whole node span
-    /// (design §4.4's coarse fallback) rather than a proportional one.
+    /// (its coarse fallback) rather than a proportional one.
     pub(super) synthesized: bool,
 }
 
@@ -752,9 +753,8 @@ fn match_level<'src>(
     rebuild_level(&nodes, &pieces, &s, &matches, root, parser)
 }
 
-/// Reports whether a match's attribute list, if it has one, is one this step
-/// can read the same bytes out of that the string pipeline's own quote
-/// replacer reads out of its haystack — i.e. crosses no **opaque** piece (see
+/// Reports whether a match's attribute list, if it has one, is readable from
+/// the level's own match string without crossing an **opaque** piece (see
 /// [`range_has_no_opaque_piece`]).
 ///
 /// A match with no attribute list is always readable, which is the
@@ -763,13 +763,13 @@ fn match_level<'src>(
 /// The one shape this rejects is an attribute list crossing a piece whose
 /// bytes exist only at fold time or behind a placeholder — a rendered span
 /// from an earlier sub, or a masked passthrough or STEM expression
-/// (`[.a+++x+++b]#y#`). The string pipeline parses its attribute list with the
-/// passthrough's own placeholder inside it, restoring the passthrough's text
-/// into the rendered `class` afterwards, which a tree that keeps that text as
-/// its own node cannot reproduce (splicing the text back in at parse time
-/// would let a comma inside it split the attribute list, where the string
-/// pipeline's one atomic placeholder never can). Leaving the whole construct
-/// unrecognized — literal text, never a *wrong* node — is the same boundary
+/// (`[.a+++x+++b]#y#`). A passthrough's own placeholder holds no bytes to
+/// splice an attribute list around: reading the passthrough's real text back
+/// through the placeholder and splicing it into the parsed attribute list
+/// would let a comma inside that text split the list, since the placeholder
+/// is one atomic piece and cannot be read into partway. Leaving the whole
+/// construct unrecognized — literal text, never a *wrong* node — is the same
+/// boundary
 /// every macro family draws, and puts this match back in the same position a
 /// rejected look-ahead leaves one: out of the match list, so the surrounding
 /// gap reproduces its original nodes and a later sub may still match there.
@@ -794,11 +794,11 @@ fn attrlist_is_readable(nodes: &[InlineNode<'_>], pieces: &[Piece], m: &QuoteMat
 /// [`Entity`](CharRef::Entity)), or the entity the built-in backend renders it
 /// as (a typographic [`Replacement`](CharRef::Replacement), via
 /// [`replacement_entity`]), so the boundary classes the quote patterns key off
-/// (`&`, `;`) see exactly what the string pipeline's escaped text presents —
-/// and so does a later step reading a value across one; a *synthesized*
-/// `Text` run (design §3.4.1 — an attribute expansion, a `counter` directive)
+/// (`&`, `;`) see exactly the bytes this content's own escaped rendering
+/// presents — and so does a later step reading a value across one; a
+/// *synthesized* `Text` run (an attribute expansion, a `counter` directive)
 /// contributes its `value` too, so [`apply_character_replacements`]
-/// (design §3.4.1: `replacements` still runs over an expanded value) can
+/// (character replacements still runs over an expanded value) can
 /// recognize a construct inside it, but is flagged
 /// [`synthesized`](Piece::synthesized) since those bytes have no honest
 /// `'src` counterpart; every other node contributes a single opaque
@@ -1048,7 +1048,7 @@ pub(super) fn build_match_string(
                 // A synthesized run (its value has no `'src` slice of its
                 // own): still splittable for matching purposes, but any
                 // resulting node falls back to this node's whole `location`
-                // (design §4.4) rather than a proportional slice of it.
+                // (its coarse fallback) rather than a proportional slice of it.
                 s.push_str(value);
 
                 pieces.push(Piece {
@@ -1087,11 +1087,11 @@ pub(super) fn build_match_string(
                 // A *restored* entity (`&amp;copy;` un-escaped back to
                 // `&copy;` by the character-replacements step) contributes its
                 // own bytes for the same reason a `Special` contributes its
-                // canonical entity: those bytes *are* what the string
-                // pipeline's own haystack holds at that position from the
-                // replacements step onward, and the fold emits them verbatim
-                // (see `fold`'s `CharRef::Entity` arm), so the two agree with
-                // no renderer involved. It stays `atomic` — the leaf is one
+                // canonical entity: those are the bytes this position holds
+                // from the replacements step onward, and the fold emits them
+                // verbatim (see `fold`'s `CharRef::Entity`
+                // arm), so the two agree with no renderer
+                // involved. It stays `atomic` — the leaf is one
                 // indivisible node, never sliced — but is *recoverable*, which
                 // is the distinction
                 // [`range_has_no_opaque_piece`](super::macros::image::range_has_no_opaque_piece)
@@ -1117,12 +1117,11 @@ pub(super) fn build_match_string(
                 // replacements step turned into a copyright sign and a
                 // typographic apostrophe) contributes the entity the built-in
                 // backend renders it as, for the same reason the two other
-                // `CharRef` leaves contribute theirs: those bytes *are* what
-                // the string pipeline's own haystack holds at that position
-                // from the replacements step onward (`&#169;`, `&#8217;`), so
-                // a later step matching across one — or reading a value out of
-                // the match string — sees exactly what the string replacer
-                // sees. It stays `atomic` (the leaf is one indivisible node,
+                // `CharRef` leaves contribute theirs: those are the bytes this
+                // position holds from the replacements step onward (`&#169;`,
+                // `&#8217;`), so a later step matching across one — or reading
+                // a value out of the match string — sees exactly the same
+                // bytes. It stays `atomic` (the leaf is one indivisible node,
                 // never sliced) but is *recoverable*, which is the distinction
                 // [`range_has_no_opaque_piece`](super::macros::image::range_has_no_opaque_piece)
                 // draws.
@@ -1201,10 +1200,11 @@ pub(super) fn build_match_string(
 /// *shown* text straight from the match string (rather than needing an honest
 /// `'src` slice — e.g. an index term's `arg`/`term_src`, already checked
 /// against [`SPAN_PLACEHOLDER`] for a crossed span) still needs this check
-/// too: a synthesized run's bytes have no source counterpart, and design
-/// §3.4.1 leaves recognizing a macro *inside* one for a later increment (see
+/// too: a synthesized run's bytes have no source counterpart, so even once a
+/// construct inside it is recognized, the match still needs the coarse
+/// `location` fallback
 /// [`apply_attribute_references`](super::attribute_refs::apply_attribute_references)'s
-/// doc comment) — distinct from
+/// doc comment describes — distinct from
 /// [`range_is_verbatim`],
 /// which a family needing to *slice* `'src` (a target, an `Attrlist<'src>`)
 /// uses instead and which already rejects a synthesized piece outright.
@@ -1239,7 +1239,7 @@ pub(super) fn special_entity(ch: char) -> &'static str {
 
 /// The entity a [`CharRef::Replacement`] contributes to the match string: the
 /// bytes the **built-in** HTML backend renders that replacement as, which are
-/// exactly what the string pipeline's own haystack holds from the replacements
+/// exactly what this position holds from the replacements
 /// step onward. Returns `None` for a value no replacement rule produces (only a
 /// hand-built node can carry one), which [`build_match_string`] then stands in
 /// as one opaque [`SPAN_PLACEHOLDER`], as it did for every replacement before
@@ -1383,10 +1383,9 @@ enum QuoteMatchKind {
     },
 }
 
-/// Drives `sub` over the match string, mirroring the string pipeline's
-/// look-ahead retry: a rejected monospace-before-quote match slices the
-/// haystack forward and re-searches, exactly as `replace_with_lookahead`
-/// does.
+/// Drives `sub` over the match string with a look-ahead retry: a rejected
+/// monospace-before-quote match slices the haystack forward and re-searches,
+/// rather than giving up on the level.
 fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
     let mut matches = Vec::new();
 
@@ -1600,29 +1599,29 @@ fn rebuild_level<'src>(
 }
 
 /// Parses an **attributed quote's** attribute list out of the level's own
-/// match string, returning the id, roles, and the full [`Attrlist`] (kept so
-/// the fold renders exactly as the string pipeline).
+/// match string, returning the id, roles, and the full [`Attrlist`] the
+/// node's fold renders from.
 ///
-/// Those match-string bytes are the ones the string pipeline's quote replacer
-/// parses: by the time the quotes step runs, its haystack holds the *escaped*
-/// text (`['a&lt;b&amp;c']*bold*`), so the role it parses — and renders into
-/// the `class` attribute verbatim — carries the entity, not the author's raw
-/// `<`. Parsing the source slice instead would put an unescaped `<`/`&` into
-/// rendered markup, which is both a divergence and, for a `"`-bearing value,
-/// exactly the injection the escaping is there to prevent (pinned by
+/// By the time the quotes step runs, the match string holds the *escaped*
+/// text (`['a&lt;b&amp;c']*bold*`), so the role parsed out of it — and
+/// rendered into the `class` attribute verbatim — carries the entity, not the
+/// author's raw `<`. Parsing the source slice instead would put an unescaped
+/// `<`/`&` into rendered markup, which is both a divergence from
+/// Asciidoctor's own output and, for a `"`-bearing value, exactly the
+/// injection the escaping is there to prevent (pinned by
 /// `quoted_positional_role_class_does_not_double_escape_special_characters` in
 /// the crate's own security tests).
 ///
 /// A **verbatim** range's match-string bytes *are* its source bytes, so it
-/// parses straight from `'src` and its attribute names and values borrow
-/// (§4.5) — the shape every ordinary `[.role]#text#` takes. Any other range
+/// parses straight from `'src` and its attribute names and values borrow —
+/// the shape every ordinary `[.role]#text#` takes. Any other range
 /// (an escaped special, a restored entity or typographic replacement, or a
 /// [`synthesized`](Piece::synthesized) expansion under an order that runs
 /// `attributes` before `quotes`) has no `'src` slice whose bytes are the
 /// attrlist text, so it parses from a [`Span::new`] over the match-string
 /// slice — whose `line`/`col`/`offset` are meaningless and never escape this
 /// function — and [`into_owned`](Attrlist::into_owned)s the result onto the
-/// range's coarse source span (design §4.4), exactly as
+/// range's coarse source span, exactly as
 /// [`bracket_attrlist`](super::macros::image) does for an image's bracket and
 /// [`text_attrlist`](super::macros::links) for a link's display text.
 ///
@@ -1656,8 +1655,8 @@ fn quote_attributes<'src>(
 /// attrlist the same way and fold through the same [`Styled`] node. Unlike an
 /// attributed quote's (see [`quote_attributes`]), a passthrough's attrlist is
 /// read from the source slice, and correctly so: the extraction pass that
-/// recognizes it runs *before* the escaping step, so the string pipeline
-/// parses the author's raw bytes there too.
+/// recognizes it runs *before* the escaping step, so those are still the
+/// author's raw bytes.
 pub(super) fn attributes_of<'src>(
     source: Span<'src>,
     parser: &Parser,
@@ -1678,15 +1677,12 @@ fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
 fn attributes_of_attrlist<'src>(
     attrlist: Attrlist<'src>,
 ) -> (Option<CowStr<'src>>, Vec<CowStr<'src>>, Attrlist<'src>) {
-    // Extract owned id/roles before the attrlist is moved into the node,
-    // exactly as the string pipeline's quote replacer does.
+    // Extract owned id/roles before the attrlist is moved into the node.
     //
-    // Unlike that replacer, this deliberately performs *no* side effect: it
-    // does not `register_ref` an assigned id in the catalog, because the
-    // builder is additive and not yet the recognition sink — the
-    // authoritative string pipeline still registers it. The cutover (design
-    // §5.2 Phase 4, step 6) must add that registration so cross-references
-    // to an inline id resolve (tracked by #1087).
+    // This step performs no catalog side effect of its own: recognition and
+    // registration are kept apart, so an assigned id is registered later,
+    // once the tree is built and folded, by `apply_ref_side_effects` (see
+    // `macros::anchors`) rather than here.
     let id = attrlist.id().map(|id| CowStr::from(id.to_string()));
 
     let roles = attrlist
@@ -1750,11 +1746,11 @@ pub(super) fn emit_range<'src>(
             // carrying them folds verbatim, so every partition of the entity
             // folds to the entity, and a caller cutting one (a bare URL whose
             // trailing-punctuation strip lands on an entity's own `;` — see
-            // `build_inline_link_node`) reproduces the string replacer's own
-            // split rather than deferring to it. Neither half has an honest
+            // `build_inline_link_node`) can split it cleanly rather than
+            // declining to handle it. Neither half has an honest
             // `'src` slice of its own (the source holds one character, or
             // `(C)`, where the match string holds an entity), so both keep the
-            // leaf's whole `location` — design §4.4's coarse fallback, the
+            // leaf's whole `location` — its coarse fallback, the
             // same one a synthesized run's slices already take.
             //
             // Every other atomic piece stands in for markup that exists only
@@ -1793,7 +1789,7 @@ pub(super) fn emit_range<'src>(
             if piece.synthesized {
                 // No `'src` slice exists for these bytes: slice the node's
                 // *value* instead, keeping the whole original `location` as
-                // the coarse fallback span (design §4.4) — the same policy
+                // the coarse fallback span — the same policy
                 // `split_attribute_value` already applies to every fragment
                 // of an expanded value.
                 let Some(sliced) = value.get(lo..hi) else {
@@ -1821,8 +1817,8 @@ pub(super) fn emit_range<'src>(
 /// falls inside a [`synthesized`](Piece::synthesized) piece (an attribute
 /// expansion, or — reached at a tree's root — a filtered multi-line block's
 /// own joined seed): unlike [`source_slice`], which snaps a boundary landing
-/// *inside* a synthesized piece to that piece's own coarse edge (design
-/// §4.4) because it must return an honest `'src` [`Span`], this slices the
+/// *inside* a synthesized piece to that piece's own coarse edge because it
+/// must return an honest `'src` [`Span`], this slices the
 /// piece's own `value` instead, so the returned text is precise rather than
 /// approximate — the same recovery [`emit_range`] already gives a kept
 /// [`Text`](InlineNode::Text) run, just concatenated into one value instead
@@ -1878,7 +1874,7 @@ pub(super) fn text_slice<'src>(
 /// A boundary inside a verbatim [`Text`](InlineNode::Text) run maps one-to-one
 /// (its match text is its source text); a boundary inside an atomic or
 /// [`synthesized`](Piece::synthesized) piece has no such honest source
-/// position, so it falls back to that piece's own edges (design §4.4) —
+/// position, so it falls back to that piece's own edges —
 /// snapping to the *nearer* one for an atomic piece (it never legitimately
 /// falls there), or to the edge [`Bias`] names for a synthesized one, so a
 /// range wholly inside a synthesized run maps to that run's *whole* node span
@@ -1955,7 +1951,7 @@ fn s_to_src(pieces: &[Piece], x: usize, bias: Bias) -> usize {
             // `p_start` edge — already excluded `p_end` above, and `p_start`
             // is exact via the plain mapping just like a verbatim piece) has
             // no honest source position, so it falls back to the edge `bias`
-            // names (design §4.4's coarse fallback).
+            // names (its coarse fallback).
             if piece.synthesized && x > p_start {
                 return match bias {
                     Bias::Start => piece.src_offset,
@@ -1975,7 +1971,7 @@ fn s_to_src(pieces: &[Piece], x: usize, bias: Bias) -> usize {
 }
 
 /// Maps a [`QuoteType`] to its [`Styled`] variant, downgrading an attributed
-/// `mark` to an unquoted span exactly as the string pipeline does.
+/// `mark` to an unquoted span, matching Asciidoctor's own behavior.
 fn style_variant(type_: QuoteType, has_attrlist: bool) -> StyleVariant {
     match type_ {
         QuoteType::Strong => StyleVariant::Strong,
@@ -2274,7 +2270,7 @@ mod tests {
         );
 
         // The same body, with the identity in hand: the nested span's own
-        // `<strong>…</strong>` is what the string pipeline holds at both edges.
+        // `<strong>…</strong>` is what a sibling reads at both edges.
         assert_eq!(
             styled_sibling_boundaries(&transparent, Masked::known(&[])),
             (Some('<'), Some('>'))

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -2298,10 +2298,11 @@ mod tests {
         // Every tag-rendered variant keeps the bare placeholder where the
         // identity is missing — not because its rendering has no outer
         // characters (it has `<` and `>`), but because such a node may be the
-        // passthrough-extraction pass's own wrapper, which the string pipeline
-        // is still holding as a placeholder. A **transparent** span takes the
-        // same guard: `[width=10]++x ++` is a wrapper that renders its body and
-        // nothing else. See [`styled_sibling_boundaries`]'s own scope note.
+        // passthrough-extraction pass's own wrapper, which is standing in as
+        // a placeholder rather than as markup. A **transparent** span takes
+        // the same guard: `[width=10]++x ++` is a wrapper that renders its
+        // body and nothing else. See [`styled_sibling_boundaries`]'s own
+        // scope note.
         for variant in [
             StyleVariant::Strong,
             StyleVariant::Emphasis,
@@ -2319,8 +2320,8 @@ mod tests {
 
         // And a node the identity *names* keeps it too, which is the whole
         // point of carrying the identity: `[quotes]++text++` renders a
-        // `<span class="quotes">`, but the string pipeline is holding it as
-        // its own `\u{96}…\u{97}` sentinel for every step this module runs.
+        // `<span class="quotes">`, but this wrapper stands in as its own
+        // placeholder for every step this module runs.
         let wrapper = span(StyleVariant::Code);
         let identity = (
             wrapper.location.byte_offset(),
@@ -2517,7 +2518,7 @@ mod tests {
         );
 
         // With the identity in hand it presents the `>` its own `<strong>`
-        // ends in, exactly as the string pipeline's flat haystack does.
+        // ends in, exactly as a whole-content match would see there.
         assert_eq!(
             LevelContext::child_contexts(
                 &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
@@ -2533,9 +2534,9 @@ mod tests {
             ]
         );
 
-        // And a node that identity *names* is an extraction-pass wrapper the
-        // string pipeline is still holding as a placeholder, so it goes back to
-        // contributing the bare one.
+        // And a node that identity *names* is an extraction-pass wrapper that
+        // still stands in as a placeholder rather than as rendered markup, so
+        // it goes back to contributing the bare one.
         assert_eq!(
             LevelContext::child_contexts(
                 &[styled(StyleVariant::Strong), styled(StyleVariant::Unquoted)],
@@ -2547,8 +2548,8 @@ mod tests {
 
         // A **transparent** span presents no markup either, but it does
         // present its own *body*: the second span here reads the space the
-        // first one's body ends with, which is what the string pipeline's flat
-        // haystack holds between the two.
+        // first one's body ends with, which is what a whole-content match
+        // would read between the two.
         fn transparent(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
             InlineNode::Styled(Styled {
                 variant: StyleVariant::Unquoted,
@@ -2600,11 +2601,11 @@ mod tests {
     #[test]
     fn a_sub_inside_a_span_reads_that_spans_own_boundary_characters() {
         // The nesting cases the enclosing span's rendering decides, each
-        // pinned against the string pipeline's own flat haystack.
+        // pinned against the frozen golden recording (see `golden_quotes`).
         for source in [
             // The shape that named this: the double-quote sub runs *before*
-            // the monospace one, so by the time monospace matches, the string
-            // pipeline's haystack holds `&#8220;` — whose `;` its boundary
+            // the monospace one, so by the time monospace matches, the
+            // enclosing rendering holds `&#8220;` — whose `;` its boundary
             // class excludes — where the level alone would show `^`.
             r#""``end points``""#,
             r#""`_e_`""#,
@@ -2636,7 +2637,7 @@ mod tests {
                     &build_through_quotes(Span::new(source)),
                     &HtmlInlineRenderer {}
                 ),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
         }
     }
@@ -2645,7 +2646,7 @@ mod tests {
     fn a_sub_beside_a_span_reads_that_spans_own_sibling_boundary_characters() {
         // The mirror image of the fixtures above, one level out: a construct
         // written *beside* an entity-rendered span reads the last character of
-        // that span's own closing markup in the string pipeline's haystack
+        // that span's own closing markup
         // (`&#8221;`, whose `;` the monospace sub's boundary class excludes),
         // where [`build_match_string`] used to stand the whole span in as one
         // [`SPAN_PLACEHOLDER`] — a private-use codepoint that belongs to no
@@ -2691,7 +2692,7 @@ mod tests {
                     &build_through_quotes(Span::new(source)),
                     &HtmlInlineRenderer {}
                 ),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
         }
     }
@@ -2746,7 +2747,7 @@ mod tests {
                     &build_through_quotes(Span::new(source)),
                     &HtmlInlineRenderer {}
                 ),
-                "fold diverged from the string pipeline for {source:?}"
+                "fold diverged from the golden recording for {source:?}"
             );
         }
     }
@@ -2778,7 +2779,7 @@ mod tests {
             "expected the documented divergence to still reproduce"
         );
 
-        // The string pipeline's haystack is `xd #c#`, all of it one flat
+        // A whole-content match sees `xd #c#`, all of it one flat
         // string, so the sub wraps `c`; the tree holds `d #c` inside the span
         // and the closing `#` beside it, and leaves both literal.
         assert_eq!(golden_quotes(source), "xd <mark>c</mark>");
@@ -2789,10 +2790,10 @@ mod tests {
     fn a_sub_beside_a_masked_passthrough_wrapper_keeps_the_bare_placeholder() {
         // The one tag-rendered span that presents *no* markup to a sibling.
         // The passthrough-extraction pass builds a [`Styled`] wrapper of its
-        // own for an attribute-list-prefixed passthrough, which the string
-        // pipeline is holding as its `\u{96}…\u{97}` sentinel rather than as
-        // markup for every step this module runs — so a sibling reads that
-        // sentinel, which is exactly what the bare placeholder reads as. The
+        // own for an attribute-list-prefixed passthrough, standing in as its
+        // own placeholder rather than as markup for every step this module
+        // runs — so a sibling reads that placeholder, which is exactly what
+        // the bare placeholder reads as. The
         // identity `masked` carries is what tells one from a genuinely
         // rendered span of the identical shape.
         //
@@ -2834,8 +2835,8 @@ mod tests {
         assert_eq!(pieces.len(), 1);
         assert_eq!(pieces[0].s_start, 0);
 
-        // The same node, *not* named by the identity, is a span the string
-        // pipeline has really rendered — and presents the two characters its
+        // The same node, *not* named by the identity, is a span that really
+        // has been rendered — and presents the two characters its
         // `<span class="x">…</span>` puts beside its siblings.
         let (s, pieces) = build_match_string(&[InlineNode::Styled(styled)], Masked::known(&[]));
 
@@ -2897,8 +2898,8 @@ mod tests {
         assert_eq!(pieces[0].s_start, 0);
 
         // And a node the identity *names* is such a wrapper — `[width=10]++x
-        // ++` renders its body and nothing else too, and the string
-        // pipeline is holding its `\u{96}…\u{97}` sentinel there, which
+        // ++` renders its body and nothing else too, and it stands in
+        // as its own placeholder there, which
         // is exactly what a bare placeholder reads as.
         let wrapper = styled(body());
 
@@ -3025,7 +3026,7 @@ mod tests {
     fn a_real_documents_sibling_span_tree_folds_to_its_rendered_string() {
         // End-to-end, through the real parse path, on the shape one level out
         // from the test above: a construct written *beside* an entity-rendered
-        // span, whose `&#8221;` the string pipeline reads a `;` from where the
+        // span, whose rendering supplies a `;` from `&#8221;` where the
         // tree holds one placeholder.
         use crate::{
             Parser,
@@ -3073,9 +3074,8 @@ mod tests {
         // End-to-end, through the real parse path, on the **tag**-rendered half
         // of the shape above — the one the extraction pass's identity had to
         // reach recognition for. A URL written against a closing tag's own `>`
-        // links in both pipelines; one written against the pass's own wrapper,
-        // which the string pipeline is still holding as a sentinel, stays
-        // literal in both.
+        // links; one written against the pass's own wrapper, which still
+        // stands in as its own placeholder, stays literal.
         use crate::{
             Parser,
             blocks::{FindBlocks, IsBlock},
@@ -3120,8 +3120,8 @@ mod tests {
     #[test]
     fn replacement_entity_matches_the_built_in_renderer() {
         // The table `build_match_string` reads is the built-in backend's own
-        // rendering of each replacement — the bytes the string pipeline's
-        // haystack holds from the replacements step onward — so the two cannot
+        // rendering of each replacement — the bytes this position holds
+        // from the replacements step onward — so the two cannot
         // be allowed to drift. Every value the classifier recognizes is
         // checked against the renderer that produces it, and a value no rule
         // produces has no entity at all (`build_match_string` stands such a
@@ -3158,8 +3158,8 @@ mod tests {
         assert!(super::replacement_entity("not a replacement").is_none());
     }
 
-    /// The string pipeline's output through the **quotes** step for `source`,
-    /// used as the golden oracle: `Content::from` then `SpecialCharacters` then
+    /// The frozen golden recording through the **quotes** step for `source`,
+    /// used as the oracle: `Content::from` then `SpecialCharacters` then
     /// `Quotes`, exactly the order [`build`] runs them.
     fn golden_quotes(source: &str) -> String {
         crate::content::inline_builder::snapshot::recorded("quotes", source)
@@ -3168,9 +3168,9 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_quotes() {
         // For each fixture, folding the single-pass tree (special characters +
-        // quotes) reproduces the string pipeline's output byte-for-byte. This
-        // is the differential corpus (design §5.3) that pins the quotes
-        // increment.
+        // quotes) reproduces the golden recording's output byte-for-byte. This
+        // is the differential corpus that pins the quotes
+        // step.
         let fixtures = [
             // No quotes.
             "plain text",
@@ -3225,10 +3225,9 @@ mod tests {
             "['quoted role']#x#",
             "[.role1.role2]#x#",
             // An attribute list carrying a special character. The escaping
-            // step runs *before* this one, so the string pipeline parses the
+            // step runs *before* this one, so `quote_attributes` parses the
             // already-escaped text and renders the entity straight into the
-            // `class`/`id` attribute; `quote_attributes` parses the same
-            // match-string bytes, in every spelling an attribute list has.
+            // `class`/`id` attribute, in every spelling an attribute list has.
             "[.a<b]*bold*",
             "[#a&b]#x#",
             "[a<b]#x#",
@@ -3288,7 +3287,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden_quotes(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from the golden recording for {fixture:?}"
             );
         }
     }
@@ -3435,7 +3434,7 @@ mod tests {
         // A boundary inside a `CharRef` leaf cuts it, because either half of
         // its match-string bytes is what that half's own fold emits. The three
         // leaves are cut alike; each half keeps the leaf's whole location
-        // (design §4.4), and the two concatenate back to the entity.
+        // (its coarse fallback), and the two concatenate back to the entity.
         let source = Span::new("&(C)\u{a9}");
 
         let nodes = vec![

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 /// A single opaque codepoint standing in for a whole [`Styled`] span (produced
-/// by an earlier sub) while a later sub matches at that span's level. Like a
-/// rendered `<strong>…</strong>` in the string pipeline, it is a single
+/// by an earlier sub) while a later sub matches at that span's level. Like the
+/// `<strong>…</strong>` markup a completed span folds to, it is a single
 /// non-word, non-space boundary character that a quote pattern treats as
 /// opaque content.
 ///
@@ -37,18 +37,17 @@ use crate::{
 pub(super) const SPAN_PLACEHOLDER: char = '\u{10}';
 
 /// The characters an enclosing construct's own rendering presents to the level
-/// nested inside it — the bytes the string pipeline's haystack holds
-/// immediately before and after that level's own text.
+/// nested inside it — the bytes immediately before and after that level's own
+/// text once the enclosing markup is rendered.
 ///
-/// The string pipeline has no levels: a step matches over one flat string in
-/// which an earlier step's construct is already *rendered markup*, so a
-/// pattern's boundary classes read that markup's own characters. A transducer
-/// matches one level at a time, where the same position is the start (or end)
-/// of the haystack — which is what `^`, `$`, and a `(^|[^\w&;:}])`-style
-/// boundary group see instead. The two agree for a construct written at the
-/// content's own top level and diverge for one written *inside* a span, where
-/// the string pipeline reads the span's opening `<strong>` (or `&#8220;`)
-/// rather than a start anchor: ``` `"``end points``"` ``` renders
+/// A quote pattern's boundary classes (`^`, `$`, and a `(^|[^\w&;:}])`-style
+/// group) need to read the same characters a whole-content match would see at
+/// that position, but a transducer matches one level at a time, where the same
+/// position is instead the very start (or end) of that level's own haystack.
+/// The two agree for a construct written at the content's own top level and
+/// diverge for one written *inside* a span, where the enclosing rendering is
+/// the span's opening `<strong>` (or `&#8220;`) rather than a start anchor:
+/// ``` `"``end points``"` ``` renders
 /// ``` `&#8220;`end points`&#8221;` ``` there — the inner backticks stay
 /// literal, because the `;` ending the entity fails the monospace sub's own
 /// boundary class — where a level matched in isolation sees `^` and wraps them
@@ -69,7 +68,7 @@ pub(super) const SPAN_PLACEHOLDER: char = '\u{10}';
 pub(super) struct LevelContext {
     /// The last character of the enclosing construct's *opening* markup, or
     /// `None` at the content's own top level (where a pattern's `^` is
-    /// exactly what the string pipeline's haystack presents).
+    /// exactly right).
     before: Option<char>,
 
     /// The first character of the enclosing construct's *closing* markup, or
@@ -85,18 +84,19 @@ impl LevelContext {
     ///
     /// Only an order that runs `macros` *before* a step that descends into a
     /// reference's children reaches this at all (the built-in orders run it
-    /// last but one, ahead of `post_replacements` alone). A cross-reference
-    /// the string pipeline is still holding as a deferred placeholder at that
-    /// moment presents that placeholder's own characters rather than the
-    /// element's, which read the same to every boundary class in play: both
-    /// are non-word, and neither is one of the `&;:}` a constrained quote
-    /// excludes nor the space or line end a spaced em dash requires.
+    /// last but one, ahead of `post_replacements` alone). A deferred
+    /// cross-reference — one whose target resolution has not yet filled the
+    /// node's rendered text in — presents its own placeholder characters at
+    /// that moment rather than the element's, which read the same to every
+    /// boundary class in play: both are non-word, and neither is one of the
+    /// `&;:}` a constrained quote excludes nor the space or line end a spaced
+    /// em dash requires.
     pub(super) const INSIDE_REF: Self = Self {
         before: Some('>'),
         after: Some('<'),
     };
     /// The content's own top level: nothing encloses it, so a pattern's `^`
-    /// and `$` anchor exactly where the string pipeline's do.
+    /// and `$` anchor exactly where they should.
     pub(super) const ROOT: Self = Self {
         before: None,
         after: None,
@@ -136,7 +136,7 @@ impl LevelContext {
     ///
     /// A **transparent** span wraps its children in nothing, so what they read
     /// is not the enclosing construct's markup but whatever stands *beside the
-    /// span itself* in the string pipeline's own flat haystack. Inheriting the
+    /// span itself* once this level is rendered. Inheriting the
     /// enclosing context — what [`inside_styled`](Self::inside_styled) does on
     /// its own — is right only while the span is all its level holds; the
     /// moment a sibling precedes it, the haystack shows what that sibling
@@ -393,21 +393,21 @@ fn styled_boundaries(styled: &Styled<'_>) -> Option<(char, char)> {
 /// [`LevelContext`]); this one answers what the same span presents to the
 /// nodes *beside* it at its own level, where
 /// [`build_match_string`] otherwise stands the whole span in as one opaque
-/// [`SPAN_PLACEHOLDER`] belonging to no boundary class at all. The string
-/// pipeline, having no levels, holds that span's rendered markup there — so a
-/// following construct reads `>` where the span rendered a tag and `;` where
-/// it rendered a smart quote's `&#8221;`, and a preceding one reads `<` or
-/// `&`.
+/// [`SPAN_PLACEHOLDER`] belonging to no boundary class at all. A rendered
+/// span's own markup is what a following/preceding construct actually reads
+/// there — a following one reads `>` where the span rendered a tag and `;`
+/// where it rendered a smart quote's `&#8221;`, and a preceding one reads `<`
+/// or `&`.
 ///
 /// # An extraction-pass wrapper is not a rendered span
 ///
-/// A [`Styled`] node reaching [`build_match_string`] is not necessarily a span
-/// the string pipeline has rendered at all: the passthrough-extraction pass
+/// A [`Styled`] node reaching [`build_match_string`] is not necessarily one
+/// whose markup has actually been rendered: the passthrough-extraction pass
 /// builds one of its own for an attribute-list-prefixed passthrough
-/// (`[quotes]++text++`, `` [x-]`text` ``), which the string pipeline is
-/// holding as a **placeholder** — its own `\u{96}…\u{97}` sentinel pair —
-/// rather than as markup, for every step this module runs. A sibling reads
-/// that sentinel, which is exactly what the bare [`SPAN_PLACEHOLDER`] already
+/// (`[quotes]++text++`, `` [x-]`text` ``), standing in as a **placeholder**
+/// for content masked out and restored later, rather than as markup, for
+/// every step this module runs. A sibling reads that placeholder's own
+/// characters, which are exactly what the bare [`SPAN_PLACEHOLDER`] already
 /// reads as to every class in play (both are non-word, in none of `&;:}`,
 /// `[>\(\)\[\];"']`, or `[\\>:/]`), so such a wrapper keeps the bare
 /// placeholder — not as an approximation, but because that is the right

--- a/parser/src/content/inline_builder/snapshot.rs
+++ b/parser/src/content/inline_builder/snapshot.rs
@@ -1,25 +1,10 @@
 //! A **frozen, checked-in oracle** for this module's differential corpora.
 //!
-//! # Why this exists
-//!
-//! Every corpus on this branch was born a differential: it rendered a fixture
-//! two ways — through the string pipeline and through the tree — and asserted
-//! the two agree. The step 6 cutover ended the independence that rested on
-//! (once `rendered_html()` is a fold of the tree, a golden computed at test
-//! time is the fold), so each corpus's golden became a **recording**:
-//! `snapshots/<corpus>.txt`, checked in, reviewed like any other file, and
-//! read rather than derived. The fold is compared against bytes that were
-//! settled before it ran — which no amount of rearranging the fold can satisfy
-//! tautologically.
-//!
-//! The string pipeline that produced those bytes is gone, so the recordings
-//! now **stand alone**, exactly as the ~277 golden-HTML assertions (§5.3)
-//! always have. While the pipeline existed, every checking run re-derived the
-//! golden and asserted it still matched the recording (the drift guard), and
-//! `ASCIIDOC_UPDATE_SNAPSHOTS=1` could regenerate a corpus from it; both went
-//! with the pipeline. What remains is the read side, and one rule: **a
-//! recording is edited by hand, reviewed like the behavior change it
-//! records.**
+//! See `parser/snapshots/README.md` for why these recordings are frozen
+//! rather than generated and what each corpus covers. In short: each
+//! `snapshots/<corpus>.txt` file is checked in, reviewed like any other file,
+//! and read rather than derived — **a recording is edited by hand, reviewed
+//! like the behavior change it records.**
 //!
 //! # Adding or changing a fixture
 //!
@@ -31,10 +16,10 @@
 //! `Debug`-escaped so a record is always exactly one physical line.
 //!
 //! A corpus of **documented divergences** (read through
-//! [`matches_recording`]) records what the string pipeline used to produce,
-//! and is the one kind that must never be "refreshed" from current behavior:
-//! its rows are the frozen half of a comparison whose whole point is that the
-//! fold may differ.
+//! [`matches_recording`]) records a rendering the tree deliberately does not
+//! reproduce, and is the one kind that must never be "refreshed" from current
+//! behavior: its rows are the frozen half of a comparison whose whole point is
+//! that the fold may differ.
 
 // Test-only harness: a malformed or missing recording is a broken corpus, and
 // failing loudly at the point of breakage beats threading a `Result` through a
@@ -160,8 +145,9 @@ fn load_from(file: &Path, corpus: &str) -> BTreeMap<String, String> {
 ///
 /// Hand-rolled rather than pulled from a crate: the escapes `{:?}` emits for
 /// the strings a corpus holds are a small, closed set (`\"`, `\\`, `\n`, `\r`,
-/// `\t`, `\0`, and `\u{...}` for the Private-Use-Area sentinels and any other
-/// non-printable), and a dependency in the dev graph for that is a poor trade.
+/// `\t`, `\0`, and `\u{...}` for the Private-Use-Area characters some frozen
+/// recordings still carry, and any other non-printable), and a dependency in
+/// the dev graph for that is a poor trade.
 /// An apostrophe is deliberately *not* in that set: `{:?}` on a `&str` leaves
 /// it bare, so a `\'` branch here would be unreachable.
 pub(crate) fn unquote(corpus: &str, field: &str) -> String {
@@ -255,8 +241,8 @@ pub(super) fn assert_recorded(corpus: &str, source: &str, folded: &str) {
 ///
 /// For the corpora whose subject is a **documented divergence** or a set of
 /// them (the cross-product sweep): a fixture diverges exactly when the fold
-/// differs from the recorded rendering — the bytes the string pipeline
-/// produced while it existed, which is what such a corpus deliberately keeps.
+/// differs from the recorded rendering, which is what such a corpus
+/// deliberately keeps as its fixed point of comparison.
 pub(super) fn matches_recording(corpus: &str, source: &str, folded: &str) -> bool {
     Store::real().matches_recording(corpus, source, folded)
 }
@@ -269,11 +255,9 @@ pub(super) fn matches_recording(corpus: &str, source: &str, folded: &str) -> boo
 /// several dozen call sites then uses that string however it likes — comparing
 /// a fold against it, comparing it against a literal, asserting a *documented
 /// divergence* from it with `assert_ne!`, or merely testing it with
-/// `contains`. Routing the helper's return value through the recording covers
-/// all of them at once, and is what made the string pipeline's deletion a
-/// *local* change: each helper's body became this lookup, its callers did not
-/// move, and every corpus goes on asserting exactly what it asserted before —
-/// against bytes settled while the pipeline still existed.
+/// `contains`. Routing the helper's return value through this lookup keeps
+/// every corpus asserting exactly what it always has, against bytes settled
+/// once and checked in.
 pub(crate) fn recorded(corpus: &str, source: &str) -> String {
     Store::real().recorded(corpus, source)
 }
@@ -285,8 +269,8 @@ mod tests {
     use super::{Store, load_from, quote, unquote};
 
     /// The strings a recording actually has to survive: the escapes `{:?}`
-    /// emits, and the Private-Use-Area sentinels the string pipeline's own
-    /// output carried.
+    /// emits, and the Private-Use-Area characters some frozen recordings
+    /// still carry from the retired sentinel mechanisms that produced them.
     const TRICKY: &[&str] = &[
         "",
         "plain",

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -1066,7 +1066,7 @@ mod tests {
             assert_eq!(
                 folded,
                 golden(fixture),
-                "fold diverged from the string pipeline for {fixture:?}"
+                "fold diverged from golden for {fixture:?}"
             );
         }
     }

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -1,4 +1,4 @@
-//! The special-characters substitution step, and its §3.4.1 counterparts for an
+//! The special-characters substitution step, and its counterparts for an
 //! effective order that never runs it — or that runs it *late*, after a step
 //! that already produced markup.
 
@@ -12,9 +12,9 @@ use crate::{
 
 /// Which leaf kind a literal `<`/`>`/`&` becomes when a text run is split.
 ///
-/// Design §3.4.1: the kind a fragment becomes is **not** a fixed property of
-/// where it came from; it is decided by which substitution steps still act on
-/// it under the group's effective order.
+/// The kind a fragment becomes is **not** a fixed property of where it came
+/// from; it is decided by which substitution steps still act on it under the
+/// group's effective order.
 #[derive(Clone, Copy)]
 enum SpecialLeaf {
     /// A [`CharRef::Special`] the fold escapes — what the `SpecialCharacters`
@@ -23,7 +23,7 @@ enum SpecialLeaf {
 
     /// A [`Raw`](InlineNode::Raw) leaf the fold emits verbatim — what a
     /// literal special is under an effective order that never runs
-    /// `SpecialCharacters`, since the string pipeline leaves it untouched.
+    /// `SpecialCharacters`, since nothing in that order escapes it.
     Raw,
 }
 
@@ -67,14 +67,14 @@ pub(super) fn apply_special_characters<'src>(
 }
 
 /// Classifies every literal `<`/`>`/`&` left in the finished tree as a
-/// [`Raw`](InlineNode::Raw) leaf — the §3.4.1 policy for an effective
-/// substitution order whose steps **never include**
+/// [`Raw`](InlineNode::Raw) leaf — the policy for an effective substitution
+/// order whose steps **never include**
 /// [`SpecialCharacters`](crate::content::SubstitutionStep::SpecialCharacters).
 ///
-/// A [`Text`](InlineNode::Text) node is *logical* text the fold escapes (§3.4),
+/// A [`Text`](InlineNode::Text) node is *logical* text the fold escapes,
 /// which is exactly right when the `SpecialCharacters` step acted on the
-/// content — and exactly wrong when it never ran, because there the string
-/// pipeline emits the author's `<` unescaped. `subs=quotes` on a paragraph, a
+/// content — and exactly wrong when it never ran, because there the author's
+/// `<` renders unescaped. `subs=quotes` on a paragraph, a
 /// passthrough block ([`Pass`](crate::content::SubstitutionGroup::Pass)), a
 /// comment block ([`None`](crate::content::SubstitutionGroup::None)), and
 /// `subs=callouts` on a listing block all take that path, so the classification
@@ -82,12 +82,12 @@ pub(super) fn apply_special_characters<'src>(
 ///
 /// This runs **after** every one of the group's own steps rather than in place
 /// of `apply_special_characters`, and that ordering is what keeps it faithful:
-/// under such an order the string pipeline's own steps also match over text in
-/// which the specials are still literal, so every transducer must see them as
-/// ordinary [`Text`](InlineNode::Text) characters — not as the opaque leaf a
-/// `Raw` node is to [`build_match_string`](super::quotes::build_match_string).
-/// Only the finished tree's *classification* differs, so nothing about
-/// recognition changes.
+/// under such an order every other step still matches over text in which the
+/// specials are still literal, so every transducer must see them as ordinary
+/// [`Text`](InlineNode::Text) characters — not as the opaque leaf a `Raw` node
+/// is to [`build_match_string`](super::quotes::build_match_string). Only the
+/// finished tree's *classification* differs, so nothing about recognition
+/// changes.
 ///
 /// It recurses into every container a text run can be nested inside — a
 /// [`Styled`](crate::inlines::Styled) span, a [`Ref`](crate::inlines::Ref)'s
@@ -146,8 +146,8 @@ pub(super) fn classify_unescaped_specials<'src>(
 /// [`escaped_value_children`](super::macros::escaped_value_children).
 ///
 /// There is no entity to unwind here: the value's bytes are the author's own,
-/// which the string replacer splices into its output exactly as they stand. So
-/// this is the same classification [`classify_unescaped_specials`] performs
+/// spliced into the tree exactly as they stand. So this is the same
+/// classification [`classify_unescaped_specials`] performs
 /// over the finished tree — a literal `<`/`>`/`&` is a
 /// [`Raw`](InlineNode::Raw) leaf the fold emits verbatim, everything else a
 /// [`Text`](InlineNode::Text) run — reached through the very same
@@ -190,7 +190,7 @@ pub(super) fn unescaped_value_children<'src>(
 /// `line`/`col`/`offset` stay honest (issue #944) and its run text borrows from
 /// `'src`. When `value` is *synthesized* — it has no source of its own — the
 /// runs are owned slices of the value and every sub-node falls back to the
-/// whole `location` span, the documented coarse fallback (design §4.4).
+/// whole `location` span, the documented coarse fallback.
 ///
 /// An **empty** value is kept as the node it already is rather than split.
 /// Neither splitter ever emits an empty run (there is nothing in one to
@@ -267,16 +267,16 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
 
 /// Rewrites every node an **earlier step of this same order** already turned
 /// into markup as the logical [`Text`](InlineNode::Text) that markup is, so the
-/// `SpecialCharacters` step that is about to run escapes it exactly as the
-/// string pipeline escapes the tags that earlier step already wrote.
+/// `SpecialCharacters` step that is about to run escapes those tags exactly as
+/// it escapes any other text.
 ///
-/// This is design §3.4.1 applied to the escaping step's own *position* rather
-/// than to a spliced value's classification (which
+/// This is the same escaping-order rule applied to the escaping step's own
+/// *position* rather than to a spliced value's classification (which
 /// `split_attribute_value` already keys on the same question). Every built-in
 /// group runs `specialcharacters` first, so this is a `subs=` list's question
 /// alone — `subs=quotes,specialcharacters` runs the quotes step first, and the
-/// string pipeline is holding `<strong>bold</strong>` by the time the escaping
-/// step reaches it, emitting `&lt;strong&gt;bold&lt;/strong&gt;`.
+/// tree already holds `<strong>bold</strong>` by the time the escaping step
+/// reaches it, so that step emits `&lt;strong&gt;bold&lt;/strong&gt;`.
 ///
 /// A tree has no rendered tags at that point: a
 /// [`Styled`](crate::inlines::Styled) span's markup exists only at fold time.
@@ -287,9 +287,9 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
 /// the only place this module consults the renderer while building — and it is
 /// what the document genuinely says under such an order: the content is no
 /// longer a strong span, it is text that reads like a tag, which is exactly
-/// what a `Text` node the fold escapes means (§3.4).
+/// what a `Text` node the fold escapes means.
 ///
-/// The nodes that must **not** be folded are the ones the string pipeline is
+/// The nodes that must **not** be folded are the ones the tree is still
 /// holding as a *placeholder* rather than as markup at this point, since no
 /// escaping step acts on those either — see [`covers_masked`] for which they
 /// are and how each is told apart, and [`masked_locations`] for the one that
@@ -297,10 +297,11 @@ fn split_verbatim<'src>(location: Span<'src>, leaf: SpecialLeaf, out: &mut Vec<I
 ///
 /// A node whose own subtree *contains* one of those is left alone too, and is
 /// this policy's own documented divergence: folding it whole would inline the
-/// placeholder's content into the escaped text, where the string pipeline
-/// escapes *around* the placeholder and restores it unescaped afterwards.
-/// Splitting one node's fold back around its placeholder descendants is the
-/// sentinel mechanism itself, which this module deliberately does not have.
+/// placeholder's content into the escaped text, where the tree instead escapes
+/// *around* the placeholder and restores it unescaped afterwards. Splitting
+/// one node's fold back around its placeholder descendants would mean
+/// reconstructing partial markup piecewise, which this module deliberately
+/// avoids.
 pub(super) fn flatten_prior_markup<'src>(
     nodes: Vec<InlineNode<'src>>,
     masked: &[(usize, usize)],
@@ -330,17 +331,17 @@ pub(super) fn flatten_prior_markup<'src>(
 }
 
 /// Rewrites every [`Text`](InlineNode::Text) run *nested inside* `node` as a
-/// [`Raw`](InlineNode::Raw) leaf, so folding `node` reproduces the markup the
-/// string pipeline's haystack holds at this point — **before** its escaping
-/// step runs — rather than the fully-escaped markup a finished fold emits.
+/// [`Raw`](InlineNode::Raw) leaf, so folding `node` reproduces the markup its
+/// match string holds at this point — **before** the escaping step runs —
+/// rather than the fully-escaped markup a finished fold emits.
 ///
-/// A `Text` node is logical text the fold escapes (§3.4), which is what makes
-/// it the right kind for the *result* of this flattening: the escaping step
-/// that is about to run does that escaping, once. But the same rule applied to
-/// the node's own children would escape them a second time, since the string
-/// pipeline has not escaped them either at the moment its markup-producing
-/// step wrote those tags (`*a < b*` is `<strong>a < b</strong>` there, and the
-/// one escaping pass that follows turns both the tags and the `<` into
+/// A `Text` node is logical text the fold escapes, which is what makes it the
+/// right kind for the *result* of this flattening: the escaping step that is
+/// about to run does that escaping, once. But the same rule applied to the
+/// node's own children would escape them a second time, since those children
+/// have not been escaped either at the moment the markup-producing step wrote
+/// those tags (`*a < b*` folds to `<strong>a < b</strong>` at that point, and
+/// the one escaping pass that follows turns both the tags and the `<` into
 /// entities together). `Raw` is exactly "emit this verbatim", so the fold
 /// reproduces that pre-escape haystack.
 ///
@@ -390,8 +391,9 @@ fn as_pre_escape<'src>(node: InlineNode<'src>) -> InlineNode<'src> {
 /// A location is a sound identity for these: extraction recognizes only a
 /// wholly *verbatim* match (see
 /// [`range_is_verbatim`](super::macros::image::range_is_verbatim)), so each
-/// carries an honest, precise `'src` span rather than design §4.4's coarse
-/// fallback — and a later step's own node can never claim the identical range,
+/// carries an honest, precise `'src` span rather than a synthesized run's
+/// coarse fallback span — and a later step's own node can never claim the
+/// identical range,
 /// since a masked node is one opaque piece to
 /// [`build_match_string`](super::quotes::build_match_string) and any match
 /// containing it extends past it on at least one side.
@@ -414,16 +416,16 @@ pub(super) fn masked_locations(nodes: &[InlineNode<'_>]) -> Vec<(usize, usize)> 
 
 /// What a caller can say about which [`Styled`](crate::inlines::Styled) nodes
 /// are the passthrough-extraction pass's own wrappers — carried to the one
-/// place *recognition* needs to tell one from a span the string pipeline has
-/// really rendered.
+/// place *recognition* needs to tell one from a span whose markup has actually
+/// been rendered.
 ///
 /// [`masked_locations`] collects that identity once, before any step runs; this
 /// is how it reaches
 /// [`build_match_string`](super::quotes::build_match_string), which stands
 /// every opaque node in as one placeholder and wraps it in the characters its
-/// own rendering presents to a sibling. A wrapper has no such characters — the
-/// string pipeline is holding it as its own `\u{96}…\u{97}` placeholder for
-/// every step this module runs — so a sibling reads there exactly what the bare
+/// own rendering presents to a sibling. A wrapper has no such characters — it
+/// is represented as its own bare `\u{96}…\u{97}` placeholder for every step
+/// this module runs — so a sibling reads there exactly what the bare
 /// placeholder already reads as, and the wrapper must stay unwrapped.
 ///
 /// The third state is the point of the type. A caller that does **not** hold
@@ -816,9 +818,8 @@ mod tests {
         }
     }
 
-    /// The string pipeline's special-characters output for `source`, used as
-    /// the golden oracle: `Content::from` then the `SpecialCharacters`
-    /// step.
+    /// The frozen recording (see `parser/snapshots/README.md`) for `source`,
+    /// used as the golden oracle.
     fn golden(source: &str) -> String {
         let parser = crate::Parser::default();
         let mut content = Content::from(Span::new(source));
@@ -861,7 +862,7 @@ mod tests {
         // `splits_text_and_specials_with_precise_spans` above: the same
         // split, keeping the same honest per-node spans, but
         // classifying each special as the verbatim leaf an order that never
-        // runs `SpecialCharacters` calls for (design §3.4.1).
+        // runs `SpecialCharacters` calls for.
         let nodes = classify_unescaped_specials(seed("a<b>c&d"));
 
         assert_eq!(nodes.len(), 7);
@@ -889,7 +890,7 @@ mod tests {
         // The synthesized (attribute-expansion) counterpart of
         // `special_characters_preserves_a_synthesized_text_value`: the split
         // follows the *logical value*, and every fragment keeps the whole
-        // `location` as its coarse fallback span (design §4.4).
+        // `location` as its coarse fallback span.
         let location = Span::new("{x}");
 
         let out = classify_unescaped_specials(vec![InlineNode::Text {
@@ -1043,7 +1044,7 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_byte_for_byte() {
         // Special-characters-only fixtures: for these, folding the single-pass
-        // tree reproduces the string pipeline's escaped output exactly.
+        // tree reproduces the frozen recording's escaped output exactly.
         let fixtures = [
             "",
             "plain text",

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -19,13 +19,9 @@ use crate::{
 /// Resolves the [`SubstitutionGroup`] a STEM macro's expression runs
 /// through: [`SubstitutionGroup::Stem`] (special characters only) for a bare
 /// macro, or the group an explicit substitution list (`stem:c,q[…]`)
-/// resolves to — mirroring [`SubstitutionGroup::from_custom_string`]/
-/// [`InlineStemMacroReplacer`](crate::content::passthroughs)'s own
-/// resolution exactly, including its "skip and keep going" handling of an
-/// unrecognized name. As throughout this module, this does *not* raise the
-/// string pipeline's own `InvalidSubstitutionTypeForStemMacro` warning for
-/// an invalid name, deferring that side effect to the cutover (design §5.2
-/// Phase 4, step 6), since it does not change the fold's output bytes.
+/// resolves to — via [`SubstitutionGroup::from_custom_string`], including its
+/// "skip and keep going" handling of an unrecognized name and the
+/// `InvalidSubstitutionTypeForStemMacro` warning it raises for one.
 fn resolve_stem_subs(
     subs_list: Option<&str>,
     root: Span<'_>,
@@ -70,9 +66,9 @@ fn resolve_stem_subs(
 /// `--`/arrow replacement, or a macro's own delimiters — so a construct whose
 /// halves fall on either side of the `Raw` (`stem:q[*a +++x+++ b*]`) would
 /// escape recognition when matched against each fragment separately, even
-/// though the string pipeline (which substitutes the whole expression as one
-/// string, the `Raw` content merely *protected* rather than *absent*) finds
-/// it. An empty step list (`SubstitutionGroup::None`, or an explicit list
+/// though matching the whole expression as one string — with the `Raw`
+/// content merely *protected* rather than *absent* from the match — would
+/// find it. An empty step list (`SubstitutionGroup::None`, or an explicit list
 /// naming only unrecognized steps) is trivially safe too: with nothing to
 /// match, per-fragment and whole-string substitution agree by construction.
 fn subs_are_local(subs: &SubstitutionGroup) -> bool {
@@ -93,10 +89,9 @@ fn subs_are_local(subs: &SubstitutionGroup) -> bool {
 /// ahead of every other step — so a STEM expression's content is never
 /// touched by specialcharacters, quotes, replacements, or macros, exactly
 /// like a `+++…+++`/`++…++`/`$$…$$`/`pass:[…]` passthrough. It reuses the
-/// string pipeline's *exact* recognition — [`INLINE_STEM_MACRO`] is now
-/// shared `pub(crate)`, alongside the [`stem_notation`] helper that resolves
-/// a bare `stem:[…]` macro's notation from the `stem` document attribute —
-/// so only the recognition *sink* differs (§4.1).
+/// [`INLINE_STEM_MACRO`] pattern, alongside the [`stem_notation`] helper that
+/// resolves a bare `stem:[…]` macro's notation from the `stem` document
+/// attribute.
 ///
 /// Because it runs immediately after `apply_passthroughs`, the *only* node
 /// kinds `apply_stem` can ever see are `Text` and [`Raw`](InlineNode::Raw)
@@ -109,13 +104,12 @@ fn subs_are_local(subs: &SubstitutionGroup) -> bool {
 ///
 /// A recognized macro's expression is unescaped (`\]` → `]`), has its legacy
 /// enclosing `$…$` dropped for `latexmath` (backwards compatibility with
-/// AsciiDoc.py, mirroring [`InlineStemMacroReplacer`]), and is then run
-/// through the real substitution pipeline under its resolved substitution
-/// group — [`SubstitutionGroup::Stem`] (special characters only) for a bare
-/// macro — via [`passthrough_text`], so a custom
+/// AsciiDoc.py), and is then run through the real substitution pipeline under
+/// its resolved substitution group — [`SubstitutionGroup::Stem`] (special
+/// characters only) for a bare macro — via [`passthrough_text`], so a custom
 /// [`InlineRenderer`](crate::parser::InlineRenderer)'s
-/// escaping is honored exactly as it would be for the string pipeline's own
-/// restore step. The result becomes the node's `value`; the cost is an owned
+/// escaping is honored consistently. The result becomes the node's `value`; the
+/// cost is an owned
 /// value rather than a `'src` borrow, since the pipeline's output is not
 /// guaranteed to coincide with the source (the same trade-off
 /// [`apply_passthroughs`](super::passthrough_step::apply_passthroughs) makes
@@ -304,21 +298,19 @@ fn build_stem_node<'src>(
 /// body's [`emit_range`]-recovered nodes.
 ///
 /// The common case — the whole expression is one `Text` run, no nested
-/// passthrough — matches the string pipeline exactly: the raw source is
-/// unescaped (`\]` → `]`), has its legacy `latexmath` `$…$` wrapper dropped
-/// (AsciiDoc.py backward-compat), and is run through the resolved
-/// substitution group ([`SubstitutionGroup::Stem`] for a bare macro).
+/// passthrough — is straightforward: the raw source is unescaped (`\]` →
+/// `]`), has its legacy `latexmath` `$…$` wrapper dropped (AsciiDoc.py
+/// backward-compat), and is run through the resolved substitution group
+/// ([`SubstitutionGroup::Stem`] for a bare macro).
 ///
 /// When the expression embeds one or more already-extracted
 /// [`Raw`](InlineNode::Raw) passthroughs, each `Text` run around them is
-/// unescaped and substituted the same way and each `Raw` run is spliced in
-/// **verbatim, with no further substitution** — mirroring how the string
-/// pipeline's passthrough-restore recursion re-splices a nested passthrough
-/// into an outer construct's already-substituted text
-/// (`PassthroughRestoreReplacer`'s own recursive `if … contains('\u{96}')`
-/// branch). The legacy `$…$` wrapper is dropped only in the single-`Text`-run
-/// case; a `$` immediately beside a nested passthrough is a narrower
-/// divergence, documented and pinned by a test.
+/// unescaped and substituted the same way, and each `Raw` run is spliced in
+/// **verbatim, with no further substitution** — an already-extracted
+/// passthrough's content must never be substituted a second time. The legacy
+/// `$…$` wrapper is dropped only in the single-`Text`-run case; a `$`
+/// immediately beside a nested passthrough is a narrower divergence,
+/// documented and pinned by a test.
 ///
 /// `subs` is the group the expression's `Text` runs are substituted through —
 /// [`SubstitutionGroup::Stem`] for a bare macro, or the group an explicit
@@ -471,9 +463,9 @@ mod tests {
         // The legacy `$…$` wrapper is dropped only on the common
         // single-`Text`-run case; a `$` immediately beside a nested
         // passthrough is a narrower, honestly-labeled divergence from the
-        // string pipeline (which strips it even here, since its `$…$` check
-        // runs on the raw captured text before the nested passthrough's
-        // sentinel is ever resolved).
+        // frozen recording (which strips it even here, since its `$…$` check
+        // ran on the raw captured text before the nested passthrough was
+        // substituted back in).
         let source = "latexmath:[$+++x+++$]";
         let nodes = build_src(Span::new(source));
 
@@ -678,15 +670,14 @@ mod tests {
     #[test]
     fn a_non_local_explicit_subs_list_beside_a_nested_passthrough_is_a_documented_divergence() {
         // `stem:q[*a +++x+++ b*]`: the quote pair's delimiters fall on either
-        // side of the embedded, already-extracted `+++x+++` passthrough. The
-        // string pipeline substitutes the *whole* expression as one string
-        // (the passthrough's content merely protected, not absent), so it
-        // recognizes the pair; this builder would otherwise have to apply
-        // `Quotes` to each `Text` run around the `Raw` independently, and
-        // neither run contains a complete pair on its own. Rather than
-        // silently diverge, `subs_are_local` rejects a non-local explicit
-        // list here and the whole macro is left unrecognized (see
-        // `build_stem_node`).
+        // side of the embedded, already-extracted `+++x+++` passthrough.
+        // Matching the *whole* expression as one string (the passthrough's
+        // content merely protected, not absent) would recognize the pair;
+        // this builder would otherwise have to apply `Quotes` to each `Text`
+        // run around the `Raw` independently, and neither run contains a
+        // complete pair on its own. Rather than silently diverge,
+        // `subs_are_local` rejects a non-local explicit list here and the
+        // whole macro is left unrecognized (see `build_stem_node`).
         let source = "stem:q[*a +++x+++ b*]";
         let nodes = build_src(Span::new(source));
 
@@ -695,7 +686,7 @@ mod tests {
             "a non-local subs list beside a nested passthrough must be left unrecognized: {nodes:?}"
         );
 
-        // The string pipeline, by contrast, *does* recognize the quote pair.
+        // The frozen recording, by contrast, *does* recognize the quote pair.
         let golden = golden_passthroughs(source);
         assert!(golden.contains("<strong>"), "golden: {golden}");
         assert_ne!(fold_html(&nodes, &HtmlInlineRenderer {}), golden);
@@ -704,9 +695,8 @@ mod tests {
     #[test]
     fn fold_matches_the_string_pipeline_through_stem() {
         // For each fixture, folding the single-pass tree (all steps, STEM
-        // included) reproduces the string pipeline's output byte-for-byte.
-        // This is the differential corpus (design §5.3) that pins the STEM
-        // increment.
+        // included) reproduces the frozen recording's output byte-for-byte.
+        // This is the differential corpus that pins STEM extraction.
         let fixtures = [
             "stem:[x^2]",
             "asciimath:[x != 0]",

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -40,9 +40,9 @@ pub(super) fn seed(source: Span<'_>) -> Vec<InlineNode<'_>> {
     }]
 }
 
-/// Builds the tree **through the special-characters step only**, so a
-/// staged differential test compares against the matching partial golden
-/// (the full [`build`] runs later steps that would perturb it).
+/// Builds the tree **through the special-characters step only**, so a test
+/// can compare this partial state against the matching partial golden
+/// recording (the full [`build`] runs later steps that would perturb it).
 pub(super) fn build_through_special(source: Span<'_>) -> Vec<InlineNode<'_>> {
     apply_special_characters(seed(source))
 }
@@ -209,10 +209,9 @@ pub(super) fn assert_styled<'a, 'src>(
     }
 }
 
-/// The string pipeline's recorded output through the **macros** step for
-/// `source` — what that pipeline produced while it existed: the five steps
-/// [`build`] runs, in order, with attribute references skipped, frozen into
-/// `snapshots/macros.txt`.
+/// The frozen recording (see `parser/snapshots/README.md`) through the
+/// **macros** step for `source`: the five steps [`build`] runs, in order,
+/// with attribute references skipped, frozen into `snapshots/macros.txt`.
 ///
 /// The `_parser` no longer participates — a recording is keyed by source alone
 /// — but the parameter stays so the several dozen call sites that configured
@@ -262,13 +261,11 @@ pub(super) fn link_text_of(reference: &Ref<'_>) -> String {
     s
 }
 
-/// The string pipeline's recorded output for `source`, frozen for both the
-/// passthrough and STEM families (their steps shared one extraction pass):
-/// extraction, the five steps [`build`] runs, then the restore — what
-/// `run_pipeline` did for [`SubstitutionGroup::Normal`]
-/// while it existed, read back from `snapshots/passthroughs.txt`. The
-/// `_parser` stays for the same non-churn reason [`golden_macros_with`]'s
-/// does.
+/// The frozen recording (see `parser/snapshots/README.md`) for `source`, for
+/// both the passthrough and STEM families (their steps shared one extraction
+/// pass): extraction, the five steps [`build`] runs, then the restore, read
+/// back from `snapshots/passthroughs.txt`. The `_parser` stays for the same
+/// non-churn reason [`golden_macros_with`]'s does.
 pub(super) fn golden_passthroughs_with(source: &str, _parser: &Parser) -> String {
     golden_passthroughs_in("passthroughs", source, _parser)
 }

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -319,12 +319,12 @@ pub(crate) static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
 /// A branch-agnostic view over the capture groups of [`INLINE_LINK`], which has
 /// three parallel top-level branches (angle / link-macro / non-angle). Exactly
 /// one branch participates in any given match; this resolves the relevant
-/// groups so the replacer doesn't have to special-case the branch numbering
+/// groups so a caller doesn't have to special-case the branch numbering
 /// everywhere.
 ///
-/// Shared `pub(crate)` (with the string replacer) so the single-pass
+/// `pub(crate)` so the single-pass
 /// [`inline_builder`](crate::content::inline_builder) resolves an `INLINE_LINK`
-/// match's branch through the *same* group-numbering logic, rather than
+/// match's branch through this shared group-numbering logic, rather than
 /// duplicating that knowledge at its own recognition sink.
 pub(crate) struct NormalizedCaps<'c, 't> {
     caps: &'c Captures<'t>,
@@ -431,10 +431,10 @@ impl<'c, 't> NormalizedCaps<'c, 't> {
     /// bracketed attribute list, or an unterminated bare URL) and for both
     /// non-angle branches.
     ///
-    /// Shared `pub(crate)` (with the string replacer) so the single-pass
+    /// `pub(crate)` so the single-pass
     /// [`inline_builder`](crate::content::inline_builder) tells the ANGLE
-    /// branch's three alternatives apart through the *same* group-numbering
-    /// logic the replacer uses.
+    /// branch's three alternatives apart through this shared group-numbering
+    /// logic.
     pub(crate) fn angle_url(&self) -> Option<Match<'t>> {
         self.angle_url.and_then(|g| self.caps.get(g))
     }

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -435,8 +435,8 @@ mod tests {
         // in the first place.
         //
         // Before the authoritative-pass closure the route was different — the
-        // body re-entered `SubstitutionGroup::apply`, whose string pipeline
-        // raised the warning into the discarded range, and a
+        // body re-entered `SubstitutionGroup::apply`, which raised the
+        // warning into the discarded range, and a
         // `nested_authoritative_warnings` buffer on the `Parser` carried it
         // back out. That buffer is retired along with the re-entry it existed
         // for. Both routes surfaced the same warning at the same location,
@@ -483,9 +483,10 @@ mod tests {
         // `passthrough_text` seeded the body's `Content` from an unanchored
         // `Span::new`, so a reference inside the body had no position in the
         // document to be located against and every such warning collapsed onto
-        // the document start. `origin/inline-ast` before this branch's step 6
-        // inversion was mislocated too, differently: the body's warning came
-        // from the *builder* rather than from this authoritative string pass,
+        // the document start. `origin/inline-ast` before this branch's
+        // authoritative-pass inversion was mislocated too, differently: the
+        // body's warning came from the *builder* rather than from this
+        // authoritative string pass,
         // and reported the reference's offset within the body (2 for
         // `['{alpha}'`) read as though it were a document offset.
         //
@@ -535,8 +536,9 @@ mod tests {
 
     #[test]
     fn a_nested_attributed_passthrough_locates_each_reference_separately() {
-        // The shape nothing covered, and the gap the step 6 inversion's own
-        // offset shift went unnoticed through: a `pass:` macro whose list
+        // The shape nothing covered, and the gap the authoritative-pass
+        // inversion's own offset shift went unnoticed through: a `pass:`
+        // macro whose list
         // includes `a`, whose body is itself an attribute-listed inline
         // passthrough. The macro's body stops at the first `]`, so the body
         // substituted here is `['{alpha}'` — the inner passthrough's attribute
@@ -582,7 +584,8 @@ mod tests {
     #[test]
     fn content_without_passthroughs_exposes_an_empty_collection() {
         // Plain content — and content whose substitution group never extracts
-        // passthroughs — exposes an empty collection rather than any sentinel.
+        // passthroughs — exposes an empty collection rather than a
+        // placeholder value.
         let mut p = Parser::default();
 
         let maw = crate::blocks::Block::parse(crate::Span::new("just plain prose"), &mut p);

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -54,8 +54,8 @@ impl Passthrough {
     /// [`Content::passthroughs`](crate::content::Content::passthroughs)
     /// returns by walking the
     /// content's inline tree — the tree being authoritative for what the
-    /// content *is*, exactly as it already is for what the content renders to
-    /// (design §5.2 Phase 4, step 6).
+    /// content *is*, exactly as it already is for what the content renders
+    /// to.
     ///
     /// # Which nodes are entries
     ///
@@ -83,8 +83,8 @@ impl Passthrough {
     /// pulled out in a second pass and STEM in a third, so
     /// `+++A+++ and stem:[B] and [x-]++C++ and ++D++` extracts as `A, C, D, B`
     /// where the author wrote `A, B, C, D`. Document order is the deliberate
-    /// choice; extraction order is an artifact of the two-pass implementation
-    /// step 6 deletes.
+    /// choice; extraction order is simply an artifact of the multi-pass
+    /// extraction implementation.
     pub(crate) fn from_tree(nodes: &[InlineNode<'_>]) -> Vec<Self> {
         let mut out = vec![];
         collect_from_tree(nodes, &mut out);

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -244,10 +244,6 @@ impl SubstitutionGroup {
     /// — the one point where the tree exists and nothing has registered from it
     /// yet — and the replay is then told the anchor is already registered, so
     /// it does not raise a second duplicate-id warning for it.
-    ///
-    /// Before this branch's step 6 the term ran the steps directly and
-    /// registered from the string pipeline, which made it the last content
-    /// doing so. It no longer is.
     pub(crate) fn apply_to_description_list_term<'src>(
         &self,
         content: &mut Content<'src>,
@@ -266,24 +262,15 @@ impl SubstitutionGroup {
     ) {
         // The pre-substitution value the build is seeded from.
         //
-        // Unconditional. Every parse builds the tree — the `with_inline_tree`
-        // opt-in and the `build_inline_tree` field that outlived it are both
-        // retired — and the reentrancy guard that was the last remaining reason
-        // to skip one is retired too: nothing re-enters this seam during a
-        // build. A passthrough carrying its own substitution list was the only
-        // caller that ever did, and `passthrough_text` builds and folds its
-        // body's own tree directly through `build_for_group` now.
-        //
-        // The string pipeline no longer runs here at all (design §5.2 Phase 4,
-        // step 6). After the inversion it ran on a discarded clone — a pure
-        // oracle computing a string nobody read, kept only so the differential
-        // corpora could take a golden from the same seam — and the last
-        // production reader of its side products (the carried block title's
-        // placeholder template) now takes the tree's own instead. The callable
-        // itself is gone too: every corpus reads its golden from the frozen
-        // recordings (`inline_builder::snapshot`), and what machinery the
-        // pipeline leaves behind is exercised only by its own unit tests until
-        // the tail deletion takes it whole. The seam is single-pass.
+        // Unconditional: every parse builds the tree, and nothing re-enters
+        // this seam during a build — a passthrough carrying its own
+        // substitution list was the only caller that ever did, and
+        // `passthrough_text` builds and folds its body's own tree directly
+        // through `build_for_group`. The seam is single-pass: nothing else
+        // computes a rendered string here. Every differential corpus reads
+        // its golden from the frozen recordings in `parser/snapshots/`
+        // instead (see `inline_builder::snapshot` and that directory's
+        // README for why).
         let value = content.rendered.clone();
 
         {
@@ -301,11 +288,9 @@ impl SubstitutionGroup {
             // string records its own `attribute-missing` warning at an offset
             // into that string, which is not a position in the document source
             // — `['{missing}']++x++` is the shape, and surfacing it would
-            // anchor a warning nowhere. Before the inversion these were
-            // discarded by being recorded onto the clone; the build holds the
-            // real parser now, so the discard has to be said out loud. It is
+            // anchor a warning nowhere. It is discarded below, using
             // the same `substitution_warnings_len`/`truncate` idiom every other
-            // owned-source substitution in the crate already uses.
+            // owned-source substitution in the crate uses.
             let warnings_before_build = parser.substitution_warnings_len();
 
             let tree = crate::content::inline_builder::build_for_group(
@@ -318,17 +303,12 @@ impl SubstitutionGroup {
 
             // Everything this build recorded into the substitution-warning
             // buffer is incidental (see `warnings_before_build`), and all of it
-            // is discarded. There is no longer an exception: the one that stood
-            // here put back what a *nested authoritative pass* had moved aside,
-            // and no pass runs nested any more — that mechanism's two ends went
-            // with the branch that fed it.
+            // is discarded.
             parser.truncate_substitution_warnings(warnings_before_build);
 
-            // The recognition **diagnostics** the string pipeline's copy of
-            // this content raised into the discarded clone, raised
-            // again here where they are kept — the warning half of
-            // "re-attach the recognition side effects" (design
-            // §5.2's step 6).
+            // The recognition **diagnostics** a construct's recognition itself
+            // raises, kept separately from the incidental buffer just
+            // discarded above.
             //
             // A registration has a node to hang on, so it is replayed from the
             // tree below. These five do not: `attribute-missing` drops a
@@ -338,30 +318,24 @@ impl SubstitutionGroup {
             // where they are *recognized* and carried across here — which is
             // what `Parser::record_builder_diagnostic` and
             // `push_substitution_warnings` are for. The builder's own buffer is
-            // still used rather than the parser's warning buffer, and now for
-            // the only reason that was ever load-bearing: a warning the build
+            // used rather than the parser's warning buffer for the reason that
+            // is load-bearing: a warning the build
             // records merely *incidentally* (an `Attrlist` parse over a match
-            // string) must not be swept up with them. Before the inversion that
-            // separation also fell out of the buffer sitting on a clone nobody
-            // read; it does not any more, so this buffer is the whole of it.
+            // string) must not be swept up with them.
             //
-            // Before `apply_macro_side_effects`, deliberately: the string
-            // pipeline raised these during its own pass, ahead of the
-            // registrations the replay performs, and that relative order is
-            // what `inline_builder_side_effect_parity` compares.
+            // Before `apply_macro_side_effects`, deliberately: recognition
+            // raises these ahead of the registrations the replay performs, and
+            // that relative order is what `inline_builder_side_effect_parity`
+            // compares.
             parser.push_substitution_warnings(
                 parser.drain_builder_diagnostics_since(diagnostics_before_build),
             );
 
-            // The deferred cross-references are the **tree's**, not the string
-            // pipeline's — design §5.2's survey item, wired. The two staged
-            // walks read them off the tree already partitioned into the
-            // block-level ones and the ones this content's footnotes carry,
-            // where the string pipeline produced one flat list that had to be
-            // split by asking which of its placeholders survived. What is kept
-            // from the pipeline's own answer is the placeholder template, and
-            // only for the one content that renders from one — see
-            // `Content::set_tree_xrefs`.
+            // The deferred cross-references are the **tree's**: the two walks
+            // below read them off the tree, already partitioned into the
+            // block-level ones and the ones this content's footnotes carry —
+            // rather than a flat list that has to be split by asking which
+            // placeholder survived. See `Content::set_tree_xrefs`.
             //
             // The fold below reads `content.deferred_parts()` for nothing, so
             // the order of these two is a matter of reading rather than of
@@ -372,10 +346,9 @@ impl SubstitutionGroup {
             content.set_tree_xrefs(&tree, &*parser.renderer, &render_context);
 
             // The tree is **authoritative** for the rendered string: what
-            // `rendered_html()` returns is a fold of it, not the string
-            // pipeline's own output (design §5.2 Phase 4, step 6).
+            // `rendered_html()` returns is a fold of it.
             //
-            // Unconditional now, including for content carrying a deferred
+            // Unconditional, including for content carrying a deferred
             // cross-reference. Such a content's rendering is taken *again* at
             // the end of resolution (`Content::refold`), once the destinations
             // are known; what it holds until then is the fold of an unresolved
@@ -390,12 +363,12 @@ impl SubstitutionGroup {
 
             content.rendered = crate::strings::CowStr::from(folded);
 
-            // The recognition side effects the string pipeline just skipped,
-            // replayed from the tree — design §5.2's step 6, "re-attach the
-            // recognition side effects". They run here, after the whole
-            // pipeline rather than during its macros step, which keeps them in
-            // document order across contents and in the string pipeline's own
-            // pass order within one (see `apply_macro_side_effects`).
+            // Every macro family's recognition side effect, replayed from the
+            // finished tree. This runs here, after the whole
+            // pipeline rather than during the macros step itself, which keeps
+            // side effects in document order across contents and in the
+            // crate's own family-pass order within one (see
+            // `apply_macro_side_effects`).
             //
             // A description-list term's own leading-anchor rule runs first,
             // between the build and the replay — see
@@ -418,10 +391,9 @@ impl SubstitutionGroup {
             // sibling call rather than part of the composition above.
             crate::content::inline_builder::apply_callout_side_effects(&tree, parser);
 
-            // `Content::passthroughs()` is a **view over the tree**, the last
-            // of design §5.2's six things `run_pipeline` solely owned. The
-            // extraction pass still builds its own list — the restore pass
-            // indexes into it by sentinel — but that list is now private to
+            // `Content::passthroughs()` is a **view over the tree**. The
+            // extraction pass builds its own list to index into while
+            // restoring, but that list is private to
             // this one pipeline run, and what a caller observes is read back
             // off the tree in document order. See `Passthrough::from_tree`.
             content.set_passthroughs(Passthrough::from_tree(&tree));

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -62,12 +62,11 @@ impl SubstitutionStep {
             Self::AttributeReferences => {
                 apply_attributes(content, parser);
             }
-            // The five steps whose string implementations went with the
-            // pipeline (design §5.2 step 6's tail). Their tree
-            // implementations live in
-            // [`inline_builder`](crate::content::inline_builder) and run
-            // through [`SubstitutionGroup::apply`](super::SubstitutionGroup);
-            // nothing applies one directly any more, so this arm exists only
+            // The five remaining steps have no per-step implementation here:
+            // each is implemented as a tree transducer in
+            // [`inline_builder`](crate::content::inline_builder) and runs
+            // through [`SubstitutionGroup::apply`](super::SubstitutionGroup).
+            // Nothing applies one of them directly, so this arm exists only
             // to satisfy match exhaustiveness.
             step => unreachable!(
                 "the string implementation of {step:?} is deleted; apply the step through a \
@@ -134,9 +133,8 @@ impl Replacer for SpecialCharacterReplacer<'_> {
 /// the [`Regex`] that recognizes it.
 ///
 /// The rules are `pub(crate)` (via [`quote_subs`]) so the single-pass
-/// [`inline_builder`](crate::content::inline_builder) reuses the *exact* same
-/// patterns the string pipeline matches with — the design's core principle of
-/// changing the recognition *sink*, not the recognition itself (§4.1).
+/// [`inline_builder`](crate::content::inline_builder) reuses these *exact*
+/// same patterns rather than duplicating them at its own recognition sink.
 pub(crate) struct QuoteSub {
     pub(crate) type_: QuoteType,
     pub(crate) scope: QuoteScope,
@@ -441,9 +439,9 @@ impl<'p> AttributeReplacer<'p> {
     /// Records this step's `attribute-missing` diagnostic — unless the
     /// single-pass builder is going to record it instead.
     ///
-    /// The fifth and last of the recognition diagnostics the tree-walk replay
-    /// cannot carry (design §5.2 Phase 4, step 6): a dropped or warned-about
-    /// reference leaves no node to hang a diagnostic on, so the builder records
+    /// One of the recognition diagnostics the tree-walk replay cannot carry:
+    /// a dropped or warned-about reference leaves no node to hang a
+    /// diagnostic on, so the builder records
     /// it at its own recognition site (see
     /// [`apply_attribute_references`](crate::content::inline_builder)) and it
     /// is carried onto the real parser afterwards. A direct
@@ -712,10 +710,9 @@ pub(crate) fn substitute_attributes_in_reftext<'src>(
 /// [`CharacterReplacementType`] and the [`Regex`] that recognizes it.
 ///
 /// The rules are `pub(crate)` (via [`character_replacements`]) so the
-/// single-pass [`inline_builder`](crate::content::inline_builder) reuses the
-/// *exact* same patterns the string pipeline matches with — the design's core
-/// principle of changing the recognition *sink*, not the recognition itself
-/// (§4.1). This mirrors how [`quote_subs`] is shared.
+/// single-pass [`inline_builder`](crate::content::inline_builder) reuses these
+/// *exact* same patterns rather than duplicating them at its own recognition
+/// sink. This mirrors how [`quote_subs`] is shared.
 pub(crate) struct CharacterReplacement {
     pub(crate) type_: CharacterReplacementType,
     pub(crate) pattern: Regex,
@@ -938,8 +935,8 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     // Pins (and covers) the exhaustiveness arm in `SubstitutionStep::apply`:
-    // the five steps whose string implementations went with the pipeline
-    // refuse direct application rather than silently doing nothing.
+    // the five steps with no per-step implementation here refuse direct
+    // application rather than silently doing nothing.
     #[test]
     #[should_panic(expected = "the string implementation of Quotes is deleted")]
     fn a_deleted_steps_direct_application_is_refused() {

--- a/parser/src/inlines/anchor.rs
+++ b/parser/src/inlines/anchor.rs
@@ -3,9 +3,6 @@ use crate::{HasSpan, Span, inlines::InlineNode, strings::CowStr};
 /// An inline anchor (`[[id]]`, `[[id,reftext]]`, or `anchor:id[reftext]`), or
 /// the bibliography anchor (`[[[label]]]`, `[[[label,xreftext]]]`) that
 /// prefixes a bibliography list item.
-///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Anchor<'src> {
     /// The anchor's ID.
@@ -33,9 +30,9 @@ pub struct Anchor<'src> {
     /// `is_icon` tells its two forms apart.
     ///
     /// The bracketed label a bibliography anchor renders into the flow is
-    /// **not** this node's own children: it is emitted as the sibling text
-    /// nodes that follow, exactly as the string pipeline leaves that text in
-    /// the flow for its own later passes to see.
+    /// **not** this node's own children: it is built as the sibling text
+    /// nodes that follow this one, leaving that text in the flow for the
+    /// rest of the tree to see and render normally.
     pub is_bibliography: bool,
 
     /// The source location of the whole anchor.

--- a/parser/src/inlines/callout.rs
+++ b/parser/src/inlines/callout.rs
@@ -28,12 +28,11 @@ impl<'src> HasSpan<'src> for Callout<'src> {
 ///
 /// This used to be mirrored by a render-time `parser::CalloutGuard` that the
 /// fold converted into, on the reasoning that a node should stay canonical
-/// structured data rather than a render-seam type. Phase 5 retired that
-/// duplicate: with
-/// [`render_callout`](crate::parser::InlineRenderer::render_callout) taking
-/// the [`Callout`] node itself, the node *is* what the seam carries, and a
+/// structured data rather than a render-seam type. That duplicate is retired:
+/// [`render_callout`](crate::parser::InlineRenderer::render_callout) takes
+/// the [`Callout`] node itself, so the node *is* what the seam carries, and a
 /// second enum saying the same thing in `&str` where this one says
-/// [`CowStr`] bought nothing but a conversion.
+/// [`CowStr`] would buy nothing but a conversion.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CalloutGuard<'src> {
     /// A line-comment (or absent) guard. Holds the line-comment prefix that

--- a/parser/src/inlines/footnote.rs
+++ b/parser/src/inlines/footnote.rs
@@ -4,8 +4,7 @@ use crate::{HasSpan, Span, inlines::InlineNode, strings::CowStr};
 /// (`footnote:id[]`).
 ///
 /// The footnote's number is resolved into the node at parse time, so rendering
-/// stays a pure fold. Field set is provisional (Phase 0) and will be refined
-/// against the first consumer.
+/// stays a pure fold.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Footnote<'src> {
     /// The footnote's own ID, when it was given one.

--- a/parser/src/inlines/image.rs
+++ b/parser/src/inlines/image.rs
@@ -6,9 +6,6 @@ use crate::{HasSpan, Span, attributes::Attrlist, strings::CowStr};
 /// distinguishes them, because they render through different renderer methods
 /// (an icon consults the `icons`/`icontype` document attributes and carries a
 /// `size` rather than a `width`/`height`).
-///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Image<'src> {
     /// `true` for an `icon:` macro, `false` for an `image:` macro.
@@ -23,15 +20,12 @@ pub struct Image<'src> {
     /// crossed none.
     ///
     /// Path resolution must treat each such range as one opaque run rather
-    /// than as path syntax: the substitution pipeline resolves the `src` while
-    /// each masked construct is still its `\u{96}`*n*`\u{97}` sentinel and
-    /// splices the body in afterwards, so none of its bytes — a space
-    /// `web_path` would percent-encode, a backslash it would posixify, a `/`
-    /// or `.` its segment arithmetic would read — ever reaches the resolver.
-    /// The built-in renderer reproduces that order by masking these ranges
-    /// around its own `web_path` call — see
-    /// [`image_uri`](crate::parser::InlineRenderer::image_uri), which receives
-    /// them off this node.
+    /// than as path syntax, so that none of its bytes — a space `web_path`
+    /// would percent-encode, a backslash it would posixify, a `/` or `.` its
+    /// segment arithmetic would read — ever reaches the resolver. The
+    /// built-in renderer masks these ranges around its own `web_path` call —
+    /// see [`image_uri`](crate::parser::InlineRenderer::image_uri), which
+    /// receives them off this node.
     pub restored_target_ranges: Vec<std::ops::Range<usize>>,
 
     /// The alt text, explicit or defaulted.

--- a/parser/src/inlines/index_term.rs
+++ b/parser/src/inlines/index_term.rs
@@ -3,9 +3,8 @@ use crate::{HasSpan, Span, inlines::InlineNode, strings::CowStr};
 /// An index term (`((term))`, `(((primary, secondary, tertiary)))`,
 /// `indexterm:[…]`, or `indexterm2:[…]`).
 ///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer. The known gap is [`terms`](Self::terms), which holds less than
-/// its name promises — see that field.
+/// The known gap is [`terms`](Self::terms), which holds less than its name
+/// promises — see that field.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IndexTerm<'src> {
     /// The term levels, from primary to tertiary — the field's *intent*, and
@@ -23,9 +22,9 @@ pub struct IndexTerm<'src> {
     /// So a consumer building an index cannot yet recover the authored
     /// primary/secondary/tertiary levels of an `indexterm:[p, s, t]` or
     /// `(((p, s, t)))` — which are exactly the terms that exist *only* to be
-    /// indexed. Recording them is a change to what the builder parses, and is
-    /// the concrete work behind this type's provisional status; the field is
-    /// named and typed for it so that filling it in later is additive.
+    /// indexed. Recording them is a change to what the builder parses; the
+    /// field is named and typed for it so that filling it in later is
+    /// additive.
     pub terms: Vec<CowStr<'src>>,
 
     /// The shown text of a *visible* term, as the child inline nodes it

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -318,22 +318,20 @@ mod tests {
 /// Orthogonal to [`RawForm`], which says what the fold *does* with the bytes.
 /// This says who produced them, and it answers two different questions.
 ///
-/// For a **consumer**, it sharpens the security story design §3.4 gives this
-/// node kind. "This document emits raw HTML" is visible as `Raw` nodes in the
+/// For a **consumer**, it sharpens this node kind's own security story:
+/// "This document emits raw HTML" is visible as `Raw` nodes in the
 /// tree; whether that came from an author writing an explicit passthrough or
 /// from a substitution expanding an attribute value is the difference between a
 /// deliberate escape hatch and a value that may have arrived from elsewhere.
 ///
 /// For the **builder**, it is the difference between content the extraction
-/// pass is holding and content that is simply there. The string pipeline's own
-/// haystack carries a sentinel where a [`Passthrough`](Self::Passthrough)
-/// node's text belongs, and splices the real text back only when it rewrites
-/// the rendered string — so a *computed value* that reads those bytes before
-/// the restore (a cross-reference's target, captured into its deferred segment)
-/// sees the sentinel, while one that reads a
-/// [`Substitution`](Self::Substitution) node's bytes sees exactly what the
-/// replacer saw. Recording it on the node is what lets a recognition gate tell
-/// the two apart without having to know which pass it is running in.
+/// pass pulled out before any step ran and content a later step produced in
+/// place: a [`Substitution`](Self::Substitution) node's bytes are exactly
+/// what produced them (a literal `<`/`>`/`&` from an expanded attribute
+/// value, for instance), while a [`Passthrough`](Self::Passthrough) node's
+/// text was set aside up front. Recording which one produced a given node is
+/// what lets a recognition gate tell the two apart without re-deriving it
+/// from context.
 ///
 /// A [`Passthrough`](Self::Passthrough) additionally carries the two facts the
 /// extraction pass resolved for it, which nothing else in the tree records: the
@@ -378,9 +376,9 @@ pub enum RawOrigin {
 
     /// Raw output a substitution produced **in place**, with no extraction
     /// involved: a literal `<`, `>`, or `&` from an expanded attribute value
-    /// (which §3.4.1 leaves unescaped, since the value expands *after*
-    /// `specialcharacters` ran), a special an effective order never escaped, or
-    /// a slice of an entity's own bytes.
+    /// (left unescaped since the value expands *after* `specialcharacters`
+    /// ran), a special an effective order never escaped, or a slice of an
+    /// entity's own bytes.
     Substitution,
 }
 

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -1,24 +1,17 @@
 //! A first-class **inline AST**: the structured representation of the inline
 //! content of a leaf block.
 //!
-//! This module defines the public node vocabulary described in the [inline AST
-//! architecture] design document. It is aligned with the Eclipse AsciiDoc
-//! Language project's [Abstract Semantic Graph (ASG)]: the ASG's small inline
-//! core — `span` / `ref` / `text` / `charref` / `raw` — forms the spine, and
-//! the constructs this crate supports beyond that core (images, footnotes, UI
-//! macros, index terms, callouts, anchors, line breaks, and STEM) are modeled
-//! as additional variants that project down to ASG-legal nodes when emitting
-//! conformant ASG.
+//! This module defines the public node vocabulary. It is aligned with the
+//! Eclipse AsciiDoc Language project's [Abstract Semantic Graph (ASG)]: the
+//! ASG's small inline core — `span` / `ref` / `text` / `charref` / `raw` —
+//! forms the spine, and the constructs this crate supports beyond that core
+//! (images, footnotes, UI macros, index terms, callouts, anchors, line
+//! breaks, and STEM) are modeled as additional variants that project down to
+//! ASG-legal nodes when emitting conformant ASG.
 //!
-//! # Status: skeleton (Phase 0)
-//!
-//! These are **types only, with no wiring.** Nothing in the parser or the
-//! rendering pipeline produces or consumes them yet; [`Content`] still exposes
-//! inline content as a rendered string. The types are landed first so the
-//! public shape can be reviewed and the later phases — building the tree,
-//! making it canonical, and folding it back to HTML — can proceed against a
-//! stable vocabulary. Field sets on the crate-extension nodes are provisional
-//! and will be refined against the first real consumer.
+//! This tree is the crate's single inline representation, built directly from
+//! source; both [`Content::rendered_html`] and every macro family's
+//! catalog/warning registration are derived from it.
 //!
 //! # Logical text, not output text
 //!
@@ -27,9 +20,8 @@
 //! meaning of the ASG's `text` / `charref` / `raw` trichotomy, captured here by
 //! [`InlineNode::Text`], [`InlineNode::CharRef`], and [`InlineNode::Raw`].
 //!
-//! [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
 //! [Abstract Semantic Graph (ASG)]: https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/blob/main/asg/schema.json
-//! [`Content`]: crate::content::Content
+//! [`Content::rendered_html`]: crate::content::Content::rendered_html
 
 mod anchor;
 pub use anchor::Anchor;

--- a/parser/src/inlines/ref_node.rs
+++ b/parser/src/inlines/ref_node.rs
@@ -60,10 +60,9 @@ pub struct Ref<'src> {
     /// For a cross-reference whose target names another document, or the
     /// empty target naming the current document as a whole, the destination
     /// derived from the target itself — computed once, at build time, without
-    /// consulting any catalog (mirroring the string pipeline's own target
-    /// interpretation). `None` for a same-document reference to a specific id,
-    /// which resolves through [`resolved`](Self::resolved) instead, and always
-    /// `None` for a [`Link`](RefVariant::Link).
+    /// consulting any catalog. `None` for a same-document reference to a
+    /// specific id, which resolves through [`resolved`](Self::resolved)
+    /// instead, and always `None` for a [`Link`](RefVariant::Link).
     pub derived: Option<DerivedReference>,
 
     /// For a cross-reference, the **effective** `xrefstyle`: the
@@ -81,10 +80,9 @@ pub struct Ref<'src> {
     /// effect at the end of the parse. Reading it at fold time would therefore
     /// re-style a reference whenever the fold runs later than the parse — which
     /// is precisely what a re-fold at reference-resolution time does. Resolving
-    /// it into the node is design §3.3.1 point 1 (rendering is a pure fold,
-    /// with every order-dependent fact already resolved into node values),
-    /// and it is the same reading `InlineXrefReplacer` makes, in the same
-    /// pass.
+    /// it into the node keeps rendering a pure fold, with every
+    /// order-dependent fact already resolved into node values before the
+    /// fold ever runs.
     ///
     /// The `<<id>>` shorthand carries no attribute-list text, so its effective
     /// style is always the document-wide one.

--- a/parser/src/inlines/stem.rs
+++ b/parser/src/inlines/stem.rs
@@ -1,9 +1,6 @@
 use crate::{HasSpan, Span, content::SubstitutionGroup, inlines::InlineNode, strings::CowStr};
 
 /// Inline STEM content (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`).
-///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stem<'src> {
     /// The notation the expression is written in.

--- a/parser/src/inlines/ui.rs
+++ b/parser/src/inlines/ui.rs
@@ -6,13 +6,9 @@ use crate::{HasSpan, Span, strings::CowStr};
 /// menu's name, submenu path, and item — is held in **already-substituted**
 /// form, i.e. with special characters escaped (`kbd:[Ctrl&C]`'s single key is
 /// `Ctrl&amp;C`) and author-written entities kept as written. That is the form
-/// the renderer emits verbatim, and the form the string pipeline's own render
-/// parameters carry; it is not the *logical* text a
+/// the renderer emits verbatim; it is not the *logical* text a
 /// [`Text`](super::InlineNode::Text) node holds, which the fold escapes. An
 /// [`IndexTerm`](super::IndexTerm)'s `terms` use the same contract.
-///
-/// Field set is provisional (Phase 0) and will be refined against the first
-/// consumer.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ui<'src> {
     /// Which UI macro this is, with its parsed contents.


### PR DESCRIPTION
## Summary

- The `inline-ast` branch's tree builder is now the single source of truth for both rendering and every macro family's catalog/warning registration — the old string-substitution implementation and its three Unicode-sentinel hacks are fully retired from production code. A lot of doc comments and inline comments across `parser/src/content` and `parser/src/inlines`, though, were written *during* that migration and still describe things in terms of its stages: bare `design §X.Y` citations into `docs/design/inline-ast-architecture.md`, `Phase N`/`step N` references, `Strategy A`/`Strategy B` naming, the word "cutover", things described as "staged"/"not yet wired", and comparisons phrased as "the string pipeline does X" as if that system still ran.
- Rewrites those references across every file in `parser/src/content` and `parser/src/inlines` to state the crate's current, final behavior directly instead. Where genuine history is worth keeping (why a divergence from Asciidoctor is intentional, why a mechanism looks the way it does), it's now phrased as a brief past-tense clause, matching the style already established in `parser/snapshots/README.md`.
- Adds a new `parser/src/content/inline_builder/README.md` holding the inline-builder module's background (the move from string rewriting to a tree, the escaping-order rule several steps refer to, how a construct with no `Span`-typed field recovers its text from a match string) so code comments can point at it instead of re-narrating the history inline, and trims `inline_builder/mod.rs`'s own module doc to match.
- Along the way, corrected a handful of doc comments that weren't just stale in *tone* but factually wrong relative to current code: `inline_builder/mod.rs`'s header still claimed `rendered_html()` was "still produced by the string pipeline" and described macro-family side-effect registration as "staged" and not yet called from any real parse path — both are false today (`substitution_group.rs`'s `apply_inner` calls `apply_macro_side_effects`/`apply_callout_side_effects` unconditionally), which also meant two `#[allow(unused_imports)]` markers on now-genuinely-used re-exports were dead and are removed. `content.rs`'s `block_tree_xref_segments` doc still described a dead `run_pipeline`/`InlineXrefReplacer`. A few other files had similar drift (a doc claiming a diagnostic was "deferred to the cutover" when the code already raises it directly, a doc claiming cross-reference resolution wasn't wired into the tree when it already is, a claim about which forms were "later increments" when the code already handles them).
- No logic, identifiers, or test-assertion *values* changed — only comments, doc comments, and a handful of `assert_eq!`/`assert!` panic-message strings (e.g. `"fold diverged from the string pipeline for {source:?}"` → `"fold diverged from golden for {source:?}"`).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets`
- [x] `cargo test --workspace` (5485 passed, 0 failed)
- [x] `cargo +nightly doc --no-deps --document-private-items` (no broken intra-doc links)
- [x] Coverage diff (`cargo llvm-cov -p asciidoc-parser --lib`) against `origin/inline-ast`: identical missed counts (544 lines / 39 functions / 320 regions missed on both), confirming the change is coverage-neutral as expected for a comment-only rewrite.
- [x] Full-repo grep sweep for the flagged patterns (`design §`, bare `§N`, `Phase N`/`step N`, `string pipeline`/`string replacer`, `Strategy A`/`B`, `cutover`, `staged`/`staging`, `sentinel`) across `parser/src/content` and `parser/src/inlines`: every remaining hit is either a code identifier (e.g. `escape_passthrough_sentinels`, a currently-live function name) or an already-correct past-tense historical mention.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191PbZg2aTw8atGxgBH8nvu)_