### PR TITLE
chore: Close the masked-piece offset-table follow-up as rejected

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -12033,7 +12033,10 @@ has its own internal attribute-reference re-substitution (for a literal `{missin
 `attribute-missing=skip`/`warn` policy leaves behind), which can in principle shift byte
 offsets inside the very string `tokened_bracket`'s table would be computed against, and ruling
 that out — or handling it — needs more validation than this increment's scope covered. Left as
-open follow-up work, not silently dropped.
+open follow-up work, not silently dropped. **Closed since:** that validation ran as its own
+increment and the move is rejected — see "The masked-piece placeholder's offset table cannot be
+carried through `Attrlist::parse`" below, which also corrects the claim two paragraphs up about
+the typed-in-the-clear case being covered.
 
 `cargo test --workspace` is green (5,485 tests in the library crate, three more than before —
 the same shorthand-role and cross-attribute-offset assertions folded into extended existing
@@ -12046,6 +12049,101 @@ shape's "malformed token" case no longer exists to reach it by a different path 
 `image.rs`'s own sentinel-shaped-bytes test was extended with a case exercising it directly
 (an author-typed adjacent pair after a bracket's only real passthrough already spent the one
 body supplied).
+
+##### The masked-piece placeholder's offset table cannot be carried through `Attrlist::parse` (2026-08-30)
+
+The open follow-up the note above left — "carry `tokened_bracket`'s own byte-offset table
+through `Attrlist::parse`'s split, so restoration never re-scans text for the placeholder's
+byte value at all" — was taken up as its own increment and **investigated and rejected**. The
+spike is written down here in full rather than merely deferred again, because the reasoning is
+the kind that gets re-litigated from scratch otherwise: the idea is genuinely attractive (it is
+exactly the property `quotes.rs`'s `Piece` table has one layer up, and it would let
+`escape_passthrough_sentinels` be deleted rather than merely widened), and the two things that
+kill it are both invisible from the call site.
+
+*Blocker 1 — `Attrlist::parse`'s own attribute-reference re-substitution runs on tokened text,
+and does change its length.* The note above guessed at this ("can in principle shift byte
+offsets") and named `attribute-missing=skip`/`warn`'s literal `{missing}` as the shape to
+worry about. That particular shape is harmless — a policy that leaves a reference literal
+leaves it the same length — but the real one is not, and is not exotic. `Attrlist::parse`
+substitutes whenever the text it is handed holds both a `{` and a `}`, and a `subs=` list
+naming `macros` without `attributes` reaches the macros step with *every* reference still
+unresolved, because the content-level pass never ran. The inner substitution is then the one
+that expands them, after `tokened_bracket` has already written its placeholder into the same
+string. Measured on `[subs=macros]` + `image:x.png[alt={name},title=++real++]` with `:name:
+a-much-longer-value`: the tokener writes `alt={name},title=\u{96}\u{97}` and the split reads
+`alt=a-much-longer-value,title=\u{96}\u{97}` — the occurrence sits at byte 30 where the table
+would record byte 17. Ordinal restoration is indifferent to this (the occurrence *count*
+either side of an expansion is unchanged, which is why this renders correctly today); a byte
+-offset table is not. Pinned by
+`an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`
+(`tests/sentinels.rs`), in both the image and link spellings.
+
+*Blocker 2 — a parsed value is not a slice of the text that was split, and nothing reports the
+mapping.* This one is independent of blocker 1, holds for text containing no brace at all, and
+is the decisive one, because it also rules out the obvious sidestep (trust the table only when
+the tokened text provably holds no `{`/`}`, and fall back to the guarded re-scan otherwise —
+which would keep `escape_passthrough_sentinels` alive anyway, defeating the purpose).
+`Attrlist::parse`'s entry loop does hand out `(start_index, new_index)` byte ranges, but the
+value inside one is derived by `ElementAttribute::parse` through a chain of rewrites it does
+not report: leading whitespace skipped, the name and `=` stripped, the quotes stripped, `\"`
+rewritten to `"` by a plain `String::replace`, trailing spaces trimmed — and, for a
+single-quoted value in a *block* attrlist, a whole `SubstitutionGroup::Normal` pass (out of
+reach for the tokened path, which is `AttrlistContext::Inline`, but it is the same return
+signature). What comes back is `(attribute, end_offset, warnings)` and nothing else. Remapping
+tokened coordinates into value coordinates would therefore mean threading a byte mapping out of
+`ElementAttribute::parse`, and into `take_quoted_string`, the `replace`, and
+`trim_item_trailing_spaces` — and then again through `parse_shorthand_items`,
+`split_role_value`, and `roles_with_token_offset`, each of which slices the value further.
+That is a side channel through most of `attributes/`, several increments' worth, in service of
+deleting one guard. Pinned by
+`a_quoted_values_own_unescape_moves_a_placeholder_in_the_parsed_value` (`tests/sentinels.rs`):
+`image:x.png[alt="a \" b ++real++ c"]` shortens the value by one byte ahead of the placeholder,
+with no brace anywhere in the bracket.
+
+*What the spike found on the way — the guard is not the whole defense.* `restore_into`'s
+positional walk cannot tell a genuine occurrence from any other, and
+`escape_passthrough_sentinels` guards exactly **one** road to a forged one: a value spliced in
+by `split_attribute_value`, the attribute-reference step's content-level splice. A document
+that types the pair *in the clear* inside the bracket never passes through that splice, so
+nothing escapes it — and ahead of a real masked piece it captures that piece's body just as a
+spliced forgery would. `image:x.png[alt=\u{96}\u{97},++real++]` renders `alt="real"
+width="\u{96}\u{97}"`, and `link:x[role=\u{96}\u{97},++real++]` renders `class="bare real"` with
+the display text collapsed to the target. The note above asserted the pair's collision
+resistance and extended `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched` to
+cover it, but only in the order where the typed pair sits *behind* the bracket's one real piece
+— by which point `bodies` is spent and `restore_tokens`' leniency keeps it literal. The
+forging order is the other one, and it was not covered. It is recorded rather than fixed here
+(fixing it is a mechanism change, and this increment is a spike):
+`a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore` (`tests/sentinels.rs`)
+pins the current behavior in both families, named so it reads as the gap it is.
+
+The same spike found the two `a_placeholder_from_an_attribute_value_cannot_forge_*` regressions
+had gone stale in exactly the way that hides this: both still spelled the *retired*
+digit-carrying shape (`\u{96}0\u{97}`) and both put the forgery behind the real passthrough, so
+both passed with `escape_passthrough_sentinels` deleted — they were pinning the escape's output,
+not the forgery it prevents. Retargeted here to the two-codepoint pair in the forging order;
+both now fail on their own "must not restore the passthrough's body" assertion when the guard is
+removed, which is what they were always meant to say.
+
+*Where this leaves the mechanism.* `escape_passthrough_sentinels` stays, as documented,
+intentional debt rather than an oversight, and the byte-offset table is closed rather than
+deferred. The move that *would* get the construction-time property the table was after is a
+different one, and it is the recommended next increment: escape the placeholder's codepoints in
+the bytes `tokened_bracket`/`tokened_text` **copy** from their non-tokened pieces, at the one
+moment provenance is still known — after which every occurrence in the tokened text is one the
+tokener itself wrote, by construction, with no coordinates to carry through anything. It is
+strictly stronger than today's guard (it closes the typed-in-the-clear road as well as the
+spliced one, and being two-way it would let a typed pair round-trip to the output instead of
+arriving escaped), and it lets `escape_passthrough_sentinels` and its `split_attribute_value`
+call site go. Its cost is the un-escape, which has to happen at every consumer of a tokened
+parse and must not be missed at any: `restore_into`'s both paths (including the
+no-placeholder early return), `untranslated_value`, `restored_value_children` /
+`computed_value_children`, `TextAttrlist::text`, and `Attrlist::source_text`. That audit is
+the increment.
+
+`cargo test --workspace` is green. No production code changed: this increment is the two
+evidence fixtures, the open-gap fixture, the two retargeted regressions, and this note.
 
 ##### Phase 3's first criterion cannot close before Landing
 
@@ -12072,7 +12170,10 @@ policies written down; §4.6's stale sentence (done here); the `escape_sentinels
 `RESERVED_SENTINELS` table under it (done — see the sentinel table's own landed-as note
 above). Firm and substantial: the last
 `XrefRenderParams` fold (Phase 5) — the xref template mechanism itself is retired now, both
-halves. Open-ended: the `asciidoctor`-port review, which gates both Phase 3 and Landing and
+halves — and the masked-piece placeholder's provenance fix (escape at the tokener rather than
+at the content-level splice), newly enumerated by the offset-table spike's own note above,
+which is a mechanism change plus an audit of every consumer of a tokened parse. Open-ended:
+the `asciidoctor`-port review, which gates both Phase 3 and Landing and
 whose cost is unknown from inside this repository. Any session count that does not separate
 those three tiers is guessing.
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -1019,6 +1019,59 @@ mod tests {
     }
 
     #[test]
+    fn attribute_reference_substitution_shifts_a_placeholder_byte_offset_in_source_text() {
+        // Direct evidence for the design doc's "The masked-piece placeholder's
+        // offset table cannot be carried through `Attrlist::parse`" note's
+        // first blocker, checked against this method's own `source_text()`
+        // rather than only a full document's final rendered HTML (as
+        // `tests/sentinels.rs`'s
+        // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`
+        // does) — so a future change to how this substitution works cannot
+        // silently stop supporting the claim while rendering still happens to
+        // come out right.
+        //
+        // `tokened_bracket`/`tokened_text` would write
+        // `MASKED_PIECE_PLACEHOLDER` at byte 17 of
+        // `alt={name},title=<placeholder>` — right after `title=`. This
+        // method's own attribute-reference substitution
+        // expands `{name}` before splitting entries — unconditional whenever
+        // the text holds both a `{` and a `}` — so the placeholder the parsed
+        // entries actually see has moved by however much longer the expanded
+        // `alt` value is than the reference that named it.
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let p = Parser::default().with_intrinsic_attribute(
+            "name",
+            "a-much-longer-value",
+            ModificationContext::Anywhere,
+        );
+
+        let source = format!("alt={{name}},title={MASKED_PIECE_PLACEHOLDER}");
+        let written_offset = source.find(MASKED_PIECE_PLACEHOLDER).unwrap();
+        assert_eq!(written_offset, 17);
+
+        let attrlist = crate::attributes::Attrlist::parse(
+            crate::Span::new(&source),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        let split_offset = attrlist
+            .source_text()
+            .find(MASKED_PIECE_PLACEHOLDER)
+            .unwrap();
+
+        assert_eq!(
+            split_offset,
+            30,
+            "the substitution's own extra length must have moved the placeholder: {:?}",
+            attrlist.source_text()
+        );
+    }
+
+    #[test]
     fn token_offset_helpers_count_placeholders_before_the_target_attribute() {
         // Two masked pieces (each one `MASKED_PIECE_PLACEHOLDER` occurrence,
         // as `tokened_bracket`/`tokened_text` would leave it before a

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -822,6 +822,17 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// escape each codepoint on its own — a forged value contributing only one
 /// half, beside the other half from an unrelated source, would complete the
 /// same pair.
+///
+/// "Unlikely", though, is the whole of what the pair buys: a document that
+/// *does* type both codepoints adjacent, in the clear, **ahead** of a real
+/// masked piece in the same bracket takes that piece's body — the escape
+/// guard guards the attribute-reference splice only, and this byte never
+/// passes through it. Pinned as a known gap by
+/// `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`
+/// (`tests/sentinels.rs`); the fix is provenance at the tokener rather than a
+/// wider escape, and is written up in the design doc's "The masked-piece
+/// placeholder's offset table cannot be carried through `Attrlist::parse`"
+/// note.
 pub(crate) const MASKED_PIECE_PLACEHOLDER_START: char = '\u{96}';
 
 /// See [`MASKED_PIECE_PLACEHOLDER`].

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -992,6 +992,48 @@ mod tests {
     }
 
     #[test]
+    fn quoted_values_own_unescape_shortens_a_value_by_one_byte_ahead_of_a_placeholder() {
+        // Direct evidence for the design doc's "The masked-piece placeholder's
+        // offset table cannot be carried through `Attrlist::parse`" note's
+        // second blocker, checked against this method's own parsed value
+        // rather than only a full document's final rendered HTML (as
+        // `tests/sentinels.rs`'s
+        // `a_quoted_values_own_unescape_moves_a_placeholder_in_the_parsed_value`
+        // does). `\"` is rewritten to `"` by a plain `String::replace` on the
+        // way to a quoted value — one byte shorter than what it replaces —
+        // and that rewrite is not reported back anywhere a caller could use
+        // to remap a byte offset recorded against the source it parsed.
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let source = format!(r#"alt="a \" b {MASKED_PIECE_PLACEHOLDER} c""#);
+        let written_offset = source.find(MASKED_PIECE_PLACEHOLDER).unwrap();
+
+        let p = Parser::default();
+        let (attr, _offset, warning_types) = crate::attributes::ElementAttribute::parse(
+            &CowStr::from(source.as_str()),
+            0,
+            &p,
+            ParseShorthand(false),
+            AttrlistContext::Inline,
+        );
+
+        assert!(warning_types.is_empty());
+        assert!(attr.value_is_quoted());
+
+        let parsed_offset = attr.value().find(MASKED_PIECE_PLACEHOLDER).unwrap();
+
+        // `alt="` (5 bytes) is stripped entirely, since the parsed value
+        // holds only the entry's own content; the `\"` -> `"` unescape ahead
+        // of the placeholder accounts for the other byte.
+        assert_eq!(
+            parsed_offset,
+            written_offset - 5 - 1,
+            "the value's own unescape must shorten it by one byte ahead of the placeholder: {:?}",
+            attr.value()
+        );
+    }
+
+    #[test]
     fn empty_source() {
         let p = Parser::default();
 

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1271,6 +1271,28 @@ fn split_attribute_value<'src>(
 ///
 /// Text with none of the three reserved codepoints — the overwhelming
 /// majority — is borrowed through unchanged.
+///
+/// # Known limits — documented, intentional debt
+///
+/// This guards **one** road to a forged occurrence: a value this step splices
+/// in. A document that types the pair in the clear inside a macro bracket
+/// never reaches this function, and ahead of a real masked piece it forges the
+/// same restore (`tests/sentinels.rs`'s
+/// `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`). The
+/// structural cure — capture each occurrence's provenance where it is written
+/// instead of re-deriving it from bytes, which is what `quotes.rs`'s `Piece`
+/// table does one layer up — was investigated as a byte-offset table carried
+/// through `Attrlist::parse` and **rejected**: that parse re-substitutes
+/// attribute references over the tokened text (length-changing under any
+/// `subs=` list naming `macros` without `attributes`), and a parsed value is
+/// not a slice of the split text in any case, since
+/// [`ElementAttribute::parse`](crate::attributes::ElementAttribute) derives it
+/// through unreported rewrites. Both are pinned by fixtures in
+/// `tests/sentinels.rs`, and the full reasoning — including the alternative
+/// that *would* work, escaping in the bytes `tokened_bracket`/`tokened_text`
+/// copy rather than in this splice — is in the design doc's "The masked-piece
+/// placeholder's offset table cannot be carried through `Attrlist::parse`"
+/// note. Until that lands, this stays.
 fn escape_passthrough_sentinels(value: &str) -> Cow<'_, str> {
     const ESCAPE: char = '\u{E005}';
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2196,6 +2196,14 @@ mod tests {
         // the cursor is already past `bodies.len()` by the time the typed
         // pair is reached, and `restore_tokens`' own leniency for that case
         // is what keeps it literal instead of panicking or misattributing.
+        //
+        // The leniency is *order-dependent*, and only this order is safe: a
+        // typed pair **ahead** of the bracket's real masked piece reaches an
+        // unspent `bodies` and takes that piece's body. That is a known gap,
+        // pinned by
+        // `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`
+        // (`tests/sentinels.rs`) — see `escape_passthrough_sentinels`' own
+        // "Known limits" section for why it is open.
         let nodes = build_src(Span::new("image:x.png[++a++ \u{96}\u{97}]"));
         let image = assert_image(&nodes[0]);
 

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -23,6 +23,17 @@
 //!     read back as the parser's own; and
 //!   * the typed codepoints reach the output unchanged, since a Private Use
 //!     Area character is content like any other.
+//!
+//! One byte-pattern mechanism is still live, and the last five tests here are
+//! about it rather than about issue #1235: `tokened_bracket`/`tokened_text`
+//! write a `MASKED_PIECE_PLACEHOLDER` pair per masked piece into the text
+//! `Attrlist::parse` splits, and every reader recovers which piece an
+//! occurrence stands for by counting occurrences in the parsed text. Two of
+//! those tests pin `escape_passthrough_sentinels`, the guard on the one road a
+//! forged occurrence can take today; one records the road it does *not* guard;
+//! and two pin the inputs that rule out replacing the whole scheme with a
+//! byte-offset table (see the design doc's "The masked-piece placeholder's
+//! offset table cannot be carried through `Attrlist::parse`" note).
 
 use crate::{
     Document, Parser,
@@ -124,15 +135,26 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
     // occurrence (`tokened_bracket`/`Attrlist::into_owned_restoring`), rather
     // than by node structure. An attribute reference is substituted into the
     // bracket *before* the image macro is even recognized, so an attribute
-    // whose value happens to spell that same byte — sitting in the same
+    // whose value happens to spell that same pair — sitting in the same
     // bracket as a real passthrough — would otherwise be indistinguishable
     // from the pipeline's own placeholder and splice the passthrough's
     // rendered body into `alt` instead of the literal text the document
     // defined.
+    //
+    // The forged value has to spell the placeholder **exactly**
+    // (`MASKED_PIECE_PLACEHOLDER`'s own two adjacent codepoints, no digit
+    // between them) and has to sit **ahead** of the real masked piece in the
+    // list's own parse order: the restore walks a shared cursor left to
+    // right, so a forgery behind the real piece only reaches an already
+    // spent `bodies` and is copied through by `restore_tokens`' leniency
+    // instead. Both halves matter — this test spelled the retired
+    // digit-carrying shape in the other order until 2026-08-30 and passed
+    // with the escape guard removed, pinning the escape's *output* rather
+    // than the forgery it exists to prevent.
     let doc = Parser::default().parse(concat!(
-        ":forge: \u{96}0\u{97}\n",
+        ":forge: \u{96}\u{97}\n",
         "\n",
-        "image:x.png[++real++,alt={forge}]\n",
+        "image:x.png[alt={forge},++real++]\n",
     ));
 
     let rendered = last_paragraph(&doc);
@@ -141,9 +163,125 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
         !rendered.contains("alt=\"real\""),
         "the forged attribute value must not restore the passthrough's body: {rendered:?}"
     );
+
+    // The genuine occurrence keeps the one body supplied, in the positional
+    // slot it actually stands in (`width`), and the forged value reaches the
+    // output escaped.
     assert_eq!(
         rendered,
-        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{e005}s0\u{e005}e\"></span>"
+        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{e005}s\u{e005}e\" width=\"real\"></span>"
+    );
+}
+
+#[test]
+fn a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore() {
+    // The **open** half of the same hole, pinned rather than fixed (see the
+    // design doc's "The masked-piece placeholder's offset table cannot be
+    // carried through `Attrlist::parse`" note).
+    //
+    // `escape_passthrough_sentinels` guards exactly one road to a forged
+    // placeholder: a value spliced in by `split_attribute_value`, the
+    // attribute-reference step's own content-level splice. A document that
+    // types the pair **in the clear** inside the bracket never passes through
+    // that splice, so nothing escapes it — and ahead of a real masked piece
+    // it captures that piece's body exactly as a spliced forgery would.
+    //
+    // `image.rs`'s
+    // `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched`
+    // covers the *other* order (a typed pair behind the only real piece,
+    // where `bodies` is already spent and the leniency keeps it literal),
+    // which is why this one went unnoticed. The fix is the mechanism change
+    // the design-doc note recommends — escaping the placeholder codepoints in
+    // the bytes `tokened_bracket`/`tokened_text` *copy*, so every occurrence
+    // in the tokened text is one the tokener itself wrote — and it is a
+    // separate increment; until it lands this test records the behavior
+    // rather than blessing it.
+    let doc = Parser::default().parse("image:x.png[alt=\u{96}\u{97},++real++]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"real\" width=\"\u{96}\u{97}\"></span>",
+        "known gap: the typed pair captured the passthrough's body"
+    );
+
+    // The link family's display-text list shares `tokened_bracket`, so it
+    // shares the gap: the typed pair takes `++real++`'s body as the role, and
+    // the display text falls back to the target.
+    let doc = Parser::default().parse("link:x[role=\u{96}\u{97},++real++]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"x\" class=\"bare real\">x</a>",
+        "known gap: the typed pair captured the passthrough's body"
+    );
+}
+
+#[test]
+fn an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text() {
+    // Evidence for the design-doc note named above: the byte offsets
+    // `tokened_bracket` could record for the occurrences it writes are not
+    // stable across the parse that consumes them.
+    //
+    // `Attrlist::parse` runs an attribute-reference substitution of its own
+    // over the text it is handed, whenever that text holds both a `{` and a
+    // `}`. A `subs=` list naming `macros` but not `attributes` reaches the
+    // macros step with every reference still unresolved — the content-level
+    // pass never ran — so that inner substitution is the one that expands
+    // `{name}` here, *after* `tokened_bracket` has already written its
+    // placeholder into the same string. The text splits as
+    // `alt=a-much-longer-value,title=\u{96}\u{97}` where the tokener wrote
+    // `alt={name},title=\u{96}\u{97}`: the occurrence sits at byte 30, not at
+    // byte 17.
+    //
+    // Restoration by *position* is unaffected — the occurrence count either
+    // side of the expansion is what it walks — which is why this renders
+    // correctly today and would not under a byte-offset table.
+    let doc = Parser::default().parse(concat!(
+        ":name: a-much-longer-value\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={name},title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"a-much-longer-value\" title=\"real\"></span>"
+    );
+
+    // The link family's display-text list reaches the same inner
+    // substitution through the same `Attrlist::parse` call.
+    let doc = Parser::default().parse(concat!(
+        ":name: a-much-longer-value\n",
+        "\n",
+        "[subs=macros]\n",
+        "link:x[++real++,role={name}]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"x\" class=\"a-much-longer-value\">real</a>"
+    );
+}
+
+#[test]
+fn a_quoted_values_own_unescape_moves_a_placeholder_in_the_parsed_value() {
+    // The second, brace-independent half of the same evidence.
+    //
+    // Even if the text `Attrlist::parse` splits were byte-identical to what
+    // `tokened_bracket` wrote, a *parsed value* is not a slice of it:
+    // `ElementAttribute::parse` skips leading whitespace, strips the name and
+    // `=`, strips the quotes, rewrites `\"` to `"` with a plain
+    // `String::replace`, and trims trailing spaces — and reports none of
+    // that back, returning only the attribute and the offset the entry ends
+    // at. The `\"` here sits ahead of the placeholder and shortens the value
+    // by one byte, so an offset recorded against the tokened text lands one
+    // byte late inside the value even before the four bytes `alt="` accounts
+    // for.
+    let doc = Parser::default().parse("image:x.png[alt=\"a \\\" b ++real++ c\"]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"a &quot; b real c\"></span>"
     );
 }
 
@@ -151,25 +289,29 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
 fn a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restore() {
     // The `link:` macro's display-text list shares `tokened_bracket` and
     // `Attrlist::into_owned_restoring` with the image family's bracket (see
-    // `a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore`),
-    // so the same forgery would reach it through a `role=` attribute sitting
-    // beside a real passthrough in the same display-text list, absent the
-    // same escape guard.
+    // `a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore`,
+    // including why the forged value has to spell the pair exactly and sit
+    // ahead of the real passthrough), so the same forgery reaches it through
+    // a `role=` attribute sitting beside a real passthrough in the same
+    // display-text list, absent the same escape guard.
     let doc = Parser::default().parse(concat!(
-        ":forge: \u{96}0\u{97}\n",
+        ":forge: \u{96}\u{97}\n",
         "\n",
-        "link:x[++real++,role={forge}]\n",
+        "link:x[role={forge},++real++]\n",
     ));
 
     let rendered = last_paragraph(&doc);
 
     assert!(
-        !rendered.contains("class=\"real\""),
+        !rendered.contains("class=\"bare real\""),
         "the forged attribute value must not restore the passthrough's body: {rendered:?}"
     );
+
+    // With no positional attribute left to be the display text, the target
+    // stands in for it and the auto-link `bare` role joins the escaped one.
     assert_eq!(
         rendered,
-        "<a href=\"x\" class=\"\u{e005}s0\u{e005}e\">real</a>"
+        "<a href=\"x\" class=\"bare \u{e005}s\u{e005}e\">x</a>"
     );
 }
 


### PR DESCRIPTION
PR #1349 closed with an open follow-up: *"Eliminating the guard outright would need the harder structural move: carry `tokened_bracket`'s own byte-offset table through `Attrlist::parse`'s split, so restoration never re-scans text for the placeholder's byte value at all… Left as open follow-up work, not silently dropped."*

This increment takes it up, **spikes it, and rejects it** — with the evidence checked in so it does not get re-litigated from scratch. No production code path changes; the diff is two evidence fixtures, one open-gap fixture, two retargeted regressions, and documentation.

## Why the offset table doesn't work

**Blocker 1 — `Attrlist::parse`'s own attribute-reference re-substitution runs on the tokened text, and *does* change its length.**

#1349 guessed at this and named `attribute-missing=skip`/`warn`'s literal `{missing}` as the shape to worry about. That shape is harmless (a policy that leaves a reference literal leaves it the same length). The real one is not, and is not exotic: `Attrlist::parse` substitutes whenever the text it is handed holds both a `{` and a `}`, and a `subs=` list naming `macros` without `attributes` reaches the macros step with **every** reference still unresolved, because the content-level pass never ran. That inner substitution is then the one that expands them — after `tokened_bracket` has already written its placeholder into the same string.

Measured on `[subs=macros]` + `image:x.png[alt={name},title=++real++]` with `:name: a-much-longer-value`:

```
tokener writes:  "alt={name},title=\u{96}\u{97}"          placeholder at byte 17
the split reads: "alt=a-much-longer-value,title=\u{96}\u{97}"  placeholder at byte 30
```

Ordinal restoration is indifferent to this — the occurrence *count* either side of an expansion is unchanged, which is why it renders correctly today. A byte-offset table is not.

**Blocker 2 — a parsed value is not a slice of the text that was split, and nothing reports the mapping.**

Independent of blocker 1, holds for text with no brace at all, and decisive — it also rules out the obvious sidestep (trust the table only when the tokened text provably holds no `{`/`}`, falling back to the guarded re-scan otherwise, which keeps `escape_passthrough_sentinels` alive anyway and so defeats the purpose).

`Attrlist::parse`'s entry loop does hand out `(start_index, new_index)` ranges, but the value inside one is derived by `ElementAttribute::parse` through a chain of rewrites it does not report: leading whitespace skipped, name and `=` stripped, quotes stripped, `\"` rewritten to `"` by a plain `String::replace`, trailing spaces trimmed. It returns `(attribute, end_offset, warnings)` and nothing else. Remapping would mean threading a byte mapping out of `ElementAttribute::parse` and into `take_quoted_string`, the `replace`, and `trim_item_trailing_spaces` — then again through `parse_shorthand_items`, `split_role_value`, and `roles_with_token_offset`. A side channel through most of `attributes/`, several increments' worth, to delete one guard.

Pinned by `image:x.png[alt="a \" b ++real++ c"]`: the `\"` shortens the value by one byte ahead of the placeholder, with no brace anywhere in the bracket.

## What the spike found on the way

**The guard is not the whole defense.** `escape_passthrough_sentinels` guards exactly one road to a forged occurrence: a value spliced in by `split_attribute_value`. A document that types the pair *in the clear* inside a bracket never passes through that splice, so nothing escapes it — and ahead of a real masked piece it captures that piece's body just as a spliced forgery would:

```
image:x.png[alt=\u{96}\u{97},++real++]  →  alt="real" width="\u{96}\u{97}"
link:x[role=\u{96}\u{97},++real++]      →  <a href="x" class="bare real">x</a>
```

#1349 extended `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched` to cover the typed pair, but only in the order where it sits *behind* the bracket's one real piece — by which point `bodies` is spent and `restore_tokens`' leniency keeps it literal. The forging order is the other one. Recorded rather than fixed here (fixing it is a mechanism change; this increment is a spike).

**Both `a_placeholder_from_an_attribute_value_cannot_forge_*` regressions had gone stale.** They still spelled the *retired* digit-carrying shape (`\u{96}0\u{97}`) and put the forgery behind the real passthrough, so both passed with `escape_passthrough_sentinels` deleted — they were pinning the escape's *output*, not the forgery it prevents. Retargeted to the two-codepoint pair in the forging order; both now fail on their own "must not restore the passthrough's body" assertion when the guard is removed.

## What lands

- `tests/sentinels.rs`: `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text` and `a_quoted_values_own_unescape_moves_a_placeholder_in_the_parsed_value` (the two blockers' fixtures); `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore` (the open gap, both families); the two retargeted regressions; an extended module doc.
- `escape_passthrough_sentinels` gains a "Known limits — documented, intentional debt" section; `MASKED_PIECE_PLACEHOLDER_START`'s collision-resistance claim is corrected; `image.rs`'s test comment notes the leniency is order-dependent.
- Design doc: a new §5.2 note, *"The masked-piece placeholder's offset table cannot be carried through `Attrlist::parse`"*, plus a forward pointer from #1349's note and an entry in the "how much further" tiers.

## The recommended next increment

The move that *would* get the construction-time property the table was after: escape the placeholder's codepoints in the bytes `tokened_bracket`/`tokened_text` **copy** from their non-tokened pieces, at the one moment provenance is still known. Every occurrence in the tokened text is then one the tokener itself wrote, by construction, with no coordinates to carry through anything. It is strictly stronger than today's guard (closes the typed-in-the-clear road as well as the spliced one, and being two-way it would let a typed pair round-trip to the output instead of arriving escaped), and it lets `escape_passthrough_sentinels` and its call site go. Its cost is the un-escape, which has to happen at every consumer of a tokened parse and must not be missed at any: `restore_into`'s both paths (including the no-placeholder early return), `untranslated_value`, `restored_value_children` / `computed_value_children`, `TextAttrlist::text`, and `Attrlist::source_text`. That audit is the increment.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green (5,493 lib tests, three more than the base's 5,490)
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Fold-parity audit vs. `origin/inline-ast` — **no new divergences** (8 before, 8 after, `comm` empty both ways)
- Coverage vs. a detached checkout of `326be95` — byte-identical: every touched file and the total unchanged (81,707 regions / 544 missed; 54,742 lines / 320 missed). `attribute_refs.rs`'s six missed lines shift by exactly the 22 lines of doc comment added, confirming they are the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGhnADXtgBYMx75uDh9duZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGhnADXtgBYMx75uDh9duZ)_