### PR TITLE
doc: Drop dangling design-doc citations left from the inline-AST migration

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -810,7 +810,7 @@ impl<'src> Attrlist<'src> {
     /// For every list parsed straight from the source it describes, that is
     /// its [`source`](Self::span) span's own bytes. For one rebuilt by
     /// [`into_owned`](Self::into_owned) from a temporary — whose `source` is a
-    /// coarser *location tag* rather than the text (design §4.4) — it is the
+    /// coarser *location tag* rather than the text — it is the
     /// owned copy that method kept.
     fn source_text(&'src self) -> &'src str {
         match &self.source_text {
@@ -2983,7 +2983,7 @@ mod tests {
             // `into_owned` re-tags a list parsed from a temporary with a
             // *coarser* source span — the inline AST builder's case, where the
             // attrlist text is the escaped or attribute-expanded bytes of a
-            // match string and the span is only a location tag (design §4.4).
+            // match string and the span is only a location tag.
             // This is the one accessor that reads the list's own text rather
             // than a parsed attribute, so it reads the kept copy: recovering
             // the raw span's `'a<b'` here would drop the escaping the string

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -226,8 +226,8 @@ impl<'src> ListItemMarker<'src> {
         // Running it through `SubstitutionGroup::apply` rather than the steps
         // directly is what gives the term a **tree**: the seed, the
         // authoritative fold, and the replay of every recognition side effect
-        // come with it, so a term no longer registers from the string pipeline
-        // (design §5.2 Phase 4, step 6 — this was the last content that did).
+        // come with it, so a term no longer registers from the string
+        // pipeline (this was the last content that did).
         TERM_SUBSTITUTIONS.apply_to_description_list_term(term, parser, warnings);
     }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -266,8 +266,7 @@ impl<'src> SectionBlock<'src> {
         // than about bytes. Still a single substitution pass, so
         // counters and attribute-expanded footnotes are
         // processed exactly once — which is what the sentinel pair this
-        // replaces existed to buy (design §4.2's first sentinel
-        // system).
+        // replaces used to buy.
         let mut section_title = Content::from(title_span);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
 

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -799,8 +799,8 @@ mod tests {
         );
     }
 
-    /// Builds and folds the single-pass tree for `source` — the same [`build`]
-    /// a real cutover would call — through the built-in HTML renderer.
+    /// Builds and folds the single-pass tree for `source` through the
+    /// built-in HTML renderer.
     fn built(source: &str, parser: &Parser) -> String {
         let nodes = build(Span::new(source), parser, None);
         fold_html(&nodes, &HtmlInlineRenderer {}, &parser.render_context())

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -90,7 +90,7 @@ struct TitleNode<'src> {
 
     /// The document attributes in force where this title was written, retained
     /// on its content because a fold running later than its parse cannot read
-    /// them from the parser (design §4.2's second sentinel system).
+    /// them from the parser.
     ///
     /// `None` leaves the title on the template path, as it does everywhere
     /// else.

--- a/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
+++ b/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
@@ -445,9 +445,8 @@ The mix of constrained and unconstrained formatting marks in the line is ambiguo
             panic!("Unexpected block type: {block2:?}");
         };
 
-        // NOTE: this is the **one golden output the inline-AST cutover
-        // changes** (design §5.2 Phase 4, step 6), and it changes for
-        // the better.
+        // NOTE: this is the **one golden output the inline-AST migration
+        // changes**, and it changes for the better.
         //
         // The string pipeline ran its quoted-text subs as passes over one flat
         // string, so the `#`-delimited highlight pass matched across the markup

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -9562,8 +9562,7 @@ mod passthroughs {
     // The restore pass the next two upstream tests drive — re-expanding
     // hand-planted placeholders over an extracted list — has no analog here:
     // the tree is authoritative, and a passthrough body is folded in place
-    // rather than re-spliced into a placeholder-bearing string (design §5.2,
-    // Phase 4 step 6).
+    // rather than re-spliced into a placeholder-bearing string.
     non_normative!(
         r##"
     test 'restore inline passthroughs without subs' do

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -4,9 +4,10 @@
 //! ([`inline_builder`](crate::content::inline_builder)'s test module) drive
 //! [`SubstitutionGroup::apply`](crate::content::SubstitutionGroup)
 //! on a bare [`Content`](crate::content::Content), which has no document
-//! catalog and so **cannot resolve cross-references**. (The whole-document
-//! sweep that used to sit beside this one drove the *Strategy-A recorder* and
-//! retired with it.)
+//! catalog and so **cannot resolve cross-references**. (A whole-document
+//! sweep used to sit beside this one, driving a since-retired recorder that
+//! reconstructed trees from the string pipeline's rendered output; it
+//! retired along with that recorder.)
 //!
 //! That leaves one thing unverified, and it is the thing the
 //! cutover rests on: **the tree the single-pass builder produces, folded

--- a/parser/src/tests/inline_builder_document_parity.rs
+++ b/parser/src/tests/inline_builder_document_parity.rs
@@ -9,15 +9,15 @@
 //! reconstructed trees from the string pipeline's rendered output; it
 //! retired along with that recorder.)
 //!
-//! That leaves one thing unverified, and it is the thing the
-//! cutover rests on: **the tree the single-pass builder produces, folded
-//! *after* cross-reference resolution has run, reproduces the rendered string
-//! byte-for-byte.** Design §4.2 retires the deferred-cross-reference sentinel
-//! system on exactly that basis — an `xref` is a
+//! That leaves one thing unverified, and it is the guarantee the whole
+//! single-pass design rests on: **the tree the single-pass builder produces,
+//! folded *after* cross-reference resolution has run, reproduces the
+//! rendered string byte-for-byte.** Design §4 describes resolution as
+//! non-destructive and re-resolvable by construction — an `xref` is a
 //! [`Ref`](crate::inlines::Ref)`{resolved: None}` node that resolution fills in
-//! place, "non-destructive by construction, re-resolvable, no template" — and
-//! §4.3 extends the same claim to section titles (whose own document-order
-//! pass mutates the title's tree) and to footnote-embedded references (which
+//! place, with no template involved — for all three cases this harness
+//! checks: plain cross-references, section titles (whose own document-order
+//! pass mutates the title's tree), and footnote-embedded references (which
 //! live in a footnote's subtree).
 //!
 //! This harness checks all three, over whole documents, in one parse: every
@@ -426,7 +426,7 @@ fn fold_matches_the_rendered_string_after_resolution() {
 fn a_stateful_renderer_is_not_required_for_the_fold() {
     // The fold takes the renderer as an argument, so the same tree renders
     // through a second, independently-constructed renderer to the same bytes —
-    // the property `render_with` will rest on (design §3.3.1). Driven here on
+    // the property `render_with` rests on. Driven here on
     // a document whose references resolve, since that is this harness's own
     // subject.
     let mut parser = parser();
@@ -466,9 +466,8 @@ fn a_stateful_renderer_is_not_required_for_the_fold() {
     }
 }
 
-// The document-attribute state each content retains for the fold that will run
-// *after* resolution — design §4.2's second sentinel system, whose retirement
-// is the increment this one stages.
+// The document-attribute state each content retains for the fold that runs
+// *after* resolution.
 
 #[test]
 fn document_stays_send_and_sync() {

--- a/parser/src/tests/inline_builder_passthrough_record_parity.rs
+++ b/parser/src/tests/inline_builder_passthrough_record_parity.rs
@@ -1,11 +1,10 @@
 //! A differential harness for [`Content::passthroughs`], which is now a **view
 //! over the inline tree** rather than the extraction pass's own list.
 //!
-//! Design §5.2's survey named this API as one of the six things `run_pipeline`
-//! still solely owned, and called it the one where *deleting* the API was as
-//! live an option as building a tree-backed view. The view is the chosen path,
-//! and this is the corpus that gates it: for every fixture, what the string
-//! pipeline extracted and what the tree holds must be the same facts.
+//! Deleting the API outright was as live an option as building a tree-backed
+//! view; the view is the path that was chosen, and this is the corpus that
+//! gated it: for every fixture, what the string pipeline extracted and what
+//! the tree holds must be the same facts.
 //!
 //! Three increments were needed before the tree could answer at all, and each
 //! one is visible in what this corpus asserts:
@@ -27,9 +26,10 @@
 //! [`the_view_returns_document_order`] pins it from both ends.
 //!
 //! The golden side is **frozen** (`snapshots/passthrough_records.txt`). Its
-//! source is [`Passthroughs::extract_from`] — the passthrough sentinel system
-//! design §4.2 retires — so it is one of the corpora that would otherwise have
-//! nothing left to compare against once that system is deleted. See
+//! source was `Passthroughs::extract_from` — the passthrough sentinel system,
+//! retired along with the rest of the crate's string-substitution
+//! implementation — so this is one of the corpora that would otherwise have
+//! nothing left to compare against now that system is gone. See
 //! [`golden`] for why this one round-trips the recording rather than comparing
 //! rendered bytes, and why the sentinel it preserves is the point.
 
@@ -48,30 +48,32 @@ const RECORDING: &str = "passthrough_records";
 /// group it is restored under.
 type Record = (String, SubstitutionGroup);
 
-/// What the **string pipeline** extracts, in extraction order — read back from
-/// the recording, having been frozen there while the extraction pass still ran.
+/// What the **string pipeline** extracted, in extraction order — read back
+/// from the recording, having been frozen there while the extraction pass
+/// still ran.
 ///
-/// Read from a throwaway [`Passthroughs::extract_from`] over the same source
-/// rather than from the content under test, whose own list is the view now —
-/// comparing that against itself would assert nothing.
+/// The recording was read from a throwaway `Passthroughs::extract_from` over
+/// the same source rather than from the content under test, whose own list
+/// was the view even then — comparing that against itself would have
+/// asserted nothing.
 ///
-/// That independence is what the recording *keeps*. `Passthroughs` is the
-/// passthrough sentinel system (design §4.2), which this branch is about to
-/// delete: once it is gone the extraction pass cannot answer, and a golden
-/// computed from it would have nowhere left to come from but the view. So the
-/// answer is frozen now, exactly as design §5.2's own freeze did for the
-/// golden-HTML corpora — the helper's body becomes a lookup and none of this
-/// module's assertions move.
+/// That independence is what the recording *keeps*. `Passthroughs` was the
+/// passthrough sentinel system, retired along with the rest of the crate's
+/// string-substitution implementation: once it was gone the extraction pass
+/// could no longer answer, and a golden computed from it would have had
+/// nowhere left to come from but the view. So the answer was frozen ahead of
+/// that, the same way the golden-HTML corpora's own freeze was — the
+/// helper's body is a lookup and none of this module's assertions move.
 ///
 /// The freeze is a **round trip**, not a string comparison, because this
 /// corpus's assertions read the golden's *structure*: its length, whether it
 /// `contains` one of the view's entries, and — in
 /// [`a_stem_expression_embedding_a_passthrough_reports_both_entries`] — whether
 /// its outer STEM body still carries the `\u{96}` extraction sentinel. That
-/// last one is the reason to freeze this corpus rather than retire it with the
-/// pass: the recording preserves the exact artifact the deletion removes, so
+/// last one is the reason this corpus was frozen rather than retired with the
+/// pass: the recording preserves the exact artifact the deletion removed, so
 /// the documented difference between the two sides stays pinned to bytes
-/// afterwards rather than becoming untestable.
+/// rather than becoming untestable.
 fn golden(source: &str, _parser: &Parser) -> Vec<Record> {
     decode(&recorded(RECORDING, source))
 }
@@ -404,8 +406,8 @@ fn a_stem_expression_embedding_a_passthrough_reports_both_entries() {
     // Reporting the restored body is the decision, not an oversight: the
     // sentinel is an artifact of the extraction pass's own bookkeeping, and a
     // caller asking what the author wrote is better served by `x <b> y` than by
-    // a private control character. The sentinel disappears entirely when step 6
-    // deletes that pass.
+    // a private control character. The sentinel disappeared entirely once that
+    // pass was deleted; only this frozen recording still carries it.
     let parser = Parser::default();
 
     for (source, restored) in [
@@ -448,10 +450,11 @@ fn a_deferred_stem_macro_reports_only_its_inner_passthrough() {
     // `children`, and nothing to report the outer entry from. The view reports
     // only the inner passthrough where the pass reports both.
     //
-    // Closing it means building the node anyway, which would risk a construct
-    // spanning the boundary going unrecognized — a rendering regression traded
-    // for a reporting one. It waits for the cutover that deletes the extraction
-    // pass and with it the question.
+    // Closing it would mean building the node anyway, which would risk a
+    // construct spanning the boundary going unrecognized — a rendering
+    // regression traded for a reporting one. That trade was never made: the
+    // extraction pass retired with the divergence still open, so it is now
+    // pinned to the frozen recording rather than closed.
     let parser = Parser::default();
 
     let (golden, view) = both("a stem:c,q[x +++<b>+++ y] z", &parser);

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -8,11 +8,11 @@
 //! (and a bibliography entry) registers its id in the reference catalog, an
 //! image whose `link=` names a dangerous scheme records a warning, and a
 //! `footnote:`/`footnoteref:` macro registers its numbered entry — text and
-//! deferred cross-references included — in the footnote catalog. Step 6 of
-//! the inline-AST cutover has to replay the first four from the tree, exactly
-//! once per parse and in the string pipeline's own pass order, which is what
+//! deferred cross-references included — in the footnote catalog. The
+//! inline-AST cutover's step 6 wired
 //! [`apply_macro_side_effects`](crate::content::inline_builder::apply_macro_side_effects)
-//! is staged to do.
+//! to replay the first four from the tree, exactly once per parse and in the
+//! string pipeline's own pass order.
 //!
 //! The **footnote** catalog is the one that cannot be staged, and the builder
 //! has always written it during the build: a footnote's number *is* its
@@ -40,10 +40,10 @@
 //! catalog entries, in registration order, and the warnings, in the order one
 //! shared list received them.
 //!
-//! The golden side is **frozen** (`snapshots/side_effects.txt`). Its source is
-//! `SubstitutionGroup::apply_string_pipeline`, which step 6 of the cutover is
-//! about to delete; without the freeze every assertion below would be left
-//! comparing the builder against itself the moment it went. The survey that
+//! The golden side is **frozen** (`snapshots/side_effects.txt`). Its source
+//! was `SubstitutionGroup::apply_string_pipeline`, which step 6 of the
+//! cutover deleted; without the freeze every assertion below would now be
+//! comparing the builder against itself. The survey that
 //! scoped that deletion named this corpus as the second of the two
 //! *record-shaped* ones — a flat list of plainly serializable facts, needing a
 //! codec for its own record rather than the `InlineNode` serialization the
@@ -191,15 +191,15 @@ fn snapshot(parser: &Parser) -> SideEffects {
 /// What the **string pipeline** wrote down, read back from the recording — the
 /// frozen half of every comparison in this module.
 ///
-/// The pipeline still runs, and `recorded` still checks its answer
-/// against the recorded one on every call, so nothing here is taken on trust
-/// while the pipeline exists. What the freeze buys is the day it does not:
-/// `apply_string_pipeline` is this corpus's only golden source, so deleting it
-/// would otherwise leave every assertion below comparing the builder against
-/// itself. This corpus is the second of the two *record-shaped* ones — a flat
-/// list of plainly serializable facts, needing a
-/// codec for its own record rather than an `InlineNode` serialization — and
-/// this is that codec.
+/// While the pipeline still ran, `recorded` also checked its answer against
+/// the recorded one on every call, so nothing here was taken on trust while
+/// the pipeline existed. What the freeze bought is the day it stopped:
+/// `apply_string_pipeline` was this corpus's only golden source, and step 6
+/// of the cutover deleted it; without the freeze every assertion below would
+/// now be comparing the builder against itself. This corpus is the second of
+/// the two *record-shaped* ones — a flat list of plainly serializable facts,
+/// needing a codec for its own record rather than an `InlineNode` serialization
+/// — and this is that codec.
 ///
 /// It is a **round trip** rather than a string comparison for the same reason
 /// the passthrough record corpus's is: the assertions below read the golden's

--- a/parser/src/tests/inline_builder_side_effect_parity.rs
+++ b/parser/src/tests/inline_builder_side_effect_parity.rs
@@ -8,10 +8,9 @@
 //! (and a bibliography entry) registers its id in the reference catalog, an
 //! image whose `link=` names a dangerous scheme records a warning, and a
 //! `footnote:`/`footnoteref:` macro registers its numbered entry — text and
-//! deferred cross-references included — in the footnote catalog. The
-//! inline-AST cutover's step 6 wired
+//! deferred cross-references included — in the footnote catalog.
 //! [`apply_macro_side_effects`](crate::content::inline_builder::apply_macro_side_effects)
-//! to replay the first four from the tree, exactly once per parse and in the
+//! replays the first four from the tree, exactly once per parse and in the
 //! string pipeline's own pass order.
 //!
 //! The **footnote** catalog is the one that cannot be staged, and the builder
@@ -41,15 +40,16 @@
 //! shared list received them.
 //!
 //! The golden side is **frozen** (`snapshots/side_effects.txt`). Its source
-//! was `SubstitutionGroup::apply_string_pipeline`, which step 6 of the
-//! cutover deleted; without the freeze every assertion below would now be
-//! comparing the builder against itself. The survey that
-//! scoped that deletion named this corpus as the second of the two
-//! *record-shaped* ones — a flat list of plainly serializable facts, needing a
-//! codec for its own record rather than the `InlineNode` serialization the
-//! tree-shaped corpora still owe. See [`frozen`] for why this one round-trips
-//! the recording rather than comparing bytes, and [`key`] for why it is the
-//! first corpus whose recording key is not the fixture source alone.
+//! was `SubstitutionGroup::apply_string_pipeline`, retired along with the
+//! rest of the crate's string-substitution implementation; without the
+//! freeze every assertion below would now be comparing the builder against
+//! itself. The survey that scoped that retirement named this corpus as the
+//! second of the two *record-shaped* ones — a flat list of plainly serializable
+//! facts, needing a codec for its own record rather than the `InlineNode`
+//! serialization the tree-shaped corpora still owe. See [`frozen`] for why this
+//! one round-trips the recording rather than comparing bytes, and [`key`] for
+//! why it is the first corpus whose recording key is not the fixture source
+//! alone.
 
 use crate::{
     Parser, Span,
@@ -194,9 +194,10 @@ fn snapshot(parser: &Parser) -> SideEffects {
 /// While the pipeline still ran, `recorded` also checked its answer against
 /// the recorded one on every call, so nothing here was taken on trust while
 /// the pipeline existed. What the freeze bought is the day it stopped:
-/// `apply_string_pipeline` was this corpus's only golden source, and step 6
-/// of the cutover deleted it; without the freeze every assertion below would
-/// now be comparing the builder against itself. This corpus is the second of
+/// `apply_string_pipeline` was this corpus's only golden source, and it was
+/// retired along with the rest of the crate's string-substitution
+/// implementation; without the freeze every assertion below would now be
+/// comparing the builder against itself. This corpus is the second of
 /// the two *record-shaped* ones — a flat list of plainly serializable facts,
 /// needing a codec for its own record rather than an `InlineNode` serialization
 /// — and this is that codec.

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -6,8 +6,8 @@
 //!
 //! This began life as `inline_recorder.rs`, the corpus for a since-retired
 //! `RecordingRenderer` that recovered a tree from the string pipeline's
-//! rendered output. That recorder retired with the string pipeline it
-//! wrapped at the step 6 cutover; its corpus tests, which compared
+//! rendered output. That recorder retired along with the string pipeline it
+//! wrapped; its corpus tests, which compared
 //! its tree against that pipeline's own bytes, could only ever compare the
 //! pipeline against itself once both were gone, so they went with it. What
 //! stayed is everything here: tests whose subject is the single-pass
@@ -668,8 +668,8 @@ fn inline_tree_for_a_listing_block_carries_callout_nodes() {
 
 #[test]
 fn the_xref_mirror_correlates_the_form_that_used_to_defer() {
-    // The counterpart of the deferral divergence at the step 6 cutover, seen
-    // from resolution.
+    // The counterpart of the deferral divergence that closed with the
+    // string-substitution pipeline's retirement, seen from resolution.
     //
     // `xref:sec[a *b, c* d,role=hl]` used to be deferred by the builder,
     // because the string replacer splits the attribute list over the span's

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -4,9 +4,9 @@
 //! [`IsBlock::inlines`](crate::blocks::IsBlock) — and for the resolution
 //! machinery that installs cross-reference destinations back into it.
 //!
-//! This began life as `inline_recorder.rs`, the Strategy-A recorder's own
-//! corpus. The recorder — a `RecordingRenderer` that recovered a tree from the
-//! string pipeline's rendered output — retired with the string pipeline it
+//! This began life as `inline_recorder.rs`, the corpus for a since-retired
+//! `RecordingRenderer` that recovered a tree from the string pipeline's
+//! rendered output. That recorder retired with the string pipeline it
 //! wrapped at the step 6 cutover; its corpus tests, which compared
 //! its tree against that pipeline's own bytes, could only ever compare the
 //! pipeline against itself once both were gone, so they went with it. What
@@ -1217,13 +1217,14 @@ fn inline_tree_xref_resolution_matches_the_rendered_string() {
 #[test]
 fn inline_tree_build_tolerates_a_stateful_renderer() {
     /// A renderer whose output depends on mutable internal state: it emits
-    /// different bytes on each invocation. Under the retired Strategy-A
-    /// recorder, tree building re-ran the whole pipeline through the shared
-    /// renderer instance, so such a renderer poisoned the recorded tree (and a
-    /// debug assertion rejected it). The single-pass builder derives the tree
-    /// from source instead — a `CharRef` node carries the *logical* character,
-    /// not renderer output — so a stateful renderer is now safe: the
-    /// authoritative rendered string sees the renderer's stateful bytes, and
+    /// different bytes on each invocation. Under the retired
+    /// `RecordingRenderer` (see the module doc), tree building re-ran the
+    /// whole pipeline through the shared renderer instance, so such a
+    /// renderer poisoned the recorded tree (and a debug assertion rejected
+    /// it). The single-pass builder derives the tree from source instead —
+    /// a `CharRef` node carries the *logical* character, not renderer
+    /// output — so a stateful renderer is now safe: the authoritative
+    /// rendered string sees the renderer's stateful bytes, and
     /// the tree stays logical.
     #[derive(Debug, Default)]
     struct FlipRenderer {

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -12,9 +12,9 @@
 //! over the source, and a carried title's deferred template (the splice that
 //! outlives the parse) is a structured piece list rather than a marked
 //! string — so these tests now pin the simpler invariant that a typed
-//! sentinel is ordinary content. The one in-band form left in production is a
-//! footnote's deferred template (see `FootnoteDeferred::render`); retiring it
-//! is the remaining slice of design §4.2's third sentinel system.
+//! sentinel is ordinary content. The last in-band form, a footnote's
+//! deferred template, has retired too (see `FootnoteDeferred::render`):
+//! it is now a structured piece list rather than escaped sentinel text.
 //!
 //! Two properties are covered:
 //!
@@ -694,9 +694,9 @@ fn a_resolved_destination_holding_a_sentinel_survives_resolution() {
     // path's decode-once pass, which turned `#a\u{e004}b` into `#a\u{e001}`.
     //
     // The second anchor is whole rather than cut short inside its span since
-    // the deferral divergence (design §5.2's step 6) — the sentinel handling
-    // this test is about is unchanged by that, and the expected bytes simply
-    // carry the tree's reading now.
+    // the deferral divergence closed — the sentinel handling this test is
+    // about is unchanged by that, and the expected bytes simply carry the
+    // tree's reading now.
     let (rendered, warnings) = last_paragraph_and_warnings(SENTINEL_ID_SOURCE);
 
     assert_eq!(warnings, 0, "reference did not resolve: {rendered:?}");


### PR DESCRIPTION
## Summary

The design doc (`docs/design/inline-ast-architecture.md`) was downsized from a ~12,000-line phase-by-phase build log to a ~400-line permanent architecture reference once the inline-AST migration finished (#1353). That drop took the phase/step tracking and every numbered subsection under §3-§5 with it, leaving a scattered set of comments across the crate citing sections and steps that no longer exist — and in a few cases, describing already-retired mechanisms as still live or still pending:

- `parser/src/tests/inline_tree.rs` and `parser/src/tests/inline_builder_document_parity.rs` named the **"Strategy-A recorder"**, a term cut along with the design doc's own history of it. Reworded to describe the retired `RecordingRenderer` without the orphaned label (also merges over wording an unrelated concurrent PR, #1355, touched in `inline_tree.rs`).
- `parser/src/tests/inline_builder_side_effect_parity.rs` described "step 6 of the cutover" and `apply_string_pipeline` in future tense ("is staged to do", "is about to delete", "the pipeline still runs") — stale now that step 6 landed and `apply_string_pipeline` no longer exists in the codebase.
- `parser/src/tests/inline_builder_passthrough_record_parity.rs` described the passthrough sentinel system (`Passthroughs::extract_from`) as something "this branch is about to delete" and linked to it via `[`...`]` (a broken intra-doc link outside what `cargo doc` checks, since it's inside `#[cfg(test)]`) — the type no longer exists anywhere in the crate.
- `parser/src/tests/sentinels.rs` claimed a footnote's deferred template was **"the one in-band sentinel form left in production"** — false: `FootnoteDeferred::render` already builds it as a structured piece list, per its own doc comment.
- Remaining dangling `design §5.2` / `design §4.2` / `design §4.4` / `design §3.3.1` / `Phase 4 step 6` / "the cutover" citations in `parser/src/document/title_refs.rs`, `parser/src/blocks/section.rs`, `parser/src/blocks/list_item_marker.rs`, `parser/src/attributes/attrlist.rs`, `parser/src/content/inline_builder/mod.rs`, and `parser/src/tests/asciidoctor_rb/substitutions_test.rs` — all reworded to describe the retired mechanism in plain past tense instead of citing a section number that no longer resolves.

No behavior change — doc-comment and code-comment wording only.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets`
- [x] `cargo test --workspace` (5500 passed)
- [x] `cargo +nightly doc --no-deps --document-private-items`
- [x] Confirmed no remaining `Strategy-A`/`strategy_a`/`design §`/`step 6`/`cutover` references in `parser/` or `docs/` (excluding vendored `ref/`)
