### PR TITLE
fix: Copy the fold's clean text runs wholesale instead of per character

### DIFF
--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -302,9 +302,7 @@ fn fold_into_html(
                 // builder never leaves a special inside a `Text`, so this is
                 // belt-and-suspenders, but it keeps the fold correct in its own
                 // right.
-                for ch in value.chars() {
-                    render_char(ch, renderer, out);
-                }
+                render_text(value, renderer, out);
             }
 
             InlineNode::Raw {
@@ -323,9 +321,7 @@ fn fold_into_html(
                 form: RawForm::Escaped,
                 ..
             } => {
-                for ch in value.chars() {
-                    render_char(ch, renderer, out);
-                }
+                render_text(value, renderer, out);
             }
 
             InlineNode::CharRef {
@@ -458,6 +454,43 @@ fn fold_into_html(
             }
         }
     }
+}
+
+/// Appends `text` — logical, un-escaped text — to `out`, routing each of the
+/// three special characters through `renderer` exactly as [`render_char`]
+/// does and copying every run between them wholesale.
+///
+/// This is [`render_char`] applied to every character of `text`, spelled as
+/// one `memchr` sweep per special instead of a per-character loop: the runs
+/// between specials — for most text, all of it — are appended as one
+/// `push_str` each. The output is byte-identical for any renderer, since
+/// only the three characters `render_char` routes through the renderer are
+/// ever handed to it.
+pub(super) fn render_text(text: &str, renderer: &dyn InlineRenderer, out: &mut String) {
+    let mut rest = text;
+
+    while let Some(pos) = memchr::memchr3(b'<', b'>', b'&', rest.as_bytes()) {
+        // `pos` is the offset of a byte `memchr3` itself just found in
+        // `rest`, and each of the three searched-for bytes is ASCII, so the
+        // split point is in bounds and on a character boundary: this
+        // `split_at` cannot panic.
+        let (clean, special_and_rest) = rest.split_at(pos);
+
+        out.push_str(clean);
+
+        let mut chars = special_and_rest.chars();
+
+        // `special_and_rest` starts with the byte just found, so there is
+        // always a first character to take, and it is one of the three
+        // specials `render_char` routes through the renderer.
+        for ch in chars.by_ref().take(1) {
+            render_char(ch, renderer, out);
+        }
+
+        rest = chars.as_str();
+    }
+
+    out.push_str(rest);
 }
 
 /// Appends `ch` to `out`, routing the three special characters through
@@ -1125,5 +1158,39 @@ mod tests {
         // quoted-title suffix.
         assert!(folded.contains(">Section 2<"), "folded: {folded}");
         assert!(!folded.contains("&#8220;"), "folded: {folded}");
+    }
+
+    #[test]
+    fn render_text_matches_render_char_character_by_character() {
+        // `render_text` is `render_char` applied to every character, spelled
+        // as a bulk sweep; this pins the two as byte-identical across the
+        // shapes the sweep has to get right — no special at all, specials at
+        // either edge, adjacent specials, and multi-byte characters between
+        // them. The per-character loop is also what keeps `render_char`'s
+        // ordinary-character arm exercised now that production callers hand
+        // it only specials.
+        let renderer = HtmlInlineRenderer {};
+
+        for text in [
+            "",
+            "plain text with nothing special",
+            "a < b & c > d",
+            "<&>",
+            "&&&",
+            "ends with a special <",
+            "> starts with one",
+            "unicode — bullet • and a < special",
+        ] {
+            let mut bulk = String::new();
+            super::render_text(text, &renderer, &mut bulk);
+
+            let mut per_char = String::new();
+
+            for ch in text.chars() {
+                super::render_char(ch, &renderer, &mut per_char);
+            }
+
+            assert_eq!(bulk, per_char, "render_text diverged for {text:?}");
+        }
     }
 }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -12,7 +12,7 @@ use crate::{
     content::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
-            fold::{fold_html, fold_stem, render_char},
+            fold::{fold_html, fold_stem, render_text},
             quotes::{
                 LevelContext, Piece, build_match_string, charref_entity, single_text_value,
                 source_slice, text_slice,
@@ -517,11 +517,7 @@ pub(in crate::content::inline_builder) fn restorable_body<'a>(
             ..
         } => {
             let mut out = String::with_capacity(value.len());
-
-            for ch in value.chars() {
-                render_char(ch, renderer, &mut out);
-            }
-
+            render_text(value, renderer, &mut out);
             Some(Cow::Owned(out))
         }
 


### PR DESCRIPTION
Fourth increment of the CodSpeed regression work discussed on [#1059](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following [#1360](https://github.com/asciidoc-rs/asciidoc-parser/pull/1360), [#1361](https://github.com/asciidoc-rs/asciidoc-parser/pull/1361), and [#1362](https://github.com/asciidoc-rs/asciidoc-parser/pull/1362).

## What

A per-iteration profile of `throughput/plain_prose` (isolating one-time `LazyLock` costs by differencing 43- and 3-iteration callgrind runs) put `fold_into_html` at ~17% of a plain paragraph's entire parse — the single largest item. The cause: the fold's `Text` and escaped-`Raw` arms (and the image alt-text escape in `macros/image.rs`) push every character through `render_char` one at a time, though only `<`, `>`, and `&` ever route through the renderer.

The new `render_text` sweeps for those three bytes with `memchr3` (already a dependency) and appends every run between them as one `push_str`, calling `render_char` only at the specials it found.

## Why the output is unchanged

`render_text` is `render_char` applied to every character, re-spelled: only the three characters `render_char` itself routes through the renderer are ever handed to it, so the output is byte-identical for any renderer. A new differential test (`render_text_matches_render_char_character_by_character`) pins the two across the edge shapes — no specials, specials at either edge, adjacent specials, multi-byte characters — and keeps `render_char`'s ordinary-character arm exercised now that production callers hand it only specials.

## Measured effect

Callgrind instruction counts on the `inline_throughput` fixtures (against the current `inline-ast` tip with #1360–#1362 merged):

| benchmark | before | after |
|---|---|---|
| `throughput/plain_prose` (43 parses) | 123.6M | 103.1M (**−16.6%** total, ≈ −21% per parse net of one-time costs) |
| `throughput/formatted_prose` (23 parses) | 340.0M | 312.8M (**−8.0%**) |

Every benchmark folds, so `replacement_prose`, `mixed_document`, and the small fixtures benefit too.

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5506 lib tests, one new)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: `fold.rs` back to exactly its 3 pre-existing missed lines (the unsupported-node `debug_assert` arm); `image.rs` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_