### PR TITLE
fix: Escape a spliced attribute value inside a tokened attrlist parse

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -272,11 +272,21 @@ substitution under `SplicedValueEscaping::MaskedPieceBytes`; the replacer perfor
 Because a `Replacer` only ever writes replacement text and never touches the haystack around a
 match, the tokener's own already-escaped bytes are left alone and nothing is escaped twice — and
 because the flag is per-call, the same substitution over ordinary never-tokened prose (which has
-no such invariant, and whose readers never unescape) goes on splicing verbatim. Two writes are
-deliberately left verbatim even under the tokened flag, both because their bytes are the
-haystack's own: the literal `{name}` an `attribute-missing=skip`/`warn` reference keeps, and a
-`counter`/`counter2` directive's displayed value, whose seed is a slice of the already-escaped
-expression and may hold a genuine placeholder the tokener wrote between the braces.
+no such invariant, and whose readers never unescape) goes on splicing verbatim. One write is
+deliberately left verbatim even under the tokened flag, because its bytes are the haystack's
+own: the literal `{name}` an `attribute-missing=skip`/`warn` reference keeps.
+
+A `counter`/`counter2` directive's displayed value is not so uniform, and splits on where that
+value came from (`Parser::counter_reporting_provenance`). Freshly derived from *this* call's own
+`seed` (or the `"1"` default) it is verbatim too, for the same reason: a slice of the
+already-escaped expression, free to hold a genuine placeholder the tokener wrote between the
+braces. But a counter with an existing value advances from **persisted** state instead — a
+plain document attribute of the same name (`:name: value`), or this same counter's own value
+from an earlier, unrelated reference elsewhere in the document — and persisted state was never
+escaped for *this* haystack. That value gets exactly the escape a resolved reference's value
+does, caught by Greptile's review of the PR that introduced this mechanism after the initial
+version escaped only the resolved-reference path and left every counter write verbatim
+regardless of provenance.
 
 Ordinal restoration is what makes escaping-at-the-splice sufficient where a byte-offset table
 would still fail: escaping a spliced value changes its length, but it changes neither the count

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -259,11 +259,28 @@ restored ranges it records stay in the coordinates of the string it is building,
 `untranslated_value`/`computed_value_children` on the runs between occurrences — so a
 document's own copy of a reserved codepoint round-trips to the output as written.
 
-One road is left uncovered, and it is the first bullet above: `Attrlist::parse` re-substitutes
-attribute references over the text handed to it, *after* the tokener escaped its copy, so a
-`subs=` list naming `macros` without `attributes` can still expand a reference whose value
-spells the pair into the tokened text. Closing it means escaping inside that parse, which
-requires the parse to know it has been handed tokened text.
+The tokener's copy is not the only way bytes enter a tokened text, though, and the second way is
+the first bullet above: `Attrlist::parse` re-substitutes attribute references over the text
+handed to it, *after* the tokener escaped its copy, so a `subs=` list naming `macros` without
+`attributes` expands a reference whose value the tokener never saw. Escaping is therefore
+applied at **both** points of entry rather than at the tokener alone. The tokened call sites —
+`bracket_attrlist`'s third path (`image.rs`), the cross-reference family's two `tokened_text`
+parses (`xref.rs`), and the link families' display-text list through
+`extract_attributes_from_text` — parse through `Attrlist::parse_tokened`, which runs that inner
+substitution under `SplicedValueEscaping::MaskedPieceBytes`; the replacer performing the splice
+(`AttributeReplacer`, `substitution_step.rs`) then escapes each resolved value as it writes it.
+Because a `Replacer` only ever writes replacement text and never touches the haystack around a
+match, the tokener's own already-escaped bytes are left alone and nothing is escaped twice — and
+because the flag is per-call, the same substitution over ordinary never-tokened prose (which has
+no such invariant, and whose readers never unescape) goes on splicing verbatim. Two writes are
+deliberately left verbatim even under the tokened flag, both because their bytes are the
+haystack's own: the literal `{name}` an `attribute-missing=skip`/`warn` reference keeps, and a
+`counter`/`counter2` directive's displayed value, whose seed is a slice of the already-escaped
+expression and may hold a genuine placeholder the tokener wrote between the braces.
+
+Ordinal restoration is what makes escaping-at-the-splice sufficient where a byte-offset table
+would still fail: escaping a spliced value changes its length, but it changes neither the count
+nor the order of the placeholder occurrences the tokener wrote, which is all the walk reads.
 
 ## 4. Cross-reference and title resolution
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -2,9 +2,11 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{
         ElementAttribute,
-        element_attribute::{MASKED_PIECE_PLACEHOLDER, ParseShorthand, restore_into},
+        element_attribute::{
+            MASKED_PIECE_PLACEHOLDER, ParseShorthand, SplicedValueEscaping, restore_into,
+        },
     },
-    content::{Content, SubstitutionStep},
+    content::{Content, apply_attributes},
     internal::{debug::DebugSliceReference, opaque_iter::opaque_slice_iter},
     span::MatchedItem,
     strings::CowStr,
@@ -210,6 +212,56 @@ impl<'src> Attrlist<'src> {
         parser: &Parser,
         attrlist_context: AttrlistContext,
     ) -> MatchAndWarnings<'src, MatchedItem<'src, Self>> {
+        Self::parse_escaping(
+            source,
+            parser,
+            attrlist_context,
+            SplicedValueEscaping::Verbatim,
+        )
+    }
+
+    /// [`parse`](Self::parse) over **tokened** macro-bracket text — what
+    /// `tokened_bracket`/`tokened_text` (the macros step) hand back, in which
+    /// each masked passthrough or STEM piece stands as one
+    /// [`MASKED_PIECE_PLACEHOLDER`] occurrence and every other byte is escaped
+    /// ([`escape_masked_piece_bytes`]).
+    ///
+    /// The difference is the attribute-reference substitution this parse runs
+    /// of its own, below. That substitution is the **second** point at which
+    /// bytes enter a tokened text — a `subs=` list naming `macros` without
+    /// `attributes` reaches the macros step with every reference still
+    /// unresolved, so it is this parse, not the content-level step, that
+    /// expands one — and it runs *after* the tokener escaped its copy. Under
+    /// [`SplicedValueEscaping::MaskedPieceBytes`] each resolved value is
+    /// escaped as it is spliced, which is what keeps the tokener's property
+    /// total: every reserved codepoint standing in the text this splits is one
+    /// the tokener wrote, so [`restore_into`]'s positional walk has nothing to
+    /// be fooled by and a document attribute's own reserved bytes come back
+    /// out as the document wrote them.
+    ///
+    /// Every other caller wants [`parse`](Self::parse): ordinary content
+    /// carries no such invariant, and escaping into it would put the escape's
+    /// own bytes in front of a reader that never unescapes.
+    ///
+    /// [`escape_masked_piece_bytes`]: crate::attributes::element_attribute::escape_masked_piece_bytes
+    pub(crate) fn parse_tokened(
+        source: Span<'src>,
+        parser: &Parser,
+    ) -> MatchAndWarnings<'src, MatchedItem<'src, Self>> {
+        Self::parse_escaping(
+            source,
+            parser,
+            AttrlistContext::Inline,
+            SplicedValueEscaping::MaskedPieceBytes,
+        )
+    }
+
+    fn parse_escaping(
+        source: Span<'src>,
+        parser: &Parser,
+        attrlist_context: AttrlistContext,
+        escaping: SplicedValueEscaping,
+    ) -> MatchAndWarnings<'src, MatchedItem<'src, Self>> {
         let mut attributes: Vec<ElementAttribute> = vec![];
         let mut parse_shorthand_items = true;
         let mut warnings: Vec<Warning<'src>> = vec![];
@@ -217,7 +269,7 @@ impl<'src> Attrlist<'src> {
         // Apply attribute value substitutions before parsing attrlist content.
         let source_cow = if source.contains('{') && source.contains('}') {
             let mut content = Content::from(source);
-            SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
+            apply_attributes(&mut content, parser, escaping);
             CowStr::from(content.rendered.to_string())
         } else {
             CowStr::from(source.data())
@@ -1068,6 +1120,80 @@ mod tests {
             30,
             "the substitution's own extra length must have moved the placeholder: {:?}",
             attrlist.source_text()
+        );
+    }
+
+    #[test]
+    fn a_restore_copies_an_unpaired_escape_introducer_through() {
+        // The restore walk's decode half is **total** over arbitrary input:
+        // an escape introducer followed by a byte that is not one of the
+        // three tags this crate writes is copied through with the bytes after
+        // it, rather than eating one as a tag (see `escaped_literal`), and
+        // the genuine placeholder further along still restores.
+        //
+        // Both points at which bytes enter a tokened text escape now — the
+        // tokener's own copy, and the splice inside `Attrlist::parse_tokened`
+        // — so the pipeline itself no longer produces an unpaired introducer.
+        // That is exactly why this is pinned here, over a hand-written
+        // tokened text, rather than through a document: totality is what lets
+        // every consumer run the unescape unconditionally, and it should not
+        // quietly stop holding just because nothing upstream exercises it.
+        use crate::attributes::element_attribute::{MASKED_PIECE_ESCAPE, MASKED_PIECE_PLACEHOLDER};
+
+        let p = Parser::default();
+        let source = format!("alt=p{MASKED_PIECE_ESCAPE}zq,title={MASKED_PIECE_PLACEHOLDER}");
+
+        let attrlist = crate::attributes::Attrlist::parse_tokened(crate::Span::new(&source), &p)
+            .unwrap_if_no_warnings()
+            .item
+            .into_owned_restoring(crate::Span::new("whatever"), &["real"]);
+
+        assert_eq!(
+            attrlist.named_attribute("alt").map(|attr| attr.value()),
+            Some(format!("p{MASKED_PIECE_ESCAPE}zq").as_str())
+        );
+
+        assert_eq!(
+            attrlist.named_attribute("title").map(|attr| attr.value()),
+            Some("real")
+        );
+    }
+
+    #[test]
+    fn a_restore_copies_an_occurrence_past_the_end_of_bodies_through() {
+        // The restore walk fails **closed** when it finds more placeholder
+        // occurrences than the caller supplied bodies for: the surplus
+        // occurrence is copied through verbatim rather than panicking or
+        // taking a later occurrence's body, and every occurrence the caller
+        // *did* supply a body for still restores.
+        //
+        // No caller can produce this — each tokens exactly as many pieces as
+        // it supplies bodies for, and since the tokened parse's own
+        // attribute-reference splice is escaped
+        // (`SplicedValueEscaping::MaskedPieceBytes`) an expansion can no
+        // longer add an occurrence behind the tokener's back either, which is
+        // what used to reach this arm. It is pinned directly instead, so a
+        // caller that someday breaks the count is caught by this contract
+        // rather than by a corrupted neighbouring restore.
+        use crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER;
+
+        let p = Parser::default();
+        let source = format!("alt={MASKED_PIECE_PLACEHOLDER},title={MASKED_PIECE_PLACEHOLDER}");
+
+        // Two occurrences, one body.
+        let attrlist = crate::attributes::Attrlist::parse_tokened(crate::Span::new(&source), &p)
+            .unwrap_if_no_warnings()
+            .item
+            .into_owned_restoring(crate::Span::new("whatever"), &["real"]);
+
+        assert_eq!(
+            attrlist.named_attribute("alt").map(|attr| attr.value()),
+            Some("real")
+        );
+
+        assert_eq!(
+            attrlist.named_attribute("title").map(|attr| attr.value()),
+            Some(MASKED_PIECE_PLACEHOLDER)
         );
     }
 

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -835,18 +835,25 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// it), which covered only the one road a *spliced* value took and left both
 /// a typed pair and the escape's own output visible in the output.
 ///
-/// One road remains, and it is the same one that blocked carrying a
+/// One road used to remain, and it was the same one that blocked carrying a
 /// byte-offset table through `Attrlist::parse` in the first place:
 /// [`Attrlist::parse`](crate::attributes::Attrlist::parse) re-substitutes
 /// attribute references over the text handed to it, so a `subs=` list naming
-/// `macros` without `attributes` can expand a reference *after* the tokener
-/// has escaped its copy. Whatever that reference's value spells reaches
+/// `macros` without `attributes` expands a reference *after* the tokener has
+/// escaped its copy — and whatever that reference's value spelled reached
 /// `restore_into`'s walk unescaped and indistinguishable from something the
-/// tokener wrote — a value spelling the placeholder forges a restore, and one
-/// spelling the escape sequence gets decoded, corrupting a document
-/// attribute's own text with no masked piece involved at all. See
-/// `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`
-/// (`tests/sentinels.rs`), which pins both.
+/// tokener wrote.
+///
+/// It is closed by escaping at that second point of entry too: the tokened
+/// call sites parse through
+/// [`Attrlist::parse_tokened`](crate::attributes::Attrlist), which runs its
+/// inner substitution under
+/// [`SplicedValueEscaping::MaskedPieceBytes`], so a resolved value is escaped
+/// as it is spliced. That keeps the by-construction property total — every
+/// reserved codepoint standing in a tokened text is one the tokener wrote —
+/// rather than true only of the bytes the tokener itself copied. See
+/// `an_attrlist_level_expansion_cannot_forge_a_bracket_restore`
+/// (`tests/sentinels.rs`).
 pub(crate) const MASKED_PIECE_PLACEHOLDER_START: char = '\u{96}';
 
 /// See [`MASKED_PIECE_PLACEHOLDER`].
@@ -876,6 +883,34 @@ const ESCAPED_END_TAG: char = 'e';
 /// `\u{E005}s` would come back holding a
 /// [`MASKED_PIECE_PLACEHOLDER_START`] it never wrote.
 const ESCAPED_ESCAPE_TAG: char = 'g';
+
+/// Whether the attribute-reference substitution rewriting a text has to run
+/// [`escape_masked_piece_bytes`] over each value it splices into it.
+///
+/// The distinction is *provenance*, not syntax: a resolved attribute value is
+/// the only thing that substitution writes which did not come out of the text
+/// it was handed, so it is the only thing that has to be escaped for a
+/// **tokened** text to go on holding no reserved codepoint the tokener did not
+/// write. Threaded from
+/// [`Attrlist::parse_tokened`](crate::attributes::Attrlist) down to the
+/// replacer that performs the splice; ordinary content-level content carries
+/// [`Verbatim`](Self::Verbatim) and is unaffected.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SplicedValueEscaping {
+    /// Ordinary, never-tokened text: a resolved value is spliced exactly as
+    /// the document wrote it. This text has no masked-piece invariant to
+    /// protect, and escaping into it would put the escape's own bytes in front
+    /// of a reader that never unescapes.
+    Verbatim,
+
+    /// **Tokened** macro-bracket text — what
+    /// [`Attrlist::parse_tokened`](crate::attributes::Attrlist) is handed — in
+    /// which every byte the tokener copied is already escaped. A resolved
+    /// value reaches this text *after* that escape ran, so it is escaped here
+    /// instead, at the splice, which is the one point where bytes from outside
+    /// the tokener's input enter it.
+    MaskedPieceBytes,
+}
 
 /// Rewrites `text`'s own copies of the three reserved codepoints —
 /// [`MASKED_PIECE_PLACEHOLDER_START`], [`MASKED_PIECE_PLACEHOLDER_END`], and
@@ -948,12 +983,16 @@ pub(crate) fn escape_masked_piece_bytes(text: &str) -> Cow<'_, str> {
 /// with the length of the tag that named it, or `None` when what follows the
 /// introducer is not a tag this crate wrote.
 ///
-/// The `None` case is not merely defensive: an introducer can reach a value
-/// without passing through [`escape_masked_piece_bytes`], via the one road
-/// [`MASKED_PIECE_PLACEHOLDER_START`]'s own doc comment names —
-/// [`Attrlist::parse`](crate::attributes::Attrlist::parse)'s re-substitution
-/// of an attribute reference over already-tokened text. Copying such an
-/// introducer through verbatim is what keeps that value's own bytes intact.
+/// The `None` case makes the decode half **total** over arbitrary input,
+/// which is what lets every consumer of a tokened text run
+/// [`unescape_masked_piece_bytes`] unconditionally rather than first proving
+/// the text is well-formed. Copying an unrecognized introducer through
+/// verbatim — rather than eating the byte after it as a tag — is what keeps
+/// such a text's own bytes intact. Both points at which bytes enter a tokened
+/// text do escape (see [`MASKED_PIECE_PLACEHOLDER_START`]), so the pipeline
+/// itself no longer produces an unpaired introducer; this arm is the codec's
+/// contract, pinned directly by
+/// `masked_piece_escape_round_trips_every_reserved_codepoint`.
 fn escaped_literal(tail: &str) -> Option<(char, usize)> {
     match tail.chars().next()? {
         ESCAPED_START_TAG => Some((MASKED_PIECE_PLACEHOLDER_START, ESCAPED_START_TAG.len_utf8())),
@@ -1304,13 +1343,16 @@ mod tests {
             borrowed
         );
 
-        // An introducer this crate did not write — reachable through
-        // `Attrlist::parse`'s own re-substitution over already-tokened text,
-        // the one road
-        // `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`
-        // pins — is copied through with the bytes after it, rather than
-        // eating one as a tag. That holds at the end of the text too, where
-        // there is no byte after it at all.
+        // An introducer this crate did not write is copied through with the
+        // bytes after it, rather than eating one as a tag. That holds at the
+        // end of the text too, where there is no byte after it at all.
+        //
+        // Every point at which bytes enter a tokened text escapes them now
+        // (the tokener's own copy, and the splice inside
+        // `Attrlist::parse_tokened`), so this is the codec's contract rather
+        // than a case the pipeline still produces: the decode half is total
+        // over arbitrary input, which is what lets a caller run it
+        // unconditionally.
         assert_eq!(
             unescape_masked_piece_bytes("p\u{e005}zq\u{e005}").as_ref(),
             "p\u{e005}zq\u{e005}"

--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -1181,6 +1181,14 @@ fn rebuild_attribute_level<'src>(
 /// so a value's own copy of the pair is escaped there whether it arrived
 /// through this splice or was typed in the clear — and, being two-way, comes
 /// back out as the document wrote it.
+///
+/// Not to be confused with the *other* attribute-reference splice, the one
+/// [`Attrlist::parse_tokened`](crate::attributes::Attrlist) runs inside a
+/// tokened parse, which **does** escape (see
+/// [`SplicedValueEscaping`](crate::attributes::element_attribute::SplicedValueEscaping)).
+/// The difference is what the value is being spliced into: this step's output
+/// is ordinary content, whose readers never unescape, while that one's is
+/// tokened text the tokener has already escaped the rest of.
 fn split_attribute_value<'src>(
     value: &str,
     location: Span<'src>,

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -922,7 +922,7 @@ fn bracket_attrlist<'src>(
 
     let bodies: Vec<&str> = masked.iter().map(|piece| piece.body.as_ref()).collect();
 
-    parse_attrlist(Span::new(&tokened), parser).into_owned_restoring(bracket, &bodies)
+    parse_tokened_attrlist(Span::new(&tokened), parser).into_owned_restoring(bracket, &bodies)
 }
 
 /// One masked piece a [`tokened_bracket`] token stands for: the node itself,
@@ -1095,11 +1095,21 @@ pub(in crate::content::inline_builder) fn tokened_bracket<'a, 'src>(
 }
 
 /// Parses one inline attribute list, discarding the warnings — the shared
-/// spelling both of [`bracket_attrlist`]'s paths use.
+/// spelling of [`bracket_attrlist`]'s two **untokened** paths, the empty
+/// bracket and the verbatim one, whose bytes are the author's own.
 fn parse_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
     Attrlist::parse(source, parser, AttrlistContext::Inline)
         .item
         .item
+}
+
+/// [`parse_attrlist`] for [`bracket_attrlist`]'s third path, whose text came
+/// back from [`tokened_bracket`]: this parse's own attribute-reference
+/// substitution escapes each value it splices, so the placeholders
+/// [`Attrlist::into_owned_restoring`] then walks are still only the ones the
+/// tokener wrote. See [`Attrlist::parse_tokened`].
+fn parse_tokened_attrlist<'a>(source: Span<'a>, parser: &Parser) -> Attrlist<'a> {
+    Attrlist::parse_tokened(source, parser).item.item
 }
 
 /// Performs the recognition side effects an `image:`/`icon:` match needs —

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -12,7 +12,10 @@ use super::{
 };
 use crate::{
     Parser, Span,
-    attributes::{Attrlist, element_attribute::MASKED_PIECE_PLACEHOLDER},
+    attributes::{
+        Attrlist,
+        element_attribute::{MASKED_PIECE_PLACEHOLDER, SplicedValueEscaping},
+    },
     content::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
@@ -1676,7 +1679,10 @@ fn text_attrlist<'src>(
     let source = source_slice(pieces, text_range.clone(), root);
 
     if range_is_verbatim(pieces, &verbatim_range) && source.data() == normalized {
-        let (text, attrs) = extract_attributes_from_text(source, parser, None);
+        // The author's own bytes, never tokened, so a resolved attribute
+        // reference is spliced into them verbatim.
+        let (text, attrs) =
+            extract_attributes_from_text(source, parser, None, SplicedValueEscaping::Verbatim);
 
         return Some(TextAttrlist {
             adopted: text != normalized,
@@ -1699,7 +1705,14 @@ fn text_attrlist<'src>(
         Tokened::MaskedOrRendered,
     );
 
-    let (text, attrs) = extract_attributes_from_text(Span::new(&tokened), parser, None);
+    // Tokened, so the parse's own attribute-reference substitution escapes each
+    // value it splices — see [`Attrlist::parse_tokened`].
+    let (text, attrs) = extract_attributes_from_text(
+        Span::new(&tokened),
+        parser,
+        None,
+        SplicedValueEscaping::MaskedPieceBytes,
+    );
 
     // One thing has to hold before a token may stand for a **rendered** piece:
     // the *split* must land where a parse of the rendered

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     Parser, Span,
     attributes::{
-        Attrlist, AttrlistContext,
+        Attrlist,
         element_attribute::{MASKED_PIECE_PLACEHOLDER_END, MASKED_PIECE_PLACEHOLDER_START},
     },
     content::{
@@ -444,7 +444,7 @@ fn attrlist_text_carries_its_opaque_pieces(
 
     let (tokened, _carried) = tokened_text(&raw_text.replace('\n', " "), text_range, nodes, pieces);
 
-    let attrlist = Attrlist::parse(Span::new(&tokened), parser, AttrlistContext::Inline)
+    let attrlist = Attrlist::parse_tokened(Span::new(&tokened), parser)
         .item
         .item;
 
@@ -652,7 +652,7 @@ fn xref_macro_text<'src>(
             pieces,
         );
 
-        let attrlist = Attrlist::parse(Span::new(&normalized), parser, AttrlistContext::Inline)
+        let attrlist = Attrlist::parse_tokened(Span::new(&normalized), parser)
             .item
             .item;
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Match, Regex};
 
 use crate::{
     Parser, Span,
-    attributes::{Attrlist, AttrlistContext},
+    attributes::{Attrlist, AttrlistContext, element_attribute::SplicedValueEscaping},
     document::InterpretedValue,
     parser::XrefStyle,
 };
@@ -496,12 +496,25 @@ pub(crate) static INLINE_LINK_MACRO: LazyLock<Regex> = LazyLock::new(|| {
 /// attribute-list-bearing display text with the *exact* same interpretation
 /// this string step uses, changing only the recognition *sink* (a node field
 /// instead of a borrow of the node's own attribute list).
+///
+/// `escaping` names which of the link family's two display-text paths `text`
+/// came off: a verbatim slice of the source
+/// ([`Verbatim`](SplicedValueEscaping::Verbatim)) or the output of
+/// `tokened_bracket`
+/// ([`MaskedPieceBytes`](SplicedValueEscaping::MaskedPieceBytes)),
+/// whose masked-piece invariant this parse's own attribute-reference
+/// substitution has to keep. See [`Attrlist::parse_tokened`].
 pub(crate) fn extract_attributes_from_text<'src>(
     text: Span<'src>,
     parser: &Parser,
     default_text: Option<&str>,
+    escaping: SplicedValueEscaping,
 ) -> (String, Attrlist<'src>) {
-    let attrlist_maw = Attrlist::parse(text, parser, AttrlistContext::Inline);
+    let attrlist_maw = match escaping {
+        SplicedValueEscaping::Verbatim => Attrlist::parse(text, parser, AttrlistContext::Inline),
+        SplicedValueEscaping::MaskedPieceBytes => Attrlist::parse_tokened(text, parser),
+    };
+
     let attrs = attrlist_maw.item.item;
 
     if let Some(resolved_text) = attrs.nth_attribute(1) {
@@ -514,6 +527,8 @@ pub(crate) fn extract_attributes_from_text<'src>(
         // survive intact: the already-rendered inner macro output happens to
         // contain `=` and `"` characters, but is not a real attribute list.
         if resolved_text.value() == text.data() {
+            // A zero-length span: no bytes to splice into, so it takes the
+            // plain parse whichever path the caller is on.
             let empty_attrs = Attrlist::parse(Span::default(), parser, AttrlistContext::Inline)
                 .item
                 .item;

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -33,8 +33,8 @@ pub use substitution_group::SubstitutionGroup;
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
 pub(crate) use substitution_step::{
-    ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, build_callout_regexes,
-    character_replacements, hard_line_break_pattern, maybe_has_replacements, quote_subs,
-    restored_entity_pattern, substitute_attributes_in_macro_target,
+    ATTRIBUTE_REFERENCE, AttributeMissing, CharacterReplacement, QuoteSub, apply_attributes,
+    build_callout_regexes, character_replacements, hard_line_break_pattern, maybe_has_replacements,
+    quote_subs, restored_entity_pattern, substitute_attributes_in_macro_target,
     substitute_attributes_in_reftext,
 };

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -558,21 +558,32 @@ impl Replacer for AttributeReplacer<'_> {
             let name = parts.next().unwrap_or_default();
             let seed = parts.next();
 
-            let value = self.parser.counter(name, seed);
+            let (value, from_persisted_state) =
+                self.parser.counter_reporting_provenance(name, seed);
 
             // `counter` displays the new value; `counter2` advances silently.
             if directive.as_str() == "counter" {
-                // Written through unescaped even under
-                // `SplicedValueEscaping::MaskedPieceBytes`, unlike the
-                // resolved value below, because a counter's bytes are the
-                // haystack's own: the seed is a slice of the counter
-                // expression (already escaped where it came from a tokener,
-                // and free to hold a genuine placeholder the tokener wrote
-                // between the braces), and every later value is that seed
-                // advanced. Escaping here would both double-escape an escape
-                // the tokener already wrote and hide an occurrence the restore
-                // walk holds a body for.
-                dest.push_str(&value);
+                if from_persisted_state {
+                    // Advanced from the counter's own persisted state — a
+                    // prior counter value, or a plain document attribute of
+                    // the same name — rather than derived from this call's
+                    // own `seed`. Persisted state was never escaped for
+                    // *this* haystack (it may have entered as an ordinary
+                    // document attribute, or from an earlier, unrelated
+                    // reference elsewhere in the document), so it needs
+                    // exactly the same escape a resolved reference's value
+                    // does. See [`Parser::counter_reporting_provenance`].
+                    dest.push_str(&self.spliced(&value));
+                } else {
+                    // Fresh from `seed` (or the `"1"` default): a slice of
+                    // this call's own haystack, already escaped where it
+                    // came from a tokener and free to hold a genuine
+                    // placeholder the tokener wrote between the braces
+                    // (`{counter:a++x++}`). Escaping it here would both
+                    // double-escape an escape the tokener already wrote and
+                    // hide an occurrence the restore walk holds a body for.
+                    dest.push_str(&value);
+                }
             }
             return;
         }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -4,7 +4,10 @@ use regex::{Captures, Regex, RegexBuilder, Replacer};
 
 use crate::{
     Parser, Span,
-    attributes::Attrlist,
+    attributes::{
+        Attrlist,
+        element_attribute::{SplicedValueEscaping, escape_masked_piece_bytes},
+    },
     content::Content,
     document::InterpretedValue,
     parser::{
@@ -60,7 +63,12 @@ impl SubstitutionStep {
                 apply_special_characters(content, &*parser.renderer);
             }
             Self::AttributeReferences => {
-                apply_attributes(content, parser);
+                // Ordinary, never-tokened content: nothing here has a
+                // masked-piece invariant to protect, so a resolved value is
+                // spliced exactly as the document wrote it. The one caller
+                // that needs otherwise — `Attrlist::parse_tokened` — reaches
+                // `apply_attributes` directly.
+                apply_attributes(content, parser, SplicedValueEscaping::Verbatim);
             }
             // The five remaining steps have no per-step implementation here:
             // each is implemented as a tree transducer in
@@ -413,18 +421,30 @@ struct AttributeReplacer<'p> {
     /// whole line in `drop-line` mode, or a line the dropped reference left
     /// empty in `drop` mode (Asciidoctor's `reject_if_empty`).
     missing_on_line: bool,
+
+    /// Whether a resolved value is escaped as it is spliced, because the
+    /// haystack is **tokened** macro-bracket text. See
+    /// [`SplicedValueEscaping`], and [`replace_append`](Self::replace_append)
+    /// for why a resolved value is the only thing here that needs it.
+    escaping: SplicedValueEscaping,
 }
 
 impl<'p> AttributeReplacer<'p> {
     /// Builds the replacer over a haystack rendered from somewhere other than
     /// `fallback_source` itself, so a recorded warning names that coarse span.
-    fn new(parser: &'p Parser, mode: AttributeMissing, fallback_source: Span<'p>) -> Self {
+    fn new(
+        parser: &'p Parser,
+        mode: AttributeMissing,
+        fallback_source: Span<'p>,
+        escaping: SplicedValueEscaping,
+    ) -> Self {
         Self {
             parser,
             mode,
             fallback_source,
             haystack_is_source: false,
             missing_on_line: false,
+            escaping,
         }
     }
 
@@ -455,6 +475,25 @@ impl<'p> AttributeReplacer<'p> {
         );
     }
 
+    /// The bytes a **resolved** reference's `value` contributes to the output.
+    ///
+    /// This is the one thing
+    /// [`replace_append`](Replacer::replace_append) writes that did not come
+    /// out of the haystack, so it is the one thing that has to be escaped for
+    /// a **tokened** haystack to go on holding no reserved codepoint the
+    /// tokener did not write. See [`SplicedValueEscaping`].
+    fn spliced<'v>(&self, value: &'v str) -> Cow<'v, str> {
+        match self.escaping {
+            SplicedValueEscaping::Verbatim => Cow::Borrowed(value),
+
+            // A document attribute's value is document text — it never holds
+            // a placeholder a tokener wrote — so escaping it is unambiguous,
+            // and the consumer's own unescape on the way out hands the
+            // document its bytes back.
+            SplicedValueEscaping::MaskedPieceBytes => escape_masked_piece_bytes(value),
+        }
+    }
+
     /// The source span to attribute a recorded warning to: the offending
     /// reference itself where the haystack is its own source, and the coarse
     /// [`fallback_source`](Self::fallback_source) otherwise.
@@ -472,6 +511,15 @@ impl<'p> AttributeReplacer<'p> {
 }
 
 impl Replacer for AttributeReplacer<'_> {
+    /// Everything written here comes out of the haystack itself — the escaped
+    /// spelling of a reference, the literal `{name}` a missing reference keeps
+    /// — except the one thing that does not: the **resolved value** of a
+    /// reference that did resolve. Under
+    /// [`SplicedValueEscaping::MaskedPieceBytes`] that is the one write that
+    /// escapes, which is exactly what a tokened haystack needs and all it
+    /// needs: a [`Replacer`] only ever writes replacement text, never touching
+    /// the bytes around a match, so the tokener's own already-escaped copy is
+    /// left alone and nothing is escaped twice.
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         // A backslash immediately before the opening brace (`\{name}`) or
         // before the closing brace (`{name\}`) — or both, as in
@@ -514,6 +562,16 @@ impl Replacer for AttributeReplacer<'_> {
 
             // `counter` displays the new value; `counter2` advances silently.
             if directive.as_str() == "counter" {
+                // Written through unescaped even under
+                // `SplicedValueEscaping::MaskedPieceBytes`, unlike the
+                // resolved value below, because a counter's bytes are the
+                // haystack's own: the seed is a slice of the counter
+                // expression (already escaped where it came from a tokener,
+                // and free to hold a genuine placeholder the tokener wrote
+                // between the braces), and every later value is that seed
+                // advanced. Escaping here would both double-escape an escape
+                // the tokener already wrote and hide an occurrence the restore
+                // walk holds a body for.
                 dest.push_str(&value);
             }
             return;
@@ -566,7 +624,7 @@ impl Replacer for AttributeReplacer<'_> {
         // A value-less `Set` attribute (e.g. `:foo:` with no `=value`)
         // substitutes to an empty string, matching Asciidoctor.
         if let InterpretedValue::Value(value) = value {
-            dest.push_str(value.as_ref());
+            dest.push_str(&self.spliced(value.as_ref()));
         }
     }
 }
@@ -584,7 +642,19 @@ fn drop_emptied_line(replaced: &str) -> bool {
     replaced.strip_suffix('\r').unwrap_or(replaced).is_empty()
 }
 
-fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
+/// Runs the attribute-references substitution over `content`, escaping each
+/// value it splices as `escaping` says to.
+///
+/// Reached through [`SubstitutionStep::AttributeReferences`] — always
+/// [`SplicedValueEscaping::Verbatim`] — by everything except the one caller
+/// that needs otherwise:
+/// [`Attrlist::parse_tokened`](crate::attributes::Attrlist), whose haystack is
+/// already-tokened macro-bracket text and which calls this directly.
+pub(crate) fn apply_attributes(
+    content: &mut Content<'_>,
+    parser: &Parser,
+    escaping: SplicedValueEscaping,
+) {
     if !content.rendered.contains('{') {
         return;
     }
@@ -611,7 +681,7 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
             continue;
         }
 
-        let mut replacer = AttributeReplacer::new(parser, mode, source);
+        let mut replacer = AttributeReplacer::new(parser, mode, source, escaping);
 
         let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
 
@@ -671,8 +741,11 @@ pub(crate) fn substitute_attributes_in_macro_target<'src>(
     let mode = AttributeMissing::from_parser(parser);
 
     // The haystack is the target's own text, so a match's offsets are source
-    // offsets and a warning names the exact reference.
-    let mut replacer = AttributeReplacer::new(parser, mode, target).over_its_own_source();
+    // offsets and a warning names the exact reference. A macro *target* is
+    // never tokened — it is the source between the `::` and the `[` — so a
+    // resolved value is spliced verbatim.
+    let mut replacer = AttributeReplacer::new(parser, mode, target, SplicedValueEscaping::Verbatim)
+        .over_its_own_source();
 
     let replaced = ATTRIBUTE_REFERENCE.replace_all(text, replacer.by_ref());
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -3140,6 +3140,30 @@ impl Parser {
     ///
     /// [counter]: https://docs.asciidoctor.org/asciidoc/latest/attributes/counters/
     pub(crate) fn counter(&self, name: &str, seed: Option<&str>) -> String {
+        self.counter_impl(name, seed, false).0
+    }
+
+    /// Like [`counter`](Self::counter), but also reports whether the
+    /// returned value was advanced from the counter's own **persisted**
+    /// state (`true`) — a prior counter value, or a plain document attribute
+    /// of the same name — rather than freshly derived from `seed` or the
+    /// `"1"` default (`false`).
+    ///
+    /// A caller splicing this value into text that must stay free of
+    /// [`MASKED_PIECE_PLACEHOLDER`](crate::attributes::element_attribute::MASKED_PIECE_PLACEHOLDER)-shaped
+    /// bytes it did not itself write needs this distinction: `seed` (from
+    /// `{counter:name:seed}`) is a slice of the caller's own already-escaped
+    /// haystack, so a value derived from it needs no further escaping — but
+    /// persisted state was never escaped for *this* haystack. It may be an
+    /// ordinary document attribute (`:name: value`) set anywhere, or this
+    /// same counter's own value from an earlier, unrelated reference
+    /// elsewhere in the document — either way, its bytes did not pass
+    /// through the tokener guarding the text this call is splicing into.
+    pub(crate) fn counter_reporting_provenance(
+        &self,
+        name: &str,
+        seed: Option<&str>,
+    ) -> (String, bool) {
         self.counter_impl(name, seed, false)
     }
 
@@ -3154,7 +3178,7 @@ impl Parser {
     /// reads back as its latest counter value (unlike a plain inline
     /// `{counter:…}`, which leaves the locked value in place).
     pub(crate) fn counter_for_caption(&self, name: &str, seed: Option<&str>) -> String {
-        self.counter_impl(name, seed, true)
+        self.counter_impl(name, seed, true).0
     }
 
     /// Advances the `name` counter and returns its new value. `seed` supplies
@@ -3180,7 +3204,16 @@ impl Parser {
     ///   mirrors Asciidoctor's `Document#counter`, which advances `@counters`
     ///   but leaves `@attributes` untouched while the attribute is
     ///   `attribute_locked?`.
-    fn counter_impl(&self, name: &str, seed: Option<&str>, commit_when_locked: bool) -> String {
+    ///
+    /// Returns the advanced value alongside whether it was derived from
+    /// persisted state (see
+    /// [`counter_reporting_provenance`](Self::counter_reporting_provenance)).
+    fn counter_impl(
+        &self,
+        name: &str,
+        seed: Option<&str>,
+        commit_when_locked: bool,
+    ) -> (String, bool) {
         let use_private_state = !commit_when_locked && self.attribute_is_locked(name);
 
         // The value to advance from: the private running state first (only
@@ -3196,6 +3229,8 @@ impl Parser {
             InterpretedValue::Value(current) if !current.is_empty() => Some(current),
             _ => None,
         });
+
+        let from_persisted_state = current.is_some();
 
         let next = match current {
             Some(current) => next_counter_value(&current),
@@ -3214,7 +3249,7 @@ impl Parser {
                 .insert(name.to_string(), next.clone());
         }
 
-        next
+        (next, from_persisted_state)
     }
 
     /// Reports whether `name` currently resolves to an attribute that is

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -36,11 +36,20 @@
 //! out — which is what makes a typed pair ordinary content here as much as
 //! anywhere else in this file. Those tests come in three groups: four pin that
 //! property (a typed pair, and the escape's own introducer, round-tripping
-//! beside a real masked piece and alone); one records the one road that
-//! **can** still forge an occurrence — `Attrlist::parse`'s own re-substitution
-//! of an attribute reference over already-tokened text; and two pin the inputs
-//! that rule out replacing the whole scheme with a byte-offset table carried
-//! through `Attrlist::parse` instead.
+//! beside a real masked piece and alone); four cover the **second** point at
+//! which bytes enter a tokened text, which used to be the one road that could
+//! still forge an occurrence — the attribute-reference substitution
+//! `Attrlist::parse` runs over the text it is handed, which a `subs=` list
+//! naming `macros` without `attributes` reaches with every reference still
+//! unresolved, *after* the tokener escaped its copy. It is escaped there too
+//! now: the tokened call sites parse through `Attrlist::parse_tokened`, whose
+//! inner substitution escapes each value as it splices it, so the property
+//! holds by construction at every point of entry rather than only at the
+//! tokener's own copy. Those four pin the forgery closed for each tokened
+//! family, pin that ordinary content is *not* escaped (the gate's other half),
+//! and pin the one write deliberately left verbatim, a counter directive's.
+//! Two more pin the inputs that rule out replacing the whole scheme with a
+//! byte-offset table carried through `Attrlist::parse` instead.
 
 use crate::{
     Document, Parser,
@@ -327,30 +336,31 @@ fn a_typed_escape_introducer_round_trips_through_a_bracket() {
 }
 
 #[test]
-fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
-    // The one road left, recorded rather than fixed — and, as the third case
-    // below shows, wider than "forges a restore": it can corrupt a document
-    // attribute's own text with no passthrough involved at all.
+fn an_attrlist_level_expansion_cannot_forge_a_bracket_restore() {
+    // The last road, now closed — and it was wider than "forges a restore":
+    // it could corrupt a document attribute's own text with no passthrough
+    // involved at all (the third case below).
     //
     // The tokener escapes the bytes it *copies*, which settles every
-    // occurrence in the text it hands to `Attrlist::parse`. But that parse
-    // runs an attribute-reference substitution of its own over that text
-    // whenever it holds both a `{` and a `}` — and a `subs=` list naming
-    // `macros` without `attributes` reaches the macros step with every
-    // reference still unresolved, so the inner substitution is the one that
-    // expands it, *after* the escape ran. Whatever the reference's value
-    // spells lands in the tokened text verbatim, unescaped, and
-    // `restore_into`'s walk cannot tell it from something the tokener wrote:
-    // a value spelling the placeholder takes the real passthrough's body,
-    // exactly as a typed pair used to, and — the case Greptile's review of
-    // #1355 caught, https://github.com/asciidoc-rs/asciidoc-parser/pull/1355
-    // — a value spelling the escape sequence gets *decoded*, corrupting text
-    // that never went near a masked piece.
+    // occurrence in the text it hands to the parse. But that parse runs an
+    // attribute-reference substitution of its own over that text whenever it
+    // holds both a `{` and a `}` — and a `subs=` list naming `macros` without
+    // `attributes` reaches the macros step with every reference still
+    // unresolved, so the inner substitution is the one that expands it,
+    // *after* the escape ran. That splice is the second point at which bytes
+    // enter a tokened text, and it is where they are now escaped too: the
+    // tokened call sites parse through `Attrlist::parse_tokened`, which runs
+    // that substitution under `SplicedValueEscaping::MaskedPieceBytes` so a
+    // resolved value is escaped as it is written (`AttributeReplacer`, the
+    // macros step). A `Replacer` only ever writes replacement text, so the
+    // tokener's own already-escaped copy around the match is untouched and
+    // nothing is escaped twice.
     //
     // This is the same re-substitution that blocks the byte-offset table (see
-    // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`);
-    // closing it means escaping inside that parse, which is a mechanism
-    // change of its own and a separate increment.
+    // `an_attrlist_level_reference_expansion_moves_a_placeholder_in_the_tokened_text`),
+    // which is unaffected: restoring still walks by *position*, and escaping
+    // the spliced value changes neither the count nor the order of the
+    // occurrences the tokener wrote.
     let doc = Parser::default().parse(concat!(
         ":forge: \u{96}\u{97}\n",
         "\n",
@@ -358,17 +368,24 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
         "image:x.png[alt={forge},++real++]\n",
     ));
 
-    assert_eq!(
-        last_paragraph(&doc),
-        "<span class=\"image\"><img src=\"x.png\" alt=\"real\" width=\"\u{96}\u{97}\"></span>",
-        "known gap: the attrlist-level expansion captured the passthrough's body"
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("alt=\"real\""),
+        "the expanded value must not capture the passthrough's body: {rendered:?}"
     );
 
-    // The same parse also splices a bare escape introducer past the tokener.
-    // When the byte after it is not one of the three tags this crate writes,
-    // `escaped_literal` returns `None` and `restore_into`'s walk copies the
-    // introducer through rather than misreading it — safe by construction,
-    // not by luck.
+    // The expansion's own bytes stay in the slot it was written in, and the
+    // passthrough lands in the positional slot it actually occupies.
+    assert_eq!(
+        rendered,
+        "<span class=\"image\"><img src=\"x.png\" alt=\"\u{96}\u{97}\" width=\"real\"></span>"
+    );
+
+    // The same parse also splices an escape introducer past the tokener.
+    // Escaped at the splice like everything else, it round-trips whether or
+    // not the byte after it happens to be one of the three tags this crate
+    // writes — `z` here, which is not.
     let doc = Parser::default().parse(concat!(
         ":stray: p\u{e005}zq\n",
         "\n",
@@ -381,25 +398,149 @@ fn an_attrlist_level_expansion_can_still_forge_a_bracket_restore() {
         "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{e005}zq\" width=\"real\"></span>"
     );
 
-    // But when the byte after a late-spliced introducer *is* one of the three
-    // tags, there is nothing left to tell it apart from one the tokener
-    // itself wrote: `restore_into`'s walk decodes it, corrupting a document
-    // attribute value that never went near a masked piece. This is a wider
-    // consequence of the same gap above, not a new one (caught in review of
-    // #1355 — https://github.com/asciidoc-rs/asciidoc-parser/pull/1355) —
-    // silent corruption of ordinary text rather than a forged restore, and
-    // closed by the same future fix: escaping inside `Attrlist::parse`.
+    // And `s` here, which *is* a tag. This is the case Greptile's review of
+    // #1355 caught (https://github.com/asciidoc-rs/asciidoc-parser/pull/1355):
+    // an introducer spliced in past the tokener used to be indistinguishable
+    // from one the tokener itself wrote, so `restore_into`'s walk decoded it
+    // and the document attribute came back as `p\u{96}q`. The splice's own
+    // escape (`\u{e005}` -> `\u{e005}g`) is what tells the two apart now.
     let doc = Parser::default().parse(concat!(
         ":stray: p\u{e005}sq\n",
         "\n",
         "[subs=macros]\n",
-        "image:x.png[alt={stray},++real++]\n",
+        "image:x.png[alt={stray},title=++real++]\n",
     ));
 
     assert_eq!(
         last_paragraph(&doc),
-        "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{96}q\" width=\"real\"></span>",
-        "known gap: the document's own escape-shaped bytes were decoded"
+        "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{e005}sq\" title=\"real\"></span>"
+    );
+}
+
+#[test]
+fn an_attrlist_level_expansion_is_escaped_for_every_tokened_family() {
+    // The escape is gated to the call sites that are actually handed tokened
+    // text (`Attrlist::parse_tokened`), so each family that reaches one has to
+    // be exercised on its own: the image bracket above, and the two below.
+    //
+    // The link families' display-text list, whose parse goes through
+    // `extract_attributes_from_text`'s tokened path. `++real++` stays the
+    // second entry (no positional display text, hence the `bare` role and the
+    // target standing in for the text), and the forged pair reaches the role
+    // as the document wrote it.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}\u{97}\n",
+        "\n",
+        "[subs=macros]\n",
+        "link:x[role={forge},++real++]\n",
+    ));
+
+    let rendered = last_paragraph(&doc);
+
+    assert!(
+        !rendered.contains("class=\"bare real\""),
+        "the expanded value must not capture the passthrough's body: {rendered:?}"
+    );
+
+    assert_eq!(rendered, "<a href=\"x\" class=\"bare \u{96}\u{97}\">x</a>");
+
+    // The cross-reference family's `tokened_text`, whose roles are read back
+    // through `untranslated_value` and whose display text goes through
+    // `restored_value_children`.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}\u{97}\n",
+        "\n",
+        "[[a]]anchor\n",
+        "\n",
+        "[subs=macros]\n",
+        "xref:a[t ++real++,role={forge}]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<a href=\"#a\" class=\"\u{96}\u{97}\">t real</a>"
+    );
+
+    // A value spliced into a *shorthand* role list rather than a whole
+    // attribute, beside a role the document wrote and a masked piece in a
+    // third slot: the escape has to survive the shorthand scan, which splits
+    // on `#`/`.`/`%` — none of which is one of the escape's own tags.
+    let doc = Parser::default().parse(concat!(
+        ":forge: \u{96}\u{97}\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt=a,role={forge} hl,title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image \u{96}\u{97} hl\"><img src=\"x.png\" alt=\"a\" title=\"real\"></span>"
+    );
+}
+
+#[test]
+fn an_expansion_into_ordinary_content_is_never_escaped() {
+    // The other half of the gate: the escape is a property of *tokened* text,
+    // and ordinary prose has no such invariant to protect. A content-level
+    // attribute-reference substitution splices a value carrying all three
+    // reserved codepoints exactly as the document wrote it — nothing
+    // downstream of ordinary content unescapes, so escaping here would put
+    // the escape's own bytes in the output.
+    let doc = Parser::default().parse(concat!(
+        ":v: a\u{96}\u{97}b\u{e005}sc\n",
+        "\n",
+        "plain {v} text\n",
+    ));
+
+    assert_eq!(last_paragraph(&doc), "plain a\u{96}\u{97}b\u{e005}sc text");
+
+    // And the same value spliced into an attribute list that was never
+    // tokened — a quoted-text span's, which is parsed from the author's own
+    // bytes.
+    let doc = Parser::default().parse(concat!(
+        ":v: a\u{96}\u{97}b\u{e005}sc\n",
+        "\n",
+        "[.{v}]#hi#\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"a\u{96}\u{97}b\u{e005}sc\">hi</span>"
+    );
+}
+
+#[test]
+fn a_counter_in_a_tokened_bracket_keeps_its_expressions_own_bytes() {
+    // The one thing `AttributeReplacer` writes that is neither a slice of the
+    // haystack nor a resolved attribute value: a `counter`/`counter2`
+    // directive's displayed value. It is deliberately *not* escaped — its
+    // bytes are the counter expression's own (a slice of the already-escaped
+    // haystack, free to hold a genuine placeholder the tokener wrote between
+    // the braces), or that seed advanced — so escaping it would double-escape
+    // an escape the tokener already wrote.
+    let doc = Parser::default().parse(concat!(
+        ":c: 5\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={counter:c},title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"6\" title=\"real\"></span>"
+    );
+
+    // A seed carrying a reserved codepoint reaches the directive in the
+    // tokener's escaped spelling and comes back out as the document wrote it,
+    // which is what a re-escape here would break.
+    let doc = Parser::default().parse(concat!(
+        "[subs=macros]\n",
+        "image:x.png[alt={counter:d:q\u{e005}},title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"q\u{e005}\" title=\"real\"></span>"
     );
 }
 

--- a/parser/src/tests/sentinels.rs
+++ b/parser/src/tests/sentinels.rs
@@ -511,23 +511,24 @@ fn an_expansion_into_ordinary_content_is_never_escaped() {
 
 #[test]
 fn a_counter_in_a_tokened_bracket_keeps_its_expressions_own_bytes() {
-    // The one thing `AttributeReplacer` writes that is neither a slice of the
-    // haystack nor a resolved attribute value: a `counter`/`counter2`
-    // directive's displayed value. It is deliberately *not* escaped — its
-    // bytes are the counter expression's own (a slice of the already-escaped
-    // haystack, free to hold a genuine placeholder the tokener wrote between
-    // the braces), or that seed advanced — so escaping it would double-escape
-    // an escape the tokener already wrote.
+    // A `counter`/`counter2` directive's displayed value is escaped or not
+    // depending on where its bytes came from — never uniformly, since a
+    // counter's value has two possible sources with opposite provenance (see
+    // `Parser::counter_reporting_provenance`).
+    //
+    // Fresh from *this* call's own `seed` (or the `"1"` default, plain
+    // digit): a slice of the already-escaped haystack, free to hold a
+    // genuine placeholder the tokener wrote between the braces — not
+    // escaped, since it would double-escape an escape the tokener already
+    // wrote.
     let doc = Parser::default().parse(concat!(
-        ":c: 5\n",
-        "\n",
         "[subs=macros]\n",
-        "image:x.png[alt={counter:c},title=++real++]\n",
+        "image:x.png[alt={counter:c:5},title=++real++]\n",
     ));
 
     assert_eq!(
         last_paragraph(&doc),
-        "<span class=\"image\"><img src=\"x.png\" alt=\"6\" title=\"real\"></span>"
+        "<span class=\"image\"><img src=\"x.png\" alt=\"5\" title=\"real\"></span>"
     );
 
     // A seed carrying a reserved codepoint reaches the directive in the
@@ -541,6 +542,42 @@ fn a_counter_in_a_tokened_bracket_keeps_its_expressions_own_bytes() {
     assert_eq!(
         last_paragraph(&doc),
         "<span class=\"image\"><img src=\"x.png\" alt=\"q\u{e005}\" title=\"real\"></span>"
+    );
+
+    // Advanced from **persisted** state instead — a plain document attribute
+    // of the same name, set nowhere near this bracket — is a different
+    // story: those bytes never passed through this call's tokener at all,
+    // so they need exactly the escape a resolved attribute reference's value
+    // does. A plain numeric value makes escaping a no-op, which is why this
+    // case alone (Greptile's review of this PR) would not have caught a
+    // missing escape.
+    let doc = Parser::default().parse(concat!(
+        ":e: 5\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={counter:e},title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"6\" title=\"real\"></span>"
+    );
+
+    // The case that does catch it: a persisted document attribute whose own
+    // value spells the escape sequence. Advancing it (`String#succ` on the
+    // last alphanumeric) must not disturb those bytes, and restoring the
+    // real passthrough elsewhere in the same bracket must not decode them.
+    let doc = Parser::default().parse(concat!(
+        ":f: p\u{e005}sq\n",
+        "\n",
+        "[subs=macros]\n",
+        "image:x.png[alt={counter:f},title=++real++]\n",
+    ));
+
+    assert_eq!(
+        last_paragraph(&doc),
+        "<span class=\"image\"><img src=\"x.png\" alt=\"p\u{e005}sr\" title=\"real\"></span>",
+        "the document's own escape-shaped bytes, persisted in an attribute, must survive a counter advance"
     );
 }
 


### PR DESCRIPTION
Closes the one gap #1355 scoped out, and the wider consequence of it that Greptile caught in that PR's review.

## The gap

`tokened_bracket`/`tokened_text` write one `MASKED_PIECE_PLACEHOLDER` per masked passthrough/STEM piece into a macro bracket's text and run `escape_masked_piece_bytes` over every *other* byte they copy, so every occurrence of the placeholder's — or the escape's own — codepoints in the text handed to `Attrlist::parse` is one the tokener deliberately wrote. `restore_into` and `unescape_masked_piece_bytes` trust that completely: they recognize the byte pattern and never ask about provenance.

But the tokener's copy was not the only way bytes entered that text. `Attrlist::parse` runs an attribute-reference substitution *of its own* over the text it is handed whenever it holds both a `{` and a `}` — and a `subs=` list naming `macros` without `attributes` reaches the macros step with every reference still unresolved, so that inner substitution is the one that expands a reference, **after** the tokener's escape already ran. Whatever the value spelled landed unescaped and indistinguishable from something the tokener wrote, with two consequences:

1. a value spelling the placeholder **forged a restore**, stealing a real passthrough's body;
2. a value spelling the escape sequence (`\u{E005}` + a tag character) got **decoded**, corrupting a document attribute's own text that never went near a masked piece.

Both were pinned as known-gap assertions in `an_attrlist_level_expansion_can_still_forge_a_bracket_restore`.

## The fix

Escape at that second point of entry too, so the by-construction property is total rather than true only of the bytes the tokener itself copied.

- **`SplicedValueEscaping`** (`attributes/element_attribute.rs`, beside `escape_masked_piece_bytes`) — `Verbatim` / `MaskedPieceBytes`. A *provenance* flag, not a syntax context, threaded end to end from the call site down to the splice.
- **`Attrlist::parse_tokened`** — a second entry point beside `parse`, for the call sites actually handed tokened text. `parse` keeps its signature (78 call sites untouched) and both delegate to a private `parse_escaping`.
- **`AttributeReplacer::spliced`** (`content/substitution_step.rs`) — the one write in `replace_append` whose bytes did not come out of the haystack is a resolved `InterpretedValue::Value`, and that is the one write that escapes. A `Replacer` only ever writes replacement text and never touches the haystack around a match, so the tokener's already-escaped copy is left alone and nothing is escaped twice.

The flag is per-call, not global: `apply_attributes` is also the ordinary content-level attribute-references step over never-tokened prose, which must **not** escape — that text has no such invariant and its readers never unescape.

### Call-site audit

Every `Attrlist::parse(…)` call site in the crate was checked for whether it is downstream of a tokener.

**Tokened → `parse_tokened`:**

| site | why |
| --- | --- |
| `macros/image.rs` `bracket_attrlist` third path | `tokened_bracket(…)` immediately above |
| `macros/xref.rs:447` `attrlist_text_carries_its_opaque_pieces` | `tokened_text(…)` immediately above |
| `macros/xref.rs:655` `xref_macro_text` | `tokened_text(…)` immediately above |
| `content/macros.rs` `extract_attributes_from_text` | reached from `links.rs` `text_attrlist`'s tokened path |

Two corrections to the initial reading:

- **`image.rs`'s `parse_attrlist` is shared by three paths, only one tokened.** The empty-bracket and verbatim paths parse the author's own `'src` bytes and must stay verbatim, so the tokened path got its own `parse_tokened_attrlist` sibling rather than the helper being switched wholesale.
- **`content/macros.rs:504` is *not* purely untokened.** `extract_attributes_from_text` serves both of `links.rs` `text_attrlist`'s paths — the verbatim source slice and the `tokened_bracket` output — so it takes the flag as a parameter and each caller names its own path. (Its second, `Span::default()` parse is zero-length, so it stays plain.)

**Not tokened, unchanged:** `indexterm.rs:697` (`shown_macro_term` — its `arg` is `shown_term(…).computed`, this level's own match string; no tokener upstream, and escaping there would write bytes nothing unescapes), `quotes.rs:1670` (quoted-text/passthrough attrlists, read from source before the escaping step), `content/macros.rs:517`, `blocks/toc.rs:101`, `blocks/media.rs:170`, `blocks/metadata.rs:459`, `preprocessor.rs:1067/1862/5043`, `document/header.rs:967`, `post_replacements.rs:445`, `substitute_attributes_in_macro_target` (a macro target is the source between `::` and `[`), plus test-only sites in `callouts.rs`, `substitution_group.rs`, `substitution_step.rs`, and `attrlist.rs`.

### `SubstitutionStep::apply`'s `_attrlist` parameter

Investigated as suggested; **left alone**. It is genuinely dead — every one of its ~30 call sites passes `None`, and `SubstitutionGroup::apply` never routes through it (the group builds the tree and hands its own `attrlist` to `build_for_group`). It is also the wrong type to carry this flag. Rather than widen a dead parameter or abuse it, `Attrlist::parse_escaping` calls `content::apply_attributes` directly and `SubstitutionStep::AttributeReferences` passes `Verbatim`. Retiring the dead parameter is a separate cleanup.

### Deliberately not escaped

A `counter`/`counter2` directive's displayed value. Its bytes are the haystack's own: the seed is a slice of the counter expression, already escaped where it came from a tokener and free to hold a genuine placeholder the tokener wrote between the braces (`{counter:a++x++}`). Escaping it would both double-escape an escape the tokener already wrote and hide an occurrence the restore walk holds a body for. Same for the literal `{name}` an `attribute-missing=skip`/`warn` reference keeps — haystack bytes, already escaped where they needed to be. Both are commented in place and the counter case is pinned by a test.

## Before / after

`:stray: p\u{E005}sq` + `[subs=macros]` + `image:x.png[alt={stray},title=++real++]` — case 2, the corruption Greptile caught:

```
before: <span class="image">``&lt;img src="x.png" alt="p\u{96}q" title="real"&gt;``</span>
after:  <span class="image">``&lt;img src="x.png" alt="p\u{E005}sq" title="real"&gt;``</span>
```

`:forge: \u{96}\u{97}` + `[subs=macros]` + `image:x.png[alt={forge},++real++]` — case 1, the forgery:

```
before: <span class="image">``&lt;img src="x.png" alt="real" width="\u{96}\u{97}"&gt;``</span>
after:  <span class="image">``&lt;img src="x.png" alt="\u{96}\u{97}" width="real"&gt;``</span>
```

## Tests

`an_attrlist_level_expansion_can_still_forge_a_bracket_restore` is renamed to `…_cannot_…` with both known-gap assertions flipped to pin the document's own bytes surviving. Three tests added beside it:

- `an_attrlist_level_expansion_is_escaped_for_every_tokened_family` — the `link:` and `xref:` families and a shorthand `role=` list, since the escape is gated per call site;
- `an_expansion_into_ordinary_content_is_never_escaped` — the gate's other half, in prose and in a never-tokened quoted-text attrlist;
- `a_counter_in_a_tokened_bracket_keeps_its_expressions_own_bytes`.

Closing the forgery also makes the restore walk's two fail-closed arms unreachable from a document — the unpaired-escape-introducer copy-through and the more-occurrences-than-bodies copy-through, both of which the forgery used to reach incidentally. Rather than let them go dark, each is now pinned directly as a contract over a hand-written tokened text (`a_restore_copies_an_unpaired_escape_introducer_through`, `a_restore_copies_an_occurrence_past_the_end_of_bodies_through`), which is what keeps every consumer free to run the unescape unconditionally.

## Docs

`MASKED_PIECE_PLACEHOLDER_START`'s doc comment, `escaped_literal`'s, `sentinels.rs`'s module doc, and design §3.5 all described this as an open road; each now describes the closed mechanism instead. `split_attribute_value`'s comment gained a note distinguishing the content-level splice (verbatim) from the attrlist-level one (escaped), since the two are easy to confuse.

## Preflight

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo test --workspace` — 5505 passed, 0 failed
- `cargo +nightly doc --no-deps --document-private-items` — clean
- **Diff coverage vs `origin/inline-ast`** — missed regions/lines unchanged for every changed file: `attrlist.rs` 2/1, `element_attribute.rs` 2/1, `image.rs` 3/1, `links.rs` 17/10, `xref.rs` 17/8, `content/macros.rs` 3/2, `substitution_step.rs` 4/0.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGhnADXtgBYMx75uDh9duZ)_