### PR TITLE
fix: Gate the macros step on a lone text run's five trigger bytes

### DIFF
--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -190,9 +190,7 @@ pub(super) fn apply_macros<'src>(
     // `every_macro_family_needle_carries_a_gate_byte` pins the needle list).
     // Nothing to recognize also means nothing to descend into: a lone `Text`
     // node has no children, so the whole step is a no-op.
-    if let Some(value) = single_text_value(&nodes)
-        && !level_may_have_macros(value)
-    {
+    if single_text_value(&nodes).is_some_and(|value| !level_may_have_macros(value)) {
         return nodes;
     }
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -211,7 +211,11 @@ pub(super) fn apply_macros<'src>(
 /// Reports whether `value` holds any byte a macro family's own sniff could
 /// possibly be satisfied by — see the gate in [`apply_macros`] for the
 /// needle-by-needle accounting this five-byte class summarizes.
-fn level_may_have_macros(value: &str) -> bool {
+///
+/// `pub(super)` (and re-exported for tests) so
+/// `tests::inline_builder_macro_gate` can pin every family's needle
+/// against the byte class from outside this module.
+pub(crate) fn level_may_have_macros(value: &str) -> bool {
     value
         .bytes()
         .any(|b| matches!(b, b':' | b'[' | b'(' | b'@' | b'&'))
@@ -1712,54 +1716,5 @@ mod tests {
                 WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
             ]
         );
-    }
-
-    #[test]
-    fn every_macro_family_needle_carries_a_gate_byte() {
-        // The gate in `apply_macros` skips the whole step for a lone `Text`
-        // value holding none of its five bytes, so a minimal construct of
-        // every family — spelled as the *value* the step reads, meaning
-        // post-escaping for the xref's angle form — must answer `true`, or
-        // the gate would silently disable that family.
-        use super::level_may_have_macros;
-
-        for construct in [
-            "[[[biblio]]]",
-            "[[id]]",
-            "anchor:id[]",
-            "image:a.png[alt]",
-            "icon:heart[]",
-            "kbd:[F1]",
-            "btn:[OK]",
-            "menu:File[Save]",
-            "((term))",
-            "indexterm:[primary]",
-            "indexterm2:[shown]",
-            "https://example.com",
-            "link:page.html[text]",
-            "mailto:a@example.org[]",
-            "doc@example.org",
-            "xref:section[]",
-            "&lt;&lt;section&gt;&gt;",
-        ] {
-            assert!(
-                level_may_have_macros(construct),
-                "the gate would wrongly skip {construct:?}"
-            );
-        }
-
-        // Each of the five bytes opens the gate on its own, so no family's
-        // needle rides on a byte the class does not carry.
-        for value in [":", "[", "(", "@", "&"] {
-            assert!(
-                level_may_have_macros(value),
-                "gate byte {value:?} does not open the gate"
-            );
-        }
-
-        // And the shape the gate exists for answers `false`.
-        assert!(!level_may_have_macros(
-            "plain prose with nothing any macro family recognizes"
-        ));
     }
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -16,7 +16,8 @@ use xref::xref_macros_level;
 
 use super::{
     quotes::{
-        LevelContext, Piece, charref_entity, emit_range, source_slice, special_entity, text_slice,
+        LevelContext, Piece, charref_entity, emit_range, single_text_value, source_slice,
+        special_entity, text_slice,
     },
     special_chars::{Masked, unescaped_value_children},
 };
@@ -178,6 +179,23 @@ pub(super) fn apply_macros<'src>(
     masked: Masked<'_>,
     specials: ComputedSpecials,
 ) -> Vec<InlineNode<'src>> {
+    // One shared gate over every family's own sniff, taken while the content
+    // is still one lone `Text` node — a plain paragraph's shape. Each family
+    // sniffs for its own literals, and every one of those needles — `[[`,
+    // `[[[`, `anchor:`, `image:`, `icon:`, `kbd:`/`btn:`/`menu:` with `:[`,
+    // `((`, `indexterm` with `:[`, `://`, `link:`, `mailto:`, `@`, `xref:`,
+    // and the escaped `&lt;&lt;` — spells at least one of these five bytes,
+    // so a value carrying none of them fails every family's sniff before any
+    // is asked ([`level_may_have_macros`];
+    // `every_macro_family_needle_carries_a_gate_byte` pins the needle list).
+    // Nothing to recognize also means nothing to descend into: a lone `Text`
+    // node has no children, so the whole step is a no-op.
+    if let Some(value) = single_text_value(&nodes)
+        && !level_may_have_macros(value)
+    {
+        return nodes;
+    }
+
     // The bibliography anchor (`[[[label]]]`) runs before every other family,
     // exactly as the string step runs its own `INLINE_BIBLIO_ANCHOR` pass
     // first. It runs *only here*, at the content's own top level — its pattern
@@ -190,6 +208,15 @@ pub(super) fn apply_macros<'src>(
     let nodes = biblio_anchor_level(nodes, root, parser, masked);
 
     apply_macro_families(nodes, root, parser, LevelContext::ROOT, masked, specials)
+}
+
+/// Reports whether `value` holds any byte a macro family's own sniff could
+/// possibly be satisfied by — see the gate in [`apply_macros`] for the
+/// needle-by-needle accounting this five-byte class summarizes.
+fn level_may_have_macros(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|b| matches!(b, b':' | b'[' | b'(' | b'@' | b'&'))
 }
 
 /// Applies each macro family at this level — and, first, at every level nested
@@ -1687,5 +1714,45 @@ mod tests {
                 WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn every_macro_family_needle_carries_a_gate_byte() {
+        // The gate in `apply_macros` skips the whole step for a lone `Text`
+        // value holding none of its five bytes, so a minimal construct of
+        // every family — spelled as the *value* the step reads, meaning
+        // post-escaping for the xref's angle form — must answer `true`, or
+        // the gate would silently disable that family.
+        use super::level_may_have_macros;
+
+        for construct in [
+            "[[[biblio]]]",
+            "[[id]]",
+            "anchor:id[]",
+            "image:a.png[alt]",
+            "icon:heart[]",
+            "kbd:[F1]",
+            "btn:[OK]",
+            "menu:File[Save]",
+            "((term))",
+            "indexterm:[primary]",
+            "indexterm2:[shown]",
+            "https://example.com",
+            "link:page.html[text]",
+            "mailto:a@example.org[]",
+            "doc@example.org",
+            "xref:section[]",
+            "&lt;&lt;section&gt;&gt;",
+        ] {
+            assert!(
+                level_may_have_macros(construct),
+                "the gate would wrongly skip {construct:?}"
+            );
+        }
+
+        // And the shape the gate exists for answers `false`.
+        assert!(!level_may_have_macros(
+            "plain prose with nothing any macro family recognizes"
+        ));
     }
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1748,6 +1748,15 @@ mod tests {
             );
         }
 
+        // Each of the five bytes opens the gate on its own, so no family's
+        // needle rides on a byte the class does not carry.
+        for value in [":", "[", "(", "@", "&"] {
+            assert!(
+                level_may_have_macros(value),
+                "gate byte {value:?} does not open the gate"
+            );
+        }
+
         // And the shape the gate exists for answers `false`.
         assert!(!level_may_have_macros(
             "plain prose with nothing any macro family recognizes"

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -400,6 +400,8 @@ use char_replacements::apply_character_replacements;
 pub(crate) use fold::{fold_deferring_xrefs, fold_html, fold_reference_text};
 use footnotes::apply_footnotes;
 pub(crate) use macros::apply_macro_side_effects;
+#[cfg(test)]
+pub(crate) use macros::level_may_have_macros;
 use macros::{ComputedSpecials, apply_macros};
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;

--- a/parser/src/tests/inline_builder_macro_gate.rs
+++ b/parser/src/tests/inline_builder_macro_gate.rs
@@ -1,0 +1,55 @@
+//! Pins the macros step's shared trigger-byte gate
+//! ([`level_may_have_macros`]) against every macro family's own sniff
+//! needles, so a future needle cannot silently fall outside the byte class
+//! and have its family skipped for a lone-text level.
+//!
+//! [`level_may_have_macros`]: crate::content::inline_builder::level_may_have_macros
+
+use crate::content::inline_builder::level_may_have_macros;
+
+#[test]
+fn every_macro_family_needle_carries_a_gate_byte() {
+    // The gate in `apply_macros` skips the whole step for a lone `Text`
+    // value holding none of its five bytes, so a minimal construct of
+    // every family — spelled as the *value* the step reads, meaning
+    // post-escaping for the xref's angle form — must answer `true`, or
+    // the gate would silently disable that family.
+    for construct in [
+        "[[[biblio]]]",
+        "[[id]]",
+        "anchor:id[]",
+        "image:a.png[alt]",
+        "icon:heart[]",
+        "kbd:[F1]",
+        "btn:[OK]",
+        "menu:File[Save]",
+        "((term))",
+        "indexterm:[primary]",
+        "indexterm2:[shown]",
+        "https://example.com",
+        "link:page.html[text]",
+        "mailto:a@example.org[]",
+        "doc@example.org",
+        "xref:section[]",
+        "&lt;&lt;section&gt;&gt;",
+    ] {
+        assert!(
+            level_may_have_macros(construct),
+            "the gate would wrongly skip {construct:?}"
+        );
+    }
+
+    // Each of the five bytes opens the gate on its own, so no family's
+    // needle rides on a byte the class does not carry.
+    for value in [":", "[", "(", "@", "&"] {
+        assert!(
+            level_may_have_macros(value),
+            "gate byte {value:?} does not open the gate"
+        );
+    }
+
+    // And the shape the gate exists for answers `false`.
+    assert!(!level_may_have_macros(
+        "plain prose with nothing any macro family recognizes"
+    ));
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod block_nesting_depth;
 pub(crate) mod fixtures;
 mod hash;
 mod inline_builder_document_parity;
+mod inline_builder_macro_gate;
 mod inline_builder_passthrough_record_parity;
 mod inline_builder_side_effect_parity;
 mod inline_renderer;


### PR DESCRIPTION
Sixth increment of the CodSpeed regression work discussed on [#1059](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), the macros-step companion to [#1364](https://github.com/asciidoc-rs/asciidoc-parser/pull/1364)'s quotes marker mask.

## What

Each macro family already sniffs for its own literals before building a match string (#1346), but each sniff still scans the level's text on its own turn — around ten scans per level that all fail on a plain paragraph. Every needle those sniffs look for — `[[`, `[[[`, `anchor:`, `image:`, `icon:`, `kbd:`/`btn:`/`menu:` with `:[`, `((`, `indexterm` with `:[`, `://`, `link:`, `mailto:`, `@`, `xref:`, and the escaped `&lt;&lt;` — spells at least one of five bytes (`:` `[` `(` `@` `&`). While the content is one lone `Text` node (a plain paragraph's shape), `apply_macros` now answers all of them with one pass over the value, and a value carrying none of the five skips the whole step, bibliography-anchor pass included.

## Why the output is unchanged

A value without any of the five bytes fails every family's own sniff, so no family could have matched; and a lone `Text` node has no children, so the recursion had nothing to descend into either. The raw `<<` spelling is deliberately not in the class: the xref sniff itself only looks for `xref:` and the escaped form, so no behavior rides on it. A new test (`every_macro_family_needle_carries_a_gate_byte`) pins every family's minimal construct against the gate so a future needle cannot silently fall outside the byte class.

## Measured effect

Callgrind instruction counts, `throughput/plain_prose`, 43 parses (against the pre-#1364 base; the two changes touch disjoint steps and stack):

| | before | after |
|---|---|---|
| `throughput/plain_prose` | 103.1M | 96.6M (**−6.3%**) |

## Preflight

- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean
- `cargo test --workspace` green (5509 lib tests after rebase onto #1364, one new)
- `cargo +nightly doc --no-deps --document-private-items` clean
- Coverage: `macros/mod.rs` missed lines unchanged (2, both pre-existing test panic arms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_