### PR TITLE
doc: Note that "tokened"/"tokener" are coined vocabulary

### DIFF
--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -807,6 +807,13 @@ fn is_shorthand_delimiter(c: char) -> bool {
 /// carrying none of the `,`/`=`/`"` bytes at that position instead of the
 /// piece's own.
 ///
+/// "Tokened"/"tokener" are this crate's own coined vocabulary for that
+/// rewrite, kept deliberately apart from "tokenized"/"tokenizer": this crate
+/// has no lexer stage that splits source into a token stream, and borrowing
+/// that pair of words would wrongly suggest one. A "tokened" text is just a
+/// text in which each masked piece has been replaced by one placeholder
+/// token, recovered later by position rather than by re-parsing.
+///
 /// Carries no index — which piece a given occurrence stands for is recovered
 /// by *position*: the Nth occurrence, scanned left to right, is `bodies[N]`,
 /// never by parsing anything back out of the placeholder's own bytes.


### PR DESCRIPTION
## Summary
- A reviewer on https://github.com/asciidoc-rs/asciidoc-parser/pull/1059 asked whether "tokened"/"tokener" (used throughout the masked-piece-placeholder machinery in `parser/src/attributes/element_attribute.rs` and friends) were meant to be "tokenized"/"tokenizer".
- They're intentionally distinct: this crate has no lexer stage that splits source into a token stream, so borrowing "tokenized"/"tokenizer" would wrongly suggest one exists. "Tokened" instead means a text in which each masked piece has been replaced by one placeholder token, recovered later by position.
- Records that distinction as a note at the vocabulary's central definition point (`MASKED_PIECE_PLACEHOLDER_START`'s doc comment).

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets`
- [x] `cargo test --workspace`
- [x] `cargo +nightly doc --no-deps --document-private-items`
- Doc-comment-only change; no coverage impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EtWKpgHiFHr5dm7j7HiHYT)_