### PR TITLE
fix: Reuse the char-replacements match string across the rule loop

### DIFF
--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -105,8 +105,18 @@ fn apply_replacements_recursive<'src>(
 
     let mut nodes = nodes;
 
+    // The match string is a pure function of the level's node list, so one
+    // build here serves every rule that leaves the level unchanged — the
+    // common outcome by far, since a level rarely matches more than a couple
+    // of the rules. Only a rule that actually replaced something invalidates
+    // it, by handing back the rebuilt level.
+    let mut level = build_match_string(&nodes, Masked::UNKNOWN);
+
     for repl in character_replacements() {
-        nodes = replace_level(repl, nodes, root, ctx);
+        if let Some(rebuilt) = replace_level(repl, &nodes, &level, root, ctx) {
+            nodes = rebuilt;
+            level = build_match_string(&nodes, Masked::UNKNOWN);
+        }
     }
 
     nodes
@@ -170,8 +180,11 @@ enum ReplacementKind {
     Entity { name: std::ops::Range<usize> },
 }
 
-/// Matches `repl` over this level's escaped text, replacing each match with the
-/// leaf node(s) it produces and leaving everything else in place.
+/// Matches `repl` over this level's escaped text — `level`, the
+/// [`build_match_string`] pair the caller built for the level's current
+/// `nodes` — returning the rebuilt level when the rule replaced something and
+/// `None` when it left the level untouched, so the caller knows whether the
+/// match string it holds still describes `nodes`.
 ///
 /// Takes no [`level_may_have_replacements`] pre-filter of its own: the caller
 /// ([`apply_replacements_recursive`]) already took it once for `nodes` before
@@ -187,16 +200,17 @@ enum ReplacementKind {
 /// only ever confirm what the caller already established.
 fn replace_level<'src>(
     repl: &CharacterReplacement,
-    nodes: Vec<InlineNode<'src>>,
+    nodes: &[InlineNode<'src>],
+    level: &(String, Vec<Piece>),
     root: Span<'src>,
     ctx: LevelContext,
-) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+) -> Option<Vec<InlineNode<'src>>> {
+    let (s, pieces) = level;
 
     // The rule runs over the level wrapped in its enclosing construct's own
     // boundary characters, and every offset it reports is mapped back into the
     // level's own coordinates (see [`LevelContext`]).
-    let (haystack, prefix) = ctx.haystack(&s);
+    let (haystack, prefix) = ctx.haystack(s);
 
     // A match the clip emptied kept nothing of the level itself, so there is
     // nothing here to replace. No rule's pattern can produce one — each needs
@@ -209,10 +223,10 @@ fn replace_level<'src>(
         .collect();
 
     if matches.is_empty() {
-        return nodes;
+        return None;
     }
 
-    rebuild_replacements(&nodes, &pieces, &s, &matches, root)
+    Some(rebuild_replacements(nodes, pieces, s, &matches, root))
 }
 
 /// Finds every non-overlapping match of `repl` in the escaped match string


### PR DESCRIPTION
First increment of the CodSpeed regression work discussed on [#1059](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459).

## What

`replace_level` rebuilt the level's match string — a `String` plus a `Vec<Piece>`, via `build_match_string` — once per character-replacement rule: fourteen builds per level whenever the level-wide sniff passes, even though most rules then find nothing to replace. A callgrind profile of `throughput/replacement_prose` put `build_match_string` at ~26% of the whole parse, almost all of it from this loop.

The match string is a pure function of the level's node list, so `apply_replacements_recursive` now builds it once ahead of the rule loop and rebuilds it only after a rule actually changed the level — which `replace_level` reports by returning the rebuilt node list as an `Option`, `None` meaning the level (and therefore the cached string) is untouched.

## Why the output is unchanged

A rule that matches nothing reads exactly the string it would have built itself; a rule that matches triggers a rebuild from the new node list, which is what every rule's own build always did. The full test suite (including the frozen-recording differential corpora) passes unchanged.

## Measured effect

Callgrind instruction counts over 23 parses of the `inline_throughput` fixtures:

| benchmark | before | after |
|---|---|---|
| `throughput/replacement_prose` | 199.2M | 179.0M (**−10.2%**) |
| `throughput/formatted_prose` | 365.1M | 356.5M (−2.4%) |

The gain is capped on `replacement_prose` because that fixture is dense by design — many rules genuinely match per paragraph and each match legitimately invalidates the cache. Sparse prose benefits more. Follow-up increments (fusing the quotes subs into one descent, shrinking `InlineNode`, scratch-buffer reuse) target the remaining gap.

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5505 lib tests)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: the changed file's only misses are the three pre-existing `other =&gt; panic!` test-assertion arms; every changed line is covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_