### PR TITLE
fix: Descend in place in the four remaining vector-rebuild transducers

### DIFF
--- a/parser/src/content/inline_builder/attribute_refs.rs
+++ b/parser/src/content/inline_builder/attribute_refs.rs
@@ -267,35 +267,32 @@ fn apply_attribute_references_recursive<'src>(
     diagnostics: &mut Vec<(Span<'src>, String)>,
 ) -> Vec<InlineNode<'src>> {
     // A level with no `Styled` child — the common leaf-only case — has
-    // nothing to descend into, so it skips the rebuild of its node vector
-    // entirely.
-    let nodes: Vec<InlineNode<'src>> = if nodes
+    // nothing to descend into, so it skips the walk over its nodes entirely.
+    // The descent mutates each span's children in place rather than moving
+    // every node through a rebuild of the level's vector: only the one field
+    // the recursion refines changes hands.
+    let mut nodes = nodes;
+
+    if nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_)))
     {
-        nodes
-            .into_iter()
-            .map(|node| match node {
-                InlineNode::Styled(mut styled) => {
-                    styled.children = apply_attribute_references_recursive(
-                        styled.children,
-                        root,
-                        parser,
-                        counters,
-                        missing.nested(),
-                        &[],
-                        specials,
-                        diagnostics,
-                    );
-                    InlineNode::Styled(styled)
-                }
-
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+        for node in nodes.iter_mut() {
+            if let InlineNode::Styled(styled) = node {
+                let children = std::mem::take(&mut styled.children);
+                styled.children = apply_attribute_references_recursive(
+                    children,
+                    root,
+                    parser,
+                    counters,
+                    missing.nested(),
+                    &[],
+                    specials,
+                    diagnostics,
+                );
+            }
+        }
+    }
 
     attribute_references_level(
         nodes,

--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -63,35 +63,34 @@ fn apply_replacements_recursive<'src>(
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
     // A level with no parent node to descend into — the common leaf-only
-    // case — skips the rebuild of its node vector entirely.
-    let nodes = if nodes
+    // case — skips the walk over its nodes entirely. The descent mutates
+    // each parent's children in place rather than moving every node through
+    // a rebuild of the level's vector: only the one field the recursion
+    // refines changes hands.
+    let mut nodes = nodes;
+
+    if nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_) | InlineNode::Ref(_)))
     {
-        nodes
-            .into_iter()
-            .map(|node| match node {
-                InlineNode::Styled(mut styled) => {
-                    let inner = LevelContext::inside_styled(&styled, ctx);
-                    styled.children = apply_replacements_recursive(styled.children, root, inner);
-                    InlineNode::Styled(styled)
+        for node in nodes.iter_mut() {
+            match node {
+                InlineNode::Styled(styled) => {
+                    let inner = LevelContext::inside_styled(styled, ctx);
+                    let children = std::mem::take(&mut styled.children);
+                    styled.children = apply_replacements_recursive(children, root, inner);
                 }
 
-                InlineNode::Ref(mut reference) => {
-                    reference.children = apply_replacements_recursive(
-                        reference.children,
-                        root,
-                        LevelContext::INSIDE_REF,
-                    );
-                    InlineNode::Ref(reference)
+                InlineNode::Ref(reference) => {
+                    let children = std::mem::take(&mut reference.children);
+                    reference.children =
+                        apply_replacements_recursive(children, root, LevelContext::INSIDE_REF);
                 }
 
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+                _ => {}
+            }
+        }
+    }
 
     // Cheap pre-filter, shared by every rule below: none of them can match
     // when this level has nothing replaceable at all, so this skips all of
@@ -102,8 +101,6 @@ fn apply_replacements_recursive<'src>(
     if !level_may_have_replacements(&nodes) {
         return nodes;
     }
-
-    let mut nodes = nodes;
 
     // The match string is a pure function of the level's node list, so one
     // build here serves every rule that leaves the level unchanged — the

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -263,19 +263,22 @@ fn apply_macro_families<'src>(
     // is transparent, so `child_contexts` hands its children the character its
     // own *siblings* present instead.
     // A level with no parent node to descend into — the common leaf-only case
-    // — skips the context derivation and the rebuild of its node vector
-    // entirely (the same scan-first shape the shown-term hop below uses).
+    // — skips the context derivation and the walk over its nodes entirely
+    // (the same scan-first shape the shown-term hop below uses). The descent
+    // mutates each parent's children in place rather than moving every node
+    // through a rebuild of the level's vector: only the one field the
+    // recursion refines changes hands.
     let has_parent = nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_) | InlineNode::Ref(_)));
 
-    let nodes: Vec<InlineNode<'src>> = if has_parent {
+    let mut nodes = nodes;
+
+    if has_parent {
         let contexts = LevelContext::child_contexts(&nodes, ctx, masked);
 
-        nodes
-            .into_iter()
-            .zip(contexts)
-            .map(|(node, inner)| match node {
+        for (node, inner) in nodes.iter_mut().zip(contexts) {
+            match node {
                 // An extraction wrapper's body is **not** this content's to
                 // substitute. It is an opaque placeholder for
                 // every step from here on, and the body was already
@@ -288,40 +291,24 @@ fn apply_macro_families<'src>(
                 // place this level's `masked` could not answer even if it did
                 // descend, since the list is collected from one content's own
                 // top level and knows nothing of a nested build's nodes.
-                InlineNode::Styled(styled) if masked.covers(styled.location) => {
-                    InlineNode::Styled(styled)
+                InlineNode::Styled(styled) if masked.covers(styled.location) => {}
+
+                InlineNode::Styled(styled) => {
+                    let children = std::mem::take(&mut styled.children);
+                    styled.children =
+                        apply_macro_families(children, root, parser, inner, masked, specials);
                 }
 
-                InlineNode::Styled(mut styled) => {
-                    styled.children = apply_macro_families(
-                        styled.children,
-                        root,
-                        parser,
-                        inner,
-                        masked,
-                        specials,
-                    );
-                    InlineNode::Styled(styled)
+                InlineNode::Ref(reference) => {
+                    let children = std::mem::take(&mut reference.children);
+                    reference.children =
+                        apply_macro_families(children, root, parser, inner, masked, specials);
                 }
 
-                InlineNode::Ref(mut reference) => {
-                    reference.children = apply_macro_families(
-                        reference.children,
-                        root,
-                        parser,
-                        inner,
-                        masked,
-                        specials,
-                    );
-                    InlineNode::Ref(reference)
-                }
-
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+                _ => {}
+            }
+        }
+    }
 
     // The UI macros run before image/icon and only under `experimental`,
     // mirroring the string step's order and gate.
@@ -336,7 +323,7 @@ fn apply_macro_families<'src>(
 
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
     // `indexterm2:[…]`) run after image/icon and before the link families.
-    let nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
+    let mut nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
 
     // A **visible** term's shown text is not a boundary the later families
     // stop at — it is ordinary flow content, and
@@ -359,32 +346,24 @@ fn apply_macro_families<'src>(
         .iter()
         .any(|node| matches!(node, InlineNode::IndexTerm(term) if !term.children.is_empty()));
 
-    let nodes = if has_shown_term {
+    if has_shown_term {
         let contexts = LevelContext::child_contexts(&nodes, ctx, masked);
 
-        nodes
-            .into_iter()
-            .zip(contexts)
-            .map(|(node, inner)| match node {
-                InlineNode::IndexTerm(mut index_term) if !index_term.children.is_empty() => {
-                    index_term.children = apply_reference_families(
-                        std::mem::take(&mut index_term.children),
-                        root,
-                        parser,
-                        inner,
-                        masked,
-                        specials,
-                    );
-
-                    InlineNode::IndexTerm(index_term)
-                }
-
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+        for (node, inner) in nodes.iter_mut().zip(contexts) {
+            if let InlineNode::IndexTerm(index_term) = node
+                && !index_term.children.is_empty()
+            {
+                index_term.children = apply_reference_families(
+                    std::mem::take(&mut index_term.children),
+                    root,
+                    parser,
+                    inner,
+                    masked,
+                    specials,
+                );
+            }
+        }
+    }
 
     apply_reference_families(nodes, root, parser, ctx, masked, specials)
 

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -50,31 +50,32 @@ fn apply_level<'src>(
     // span before this level's own pass runs. A nested level is never the
     // root. A level with
     // neither — the common leaf-only case — has nothing to descend into, so
-    // it skips the rebuild of its node vector entirely.
-    let nodes: Vec<InlineNode<'src>> = if nodes
+    // it skips the walk over its nodes entirely. The descent mutates each
+    // parent's children in place rather than moving every node through a
+    // rebuild of the level's vector: only the one field the recursion
+    // refines changes hands.
+    let mut nodes = nodes;
+
+    if nodes
         .iter()
         .any(|node| matches!(node, InlineNode::Styled(_) | InlineNode::Ref(_)))
     {
-        nodes
-            .into_iter()
-            .map(|node| match node {
-                InlineNode::Styled(mut styled) => {
-                    styled.children = apply_level(styled.children, root, parser, attrlist, false);
-                    InlineNode::Styled(styled)
+        for node in nodes.iter_mut() {
+            match node {
+                InlineNode::Styled(styled) => {
+                    let children = std::mem::take(&mut styled.children);
+                    styled.children = apply_level(children, root, parser, attrlist, false);
                 }
 
-                InlineNode::Ref(mut reference) => {
-                    reference.children =
-                        apply_level(reference.children, root, parser, attrlist, false);
-                    InlineNode::Ref(reference)
+                InlineNode::Ref(reference) => {
+                    let children = std::mem::take(&mut reference.children);
+                    reference.children = apply_level(children, root, parser, attrlist, false);
                 }
 
-                other => other,
-            })
-            .collect()
-    } else {
-        nodes
-    };
+                _ => {}
+            }
+        }
+    }
 
     if parser.is_attribute_set("hardbreaks-option")
         || attrlist.is_some_and(|attrlist| attrlist.has_option("hardbreaks"))


### PR DESCRIPTION
Third increment of the CodSpeed regression work discussed on [#1059](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following [#1360](https://github.com/asciidoc-rs/asciidoc-parser/pull/1360) and [#1361](https://github.com/asciidoc-rs/asciidoc-parser/pull/1361).

## What

The same change #1361 made for the quotes step, applied to the four remaining transducers whose descent rebuilds the level's node vector solely to recurse: the macros step (both its `Styled`/`Ref` descent and its shown-index-term hop), character replacements, attribute references, and post replacements. Each moved every node of a parent-bearing level through an `into_iter().map(…).collect()` rebuild, each move copying a 384-byte `InlineNode`; the profile of `throughput/formatted_prose` showed another ~8% of the parse in `in_place_collect` under `apply_macro_families` alone.

Each descent now mutates the parent's children in place — take them out (`mem::take`), recurse, put the result back — leaving the level's other nodes untouched.

The special-characters and footnotes steps keep their rebuilds deliberately: they are not this shape. The former's split genuinely changes the node list; the latter clones from pieces behind its own subtree gate (and that clone's `CowStr` representation effect is load-bearing, per its doc comment).

## Why the output is unchanged

Order-preserving by construction: each step's descent-before-match order, its context derivation (`child_contexts` / `inside_styled`), and the macros step's masked-wrapper skip are all exactly as before; only the mechanics of handing children to the recursion changed. Full test suite, including the frozen-recording differential corpora, passes unchanged.

## Measured effect

Callgrind instruction counts over 23 parses of the `inline_throughput` fixtures, against this branch's own base (with #1360, without #1361):

| benchmark | before | after |
|---|---|---|
| `throughput/formatted_prose` | 356.5M | 340.0M (**−4.6%**) |
| `throughput/replacement_prose` | 179.0M | 180.1M (+0.6%, code-layout noise) |

Stacks with #1361's −6.7% on the same fixture.

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: every missed line in the four changed files is a pre-existing defensive branch or test panic arm, none in the changed regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_