### PR TITLE
fix: Descend into quote spans in place, not through a vector rebuild

### DIFF
--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -652,28 +652,29 @@ fn apply_quote_sub<'src>(
     // by the same sub (a sub runs once per level). A level
     // with no such span — the common leaf-only case, visited once per sub —
     // has nothing to descend into, so it skips the context derivation and the
-    // rebuild of its node vector entirely.
-    let nodes = if nodes
+    // walk over its nodes entirely.
+    //
+    // The descent mutates each span's children in place rather than moving
+    // every node through a rebuild of the level's vector: only the one field
+    // the recursion refines changes hands, and the level's other nodes are
+    // never touched. This loop runs once per sub, so what it avoids is
+    // moving every node of every span-bearing level once per sub in
+    // `quote_subs`'s list.
+    let mut nodes = nodes;
+
+    if nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_)))
     {
         let contexts = LevelContext::child_contexts(&nodes, ctx, Masked::UNKNOWN);
 
-        nodes
-            .into_iter()
-            .zip(contexts)
-            .map(|(node, inner)| match node {
-                InlineNode::Styled(mut styled) => {
-                    styled.children = apply_quote_sub(sub, styled.children, root, parser, inner);
-                    InlineNode::Styled(styled)
-                }
-
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+        for (node, inner) in nodes.iter_mut().zip(contexts) {
+            if let InlineNode::Styled(styled) = node {
+                let children = std::mem::take(&mut styled.children);
+                styled.children = apply_quote_sub(sub, children, root, parser, inner);
+            }
+        }
+    }
 
     match_level(sub, nodes, root, parser, ctx)
 }


### PR DESCRIPTION
Second increment of the CodSpeed regression work discussed on [#1059](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following [#1360](https://github.com/asciidoc-rs/asciidoc-parser/pull/1360).

## What

`apply_quote_sub`'s descent moved every node of a span-bearing level through an `into_iter().zip(contexts).map(…).collect()` rebuild of the level's vector — once per sub in `quote_subs`'s list, thirteen times per level, each move copying a 384-byte `InlineNode` to refine the one field the recursion touches. A callgrind profile of `throughput/formatted_prose` showed ~11% of the whole parse inside that rebuild (`in_place_collect`), under `apply_quote_sub`'s 41% inclusive.

The descent now mutates each span's children in place: take the children out (`mem::take`), recurse, put the result back, and leave the level's other nodes untouched.

## Why the output is unchanged

Order-preserving by construction: the per-sub outer loop, the descend-before-match order within a sub, and the `child_contexts` derivation are all exactly as before — only the mechanics of handing a span's children to the recursion changed. The full test suite, including the frozen-recording differential corpora, passes unchanged.

## Measured effect

Callgrind instruction counts over 23 parses of the `inline_throughput` fixtures (against the pre-#1360 base):

| benchmark | before | after |
|---|---|---|
| `throughput/formatted_prose` | 365.1M | 340.8M (**−6.7%**) |
| `throughput/replacement_prose` | 199.2M | 199.6M (unchanged, as expected — few styled spans in that fixture) |

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: `quotes.rs` missed-line count unchanged vs base (6 before, 6 after; all pre-existing defensive branches and test panic arms, none in the changed region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_