### PR TITLE
chore: Escape the masked-piece placeholder at the tokener, not at the splice

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -240,14 +240,30 @@ and rejected, for two reasons that don't show up at the call site:
   coordinates would mean threading a byte mapping through most of
   [`parser/src/attributes/`](../../parser/src/attributes/).
 
-The mechanism that *would* get the equivalent construction-time guarantee is different: escape
-the placeholder's own codepoints in the bytes `tokened_bracket`/`tokened_text` **copy** from
-their non-tokened pieces, at the one moment provenance is still known, rather than escaping the
-content-level splice that feeds them
-([`escape_passthrough_sentinels`](../../parser/src/content/inline_builder/attribute_refs.rs),
-§3.4 case 2). That would let `escape_passthrough_sentinels` retire, but it requires auditing
-every consumer of a tokened parse to apply the matching un-escape, so it remains a scoped,
-not-yet-taken-up follow-up rather than something this document tracks as in progress.
+The mechanism that gets the equivalent construction-time guarantee is a different one, and it
+is what the crate does: escape the placeholder's own codepoints in the bytes
+`tokened_bracket`/`tokened_text` **copy** from their non-tokened pieces, at the one moment
+provenance is still known
+([`escape_masked_piece_bytes`](../../parser/src/attributes/element_attribute.rs)). The escape
+leaves neither of the placeholder's codepoints standing anywhere in its output, so every
+occurrence of the pair in a tokened text is one a tokener wrote, and no reader downstream has
+to ask whether the occurrence in front of it is genuine. It escapes each codepoint
+individually, and its own introducer alongside them, so neither a half arriving from one source
+beside a half from another nor a document that types the introducer can produce a pair the
+escape did not intend. Unlike the content-level splice guard it replaced
+(`escape_passthrough_sentinels`, retired), it is **two-way**: every consumer of a tokened parse
+applies the matching
+[`unescape_masked_piece_bytes`](../../parser/src/attributes/element_attribute.rs) on its way
+out — `restore_into` in the same walk that substitutes the bodies, so the shorthand offsets and
+restored ranges it records stay in the coordinates of the string it is building, and
+`untranslated_value`/`computed_value_children` on the runs between occurrences — so a
+document's own copy of a reserved codepoint round-trips to the output as written.
+
+One road is left uncovered, and it is the first bullet above: `Attrlist::parse` re-substitutes
+attribute references over the text handed to it, *after* the tokener escaped its copy, so a
+`subs=` list naming `macros` without `attributes` can still expand a reference whose value
+spells the pair into the tokened text. Closing it means escaping inside that parse, which
+requires the parse to know it has been handed tokened text.
 
 ## 4. Cross-reference and title resolution
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -1020,9 +1020,9 @@ mod tests {
 
     #[test]
     fn attribute_reference_substitution_shifts_a_placeholder_byte_offset_in_source_text() {
-        // Direct evidence for the design doc's §3.5 ("A rejected refinement:
-        // carrying a byte-offset table through `Attrlist::parse`") and its
-        // first blocker, checked against this method's own `source_text()`
+        // Direct evidence for the first blocker that ruled out carrying a
+        // byte-offset table through `Attrlist::parse`, checked against this
+        // method's own `source_text()`
         // rather than only a full document's final rendered HTML (as
         // `tests/sentinels.rs`'s
         // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -1020,8 +1020,8 @@ mod tests {
 
     #[test]
     fn attribute_reference_substitution_shifts_a_placeholder_byte_offset_in_source_text() {
-        // Direct evidence for the design doc's "The masked-piece placeholder's
-        // offset table cannot be carried through `Attrlist::parse`" note's
+        // Direct evidence for the design doc's §3.5 ("A rejected refinement:
+        // carrying a byte-offset table through `Attrlist::parse`") and its
         // first blocker, checked against this method's own `source_text()`
         // rather than only a full document's final rendered HTML (as
         // `tests/sentinels.rs`'s

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     Parser, Span,
     attributes::AttrlistContext,
@@ -811,28 +813,37 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// [`restore_into`] is what walks that position order.
 ///
 /// Two fixed codepoints, adjacent, rather than one: a single reserved
-/// codepoint alone is indistinguishable from an ordinary control character a
-/// document happens to type in the clear (not spliced through an attribute
-/// reference, so the escape guard covering that seam never sees it) sitting
-/// beside a real masked construct in the same bracket — a two-codepoint run
-/// needs both, adjacent, which is exactly as unlikely for ordinary authoring
-/// to produce by accident as the digit-carrying shape this replaced. Kept as
-/// two separate consts too ([`MASKED_PIECE_PLACEHOLDER_START`],
-/// [`MASKED_PIECE_PLACEHOLDER_END`]) for the escape guard, which has to
-/// escape each codepoint on its own — a forged value contributing only one
-/// half, beside the other half from an unrelated source, would complete the
-/// same pair.
+/// codepoint alone would have to be reserved *everywhere* the tokener copies
+/// bytes, where a two-codepoint run is cheap to keep unique. Kept as two
+/// separate consts too ([`MASKED_PIECE_PLACEHOLDER_START`],
+/// [`MASKED_PIECE_PLACEHOLDER_END`]) because
+/// [`escape_masked_piece_bytes`] escapes each codepoint on its own — a
+/// document contributing only one half, beside the other half from an
+/// unrelated source, would complete the same pair otherwise.
 ///
-/// "Unlikely", though, is the whole of what the pair buys: a document that
-/// *does* type both codepoints adjacent, in the clear, **ahead** of a real
-/// masked piece in the same bracket takes that piece's body — the escape
-/// guard guards the attribute-reference splice only, and this byte never
-/// passes through it. Pinned as a known gap by
-/// `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`
-/// (`tests/sentinels.rs`); the fix is provenance at the tokener rather than a
-/// wider escape, and is written up in the design doc's "The masked-piece
-/// placeholder's offset table cannot be carried through `Attrlist::parse`"
-/// note.
+/// Which occurrences are genuine is settled **by construction**, not by
+/// likelihood. `tokened_bracket`/`tokened_text` run
+/// [`escape_masked_piece_bytes`] over every non-tokened byte they copy, and
+/// that escape leaves neither codepoint standing anywhere in its output, so
+/// the only `MASKED_PIECE_PLACEHOLDER` occurrences in a tokened text are the
+/// ones the tokener itself wrote. Nothing downstream has to ask whether an
+/// occurrence is real; every consumer of a tokened text runs the matching
+/// [`unescape_masked_piece_bytes`] on the bytes *around* those occurrences on
+/// its way out, so a document's own copy of either codepoint round-trips to
+/// the output unchanged. That replaced an earlier one-way escape at the
+/// attribute-reference splice (`escape_passthrough_sentinels`, retired with
+/// it), which covered only the one road a *spliced* value took and left both
+/// a typed pair and the escape's own output visible in the output.
+///
+/// One road remains, and it is the same one the design doc's §3.5 ("A
+/// rejected refinement: carrying a byte-offset table through
+/// `Attrlist::parse`") names as a blocker for that table:
+/// [`Attrlist::parse`](crate::attributes::Attrlist::parse) re-substitutes
+/// attribute references over the text handed to it, so a `subs=` list naming
+/// `macros` without `attributes` can expand a reference *after* the tokener
+/// has escaped its copy. See
+/// `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`
+/// (`tests/sentinels.rs`), which pins it.
 pub(crate) const MASKED_PIECE_PLACEHOLDER_START: char = '\u{96}';
 
 /// See [`MASKED_PIECE_PLACEHOLDER`].
@@ -841,6 +852,158 @@ pub(crate) const MASKED_PIECE_PLACEHOLDER_END: char = '\u{97}';
 /// See [`MASKED_PIECE_PLACEHOLDER_START`] / [`MASKED_PIECE_PLACEHOLDER_END`].
 /// Must spell the same two codepoints, adjacent and in the same order.
 pub(crate) const MASKED_PIECE_PLACEHOLDER: &str = "\u{96}\u{97}";
+
+/// Introduces an escape [`escape_masked_piece_bytes`] writes over a
+/// document's own copy of a reserved codepoint, and
+/// [`unescape_masked_piece_bytes`] reads back.
+///
+/// A private-use codepoint, so it needs no reservation of its own beyond
+/// being escaped like the two it protects (`ESCAPED_ESCAPE_TAG`).
+pub(crate) const MASKED_PIECE_ESCAPE: char = '\u{E005}';
+
+/// The tag byte that follows [`MASKED_PIECE_ESCAPE`] for an escaped
+/// [`MASKED_PIECE_PLACEHOLDER_START`].
+const ESCAPED_START_TAG: char = 's';
+
+/// The tag byte for an escaped [`MASKED_PIECE_PLACEHOLDER_END`].
+const ESCAPED_END_TAG: char = 'e';
+
+/// The tag byte for an escaped [`MASKED_PIECE_ESCAPE`] — the escape's own
+/// introducer, which has to be escapable or a document that types
+/// `\u{E005}s` would come back holding a
+/// [`MASKED_PIECE_PLACEHOLDER_START`] it never wrote.
+const ESCAPED_ESCAPE_TAG: char = 'g';
+
+/// Rewrites `text`'s own copies of the three reserved codepoints —
+/// [`MASKED_PIECE_PLACEHOLDER_START`], [`MASKED_PIECE_PLACEHOLDER_END`], and
+/// [`MASKED_PIECE_ESCAPE`] itself — as
+/// [`MASKED_PIECE_ESCAPE`]-plus-tag pairs, so the result holds none of them
+/// in the clear.
+///
+/// This is the *construction-time* half of the masked-piece placeholder's
+/// unambiguity: `tokened_bracket`/`tokened_text` run it over every byte they
+/// copy out of a **non-tokened** piece, and write
+/// [`MASKED_PIECE_PLACEHOLDER`] themselves for each piece they token. Since
+/// neither of the placeholder's codepoints survives this escape, every
+/// occurrence of the pair in a tokened text is one the tokener wrote —
+/// which is what lets [`restore_into`] and the macros step's own
+/// `untranslated_value` / `restored_value_children` recover a piece **by
+/// position** without ever asking whether the occurrence in front of them is
+/// genuine.
+///
+/// The encoding is unambiguous against all three things it has to be: a
+/// genuine placeholder (which holds no [`MASKED_PIECE_ESCAPE`], and whose own
+/// codepoints this escape never emits in the clear), itself (the introducer is
+/// escaped as `\u{E005}g`, so an introducer standing in the output is always
+/// one this function wrote), and ordinary text (which reaches
+/// [`unescape_masked_piece_bytes`] through the same pairing and comes back
+/// byte-for-byte).
+///
+/// Unlike the one-way `escape_passthrough_sentinels` it replaced, this is
+/// **two-way**: every consumer of a tokened text unescapes on the way out
+/// (see [`unescape_masked_piece_bytes`]), so a document that types a reserved
+/// codepoint sees it in the output rather than the escape's own bytes.
+///
+/// Text with none of the three — the overwhelming majority — is borrowed
+/// through unchanged.
+pub(crate) fn escape_masked_piece_bytes(text: &str) -> Cow<'_, str> {
+    if !text.contains([
+        MASKED_PIECE_PLACEHOLDER_START,
+        MASKED_PIECE_PLACEHOLDER_END,
+        MASKED_PIECE_ESCAPE,
+    ]) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+
+    for c in text.chars() {
+        match c {
+            MASKED_PIECE_PLACEHOLDER_START => {
+                out.push(MASKED_PIECE_ESCAPE);
+                out.push(ESCAPED_START_TAG);
+            }
+
+            MASKED_PIECE_PLACEHOLDER_END => {
+                out.push(MASKED_PIECE_ESCAPE);
+                out.push(ESCAPED_END_TAG);
+            }
+
+            MASKED_PIECE_ESCAPE => {
+                out.push(MASKED_PIECE_ESCAPE);
+                out.push(ESCAPED_ESCAPE_TAG);
+            }
+
+            other => out.push(other),
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+/// The codepoint an escape introduced by [`MASKED_PIECE_ESCAPE`] stands for,
+/// with the length of the tag that named it, or `None` when what follows the
+/// introducer is not a tag this crate wrote.
+///
+/// The `None` case is not merely defensive: an introducer can reach a value
+/// without passing through [`escape_masked_piece_bytes`], via the one road
+/// [`MASKED_PIECE_PLACEHOLDER_START`]'s own doc comment names —
+/// [`Attrlist::parse`](crate::attributes::Attrlist::parse)'s re-substitution
+/// of an attribute reference over already-tokened text. Copying such an
+/// introducer through verbatim is what keeps that value's own bytes intact.
+fn escaped_literal(tail: &str) -> Option<(char, usize)> {
+    match tail.chars().next()? {
+        ESCAPED_START_TAG => Some((MASKED_PIECE_PLACEHOLDER_START, ESCAPED_START_TAG.len_utf8())),
+        ESCAPED_END_TAG => Some((MASKED_PIECE_PLACEHOLDER_END, ESCAPED_END_TAG.len_utf8())),
+        ESCAPED_ESCAPE_TAG => Some((MASKED_PIECE_ESCAPE, ESCAPED_ESCAPE_TAG.len_utf8())),
+        _ => None,
+    }
+}
+
+/// Undoes [`escape_masked_piece_bytes`], putting each escaped codepoint back
+/// as the document wrote it.
+///
+/// Every consumer that reads a tokened text and produces user-visible output
+/// has to run this before that output leaves the pipeline, on the bytes
+/// *between* the genuine [`MASKED_PIECE_PLACEHOLDER`] occurrences rather than
+/// over the restored bodies — a body is the node's own bytes and was never
+/// escaped. [`restore_into`] does both halves in one walk; the macros step's
+/// `untranslated_value` and `computed_value_children` call this directly on
+/// the runs their own positional walk hands them.
+///
+/// Text holding no [`MASKED_PIECE_ESCAPE`] is borrowed through unchanged.
+pub(crate) fn unescape_masked_piece_bytes(text: &str) -> Cow<'_, str> {
+    if !text.contains(MASKED_PIECE_ESCAPE) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(at) = rest.find(MASKED_PIECE_ESCAPE) {
+        out.push_str(rest.get(..at).unwrap_or_default());
+
+        let tail = rest
+            .get(at.saturating_add(MASKED_PIECE_ESCAPE.len_utf8())..)
+            .unwrap_or_default();
+
+        match escaped_literal(tail) {
+            Some((literal, tag_len)) => {
+                out.push(literal);
+                rest = tail.get(tag_len..).unwrap_or_default();
+            }
+
+            None => {
+                out.push(MASKED_PIECE_ESCAPE);
+                rest = tail;
+            }
+        }
+    }
+
+    out.push_str(rest);
+
+    Cow::Owned(out)
+}
 
 /// Substitutes each [`MASKED_PIECE_PLACEHOLDER`] occurrence in `text` with the
 /// next of `bodies` `*cursor` finds, shifting every offset in `indices` past
@@ -862,10 +1025,20 @@ pub(crate) const MASKED_PIECE_PLACEHOLDER: &str = "\u{96}\u{97}";
 /// order. See [`ElementAttribute::into_owned_restoring`] for why the shift is
 /// right where a re-derivation would not be.
 ///
+/// The same walk also undoes [`escape_masked_piece_bytes`] over every byte
+/// that is *not* a substituted body: the tokener escaped a document's own
+/// copies of the reserved codepoints on the way in, and this is the way out
+/// for every value a bracket parse produces. Doing it in the one walk rather
+/// than in a second pass is what keeps `indices` and `restored_ranges`
+/// honest — both are byte offsets into the text being built, so an unescape
+/// that shortened it afterwards would move every offset already recorded, and
+/// a second pass would also have to know not to reach inside a restored body
+/// (which is the node's own bytes and was never escaped).
+///
 /// [`restore_tokens`] over a [`CowStr`], keeping the plain
 /// [`into_owned`](CowStr::into_owned) conversion — and with it the inline
 /// representation a short string prefers — for the overwhelmingly common text
-/// that holds no placeholder at all.
+/// that holds neither a placeholder nor an escape.
 pub(super) fn restore_into<'dst>(
     text: CowStr<'_>,
     bodies: &[&str],
@@ -873,7 +1046,11 @@ pub(super) fn restore_into<'dst>(
     indices: &mut [usize],
     restored_ranges: &mut Vec<std::ops::Range<usize>>,
 ) -> CowStr<'dst> {
-    if bodies.is_empty() || !text.contains(MASKED_PIECE_PLACEHOLDER) {
+    // `bodies.is_empty()` is deliberately *not* a reason to skip the walk any
+    // more: a text with no piece to restore may still carry an escape to
+    // undo — `tokened_bracket`/`tokened_text` escape unconditionally, whether
+    // or not the bracket held anything to token.
+    if !text.contains([MASKED_PIECE_PLACEHOLDER_START, MASKED_PIECE_ESCAPE]) {
         return text.into_owned();
     }
 
@@ -896,16 +1073,61 @@ fn restore_tokens(
     let mut out = String::with_capacity(text.len());
     let mut scan_cursor = 0usize;
 
-    // `(offset just past a substituted placeholder, cumulative delta)`, in
-    // the *original* text's coordinates and in increasing order.
+    // `(offset just past a substituted placeholder or unescaped codepoint,
+    // cumulative delta)`, in the *original* text's coordinates and in
+    // increasing order.
     let mut shifts: Vec<(usize, isize)> = vec![];
     let mut delta: isize = 0;
 
     while let Some(rel) = text
         .get(scan_cursor..)
-        .and_then(|rest| rest.find(MASKED_PIECE_PLACEHOLDER))
+        .and_then(|rest| rest.find([MASKED_PIECE_PLACEHOLDER_START, MASKED_PIECE_ESCAPE]))
     {
         let start = scan_cursor.saturating_add(rel);
+
+        // An escape the tokener wrote over a reserved codepoint the
+        // *document* typed. It is tested first because it is the only one of
+        // the two that can begin with `MASKED_PIECE_ESCAPE`, and because the
+        // escape leaves no `MASKED_PIECE_PLACEHOLDER_START` standing: a start
+        // codepoint found here is therefore always a placeholder the tokener
+        // wrote, and its `END` half always follows.
+        if let Some(tail) = text
+            .get(start..)
+            .and_then(|head| head.strip_prefix(MASKED_PIECE_ESCAPE))
+        {
+            let escape_len = MASKED_PIECE_ESCAPE.len_utf8();
+
+            let end = match escaped_literal(tail) {
+                Some((literal, tag_len)) => {
+                    let end = start.saturating_add(escape_len).saturating_add(tag_len);
+
+                    out.push_str(text.get(scan_cursor..start).unwrap_or_default());
+                    out.push(literal);
+
+                    delta = delta
+                        .saturating_add(isize::try_from(literal.len_utf8()).unwrap_or(isize::MAX))
+                        .saturating_sub(
+                            isize::try_from(end.saturating_sub(start)).unwrap_or(isize::MAX),
+                        );
+
+                    shifts.push((end, delta));
+                    end
+                }
+
+                None => {
+                    // An introducer this crate did not write (see
+                    // `escaped_literal`): copy it through and keep scanning,
+                    // so the bytes after it are still read.
+                    let end = start.saturating_add(escape_len);
+                    out.push_str(text.get(scan_cursor..end).unwrap_or_default());
+                    end
+                }
+            };
+
+            scan_cursor = end;
+            continue;
+        }
+
         let end = start.saturating_add(MASKED_PIECE_PLACEHOLDER.len());
 
         let Some(body) = bodies.get(*cursor).copied() else {
@@ -935,10 +1157,11 @@ fn restore_tokens(
     out.push_str(text.get(scan_cursor..).unwrap_or_default());
 
     for index in indices.iter_mut() {
-        // A placeholder holds none of the `#`/`.`/`%` delimiters the
-        // shorthand scan keys off, so no offset ever falls *inside* one: each
-        // is either before every substitution or after some, and takes that
-        // one's cumulative delta.
+        // Neither a placeholder nor an escape holds any of the `#`/`.`/`%`
+        // delimiters the shorthand scan keys off — the escape's own tags are
+        // `s`/`e`/`g` — so no offset ever falls *inside* one: each is either
+        // before every substitution or after some, and takes that one's
+        // cumulative delta.
         if let Some((_, delta)) = shifts.iter().rev().find(|(end, _)| *end <= *index) {
             *index = index.saturating_add_signed(*delta);
         }
@@ -993,8 +1216,8 @@ mod tests {
 
     #[test]
     fn quoted_values_own_unescape_shortens_a_value_by_one_byte_ahead_of_a_placeholder() {
-        // Direct evidence for the design doc's "The masked-piece placeholder's
-        // offset table cannot be carried through `Attrlist::parse`" note's
+        // Direct evidence for the design doc's §3.5 ("A rejected refinement:
+        // carrying a byte-offset table through `Attrlist::parse`") and its
         // second blocker, checked against this method's own parsed value
         // rather than only a full document's final rendered HTML (as
         // `tests/sentinels.rs`'s
@@ -1030,6 +1253,64 @@ mod tests {
             written_offset - 5 - 1,
             "the value's own unescape must shorten it by one byte ahead of the placeholder: {:?}",
             attr.value()
+        );
+    }
+
+    #[test]
+    fn masked_piece_escape_round_trips_every_reserved_codepoint() {
+        use std::borrow::Cow;
+
+        use crate::attributes::element_attribute::{
+            escape_masked_piece_bytes, unescape_masked_piece_bytes,
+        };
+
+        // The three codepoints the escape reserves, plus one of its own tag
+        // characters standing on its own (`s`, which must not be read as a
+        // tag when nothing introduces it).
+        let raw = "a\u{96}b\u{97}c\u{e005}d\u{e005}se";
+        let escaped = escape_masked_piece_bytes(raw);
+
+        assert_eq!(
+            escaped.as_ref(),
+            "a\u{e005}sb\u{e005}ec\u{e005}gd\u{e005}gse"
+        );
+
+        // Neither of the placeholder's own codepoints survives the escape,
+        // which is the whole property `tokened_bracket`/`tokened_text` rest
+        // on: every occurrence of the pair in a tokened text is one the
+        // tokener wrote.
+        assert!(
+            !escaped.contains(super::MASKED_PIECE_PLACEHOLDER_START)
+                && !escaped.contains(super::MASKED_PIECE_PLACEHOLDER_END)
+        );
+
+        assert_eq!(unescape_masked_piece_bytes(&escaped).as_ref(), raw);
+
+        // Text holding none of the three is borrowed through, in both
+        // directions. Compared by discriminant rather than by `matches!`,
+        // whose own non-matching arm would be a region no input reaches.
+        let borrowed = std::mem::discriminant(&Cow::<str>::Borrowed(""));
+
+        assert_eq!(
+            std::mem::discriminant(&escape_masked_piece_bytes("plain text")),
+            borrowed
+        );
+
+        assert_eq!(
+            std::mem::discriminant(&unescape_masked_piece_bytes("plain text")),
+            borrowed
+        );
+
+        // An introducer this crate did not write — reachable through
+        // `Attrlist::parse`'s own re-substitution over already-tokened text,
+        // the one road
+        // `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`
+        // pins — is copied through with the bytes after it, rather than
+        // eating one as a tag. That holds at the end of the text too, where
+        // there is no byte after it at all.
+        assert_eq!(
+            unescape_masked_piece_bytes("p\u{e005}zq\u{e005}").as_ref(),
+            "p\u{e005}zq\u{e005}"
         );
     }
 

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -840,9 +840,13 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) re-substitutes
 /// attribute references over the text handed to it, so a `subs=` list naming
 /// `macros` without `attributes` can expand a reference *after* the tokener
-/// has escaped its copy. See
+/// has escaped its copy. Whatever that reference's value spells reaches
+/// `restore_into`'s walk unescaped and indistinguishable from something the
+/// tokener wrote — a value spelling the placeholder forges a restore, and one
+/// spelling the escape sequence gets decoded, corrupting a document
+/// attribute's own text with no masked piece involved at all. See
 /// `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`
-/// (`tests/sentinels.rs`), which pins it.
+/// (`tests/sentinels.rs`), which pins both.
 pub(crate) const MASKED_PIECE_PLACEHOLDER_START: char = '\u{96}';
 
 /// See [`MASKED_PIECE_PLACEHOLDER`].

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -835,9 +835,8 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// it), which covered only the one road a *spliced* value took and left both
 /// a typed pair and the escape's own output visible in the output.
 ///
-/// One road remains, and it is the same one the design doc's §3.5 ("A
-/// rejected refinement: carrying a byte-offset table through
-/// `Attrlist::parse`") names as a blocker for that table:
+/// One road remains, and it is the same one that blocked carrying a
+/// byte-offset table through `Attrlist::parse` in the first place:
 /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) re-substitutes
 /// attribute references over the text handed to it, so a `subs=` list naming
 /// `macros` without `attributes` can expand a reference *after* the tokener
@@ -1216,9 +1215,9 @@ mod tests {
 
     #[test]
     fn quoted_values_own_unescape_shortens_a_value_by_one_byte_ahead_of_a_placeholder() {
-        // Direct evidence for the design doc's §3.5 ("A rejected refinement:
-        // carrying a byte-offset table through `Attrlist::parse`") and its
-        // second blocker, checked against this method's own parsed value
+        // Direct evidence for the second blocker that ruled out carrying a
+        // byte-offset table through `Attrlist::parse`, checked against this
+        // method's own parsed value
         // rather than only a full document's final rendered HTML (as
         // `tests/sentinels.rs`'s
         // `a_quoted_values_own_unescape_moves_a_placeholder_in_the_parsed_value`

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1,6 +1,6 @@
 //! The attribute-references substitution step.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::collections::HashMap;
 
 use super::{
     passthrough_step::is_special,
@@ -9,7 +9,6 @@ use super::{
 };
 use crate::{
     Parser, Span,
-    attributes::element_attribute::{MASKED_PIECE_PLACEHOLDER_END, MASKED_PIECE_PLACEHOLDER_START},
     content::{ATTRIBUTE_REFERENCE, AttributeMissing},
     document::InterpretedValue,
     inlines::{InlineNode, RawForm, RawOrigin},
@@ -1171,19 +1170,23 @@ fn rebuild_attribute_level<'src>(
 /// A run is never emitted empty, and an empty `value` (a value-less
 /// `InterpretedValue::Set` attribute) emits no node at all.
 ///
-/// Before either branch runs, `value` has its own copies of the masked-piece
-/// placeholder escaped by [`escape_passthrough_sentinels`] — see that
-/// function's doc comment for why a value reaching this splice point needs
-/// that unconditionally, regardless of which branch it then takes.
+/// A value spliced here needs no escaping of its own. It used to get one —
+/// `escape_passthrough_sentinels`, a one-way guard against a resolved value
+/// that happened to spell the masked-piece placeholder forging a bracket
+/// restore downstream — but that covered only the one road a *spliced* value
+/// took, and left the escape's own bytes in the output. The escape now lives
+/// where the placeholder is written instead: `tokened_bracket`/`tokened_text`
+/// escape every non-tokened byte they copy
+/// ([`escape_masked_piece_bytes`](crate::attributes::element_attribute::escape_masked_piece_bytes)),
+/// so a value's own copy of the pair is escaped there whether it arrived
+/// through this splice or was typed in the clear — and, being two-way, comes
+/// back out as the document wrote it.
 fn split_attribute_value<'src>(
     value: &str,
     location: Span<'src>,
     specials: SplicedSpecials,
     out: &mut Vec<InlineNode<'src>>,
 ) {
-    let value = escape_passthrough_sentinels(value);
-    let value = value.as_ref();
-
     if specials == SplicedSpecials::EscapedLater {
         if !value.is_empty() {
             out.push(InlineNode::Text {
@@ -1225,100 +1228,6 @@ fn split_attribute_value<'src>(
             location,
         });
     }
-}
-
-/// Escapes a document's own copies of the
-/// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER)
-/// pair's two codepoints out of a resolved attribute (or `counter`/`counter2`)
-/// value before [`split_attribute_value`] splices it into the node stream.
-///
-/// Those two C1 codepoints, adjacent, are the opaque placeholder
-/// [`tokened_bracket`](super::macros::image::tokened_bracket) (and its
-/// sibling `tokened_text`) writes for a masked passthrough or STEM expression
-/// inside an `image:`/`icon:` bracket or a link/xref family's own computed
-/// value, and both
-/// [`Attrlist::into_owned_restoring`](crate::attributes::Attrlist::into_owned_restoring)
-/// (via [`restore_into`](crate::attributes::element_attribute)) and the
-/// macros step's own `untranslated_value`/`restored_value_children` recover
-/// which piece an occurrence stands for **by position** once that bracket has
-/// been parsed: none of the three re-derive structure from anything but the
-/// bytes actually in front of them, so they cannot tell a real occurrence
-/// from a document-typed copy of the same two bytes at the same position. A
-/// macro bracket that mixes a genuine masked construct with an attribute
-/// reference whose resolved value happens to spell
-/// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER) — `image:x.png[++real++,alt={forge}]` with
-/// `:forge: \u{96}\u{97}` defined — is exactly that mix: the reference is
-/// spliced here, by this step, *before* the image macro is even recognized,
-/// so by the time the bracket is tokened the forged pair is indistinguishable
-/// from the passthrough's own placeholder, and every occurrence from that
-/// point on shifts onto the wrong body. Each codepoint is escaped on its
-/// own, not as a pair: a forged value contributing only *one* half, beside
-/// the other half from an unrelated source (a second reference, or a
-/// document-typed copy) landing adjacent to it, would complete the same
-/// pair otherwise.
-///
-/// This is the same forgery the old string-substitution implementation's own
-/// attribute-reference splice guarded against with `escape_sentinels` (since
-/// retired) for this pair among the five it
-/// covered; the other three guarded a deferred cross-reference's and a
-/// footnote marker's own in-band templates, which the tree builder replaced
-/// with structured piece lists nothing scans, so only this pair still needs
-/// a counterpart here. The escape is unconditional, for the same reason that
-/// one's was: this step splices at the content level, ahead of
-/// macro recognition, so it cannot know whether its value will end up beside
-/// a masked construct in some later bracket. It is also one-way, like its
-/// predecessor — nothing downstream unescapes it — so a document attribute
-/// whose value happens to hold one of these two rare C1 control codepoints
-/// (or the escape introducer itself) sees it come back escaped rather than
-/// silently enabling a forged restore.
-///
-/// Text with none of the three reserved codepoints — the overwhelming
-/// majority — is borrowed through unchanged.
-///
-/// # Known limits — documented, intentional debt
-///
-/// This guards **one** road to a forged occurrence: a value this step splices
-/// in. A document that types the pair in the clear inside a macro bracket
-/// never reaches this function, and ahead of a real masked piece it forges the
-/// same restore (`tests/sentinels.rs`'s
-/// `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`). The
-/// structural cure — capture each occurrence's provenance where it is written
-/// instead of re-deriving it from bytes, which is what `quotes.rs`'s `Piece`
-/// table does one layer up — was investigated as a byte-offset table carried
-/// through `Attrlist::parse` and **rejected**: that parse re-substitutes
-/// attribute references over the tokened text (length-changing under any
-/// `subs=` list naming `macros` without `attributes`), and a parsed value is
-/// not a slice of the split text in any case, since
-/// [`ElementAttribute::parse`](crate::attributes::ElementAttribute) derives it
-/// through unreported rewrites. Both are pinned by fixtures in
-/// `tests/sentinels.rs`, and the full reasoning — including the alternative
-/// that *would* work, escaping in the bytes `tokened_bracket`/`tokened_text`
-/// copy rather than in this splice — is in the design doc's "The masked-piece
-/// placeholder's offset table cannot be carried through `Attrlist::parse`"
-/// note. Until that lands, this stays.
-fn escape_passthrough_sentinels(value: &str) -> Cow<'_, str> {
-    const ESCAPE: char = '\u{E005}';
-
-    if !value.contains([
-        MASKED_PIECE_PLACEHOLDER_START,
-        MASKED_PIECE_PLACEHOLDER_END,
-        ESCAPE,
-    ]) {
-        return Cow::Borrowed(value);
-    }
-
-    let mut out = String::with_capacity(value.len());
-
-    for c in value.chars() {
-        match c {
-            MASKED_PIECE_PLACEHOLDER_START => out.push_str("\u{E005}s"),
-            MASKED_PIECE_PLACEHOLDER_END => out.push_str("\u{E005}e"),
-            ESCAPE => out.push_str("\u{E005}g"),
-            other => out.push(other),
-        }
-    }
-
-    Cow::Owned(out)
 }
 
 #[cfg(test)]
@@ -1495,17 +1404,18 @@ mod tests {
     }
 
     #[test]
-    fn a_reference_expanding_to_a_passthrough_sentinel_is_escaped() {
+    fn a_reference_expanding_to_a_passthrough_sentinel_is_spliced_verbatim() {
         // A value carrying either codepoint of the masked-piece placeholder
-        // pair, or a literal copy of the escape introducer this step's own
-        // escaping uses, is escaped out rather than spliced in verbatim —
-        // see `escape_passthrough_sentinels`. This test exercises the
-        // function directly (through the one seam that calls it) for all
-        // three codepoints its match arms cover, independent of any macro
-        // bracket: the regression this guards against is pinned end-to-end,
-        // over an actual `image:`/`link:` bracket, by the `sentinels` test
-        // module's own `a_placeholder_from_an_attribute_value_cannot_forge_*`
-        // tests.
+        // pair — or a copy of the escape introducer the tokener's own escape
+        // uses — is spliced in **as written**. This step used to escape all
+        // three out (`escape_passthrough_sentinels`, retired), which was the
+        // one-way guard on the one road a *spliced* value could forge a
+        // bracket restore by. The escape now lives where the placeholder is
+        // written, in `tokened_bracket`/`tokened_text`, so it covers a typed
+        // pair too and — being two-way — leaves nothing of its own in the
+        // output. Pinned end-to-end, over an actual `image:`/`link:` bracket,
+        // by the `sentinels` test module's own
+        // `a_placeholder_from_an_attribute_value_cannot_forge_*` tests.
         let parser = parser_with_attribute("v", "a\u{96}b\u{97}c\u{e005}d");
         let nodes = build(Span::new("{v}"), &parser, None);
 
@@ -1513,7 +1423,7 @@ mod tests {
 
         match &nodes[0] {
             InlineNode::Text { value, .. } => {
-                assert_eq!(value.as_ref(), "a\u{e005}sb\u{e005}ec\u{e005}gd");
+                assert_eq!(value.as_ref(), "a\u{96}b\u{97}c\u{e005}d");
             }
 
             other => panic!("expected Text, got {other:?}"),

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -5,7 +5,10 @@ use std::borrow::Cow;
 use super::{MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level};
 use crate::{
     Parser, Span,
-    attributes::{Attrlist, AttrlistContext, element_attribute::MASKED_PIECE_PLACEHOLDER},
+    attributes::{
+        Attrlist, AttrlistContext,
+        element_attribute::{MASKED_PIECE_PLACEHOLDER, escape_masked_piece_bytes},
+    },
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
@@ -1065,16 +1068,27 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
                 masked_pieces.push(masked);
             }
 
-            None => tokened.push_str(
+            // A piece that keeps its own bytes has them **escaped** on the way
+            // in: after this, the only `MASKED_PIECE_PLACEHOLDER` occurrences
+            // in `tokened` are the ones written just above. See
+            // [`escape_masked_piece_bytes`].
+            None => tokened.push_str(&escape_masked_piece_bytes(
                 bracket_text
                     .get(lo.saturating_sub(range.start)..hi.saturating_sub(range.start))
                     .unwrap_or_default(),
-            ),
+            )),
         }
     }
 
+    // A bracket that tokened nothing keeps the whole match string as written
+    // rather than the piece-by-piece copy above — but still **escaped**, so
+    // every consumer can unescape unconditionally without having to know
+    // whether this bracket held anything to token.
     if masked_pieces.is_empty() {
-        return (bracket_text.to_string(), masked_pieces);
+        return (
+            escape_masked_piece_bytes(bracket_text).into_owned(),
+            masked_pieces,
+        );
     }
 
     (tokened, masked_pieces)
@@ -2151,11 +2165,14 @@ mod tests {
         let image = assert_image(&nodes[0]);
         assert_eq!(image.alt.as_deref(), Some("x\u{96}1\u{97}y b"));
 
-        // The leniency the positional restore rests on, in both spellings a
-        // bracket can present: a run that is not the well-formed placeholder
-        // pair (a lone `\u{96}` or `\u{97}`, or the two separated by other
-        // bytes) is left exactly as the author wrote it, rather than being
-        // mistaken for a real occurrence.
+        // An author-typed run of the same bytes is left exactly as written,
+        // in every spelling a bracket can present: a lone `\u{96}` or
+        // `\u{97}`, the two separated by other bytes, or the well-formed
+        // adjacent pair itself. None of them is mistaken for a real
+        // occurrence, because none of them survives `tokened_bracket`'s own
+        // copy as those bytes — [`escape_masked_piece_bytes`] rewrites each
+        // one on the way into the parse, and the restore puts it back on the
+        // way out.
         let nodes = build_src(Span::new(
             "image:x.png[++a++ \u{96}x\u{97} \u{96}9\u{97} ++b++]",
         ));
@@ -2166,26 +2183,23 @@ mod tests {
             Some("a \u{96}x\u{97} \u{96}9\u{97} b")
         );
 
-        // And the leniency on the *other* side of the same shape: an
-        // author-typed **adjacent** pair — the well-formed placeholder shape
-        // itself, with no real masked piece behind it — is left as written
-        // too, rather than consuming a body meant for a later real
-        // occurrence. Only one passthrough (`++a++`) supplies a body here, so
-        // the cursor is already past `bodies.len()` by the time the typed
-        // pair is reached, and `restore_tokens`' own leniency for that case
-        // is what keeps it literal instead of panicking or misattributing.
-        //
-        // The leniency is *order-dependent*, and only this order is safe: a
-        // typed pair **ahead** of the bracket's real masked piece reaches an
-        // unspent `bodies` and takes that piece's body. That is a known gap,
-        // pinned by
-        // `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore`
-        // (`tests/sentinels.rs`) — see `escape_passthrough_sentinels`' own
-        // "Known limits" section for why it is open.
+        // The adjacent pair, in both orders relative to the bracket's one real
+        // masked piece. Neither order matters any more: the escape settles it
+        // before `bodies` is ever consulted, where the restore's own leniency
+        // for an occurrence past the end of `bodies` used to save only the
+        // *behind* order and the *ahead* one forged a restore (a gap this
+        // comment recorded until 2026-08-31, now pinned closed by
+        // `a_typed_placeholder_beside_a_masked_piece_cannot_forge_a_bracket_restore`
+        // in `tests/sentinels.rs`).
         let nodes = build_src(Span::new("image:x.png[++a++ \u{96}\u{97}]"));
         let image = assert_image(&nodes[0]);
 
         assert_eq!(image.alt.as_deref(), Some("a \u{96}\u{97}"));
+
+        let nodes = build_src(Span::new("image:x.png[\u{96}\u{97} ++a++]"));
+        let image = assert_image(&nodes[0]);
+
+        assert_eq!(image.alt.as_deref(), Some("\u{96}\u{97} a"));
 
         // The golden output reads the first fixture differently, and the
         // difference is its own wart rather than something to reproduce:

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -1713,7 +1713,12 @@ fn text_attrlist<'src>(
         return Some(TextAttrlist {
             adopted: text != tokened,
             text,
-            attrs: attrs.into_owned(source),
+            // `into_owned_restoring` with no bodies rather than the plain
+            // `into_owned`: the parse still has to come back **unescaped**
+            // (`tokened_bracket` escapes whether or not it tokened anything),
+            // and the restoring conversion is where that happens. With
+            // `bodies` empty the two are otherwise the same walk.
+            attrs: attrs.into_owned_restoring(source, &[]),
             escaped: true,
             restores: vec![],
         });
@@ -3785,11 +3790,12 @@ mod tests {
         // `replace_all` over the *finished* string, so an author's own
         // `\u{96}0\u{97}` bytes were rewritten too (both copies became the
         // body). This restore instead finds the placeholder **pair**
-        // (`MASKED_PIECE_PLACEHOLDER`) by position, so the author's own bytes
-        // — `\u{96}`, `0`, `\u{97}`, none of them adjacent to their own
-        // matching half in a way that forms the pair — are never mistaken
-        // for one and stay exactly where the author put them, ahead of the
-        // real passthrough's own body. Neither reading is reachable by
+        // (`MASKED_PIECE_PLACEHOLDER`) by position, over a text whose own
+        // copies of those codepoints `tokened_bracket` has already escaped
+        // (`escape_masked_piece_bytes`) — so the author's `\u{96}`, `0`,
+        // `\u{97}` are never mistaken for one, in this or any other
+        // arrangement, and stay exactly where the author put them, ahead of
+        // the real passthrough's own body. Neither reading is reachable by
         // ordinary authoring — these are C1 control characters.
         use super::super::super::test_support::golden_passthroughs;
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -22,7 +22,9 @@ use super::{
 };
 use crate::{
     HasSpan, Parser, Span,
-    attributes::element_attribute::MASKED_PIECE_PLACEHOLDER,
+    attributes::element_attribute::{
+        MASKED_PIECE_PLACEHOLDER, escape_masked_piece_bytes, unescape_masked_piece_bytes,
+    },
     content::restored_entity_pattern,
     inlines::{CharRef, InlineNode},
     strings::CowStr,
@@ -793,15 +795,23 @@ pub(super) fn tokened_text<'src>(
                 carried.push(node.clone());
             }
 
-            None => tokened.push_str(
+            // A piece that keeps its own bytes has them **escaped** on the way
+            // in, exactly as in
+            // [`tokened_bracket`](image::tokened_bracket): after this, the
+            // only `MASKED_PIECE_PLACEHOLDER` occurrences in `tokened` are the
+            // ones written just above.
+            None => tokened.push_str(&escape_masked_piece_bytes(
                 text.get(lo.saturating_sub(range.start)..hi.saturating_sub(range.start))
                     .unwrap_or_default(),
-            ),
+            )),
         }
     }
 
+    // A text that tokened nothing keeps its own bytes as written rather than
+    // the piece-by-piece copy above — but still escaped, so every consumer can
+    // unescape unconditionally.
     if carried.is_empty() {
-        return (text.to_string(), carried);
+        return (escape_masked_piece_bytes(text).into_owned(), carried);
     }
 
     (tokened, carried)
@@ -861,7 +871,13 @@ pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> Stri
             break;
         };
 
-        out.push_str(rest.get(..pos).unwrap_or_default());
+        // Only the bytes *between* occurrences are unescaped: they are the
+        // tokener's own copy of the author's text (see
+        // [`escape_masked_piece_bytes`]), where a node's untranslated bytes
+        // below come straight from the source and never passed through it.
+        out.push_str(&unescape_masked_piece_bytes(
+            rest.get(..pos).unwrap_or_default(),
+        ));
 
         match node {
             InlineNode::Raw { value, .. } => out.push_str(value.as_ref()),
@@ -873,7 +889,7 @@ pub(super) fn untranslated_value(text: &str, carried: &[InlineNode<'_>]) -> Stri
             .unwrap_or_default();
     }
 
-    out.push_str(rest);
+    out.push_str(&unescape_masked_piece_bytes(rest));
 
     out
 }
@@ -955,9 +971,19 @@ pub(super) fn computed_value_children<'src>(
     location: Span<'src>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
+    // This is where a run of a tokened text's own bytes leaves the pipeline,
+    // so it is where the tokener's escape comes back off (see
+    // [`escape_masked_piece_bytes`]). Its caller
+    // ([`restored_value_children`]) has already split the genuine
+    // `MASKED_PIECE_PLACEHOLDER` occurrences out, so what arrives here is only
+    // ever the author's own bytes — unescaping ahead of the special/entity
+    // trichotomy below is safe because none of the escape's own codepoints is
+    // an `&`.
+    let text = unescape_masked_piece_bytes(text);
+
     match specials {
-        ComputedSpecials::Escaped => escaped_value_children(text, location),
-        ComputedSpecials::Verbatim => unescaped_value_children(text, location),
+        ComputedSpecials::Escaped => escaped_value_children(&text, location),
+        ComputedSpecials::Verbatim => unescaped_value_children(&text, location),
     }
 }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -481,16 +481,20 @@ fn attrlist_text_carries_its_opaque_pieces(
 /// half sitting beside the *other* half completed by a real placeholder
 /// nearby would be just as ambiguous as a whole stray pair.
 ///
-/// Those bytes make the whole tokening ambiguous, and the ambiguity bites
-/// precisely where a value is read as a *string*. An occurrence is found by
-/// searching the parsed value for its bytes, and the search cannot tell an
-/// author's own copy from the one this pass emitted: it would splice a node's
-/// source into the author's text and leave the real occurrence standing (or,
-/// past it, misattribute every occurrence after it).
+/// Those bytes used to make the whole tokening ambiguous: an occurrence was
+/// found by searching the parsed value for its bytes, and the search could
+/// not tell an author's own copy from the one this pass emitted. They no
+/// longer do — [`tokened_text`] escapes every byte it copies
+/// ([`escape_masked_piece_bytes`](crate::attributes::element_attribute::escape_masked_piece_bytes)),
+/// so an author's copy is not those bytes by the time the parse sees it —
+/// which leaves this gate **conservative** rather than load-bearing. It is
+/// kept because the recorded golden this family's corpus compares against
+/// reads such a text differently — the recording's own passthrough masking
+/// used these same two codepoints, so a text carrying them reached its
+/// `xref` pass already confused — and lifting the gate would have the tree
+/// claim a shape whose fold diverges from that recording.
 ///
-/// So a text carrying either defers, which is what the per-slot check this
-/// replaced did for the same bytes. It is a deferral, not a rewrite: the tree
-/// claims no construct.
+/// It is a deferral, not a rewrite: the tree claims no construct.
 fn text_carries_author_written_token_bytes(raw_text: &str) -> bool {
     raw_text.contains([MASKED_PIECE_PLACEHOLDER_START, MASKED_PIECE_PLACEHOLDER_END])
 }

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -8,9 +8,9 @@
 //! (and a bibliography entry) registers its id in the reference catalog, an
 //! image whose `link=` names a dangerous scheme records a warning, and a
 //! `footnote:`/`footnoteref:` macro registers its numbered entry — text and
-//! deferred cross-references included — in the footnote catalog. Design
-//! §5.2's step 6 has to replay the first four from the tree, exactly once per
-//! parse and in the string pipeline's own pass order, which is what
+//! deferred cross-references included — in the footnote catalog. Step 6 of
+//! the inline-AST cutover has to replay the first four from the tree, exactly
+//! once per parse and in the string pipeline's own pass order, which is what
 //! [`apply_macro_side_effects`](crate::content::inline_builder::apply_macro_side_effects)
 //! is staged to do.
 //!
@@ -24,15 +24,15 @@
 //! pipeline wrote down), but against the build itself rather than a replay.
 //!
 //! Until now it was pinned only by hand-written fixtures inside its own
-//! module — one per ordering rule it has to honor. The blast-radius
-//! experiment recorded in the design doc (what breaks if `rendered_html()`
-//! becomes the fold today?) says so in as many words: it "neither calls the
-//! staged side effects nor sequences the fold against resolution". The
-//! sibling harness
+//! module — one per ordering rule it has to honor. The blast-radius question
+//! (what breaks if `rendered_html()` becomes the fold today?) is exactly
+//! this: doing so would neither call the staged side effects nor sequence
+//! the fold against resolution. The sibling harness
 //! [`inline_builder_document_parity`](super::inline_builder_document_parity)
 //! closed the second half of that sentence. This one closes the first.
 //!
-//! The discipline is design §5.3's: two independently-configured parsers see
+//! The discipline is the same one this branch's other fold-parity corpora
+//! use: two independently-configured parsers see
 //! the same fixture, one through the real
 //! [`SubstitutionGroup::Normal`](crate::content::SubstitutionGroup) pipeline
 //! and one through [`build`](crate::content::inline_builder::build) plus the
@@ -41,7 +41,7 @@
 //! shared list received them.
 //!
 //! The golden side is **frozen** (`snapshots/side_effects.txt`). Its source is
-//! `SubstitutionGroup::apply_string_pipeline`, which design §5.2's step 6 is
+//! `SubstitutionGroup::apply_string_pipeline`, which step 6 of the cutover is
 //! about to delete; without the freeze every assertion below would be left
 //! comparing the builder against itself the moment it went. The survey that
 //! scoped that deletion named this corpus as the second of the two
@@ -196,8 +196,8 @@ fn snapshot(parser: &Parser) -> SideEffects {
 /// while the pipeline exists. What the freeze buys is the day it does not:
 /// `apply_string_pipeline` is this corpus's only golden source, so deleting it
 /// would otherwise leave every assertion below comparing the builder against
-/// itself. Design §5.2's survey named this corpus as the second of the two
-/// *record-shaped* ones — a flat list of plainly serializable facts, needing a
+/// itself. This corpus is the second of the two *record-shaped* ones — a flat
+/// list of plainly serializable facts, needing a
 /// codec for its own record rather than an `InlineNode` serialization — and
 /// this is that codec.
 ///
@@ -484,8 +484,8 @@ fn corpus_parser() -> Parser {
 /// `configure` is called once per side rather than sharing one `Parser`: both
 /// sides register into the parser they are given, so a shared one would see
 /// every entry twice and every duplicate-id warning fire spuriously. The same
-/// two-independent-parsers discipline design §5.3 establishes for the fold's
-/// own corpora.
+/// two-independent-parsers discipline this branch's other fold-parity
+/// corpora use.
 fn side_effects_with(
     source: &str,
     config: &str,
@@ -775,12 +775,12 @@ fn two_shapes_where_a_tree_built_footnote_entry_still_diverges() {
     //    pipeline restores a passthrough *after* the macros step, over the
     //    whole block string — by which time the footnote's text has already
     //    been cut out of it, so the entry keeps a raw passthrough sentinel that
-    //    no later pass will ever replace. It is one of design §4.2's three
-    //    sentinel systems leaking into public API, and the tree simply has no
-    //    sentinels: the passthrough is a node, so folding the subtree yields
-    //    the restored text. The tree is *right* here and the string pipeline is
-    //    wrong, which is why this is pinned as a divergence rather than fixed
-    //    on the tree's side to match.
+    //    no later pass will ever replace. It is one of three sentinel systems
+    //    leaking into public API, and the tree simply has no sentinels: the
+    //    passthrough is a node, so folding the subtree yields the restored
+    //    text. The tree is *right* here and the string pipeline is wrong, which
+    //    is why this is pinned as a divergence rather than fixed on the tree's
+    //    side to match.
     for (source, string_side, tree_side) in [
         (
             "A footnote:[a +++<b>raw</b>+++ passthrough] here.",

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -7,7 +7,7 @@
 //! This began life as `inline_recorder.rs`, the Strategy-A recorder's own
 //! corpus. The recorder — a `RecordingRenderer` that recovered a tree from the
 //! string pipeline's rendered output — retired with the string pipeline it
-//! wrapped (design §5.2 Phase 4, step 6); its corpus tests, which compared
+//! wrapped at the step 6 cutover; its corpus tests, which compared
 //! its tree against that pipeline's own bytes, could only ever compare the
 //! pipeline against itself once both were gone, so they went with it. What
 //! stayed is everything here: tests whose subject is the single-pass
@@ -205,8 +205,8 @@ fn the_three_non_specialcharacters_bodies_still_consult_the_renderer() {
     //     which is a mixture rather than a form.
     //
     // All three owe `render_with` the same debt every frozen value on this
-    // branch does (design §3.3.1), and when that lands this test is what should
-    // start failing.
+    // branch does, and when that lands this test is what should start
+    // failing.
     for source in ["pass:c[a < b]", "stem:[x < y]", "+a $$b < c$$ d+"] {
         let calls = renderer_calls_while_building(source);
 
@@ -271,11 +271,11 @@ fn a_passthrough_body_is_substituted_once_per_apply() {
     // string pipeline's own substitutions of the body ran on the shared
     // renderer even though their output was discarded with the clone, and
     // those renders ended when the pipeline stopped running at the seam —
-    // exactly the transitional double render the design doc said would end
-    // "for all of them together, when step 6 takes the string pipeline off
-    // the production path". What remains is the body's one authoritative
-    // render at build time (`passthrough_text`), whose `Raw` leaf the fold
-    // then emits verbatim.
+    // exactly the transitional double render that was always going to end
+    // for all of them together, once the string pipeline came off the
+    // production path. What remains is the body's one authoritative render
+    // at build time (`passthrough_text`), whose `Raw` leaf the fold then
+    // emits verbatim.
     //
     // The exact number is not the claim; that the three agree is.
     for source in ["pass:c[a < b]", "pass:c,q[*a < b*]", "stem:[x < y]"] {
@@ -611,7 +611,7 @@ fn inline_tree_for_none_group_content_is_the_untouched_seed() {
     // string pipeline leaving the text unchanged. It is not a *single* `Text`
     // run, though: because no `SpecialCharacters` step ever acted on it, each
     // literal `<`/`>`/`&` is a `Raw` leaf the fold emits verbatim rather than
-    // a `Text` character the fold would escape (design §3.4.1).
+    // a `Text` character the fold would escape.
     let mut parser = Parser::default();
     let doc = parser.parse("[pass]\n<b>raw</b> and *not bold*\n");
 
@@ -668,7 +668,7 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 
 #[test]
 fn the_xref_mirror_correlates_the_form_that_used_to_defer() {
-    // The counterpart of the deferral divergence (design §5.2's step 6), seen
+    // The counterpart of the deferral divergence at the step 6 cutover, seen
     // from resolution.
     //
     // `xref:sec[a *b, c* d,role=hl]` used to be deferred by the builder,
@@ -981,7 +981,7 @@ fn inline_tree_numbers_footnotes_in_document_order() {
 // catalog), a cross-reference in the inline tree carries the same resolved
 // destination the rendered string reflects — so a consumer that walks
 // `inlines()` sees resolved xrefs, not just the parse-time `resolved: None`
-// state the tree is first built with (design §4.3).
+// state the tree is first built with.
 
 /// Collects every [`Ref`](InlineNode::Ref) node from the simple blocks of
 /// `doc`, recursing into formatting spans and reference children.
@@ -1287,7 +1287,7 @@ fn inline_tree_build_tolerates_a_stateful_renderer() {
 // per-content pass cannot. That pass now mirrors each resolved destination into
 // the title's own inline tree, so a consumer that walks a title's `inlines()`
 // sees the same destinations the rendered title reflects — closing the
-// section-/block-title follow-up of Phase 2 step 2 (design §4.3).
+// section-/block-title follow-up of Phase 2 step 2.
 
 /// Collects every cross-reference/link node from the inline tree of every
 /// section heading in `doc`, recursing into nested sections and into formatting
@@ -1510,7 +1510,7 @@ fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
 // cross-reference *inside* a footnote is re-homed out of the block template
 // when the footnote text is extracted, so it lives in that subtree, and the
 // shared mirror now installs its resolved destination there — the same
-// destination the rendered footnote text reflects (design §4.3).
+// destination the rendered footnote text reflects.
 
 /// The first [`Footnote`](InlineNode::Footnote) node found anywhere in the
 /// simple blocks of `doc`, in document order.

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -39,9 +39,8 @@
 //! beside a real masked piece and alone); one records the one road that
 //! **can** still forge an occurrence — `Attrlist::parse`'s own re-substitution
 //! of an attribute reference over already-tokened text; and two pin the inputs
-//! that rule out replacing the whole scheme with a byte-offset table (see the
-//! design doc's §3.5, "A rejected refinement: carrying a byte-offset table
-//! through `Attrlist::parse`").
+//! that rule out replacing the whole scheme with a byte-offset table carried
+//! through `Attrlist::parse` instead.
 
 use crate::{
     Document, Parser,
@@ -342,9 +341,9 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
     // passthrough's body, exactly as a typed pair used to.
     //
     // This is the same re-substitution that blocks the byte-offset table (see
-    // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`
-    // and the design doc's §3.5); closing it means escaping inside that
-    // parse, which is a mechanism change of its own and a separate increment.
+    // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`);
+    // closing it means escaping inside that parse, which is a mechanism
+    // change of its own and a separate increment.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}\u{97}\n",
         "\n",
@@ -376,9 +375,10 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
 
 #[test]
 fn an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text() {
-    // Evidence for the design-doc note named above: the byte offsets
-    // `tokened_bracket` could record for the occurrences it writes are not
-    // stable across the parse that consumes them.
+    // Evidence that the byte offsets `tokened_bracket` could record for the
+    // occurrences it writes are not stable across the parse that consumes
+    // them — the blocker that ruled out a byte-offset table as a replacement
+    // for the escape mechanism above.
     //
     // `Attrlist::parse` runs an attribute-reference substitution of its own
     // over the text it is handed, whenever that text holds both a `{` and a

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -24,16 +24,24 @@
 //!   * the typed codepoints reach the output unchanged, since a Private Use
 //!     Area character is content like any other.
 //!
-//! One byte-pattern mechanism is still live, and the last five tests here are
-//! about it rather than about issue #1235: `tokened_bracket`/`tokened_text`
+//! One byte-pattern mechanism is still live, and the last several tests here
+//! are about it rather than about issue #1235: `tokened_bracket`/`tokened_text`
 //! write a `MASKED_PIECE_PLACEHOLDER` pair per masked piece into the text
 //! `Attrlist::parse` splits, and every reader recovers which piece an
-//! occurrence stands for by counting occurrences in the parsed text. Two of
-//! those tests pin `escape_passthrough_sentinels`, the guard on the one road a
-//! forged occurrence can take today; one records the road it does *not* guard;
-//! and two pin the inputs that rule out replacing the whole scheme with a
-//! byte-offset table (see the design doc's "The masked-piece placeholder's
-//! offset table cannot be carried through `Attrlist::parse`" note).
+//! occurrence stands for by counting occurrences in the parsed text. Those
+//! readers no longer have to tell a genuine occurrence from a document's own
+//! copy of the same two codepoints: the two tokeners escape every non-tokened
+//! byte they copy (`escape_masked_piece_bytes`), so every occurrence in a
+//! tokened text is one a tokener wrote, and every consumer unescapes on the way
+//! out — which is what makes a typed pair ordinary content here as much as
+//! anywhere else in this file. Those tests come in three groups: four pin that
+//! property (a typed pair, and the escape's own introducer, round-tripping
+//! beside a real masked piece and alone); one records the one road that
+//! **can** still forge an occurrence — `Attrlist::parse`'s own re-substitution
+//! of an attribute reference over already-tokened text; and two pin the inputs
+//! that rule out replacing the whole scheme with a byte-offset table (see the
+//! design doc's §3.5, "A rejected refinement: carrying a byte-offset table
+//! through `Attrlist::parse`").
 
 use crate::{
     Document, Parser,
@@ -143,14 +151,19 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
     //
     // The forged value has to spell the placeholder **exactly**
     // (`MASKED_PIECE_PLACEHOLDER`'s own two adjacent codepoints, no digit
-    // between them) and has to sit **ahead** of the real masked piece in the
-    // list's own parse order: the restore walks a shared cursor left to
-    // right, so a forgery behind the real piece only reaches an already
-    // spent `bodies` and is copied through by `restore_tokens`' leniency
-    // instead. Both halves matter — this test spelled the retired
-    // digit-carrying shape in the other order until 2026-08-30 and passed
-    // with the escape guard removed, pinning the escape's *output* rather
-    // than the forgery it exists to prevent.
+    // between them) and has to sit **ahead** of the real masked piece: this
+    // test spelled the retired digit-carrying shape in the other order until
+    // 2026-08-30, which made it pass with the guard of the day
+    // (`escape_passthrough_sentinels`) removed — pinning that guard's *output*
+    // rather than the forgery it existed to prevent. Both halves are kept
+    // because they are what make the fixture a real forgery attempt.
+    //
+    // What stops it is no longer that guard, which is retired: it is the
+    // tokener's own escape over every non-tokened byte it copies, so this
+    // spliced spelling and the typed-in-the-clear one
+    // (`a_typed_placeholder_beside_a_masked_piece_cannot_forge_a_bracket_restore`)
+    // are now stopped by one mechanism. Being two-way, it also lets the value
+    // reach the output as the document defined it rather than in escaped form.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}\u{97}\n",
         "\n",
@@ -166,53 +179,198 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_an_image_restore() {
 
     // The genuine occurrence keeps the one body supplied, in the positional
     // slot it actually stands in (`width`), and the forged value reaches the
-    // output escaped.
+    // output verbatim.
     assert_eq!(
         rendered,
-        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{e005}s\u{e005}e\" width=\"real\"></span>"
+        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{96}\u{97}\" width=\"real\"></span>"
     );
 }
 
 #[test]
-fn a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore() {
-    // The **open** half of the same hole, pinned rather than fixed (see the
-    // design doc's "The masked-piece placeholder's offset table cannot be
-    // carried through `Attrlist::parse`" note).
+fn a_typed_placeholder_beside_a_masked_piece_cannot_forge_a_bracket_restore() {
+    // The road `escape_passthrough_sentinels` never covered, now closed.
     //
-    // `escape_passthrough_sentinels` guards exactly one road to a forged
-    // placeholder: a value spliced in by `split_attribute_value`, the
-    // attribute-reference step's own content-level splice. A document that
-    // types the pair **in the clear** inside the bracket never passes through
-    // that splice, so nothing escapes it — and ahead of a real masked piece
-    // it captures that piece's body exactly as a spliced forgery would.
+    // That guard sat at `split_attribute_value`, the attribute-reference
+    // step's own content-level splice, so it saw only a value *spliced* into
+    // the bracket. A document that types the pair **in the clear** never
+    // passes through that splice, and ahead of a real masked piece it captured
+    // that piece's body exactly as a spliced forgery would (this test pinned
+    // that as a known gap until 2026-08-31).
     //
-    // `image.rs`'s
-    // `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched`
-    // covers the *other* order (a typed pair behind the only real piece,
-    // where `bodies` is already spent and the leniency keeps it literal),
-    // which is why this one went unnoticed. The fix is the mechanism change
-    // the design-doc note recommends — escaping the placeholder codepoints in
-    // the bytes `tokened_bracket`/`tokened_text` *copy*, so every occurrence
-    // in the tokened text is one the tokener itself wrote — and it is a
-    // separate increment; until it lands this test records the behavior
-    // rather than blessing it.
+    // What closes it is provenance where the placeholder is *written*:
+    // `tokened_bracket` escapes every non-tokened byte it copies
+    // (`escape_masked_piece_bytes`), so the only occurrences in the text
+    // `Attrlist::parse` splits are the ones it wrote itself, and the restore
+    // has nothing to be fooled by. The escape being two-way is what lets the
+    // typed pair itself land in `alt` as the document wrote it rather than in
+    // escaped form.
     let doc = Parser::default().parse("image:x.png[alt=\u{96}\u{97},++real++]\n");
+
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("alt=\"real\""),
+        "the typed pair must not restore the passthrough's body: {rendered:?}"
+    );
+
+    assert_eq!(
+        rendered,
+        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{96}\u{97}\" width=\"real\"></span>"
+    );
+
+    // The link family's display-text list shares `tokened_bracket`, so it
+    // shares the fix: `++real++` stays the second entry (no positional display
+    // text, hence the `bare` role and the target standing in for the text),
+    // and the typed pair reaches the role verbatim.
+    let doc = Parser::default().parse("link:x[role=\u{96}\u{97},++real++]\n");
+
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("class=\"bare real\""),
+        "the typed pair must not restore the passthrough's body: {rendered:?}"
+    );
+
+    assert_eq!(rendered, "<a href=\"x\" class=\"bare \u{96}\u{97}\">x</a>");
+}
+
+#[test]
+fn a_typed_placeholder_round_trips_through_a_bracket_untouched() {
+    // The other half of what the tokener's escape has to be: two-way. With no
+    // masked piece anywhere near it, a typed pair is ordinary content, and the
+    // escape written over it on the way into `Attrlist::parse` has to come
+    // back off before the value is rendered — every consumer of a tokened
+    // parse unescapes (`unescape_masked_piece_bytes`), including the
+    // no-placeholder early return in `restore_into` that does no restoring at
+    // all.
+    let doc = Parser::default().parse("image:x.png[alt=a\u{96}\u{97}b]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"a\u{96}\u{97}b\"></span>"
+    );
+
+    // The link family's display-text list, whose values take the same restore
+    // and whose *text* takes `restored_value_children`'s own rebuild.
+    let doc = Parser::default().parse("link:x[role=a\u{96}\u{97}b]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"x\" class=\"bare a\u{96}\u{97}b\">x</a>"
+    );
+
+    // And the cross-reference family's `tokened_text`, whose display text and
+    // roles are read back through `restored_value_children` and
+    // `untranslated_value` respectively.
+    let doc = Parser::default().parse(concat!(
+        "[[a]]anchor\n",
+        "\n",
+        "xref:a[t\u{96}\u{97}u,role=r\u{96}\u{97}s]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"#a\" class=\"r\u{96}\u{97}s\">t\u{96}\u{97}u</a>"
+    );
+}
+
+#[test]
+fn a_typed_placeholder_round_trips_beside_a_real_masked_piece() {
+    // The same round-trip with a genuine masked piece in the same bracket, so
+    // the restore walk actually runs: the typed pair has to survive the walk
+    // that substitutes the piece beside it, and the piece has to land in its
+    // own positional slot rather than in the forged one.
+    let doc = Parser::default().parse("image:x.png[alt=a\u{96}\u{97}b,++real++]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"a\u{96}\u{97}b\" width=\"real\"></span>"
+    );
+
+    // The link family's *display text*, where the pair rides in the same
+    // value as the piece rather than in a neighbouring one — so the split
+    // `restored_value_children` makes on the genuine occurrence has to leave
+    // the typed one alone, and `computed_value_children` has to unescape the
+    // runs either side of it.
+    let doc = Parser::default().parse("link:x[a\u{96}\u{97}b ++real++,role=hl]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"x\" class=\"hl\">a\u{96}\u{97}b real</a>"
+    );
+}
+
+#[test]
+fn a_typed_escape_introducer_round_trips_through_a_bracket() {
+    // The escape has to be unambiguous against *itself*, so
+    // `escape_masked_piece_bytes` escapes its own introducer
+    // (`\u{e005}` → `\u{e005}g`). Without that, a document that types the
+    // introducer followed by one of the escape's tag characters — `s` here,
+    // which names the placeholder's start codepoint — would get back a
+    // `\u{96}` it never wrote.
+    let doc = Parser::default().parse("image:x.png[alt=a\u{e005}sb,++real++]\n");
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"a\u{e005}sb\" width=\"real\"></span>"
+    );
+
+    let doc = Parser::default().parse(concat!(
+        "[[a]]anchor\n",
+        "\n",
+        "xref:a[t\u{e005}su ++real++,role=hl]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"#a\" class=\"hl\">t\u{e005}su real</a>"
+    );
+}
+
+#[test]
+fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
+    // The one road left, recorded rather than fixed.
+    //
+    // The tokener escapes the bytes it *copies*, which settles every
+    // occurrence in the text it hands to `Attrlist::parse`. But that parse
+    // runs an attribute-reference substitution of its own over that text
+    // whenever it holds both a `{` and a `}` — and a `subs=` list naming
+    // `macros` without `attributes` reaches the macros step with every
+    // reference still unresolved, so the inner substitution is the one that
+    // expands it, *after* the escape ran. A value spelling the placeholder
+    // therefore lands in the tokened text unescaped and takes the real
+    // passthrough's body, exactly as a typed pair used to.
+    //
+    // This is the same re-substitution that blocks the byte-offset table (see
+    // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`
+    // and the design doc's §3.5); closing it means escaping inside that
+    // parse, which is a mechanism change of its own and a separate increment.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}\u{97}\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={forge},++real++]\n",
+    ));
 
     assert_eq!(
         last_paragraph(&doc),
         "<span class=\"image\"><img src=\"x.png\" alt=\"real\" width=\"\u{96}\u{97}\"></span>",
-        "known gap: the typed pair captured the passthrough's body"
+        "known gap: the attrlist-level expansion captured the passthrough's body"
     );
 
-    // The link family's display-text list shares `tokened_bracket`, so it
-    // shares the gap: the typed pair takes `++real++`'s body as the role, and
-    // the display text falls back to the target.
-    let doc = Parser::default().parse("link:x[role=\u{96}\u{97},++real++]\n");
+    // The same parse also splices a bare escape introducer past the tokener,
+    // where `restore_into`'s walk copies it through rather than reading the
+    // byte after it as a tag.
+    let doc = Parser::default().parse(concat!(
+        ":stray: p\u{e005}zq\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={stray},++real++]\n",
+    ));
 
     assert_eq!(
         last_paragraph(&doc),
-        "<a href=\"x\" class=\"bare real\">x</a>",
-        "known gap: the typed pair captured the passthrough's body"
+        "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{e005}zq\" width=\"real\"></span>"
     );
 }
 
@@ -293,7 +451,7 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restor
     // including why the forged value has to spell the pair exactly and sit
     // ahead of the real passthrough), so the same forgery reaches it through
     // a `role=` attribute sitting beside a real passthrough in the same
-    // display-text list, absent the same escape guard.
+    // display-text list, absent the same escape.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}\u{97}\n",
         "\n",
@@ -308,11 +466,10 @@ fn a_placeholder_from_an_attribute_value_cannot_forge_a_link_display_text_restor
     );
 
     // With no positional attribute left to be the display text, the target
-    // stands in for it and the auto-link `bare` role joins the escaped one.
-    assert_eq!(
-        rendered,
-        "<a href=\"x\" class=\"bare \u{e005}s\u{e005}e\">x</a>"
-    );
+    // stands in for it and the auto-link `bare` role joins the value the
+    // document defined — which reaches the role verbatim, the tokener's escape
+    // being two-way.
+    assert_eq!(rendered, "<a href=\"x\" class=\"bare \u{96}\u{97}\">x</a>");
 }
 
 #[test]

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -328,7 +328,9 @@ fn a_typed_escape_introducer_round_trips_through_a_bracket() {
 
 #[test]
 fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
-    // The one road left, recorded rather than fixed.
+    // The one road left, recorded rather than fixed — and, as the third case
+    // below shows, wider than "forges a restore": it can corrupt a document
+    // attribute's own text with no passthrough involved at all.
     //
     // The tokener escapes the bytes it *copies*, which settles every
     // occurrence in the text it hands to `Attrlist::parse`. But that parse
@@ -336,9 +338,14 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
     // whenever it holds both a `{` and a `}` — and a `subs=` list naming
     // `macros` without `attributes` reaches the macros step with every
     // reference still unresolved, so the inner substitution is the one that
-    // expands it, *after* the escape ran. A value spelling the placeholder
-    // therefore lands in the tokened text unescaped and takes the real
-    // passthrough's body, exactly as a typed pair used to.
+    // expands it, *after* the escape ran. Whatever the reference's value
+    // spells lands in the tokened text verbatim, unescaped, and
+    // `restore_into`'s walk cannot tell it from something the tokener wrote:
+    // a value spelling the placeholder takes the real passthrough's body,
+    // exactly as a typed pair used to, and — the case Greptile's review of
+    // #1355 caught, https://github.com/asciidoc-rs/asciidoc-parser/pull/1355
+    // — a value spelling the escape sequence gets *decoded*, corrupting text
+    // that never went near a masked piece.
     //
     // This is the same re-substitution that blocks the byte-offset table (see
     // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`);
@@ -357,9 +364,11 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
         "known gap: the attrlist-level expansion captured the passthrough's body"
     );
 
-    // The same parse also splices a bare escape introducer past the tokener,
-    // where `restore_into`'s walk copies it through rather than reading the
-    // byte after it as a tag.
+    // The same parse also splices a bare escape introducer past the tokener.
+    // When the byte after it is not one of the three tags this crate writes,
+    // `escaped_literal` returns `None` and `restore_into`'s walk copies the
+    // introducer through rather than misreading it — safe by construction,
+    // not by luck.
     let doc = Parser::default().parse(concat!(
         ":stray: p\u{e005}zq\n",
         "\n",
@@ -370,6 +379,27 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
     assert_eq!(
         last_paragraph(&doc),
         "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{e005}zq\" width=\"real\"></span>"
+    );
+
+    // But when the byte after a late-spliced introducer *is* one of the three
+    // tags, there is nothing left to tell it apart from one the tokener
+    // itself wrote: `restore_into`'s walk decodes it, corrupting a document
+    // attribute value that never went near a masked piece. This is a wider
+    // consequence of the same gap above, not a new one (caught in review of
+    // #1355 — https://github.com/asciidoc-rs/asciidoc-parser/pull/1355) —
+    // silent corruption of ordinary text rather than a forged restore, and
+    // closed by the same future fix: escaping inside `Attrlist::parse`.
+    let doc = Parser::default().parse(concat!(
+        ":stray: p\u{e005}sq\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={stray},++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{96}q\" width=\"real\"></span>",
+        "known gap: the document's own escape-shaped bytes were decoded"
     );
 }
 


### PR DESCRIPTION
PR #1352 rejected the byte-offset table and named the move that *does* get the construction-time property it was after:

> escape the placeholder's codepoints in the bytes `tokened_bracket`/`tokened_text` **copy** from their non-tokened pieces, at the one moment provenance is still known. … Its cost is the un-escape, which has to happen at every consumer of a tokened parse and must not be missed at any.

This is that increment. `escape_passthrough_sentinels` and its `split_attribute_value` call site are deleted.

## The property

`escape_masked_piece_bytes` (`attributes/element_attribute.rs`, beside the placeholder it protects) rewrites all three reserved codepoints as introducer-plus-tag pairs:

| document typed | tokened text holds |
| --- | --- |
| `\u{96}` (`MASKED_PIECE_PLACEHOLDER_START`) | `\u{E005}s` |
| `\u{97}` (`MASKED_PIECE_PLACEHOLDER_END`) | `\u{E005}e` |
| `\u{E005}` (the introducer itself) | `\u{E005}g` |

Same introducer and tag alphabet the retired guard used, and each codepoint is still escaped *individually* — a half from one source landing beside a half from another would complete the pair otherwise.

The escape's output holds **neither of the placeholder's codepoints anywhere**, so after `tokened_bracket`/`tokened_text` run it over every non-tokened byte they copy, every `MASKED_PIECE_PLACEHOLDER` occurrence in a tokened text is one a tokener wrote. That is the whole point: nothing downstream asks whether an occurrence is genuine.

Unambiguous against the three things it has to be:

- **a genuine placeholder** — which holds no introducer, and whose own codepoints the escape never emits in the clear;
- **itself** — the introducer is escaped as `\u{E005}g`, so an introducer standing in a tokened text is always one the escape wrote (without this, a document typing `\u{E005}s` would get back a `\u{96}` it never wrote);
- **ordinary text** — which round-trips byte-for-byte, because unlike its one-way predecessor this escape is **two-way**.

## The un-escape audit

Came out as #1352 predicted, with one addition:

- **`restore_into`** (`element_attribute.rs`) — both paths. The cheap early return no longer keys off `bodies.is_empty()` (a text with no piece to restore can still carry an escape to undo) but off the text holding neither reserved codepoint. The restoring walk decodes escapes **in the same pass** as the placeholder substitution rather than in a second one: `shorthand_item_indices` and `restored_value_ranges` are byte offsets into the string being built, so a later unescape would move offsets already recorded — and a second pass would also have to know not to reach inside a restored body, which is the node's own bytes and was never escaped. Neither a placeholder nor an escape holds any of the `#`/`.`/`%` delimiters the shorthand scan keys off (tags are `s`/`e`/`g`), so the existing "no offset falls inside one" argument carries over.
- **`untranslated_value`** and **`computed_value_children`** (`macros/mod.rs`) unescape the runs their own positional walk hands them — *between* the genuine occurrences, never over a node's untranslated source. `restored_value_children` needs nothing of its own: every run it emits goes through `computed_value_children`.
- **`TextAttrlist::text`** (`links.rs`) and **`Attrlist::source_text`** (`attrlist.rs`) are covered transitively, and one call site had to change to make that true: `text_attrlist`'s `masked.is_empty()` early return used the plain `Attrlist::into_owned`, which does no unescaping. It now takes `into_owned_restoring(source, &[])` — the same walk with no bodies, which is where the unescape lives.
- The **counting and sniffing** sites need nothing: `Attrlist::token_offset_before` and `roles_with_token_offset` count `MASKED_PIECE_PLACEHOLDER` occurrences in still-tokened text, and an escaped copy is not those bytes, so they count exactly the genuine ones.

## Both forgeries close

`image:x.png[alt=\u{96}\u{97},++real++]`

- before: ``'&lt;img src="x.png" alt="real" width="\u{96}\u{97}"&gt;'`` — the typed pair took the passthrough's body
- after: ``'&lt;img src="x.png" alt="\u{96}\u{97}" width="real"&gt;'``

`link:x[role=\u{96}\u{97},++real++]`

- before: `<a href="x" class="bare real">x</a>` — the typed pair took the passthrough's body
- after: `<a href="x" class="bare \u{96}\u{97}">x</a>`

And a typed pair with no real masked piece to interact with round-trips unchanged, in every family:

| source | rendering |
| --- | --- |
| `image:x.png[alt=a\u{96}\u{97}b]` | ``'&lt;img src="x.png" alt="a\u{96}\u{97}b"&gt;'`` |
| `link:x[role=a\u{96}\u{97}b]` | `<a href="x" class="bare a\u{96}\u{97}b">x</a>` |
| `xref:a[t\u{96}\u{97}u,role=r\u{96}\u{97}s]` | `<a href="#a" class="r\u{96}\u{97}s">t\u{96}\u{97}u</a>` |
| `image:x.png[alt=a\u{96}\u{97}b,++real++]` | ``'&lt;img src="x.png" alt="a\u{96}\u{97}b" width="real"&gt;'`` |
| `link:x[a\u{96}\u{97}b ++real++,role=hl]` | `<a href="x" class="hl">a\u{96}\u{97}b real</a>` |
| `image:x.png[alt=a\u{E005}sb,++real++]` | ``'&lt;img src="x.png" alt="a\u{E005}sb" width="real"&gt;'`` |

The two `a_placeholder_from_an_attribute_value_cannot_forge_*` regressions keep their forgery assertions and gain a *better* expected output: `alt="\u{96}\u{97}"` — the document's own bytes — where they previously asserted the retired guard's escaped `alt="\u{e005}s\u{e005}e"`. That is the two-way-ness paying off.

## What this does *not* close

One road survives, and it is the same one that blocks the offset table (§3.5's first bullet): `Attrlist::parse` re-substitutes attribute references over the text handed to it, so a `subs=` list naming `macros` without `attributes` expands a reference **after** the tokener escaped its copy. With `:forge: \u{96}\u{97}` defined, `[subs=macros]` over `image:x.png[alt={forge},++real++]` still renders ``'&lt;img src="x.png" alt="real" width="\u{96}\u{97}"&gt;'``.

Found while auditing, pinned by `an_attrlist_level_expansion_can_still_forge_a_bracket_restore` (which also pins a stray introducer arriving the same way being copied through — that is why `escaped_literal`'s `None` arm exists rather than being defensive). Closing it means escaping inside that parse, which needs the parse to know it is handling tokened text: a mechanism change of its own, not a widening of this one, and narrower than what this closes — it needs an explicit `subs=` list omitting `attributes` *and* a reference whose value spells the pair.

`xref.rs`'s `text_carries_author_written_token_bytes` gate stays, re-documented as **conservative** rather than load-bearing: its own reasoning is answered by the escape, but lifting it would have the tree claim a shape whose fold diverges from the recorded golden (the recording masked its own passthroughs with the same two codepoints).

## What lands

- `element_attribute.rs`: `MASKED_PIECE_ESCAPE`, `escape_masked_piece_bytes`, `unescape_masked_piece_bytes`, `escaped_literal`; `restore_into`/`restore_tokens` decode escapes in the restoring walk; `MASKED_PIECE_PLACEHOLDER_START`'s doc comment now states the by-construction property instead of the typed-in-the-clear gap.
- `image.rs`/`macros/mod.rs`: both tokeners escape what they copy, including their "nothing to token" early returns.
- `macros/mod.rs`: `untranslated_value` and `computed_value_children` unescape.
- `links.rs`: the `masked.is_empty()` branch takes `into_owned_restoring(source, &[])`.
- `attribute_refs.rs`: `escape_passthrough_sentinels` and its call site deleted; the unit test becomes `a_reference_expanding_to_a_passthrough_sentinel_is_spliced_verbatim`.
- `tests/sentinels.rs`: `a_typed_placeholder_before_a_masked_piece_forges_a_bracket_restore` → `a_typed_placeholder_beside_a_masked_piece_cannot_forge_a_bracket_restore` (asserting the closure, both families); three new round-trip fixtures; the residual-road fixture; module doc updated.
- `image.rs`'s `a_bracket_body_carrying_sentinel_shaped_bytes_is_not_re_matched` gains the *ahead* order it could not have before, and loses its order-dependence narration.
- Design doc §3.5's closing paragraphs: the follow-up it described as "not-yet-taken-up" is what the crate now does, plus the one road left. Three stale cross-references to that note's pre-#1353 heading are corrected to §3.5.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — green (5,500 lib tests, five more than the base's 5,495)
- `cargo +nightly doc --no-deps --document-private-items` — clean
- Fold-parity audit vs. `origin/inline-ast` — **no new divergences** (8 before, 8 after, `comm` empty both ways)
- Coverage vs. a detached checkout of `0bdcdcf` — diff-neutral: every touched file's missed-region and missed-line counts unchanged (`element_attribute.rs` 2/1, `attrlist.rs` 2/1, `attribute_refs.rs` 13/7, `image.rs` 3/1, `links.rs` 17/10, `macros/mod.rs` 4/2, `xref.rs` 17/8), total 548 missed regions / 322 missed lines on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGhnADXtgBYMx75uDh9duZ
