### PR TITLE
fix: Replace unanchored quote-sub sweeps with a candidate scan

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -18,6 +18,23 @@ bytecount = "0.6.7"
 memchr = "2.6.4"
 percent-encoding = "2.3.2"
 regex = "1.11.1"
+# Exactly the features `regex` itself enables on the shared build (its
+# defaults plus what this crate's use of `meta::Regex` needs, which is the
+# same set): anything beyond them — notably `dfa-build`/`dfa-search` from the
+# default `dfa` feature — would, through feature unification, change engine
+# selection for every `regex::Regex` in this crate, not just the quote subs.
+regex-automata = { version = "0.4.18", default-features = false, features = [
+    "dfa-onepass",
+    "hybrid",
+    "meta",
+    "nfa-backtrack",
+    "nfa-pikevm",
+    "perf-inline",
+    "perf-literal",
+    "std",
+    "syntax",
+    "unicode",
+] }
 self_cell = "1.2.0"
 thiserror = "2.0.1"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,16 +24,16 @@ regex = "1.11.1"
 # default `dfa` feature — would, through feature unification, change engine
 # selection for every `regex::Regex` in this crate, not just the quote subs.
 regex-automata = { version = "0.4.18", default-features = false, features = [
-    "dfa-onepass",
-    "hybrid",
-    "meta",
-    "nfa-backtrack",
-    "nfa-pikevm",
-    "perf-inline",
-    "perf-literal",
-    "std",
-    "syntax",
-    "unicode",
+  "dfa-onepass",
+  "hybrid",
+  "meta",
+  "nfa-backtrack",
+  "nfa-pikevm",
+  "perf-inline",
+  "perf-literal",
+  "std",
+  "syntax",
+  "unicode",
 ] }
 self_cell = "1.2.0"
 thiserror = "2.0.1"

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -406,6 +406,8 @@ use macros::{ComputedSpecials, apply_macros};
 use passthrough_step::apply_passthroughs;
 use post_replacements::apply_post_replacements;
 use quotes::apply_quotes;
+#[cfg(test)]
+pub(crate) use quotes::{candidate_needle, find_matches, reference_find_matches};
 use special_chars::{
     Masked, apply_special_characters, classify_unescaped_specials, flatten_prior_markup,
     masked_locations,

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1438,7 +1438,7 @@ pub(super) fn charref_entity<'a>(node: &'a InlineNode<'_>) -> Option<&'a str> {
 
 /// One accepted quote match at a level, in absolute match-string byte offsets.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-struct QuoteMatch {
+pub(crate) struct QuoteMatch {
     /// The whole match, `[start, end)`.
     full: Range<usize>,
 
@@ -1480,7 +1480,7 @@ impl QuoteMatch {
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-enum QuoteMatchKind {
+pub(crate) enum QuoteMatchKind {
     /// An escaped construct (`\*x*`): drop the leading backslash, keep the rest
     /// as literal text, wrap nothing.
     Unescape,
@@ -1514,7 +1514,7 @@ enum QuoteMatchKind {
 /// Drives `sub` over the match string with a look-ahead retry: a rejected
 /// monospace-before-quote match slices the haystack forward and re-searches,
 /// rather than giving up on the level.
-fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
+pub(crate) fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
     let mut matches = Vec::new();
 
     // Absolute offset of the current (possibly sliced) haystack within `s`.
@@ -1637,7 +1637,7 @@ fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
 /// The three types no [`QuoteSub`] carries answer an empty needle (the same
 /// shape as [`sub_markers`]'s empty answer for them;
 /// `every_quote_sub_has_a_candidate_needle` pins that no real sub does).
-fn candidate_needle(type_: QuoteType, scope: QuoteScope) -> &'static [u8] {
+pub(crate) fn candidate_needle(type_: QuoteType, scope: QuoteScope) -> &'static [u8] {
     match (type_, scope) {
         (QuoteType::Strong, QuoteScope::Unconstrained) => b"**",
         (QuoteType::Strong, QuoteScope::Constrained) => b"*",
@@ -2326,6 +2326,127 @@ pub(super) fn quote_type_of(variant: StyleVariant) -> QuoteType {
         StyleVariant::SingleQuote => QuoteType::SingleQuote,
         StyleVariant::Unquoted => QuoteType::Unquoted,
     }
+}
+
+#[cfg(test)]
+/// The unanchored `captures_iter` loop the candidate scan replaced,
+/// compiled from each sub's own [`source`](QuoteSub::source)
+/// through the `regex` crate exactly as the subs were built before — the
+/// reference `candidate_scan_matches_the_unanchored_reference` (in
+/// `crate::tests::inline_builder_quotes_candidate_scan`, kept outside this
+/// module so its lines stay out of the coverage measurement on every
+/// platform) pins [`find_matches`] against, match for match.
+// Test-only code (see `#[cfg(test)]` above); the unwraps are the tests-module
+// idiom, which the lint's own in-tests carve-out misses only because this fn
+// sits outside a `mod tests`.
+#[allow(clippy::unwrap_used)]
+pub(crate) fn reference_find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
+    // As every sub was compiled before the candidate scan: through
+    // `RegexBuilder` with `dot_matches_new_line`. (The superscript and
+    // subscript patterns were built without the flag, but contain no `.`
+    // metacharacter, so this is the same matcher.)
+    let pattern = regex::RegexBuilder::new(sub.source)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap();
+
+    let abs_kind = |caps: &regex::Captures<'_>, base: usize| -> Option<QuoteMatchKind> {
+        let abs = |r: std::ops::Range<usize>| (base + r.start)..(base + r.end);
+        let whole = caps.get(0).unwrap();
+        let escaped = whole.as_str().starts_with('\\');
+
+        match sub.scope {
+            QuoteScope::Constrained => {
+                let prefix_end = caps.get(1).map_or(base, |m| base + m.end());
+                let attrlist = caps.get(2).map(|m| abs(m.range()));
+                let body = caps.get(3).map(|m| abs(m.range()))?;
+
+                if escaped {
+                    let attrlist = attrlist?;
+
+                    return Some(QuoteMatchKind::Wrap {
+                        keep_literal: Some((attrlist.start - 1)..(attrlist.end + 1)),
+                        body,
+                        construct: (attrlist.end + 1)..(base + whole.end()),
+                        attrlist: None,
+                        variant: style_variant(sub.type_, false),
+                        form: crate::inlines::SpanForm::Constrained,
+                    });
+                }
+
+                let has_attrs = attrlist.is_some();
+
+                Some(QuoteMatchKind::Wrap {
+                    keep_literal: None,
+                    construct: prefix_end..(base + whole.end()),
+                    body,
+                    attrlist,
+                    variant: style_variant(sub.type_, has_attrs),
+                    form: crate::inlines::SpanForm::Constrained,
+                })
+            }
+
+            QuoteScope::Unconstrained => {
+                if escaped {
+                    return None;
+                }
+
+                let attrlist = caps.get(1).map(|m| abs(m.range()));
+                let body = caps.get(2).map(|m| abs(m.range()))?;
+                let has_attrs = attrlist.is_some();
+
+                Some(QuoteMatchKind::Wrap {
+                    keep_literal: None,
+                    construct: (base + whole.start())..(base + whole.end()),
+                    body,
+                    attrlist,
+                    variant: style_variant(sub.type_, has_attrs),
+                    form: crate::inlines::SpanForm::Unconstrained,
+                })
+            }
+        }
+    };
+
+    let mut matches = Vec::new();
+    let mut base = 0usize;
+
+    'retry: loop {
+        let haystack = &s[base..];
+
+        for caps in pattern.captures_iter(haystack) {
+            let whole = caps.get(0).unwrap();
+
+            let full = (base + whole.start())..(base + whole.end());
+            let after = &haystack[whole.end()..];
+
+            if sub.type_ == QuoteType::Monospaced
+                && sub.scope == QuoteScope::Constrained
+                && after.starts_with(['"', '\'', '`'])
+            {
+                let skip = if whole.as_str().starts_with('\\') {
+                    2
+                } else {
+                    whole.as_str().chars().next().map_or(1, char::len_utf8)
+                };
+
+                base = full.start + skip;
+                continue 'retry;
+            }
+
+            if let Some(kind) = abs_kind(&caps, base) {
+                matches.push(QuoteMatch { full, kind });
+            } else {
+                matches.push(QuoteMatch {
+                    full,
+                    kind: QuoteMatchKind::Unescape,
+                });
+            }
+        }
+
+        break;
+    }
+
+    matches
 }
 
 #[cfg(test)]
@@ -4801,283 +4922,6 @@ mod tests {
             );
 
             assert_ne!(folded, golden_html, "expected a divergence for {source:?}");
-        }
-    }
-
-    #[test]
-    fn every_quote_sub_has_a_candidate_needle() {
-        // The candidate scan hops between occurrences of each sub's own
-        // opening delimiter, so a real sub answering an empty needle would
-        // make its scan find nothing at all — and a needle that is not
-        // literally the text the pattern's own opening delimiter spells
-        // (escapes stripped) would skip real constructs. The three types no
-        // `QuoteSub` carries are the only ones allowed to answer empty,
-        // mirroring `sub_markers`'s empty answer for them.
-        use super::candidate_needle;
-        use crate::{
-            content::quote_subs,
-            parser::{QuoteScope, QuoteType},
-        };
-
-        for sub in quote_subs() {
-            let needle = candidate_needle(sub.type_, sub.scope);
-
-            assert!(
-                !needle.is_empty(),
-                "{:?}/{:?} has no candidate needle",
-                sub.type_,
-                sub.scope
-            );
-
-            // The needle must be the pattern's own opening delimiter: the
-            // literal run its source spells right after the optional-attrs
-            // group, with regex escapes stripped.
-            let (_, tail) = sub.source.split_once(r#"(?:\[([^\[\]]+)\])?"#).unwrap();
-            let opening = tail.replace('\\', "");
-            let needle_text = std::str::from_utf8(needle).unwrap();
-
-            assert!(
-                opening.as_bytes().starts_with(needle),
-                "{:?}/{:?}: needle {needle_text:?} is not how {tail:?} opens",
-                sub.type_,
-                sub.scope,
-            );
-        }
-
-        for type_ in [
-            QuoteType::Unquoted,
-            QuoteType::AsciiMath,
-            QuoteType::LatexMath,
-        ] {
-            for scope in [QuoteScope::Constrained, QuoteScope::Unconstrained] {
-                assert!(candidate_needle(type_, scope).is_empty(), "{type_:?}");
-            }
-        }
-    }
-
-    /// The unanchored `captures_iter` loop the candidate scan replaced,
-    /// compiled from each sub's own [`source`](super::QuoteSub::source)
-    /// through the `regex` crate exactly as the subs were built before — the
-    /// reference [`candidate_scan_matches_the_unanchored_reference`] pins
-    /// [`find_matches`](super::find_matches) against, match for match.
-    fn reference_find_matches(sub: &super::QuoteSub, s: &str) -> Vec<super::QuoteMatch> {
-        use super::{QuoteMatch, QuoteMatchKind, style_variant};
-        use crate::parser::{QuoteScope, QuoteType};
-
-        // As every sub was compiled before the candidate scan: through
-        // `RegexBuilder` with `dot_matches_new_line`. (The superscript and
-        // subscript patterns were built without the flag, but contain no `.`
-        // metacharacter, so this is the same matcher.)
-        let pattern = regex::RegexBuilder::new(sub.source)
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap();
-
-        let abs_kind = |caps: &regex::Captures<'_>, base: usize| -> Option<QuoteMatchKind> {
-            let abs = |r: std::ops::Range<usize>| (base + r.start)..(base + r.end);
-            let whole = caps.get(0).unwrap();
-            let escaped = whole.as_str().starts_with('\\');
-
-            match sub.scope {
-                QuoteScope::Constrained => {
-                    let prefix_end = caps.get(1).map_or(base, |m| base + m.end());
-                    let attrlist = caps.get(2).map(|m| abs(m.range()));
-                    let body = caps.get(3).map(|m| abs(m.range()))?;
-
-                    if escaped {
-                        let attrlist = attrlist?;
-
-                        return Some(QuoteMatchKind::Wrap {
-                            keep_literal: Some((attrlist.start - 1)..(attrlist.end + 1)),
-                            body,
-                            construct: (attrlist.end + 1)..(base + whole.end()),
-                            attrlist: None,
-                            variant: style_variant(sub.type_, false),
-                            form: crate::inlines::SpanForm::Constrained,
-                        });
-                    }
-
-                    let has_attrs = attrlist.is_some();
-
-                    Some(QuoteMatchKind::Wrap {
-                        keep_literal: None,
-                        construct: prefix_end..(base + whole.end()),
-                        body,
-                        attrlist,
-                        variant: style_variant(sub.type_, has_attrs),
-                        form: crate::inlines::SpanForm::Constrained,
-                    })
-                }
-
-                QuoteScope::Unconstrained => {
-                    if escaped {
-                        return None;
-                    }
-
-                    let attrlist = caps.get(1).map(|m| abs(m.range()));
-                    let body = caps.get(2).map(|m| abs(m.range()))?;
-                    let has_attrs = attrlist.is_some();
-
-                    Some(QuoteMatchKind::Wrap {
-                        keep_literal: None,
-                        construct: (base + whole.start())..(base + whole.end()),
-                        body,
-                        attrlist,
-                        variant: style_variant(sub.type_, has_attrs),
-                        form: crate::inlines::SpanForm::Unconstrained,
-                    })
-                }
-            }
-        };
-
-        let mut matches = Vec::new();
-        let mut base = 0usize;
-
-        'retry: loop {
-            let haystack = &s[base..];
-
-            for caps in pattern.captures_iter(haystack) {
-                let whole = caps.get(0).unwrap();
-
-                let full = (base + whole.start())..(base + whole.end());
-                let after = &haystack[whole.end()..];
-
-                if sub.type_ == QuoteType::Monospaced
-                    && sub.scope == QuoteScope::Constrained
-                    && after.starts_with(['"', '\'', '`'])
-                {
-                    let skip = if whole.as_str().starts_with('\\') {
-                        2
-                    } else {
-                        whole.as_str().chars().next().map_or(1, char::len_utf8)
-                    };
-
-                    base = full.start + skip;
-                    continue 'retry;
-                }
-
-                if let Some(kind) = abs_kind(&caps, base) {
-                    matches.push(QuoteMatch { full, kind });
-                } else {
-                    matches.push(QuoteMatch {
-                        full,
-                        kind: QuoteMatchKind::Unescape,
-                    });
-                }
-            }
-
-            break;
-        }
-
-        matches
-    }
-
-    #[test]
-    fn candidate_scan_matches_the_unanchored_reference() {
-        // The candidate scan must enumerate exactly the matches the
-        // unanchored sweep it replaced would have found, in the same order,
-        // with the same capture ranges. The fixtures concentrate on the
-        // shapes the scan's start enumeration has to get right: attribute
-        // lists that contain marker bytes (the one way a match starts well
-        // before the candidate that anchors it), escapes riding the prefix
-        // class, doubled and tripled delimiters, matches at either edge,
-        // multi-byte characters beside delimiters, unclosed brackets, and
-        // the constrained-monospace retry.
-        let fixtures = [
-            // Nothing to find.
-            "",
-            "plain prose with none of it",
-            // The plain shapes, at every position.
-            "*b*",
-            "a *b* c",
-            "*b* tail",
-            "head *b*",
-            "**b**",
-            "a **b** c",
-            "***b***",
-            "*a*b*",
-            "**a**b**",
-            "_i_ and __ii__",
-            "`m` and ``mm``",
-            "#h# and ##hh##",
-            "^s^ x ~t~",
-            "\"`dq`\" '`sq`'",
-            // Escapes (constrained: the backslash is the prefix char;
-            // unconstrained: its own optional group).
-            r"\*b*",
-            r"a \*b* c",
-            r"\**b**",
-            r"\[a]*b*",
-            r"[a]\*b*",
-            // Attribute lists, including marker bytes *inside* the list —
-            // the leftmost-faithfulness case.
-            "[a]*b*",
-            "x [.role]#m#",
-            "[a*b]*c*",
-            "[z#z]#A#",
-            ".[z#z]#A#",
-            "x[a#b]#body#",
-            "[*]*b*",
-            "[a]b *c*",
-            // Unclosed and empty brackets.
-            "[open *b*",
-            "[]*b*",
-            "]*b*",
-            "[a][b]*c*",
-            "*[a]b*",
-            // Word-adjacent (constrained boundary failures).
-            "a*b*c",
-            "1*2*3",
-            "*b*word",
-            // Doubled-delimiter interplay.
-            "**a* b*",
-            "*a **b** c*",
-            "``a` b`",
-            // Multi-byte characters beside markers.
-            "é*ü*é",
-            "→*b*←",
-            "«*b*»",
-            "*é*",
-            // Multi-line bodies (dot_matches_new_line).
-            "*a\nb*",
-            "**a\nb**",
-            // The constrained-monospace retry chain.
-            "`a`'",
-            "x `a`' y",
-            "`a`'`b`'",
-            r"\`a`'",
-            "`a`\"",
-            "`a`` b``",
-            // Smart quotes beside their own markers.
-            "\"`a`\"b",
-            "'`a`'.",
-            "\"`a`'",
-            // Prose full of the smart-quote subs' *first* bytes with no
-            // construct — the shape the whole-delimiter needle exists for —
-            // and the overlap traps beside it: a lone first byte directly
-            // before a real construct, and a needle occurrence split across
-            // an apostrophe and a monospace span.
-            "It's the author's own text, \"quoted\" the plain way.",
-            "''`a`'",
-            "\"\"`a`\"",
-            "it'`s`'",
-            "'`a`''`b`'",
-            // Dense soup.
-            "*a* [b*c]*d* \\*e* [f]#g# `h`' **i**",
-        ];
-
-        use crate::content::quote_subs;
-
-        for sub in quote_subs() {
-            for fixture in fixtures {
-                assert_eq!(
-                    super::find_matches(sub, fixture),
-                    reference_find_matches(sub, fixture),
-                    "candidate scan diverged for {:?}/{:?} on {fixture:?}",
-                    sub.type_,
-                    sub.scope,
-                );
-            }
         }
     }
 }

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1437,6 +1437,7 @@ pub(super) fn charref_entity<'a>(node: &'a InlineNode<'_>) -> Option<&'a str> {
 }
 
 /// One accepted quote match at a level, in absolute match-string byte offsets.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 struct QuoteMatch {
     /// The whole match, `[start, end)`.
     full: Range<usize>,
@@ -1478,6 +1479,7 @@ impl QuoteMatch {
     }
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 enum QuoteMatchKind {
     /// An escaped construct (`\*x*`): drop the leading backslash, keep the rest
     /// as literal text, wrap nothing.
@@ -1518,42 +1520,100 @@ fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
     // Absolute offset of the current (possibly sliced) haystack within `s`.
     let mut base = 0usize;
 
+    // One reusable capture-slot buffer for the whole scan, filled in place by
+    // each anchored attempt.
+    let mut caps = sub.pattern.create_captures();
+
+    let delim = candidate_needle(sub.type_, sub.scope);
+
     'retry: loop {
         let haystack = &s[base..];
+        let bytes = haystack.as_bytes();
+        let mut at = 0usize;
 
-        for caps in sub.pattern.captures_iter(haystack) {
-            // `unwrap` on group 0 is safe: a capture always has an overall
-            // match.
-            #[allow(clippy::unwrap_used)]
-            let whole = caps.get(0).unwrap();
+        // The candidate scan. Every match of a quote pattern contains its
+        // whole opening delimiter — so instead of handing the whole haystack
+        // to an unanchored search that spends most of its time sweeping text
+        // between constructs, hop between occurrences of that delimiter with
+        // `memmem` and run the pattern **anchored** at each position a match
+        // containing that occurrence could start at ([`candidate_starts`]).
+        // An anchored attempt either matches exactly there or fails within a
+        // few bytes; the gaps are never swept by the regex engine at all.
+        //
+        // Left-to-right order is preserved: candidates are visited in
+        // position order, each candidate's possible starts are tried in
+        // ascending order, and `candidate_starts` enumerates every start a
+        // match could structurally have — including one whose attribute list
+        // *contains* this candidate's bytes, which is the one way a match can
+        // begin well before the delimiter that anchors it.
+        'candidates: while at < haystack.len() {
+            let Some(found) = memchr::memmem::find(bytes.get(at..).unwrap_or_default(), delim)
+            else {
+                break;
+            };
 
-            let full = (base + whole.start())..(base + whole.end());
-            let after = &haystack[whole.end()..];
+            let d = at + found;
 
-            // The monospace-constrained-before-quote look-ahead: reject and
-            // resume a few bytes in, so the following quote can be recognized.
-            if sub.type_ == QuoteType::Monospaced
-                && sub.scope == QuoteScope::Constrained
-                && after.starts_with(['"', '\'', '`'])
-            {
-                let skip = if whole.as_str().starts_with('\\') {
-                    2
-                } else {
-                    whole.as_str().chars().next().map_or(1, char::len_utf8)
+            let mut starts = [0usize; 6];
+            let count = candidate_starts(haystack, d, &mut starts);
+
+            for &start in starts.get(..count).unwrap_or_default() {
+                if start < at {
+                    continue;
+                }
+
+                let input = regex_automata::Input::new(haystack)
+                    .anchored(regex_automata::Anchored::Yes)
+                    .range(start..);
+
+                sub.pattern.search_captures(&input, &mut caps);
+
+                let Some(whole) = caps.get_match() else {
+                    continue;
                 };
 
-                base = full.start + skip;
-                continue 'retry;
+                let full = (base + whole.start())..(base + whole.end());
+                let after = &haystack[whole.end()..];
+
+                // The monospace-constrained-before-quote look-ahead: reject
+                // and resume a few bytes in, so the following quote can be
+                // recognized.
+                if sub.type_ == QuoteType::Monospaced
+                    && sub.scope == QuoteScope::Constrained
+                    && after.starts_with(['"', '\'', '`'])
+                {
+                    let matched = &haystack[whole.range()];
+
+                    let skip = if matched.starts_with('\\') {
+                        2
+                    } else {
+                        matched.chars().next().map_or(1, char::len_utf8)
+                    };
+
+                    base = full.start + skip;
+                    continue 'retry;
+                }
+
+                if let Some(m) = classify_match(sub, haystack, &caps, base) {
+                    matches.push(QuoteMatch { full, kind: m });
+                } else {
+                    matches.push(QuoteMatch {
+                        full,
+                        kind: QuoteMatchKind::Unescape,
+                    });
+                }
+
+                // Every accepted match extends past `d` (its own delimiter
+                // sits at or beyond it), so the cursor always advances; `max`
+                // spells the guarantee out rather than trusting it.
+                at = whole.end().max(at + 1);
+                continue 'candidates;
             }
 
-            if let Some(m) = classify_match(sub, &caps, base) {
-                matches.push(QuoteMatch { full, kind: m });
-            } else {
-                matches.push(QuoteMatch {
-                    full,
-                    kind: QuoteMatchKind::Unescape,
-                });
-            }
+            // No match can start at any position this candidate allows; move
+            // to the next occurrence of the delimiter (which may overlap this
+            // one from `d + 1` on — `***` holds two occurrences of `**`).
+            at = d + 1;
         }
 
         break;
@@ -1562,31 +1622,167 @@ fn find_matches(sub: &QuoteSub, s: &str) -> Vec<QuoteMatch> {
     matches
 }
 
+/// `sub`'s **whole opening** delimiter — the literal byte string every match
+/// of its pattern must contain at or after its start, which is what lets
+/// [`find_matches`] enumerate candidate positions with `memmem` instead of
+/// sweeping the gaps with the regex engine.
+///
+/// Using the whole delimiter rather than just its first byte matters most for
+/// the two typographic-quote subs: their delimiters open with `"` and `'`,
+/// bytes everyday prose is full of (`it's`, `the author's`), but the byte
+/// *pair* (quote-then-backtick) almost never occurs outside a real
+/// construct — exactly the discrimination the retired unanchored engine's own
+/// literal prefilter had.
+///
+/// The three types no [`QuoteSub`] carries answer an empty needle (the same
+/// shape as [`sub_markers`]'s empty answer for them;
+/// `every_quote_sub_has_a_candidate_needle` pins that no real sub does).
+fn candidate_needle(type_: QuoteType, scope: QuoteScope) -> &'static [u8] {
+    match (type_, scope) {
+        (QuoteType::Strong, QuoteScope::Unconstrained) => b"**",
+        (QuoteType::Strong, QuoteScope::Constrained) => b"*",
+        (QuoteType::DoubleQuote, _) => b"\"`",
+        (QuoteType::SingleQuote, _) => b"'`",
+        (QuoteType::Monospaced, QuoteScope::Unconstrained) => b"``",
+        (QuoteType::Monospaced, QuoteScope::Constrained) => b"`",
+        (QuoteType::Emphasis, QuoteScope::Unconstrained) => b"__",
+        (QuoteType::Emphasis, QuoteScope::Constrained) => b"_",
+        (QuoteType::Mark, QuoteScope::Unconstrained) => b"##",
+        (QuoteType::Mark, QuoteScope::Constrained) => b"#",
+        (QuoteType::Superscript, _) => b"^",
+        (QuoteType::Subscript, _) => b"~",
+
+        (QuoteType::Unquoted | QuoteType::AsciiMath | QuoteType::LatexMath, _) => b"",
+    }
+}
+
+/// Writes into `starts` the ascending, deduplicated positions a match whose
+/// pattern contains its opening delimiter at `d` could start at, returning how
+/// many were written.
+///
+/// A quote pattern's text before its opening delimiter is at most: an
+/// optional escaping backslash *or* one boundary-prefix character (the `^`
+/// alternative consumes nothing), then an optional `[attrs]` list whose
+/// characters exclude both brackets. That gives three shapes, each
+/// contributing the delimiter-relative start and the one a single preceding
+/// character adds:
+///
+/// - **plain** — nothing between start and `d`: `d` itself and the character
+///   before it;
+/// - **closed attribute list** — `d` directly follows `]`: the matching `[` and
+///   the character before it;
+/// - **bracket interior** — `d` sits *inside* an unclosed `[…` run, meaning
+///   this byte may be attribute-list content of a match whose own delimiter
+///   comes later: that run's `[` and the character before it. This is the one
+///   way a match can begin well before the candidate that led to it, and
+///   enumerating it is what keeps the candidate scan leftmost-faithful.
+///
+/// A start the pattern cannot actually use (say, `[` with no construct after
+/// the list) just fails its anchored attempt; over-enumeration costs a few
+/// bytes of engine work, never a wrong match.
+fn candidate_starts(haystack: &str, d: usize, starts: &mut [usize; 6]) -> usize {
+    let bytes = haystack.as_bytes();
+    let mut count = 0usize;
+
+    let mut push = |position: usize, count: &mut usize| {
+        if let Some(slot) = starts.get_mut(*count) {
+            *slot = position;
+            *count += 1;
+        }
+    };
+
+    // Bracket interior: the nearest `[` before `d` with no `]` between.
+    if let Some(open) = memchr::memrchr(b'[', bytes.get(..d).unwrap_or_default())
+        && memchr::memrchr(b']', bytes.get(open + 1..d).unwrap_or_default()).is_none()
+    {
+        if let Some(before) = prev_char_start(haystack, open) {
+            push(before, &mut count);
+        }
+
+        push(open, &mut count);
+    }
+
+    // Closed attribute list: `d` directly follows `]`; find its `[`.
+    if d > 0
+        && bytes.get(d - 1) == Some(&b']')
+        && let Some(open) = memchr::memrchr(b'[', bytes.get(..d - 1).unwrap_or_default())
+        && memchr::memrchr(b']', bytes.get(open + 1..d - 1).unwrap_or_default()).is_none()
+    {
+        if let Some(before) = prev_char_start(haystack, open) {
+            push(before, &mut count);
+        }
+
+        push(open, &mut count);
+    }
+
+    // Plain: the delimiter itself and the character before it.
+    if let Some(before) = prev_char_start(haystack, d) {
+        push(before, &mut count);
+    }
+
+    push(d, &mut count);
+
+    let filled = starts.get_mut(..count).unwrap_or_default();
+    filled.sort_unstable();
+
+    // Dedup in place; the array is tiny.
+    let mut kept = 0usize;
+
+    for i in 0..count {
+        let value = filled.get(i).copied().unwrap_or_default();
+
+        if (kept == 0 || filled.get(kept - 1).copied() != Some(value))
+            && let Some(slot) = filled.get_mut(kept)
+        {
+            *slot = value;
+            kept += 1;
+        }
+    }
+
+    kept
+}
+
+/// The byte position where the character ending at `i` begins, or `None` at
+/// the start of the haystack. `i` is always the index of an ASCII byte a
+/// `memchr` scan found, so it is in bounds and on a character boundary.
+fn prev_char_start(haystack: &str, i: usize) -> Option<usize> {
+    haystack
+        .get(..i)
+        .and_then(|before| before.chars().next_back())
+        .map(|ch| i - ch.len_utf8())
+}
+
 /// Classifies one raw capture into the [`Styled`] span it produces, or `None`
 /// when it is an escaped construct that wraps nothing.
 ///
 /// Group numbering follows the shared patterns: a *constrained* sub captures
 /// `(prefix)(attrlist?)(body)`; an *unconstrained* sub captures
 /// `(attrlist?)(body)`. `base` maps a capture offset (into the current
-/// haystack) back to an absolute offset in the whole match string.
+/// haystack `h`) back to an absolute offset in the whole match string.
+///
+/// `caps` is the capture-slot buffer the anchored search in [`find_matches`]
+/// filled; a group is read as its offset span, and the overall match's text
+/// as a slice of `h`.
 fn classify_match(
     sub: &QuoteSub,
-    caps: &regex::Captures<'_>,
+    h: &str,
+    caps: &regex_automata::util::captures::Captures,
     base: usize,
 ) -> Option<QuoteMatchKind> {
     let abs = |r: std::ops::Range<usize>| (base + r.start)..(base + r.end);
+    let group = |i: usize| caps.get_group(i).map(|span| span.start..span.end);
 
-    // `unwrap` on group 0 is safe: a capture always has an overall match.
-    #[allow(clippy::unwrap_used)]
-    let whole = caps.get(0).unwrap();
+    let whole = caps.get_match()?;
 
-    let escaped = whole.as_str().starts_with('\\');
+    // The first byte of the match; the escape marker is ASCII, so the byte
+    // test and a `starts_with('\\')` over the matched text agree.
+    let escaped = h.as_bytes().get(whole.start()) == Some(&b'\\');
 
     match sub.scope {
         QuoteScope::Constrained => {
-            let prefix_end = caps.get(1).map_or(base, |m| base + m.end());
-            let attrlist = caps.get(2).map(|m| abs(m.range()));
-            let body = caps.get(3).map(|m| abs(m.range()))?;
+            let prefix_end = group(1).map_or(base, |r| base + r.end);
+            let attrlist = group(2).map(&abs);
+            let body = group(3).map(&abs)?;
 
             if escaped {
                 // `\[a]*x*`: the escape keeps `[a]` literal but still wraps the
@@ -1628,8 +1824,8 @@ fn classify_match(
                 return None;
             }
 
-            let attrlist = caps.get(1).map(|m| abs(m.range()));
-            let body = caps.get(2).map(|m| abs(m.range()))?;
+            let attrlist = group(1).map(&abs);
+            let body = group(2).map(&abs)?;
             let has_attrs = attrlist.is_some();
 
             Some(QuoteMatchKind::Wrap {
@@ -4605,6 +4801,283 @@ mod tests {
             );
 
             assert_ne!(folded, golden_html, "expected a divergence for {source:?}");
+        }
+    }
+
+    #[test]
+    fn every_quote_sub_has_a_candidate_needle() {
+        // The candidate scan hops between occurrences of each sub's own
+        // opening delimiter, so a real sub answering an empty needle would
+        // make its scan find nothing at all — and a needle that is not
+        // literally the text the pattern's own opening delimiter spells
+        // (escapes stripped) would skip real constructs. The three types no
+        // `QuoteSub` carries are the only ones allowed to answer empty,
+        // mirroring `sub_markers`'s empty answer for them.
+        use super::candidate_needle;
+        use crate::{
+            content::quote_subs,
+            parser::{QuoteScope, QuoteType},
+        };
+
+        for sub in quote_subs() {
+            let needle = candidate_needle(sub.type_, sub.scope);
+
+            assert!(
+                !needle.is_empty(),
+                "{:?}/{:?} has no candidate needle",
+                sub.type_,
+                sub.scope
+            );
+
+            // The needle must be the pattern's own opening delimiter: the
+            // literal run its source spells right after the optional-attrs
+            // group, with regex escapes stripped.
+            let (_, tail) = sub.source.split_once(r#"(?:\[([^\[\]]+)\])?"#).unwrap();
+            let opening = tail.replace('\\', "");
+            let needle_text = std::str::from_utf8(needle).unwrap();
+
+            assert!(
+                opening.as_bytes().starts_with(needle),
+                "{:?}/{:?}: needle {needle_text:?} is not how {tail:?} opens",
+                sub.type_,
+                sub.scope,
+            );
+        }
+
+        for type_ in [
+            QuoteType::Unquoted,
+            QuoteType::AsciiMath,
+            QuoteType::LatexMath,
+        ] {
+            for scope in [QuoteScope::Constrained, QuoteScope::Unconstrained] {
+                assert!(candidate_needle(type_, scope).is_empty(), "{type_:?}");
+            }
+        }
+    }
+
+    /// The unanchored `captures_iter` loop the candidate scan replaced,
+    /// compiled from each sub's own [`source`](super::QuoteSub::source)
+    /// through the `regex` crate exactly as the subs were built before — the
+    /// reference [`candidate_scan_matches_the_unanchored_reference`] pins
+    /// [`find_matches`](super::find_matches) against, match for match.
+    fn reference_find_matches(sub: &super::QuoteSub, s: &str) -> Vec<super::QuoteMatch> {
+        use super::{QuoteMatch, QuoteMatchKind, style_variant};
+        use crate::parser::{QuoteScope, QuoteType};
+
+        // As every sub was compiled before the candidate scan: through
+        // `RegexBuilder` with `dot_matches_new_line`. (The superscript and
+        // subscript patterns were built without the flag, but contain no `.`
+        // metacharacter, so this is the same matcher.)
+        let pattern = regex::RegexBuilder::new(sub.source)
+            .dot_matches_new_line(true)
+            .build()
+            .unwrap();
+
+        let abs_kind = |caps: &regex::Captures<'_>, base: usize| -> Option<QuoteMatchKind> {
+            let abs = |r: std::ops::Range<usize>| (base + r.start)..(base + r.end);
+            let whole = caps.get(0).unwrap();
+            let escaped = whole.as_str().starts_with('\\');
+
+            match sub.scope {
+                QuoteScope::Constrained => {
+                    let prefix_end = caps.get(1).map_or(base, |m| base + m.end());
+                    let attrlist = caps.get(2).map(|m| abs(m.range()));
+                    let body = caps.get(3).map(|m| abs(m.range()))?;
+
+                    if escaped {
+                        let attrlist = attrlist?;
+
+                        return Some(QuoteMatchKind::Wrap {
+                            keep_literal: Some((attrlist.start - 1)..(attrlist.end + 1)),
+                            body,
+                            construct: (attrlist.end + 1)..(base + whole.end()),
+                            attrlist: None,
+                            variant: style_variant(sub.type_, false),
+                            form: crate::inlines::SpanForm::Constrained,
+                        });
+                    }
+
+                    let has_attrs = attrlist.is_some();
+
+                    Some(QuoteMatchKind::Wrap {
+                        keep_literal: None,
+                        construct: prefix_end..(base + whole.end()),
+                        body,
+                        attrlist,
+                        variant: style_variant(sub.type_, has_attrs),
+                        form: crate::inlines::SpanForm::Constrained,
+                    })
+                }
+
+                QuoteScope::Unconstrained => {
+                    if escaped {
+                        return None;
+                    }
+
+                    let attrlist = caps.get(1).map(|m| abs(m.range()));
+                    let body = caps.get(2).map(|m| abs(m.range()))?;
+                    let has_attrs = attrlist.is_some();
+
+                    Some(QuoteMatchKind::Wrap {
+                        keep_literal: None,
+                        construct: (base + whole.start())..(base + whole.end()),
+                        body,
+                        attrlist,
+                        variant: style_variant(sub.type_, has_attrs),
+                        form: crate::inlines::SpanForm::Unconstrained,
+                    })
+                }
+            }
+        };
+
+        let mut matches = Vec::new();
+        let mut base = 0usize;
+
+        'retry: loop {
+            let haystack = &s[base..];
+
+            for caps in pattern.captures_iter(haystack) {
+                let whole = caps.get(0).unwrap();
+
+                let full = (base + whole.start())..(base + whole.end());
+                let after = &haystack[whole.end()..];
+
+                if sub.type_ == QuoteType::Monospaced
+                    && sub.scope == QuoteScope::Constrained
+                    && after.starts_with(['"', '\'', '`'])
+                {
+                    let skip = if whole.as_str().starts_with('\\') {
+                        2
+                    } else {
+                        whole.as_str().chars().next().map_or(1, char::len_utf8)
+                    };
+
+                    base = full.start + skip;
+                    continue 'retry;
+                }
+
+                if let Some(kind) = abs_kind(&caps, base) {
+                    matches.push(QuoteMatch { full, kind });
+                } else {
+                    matches.push(QuoteMatch {
+                        full,
+                        kind: QuoteMatchKind::Unescape,
+                    });
+                }
+            }
+
+            break;
+        }
+
+        matches
+    }
+
+    #[test]
+    fn candidate_scan_matches_the_unanchored_reference() {
+        // The candidate scan must enumerate exactly the matches the
+        // unanchored sweep it replaced would have found, in the same order,
+        // with the same capture ranges. The fixtures concentrate on the
+        // shapes the scan's start enumeration has to get right: attribute
+        // lists that contain marker bytes (the one way a match starts well
+        // before the candidate that anchors it), escapes riding the prefix
+        // class, doubled and tripled delimiters, matches at either edge,
+        // multi-byte characters beside delimiters, unclosed brackets, and
+        // the constrained-monospace retry.
+        let fixtures = [
+            // Nothing to find.
+            "",
+            "plain prose with none of it",
+            // The plain shapes, at every position.
+            "*b*",
+            "a *b* c",
+            "*b* tail",
+            "head *b*",
+            "**b**",
+            "a **b** c",
+            "***b***",
+            "*a*b*",
+            "**a**b**",
+            "_i_ and __ii__",
+            "`m` and ``mm``",
+            "#h# and ##hh##",
+            "^s^ x ~t~",
+            "\"`dq`\" '`sq`'",
+            // Escapes (constrained: the backslash is the prefix char;
+            // unconstrained: its own optional group).
+            r"\*b*",
+            r"a \*b* c",
+            r"\**b**",
+            r"\[a]*b*",
+            r"[a]\*b*",
+            // Attribute lists, including marker bytes *inside* the list —
+            // the leftmost-faithfulness case.
+            "[a]*b*",
+            "x [.role]#m#",
+            "[a*b]*c*",
+            "[z#z]#A#",
+            ".[z#z]#A#",
+            "x[a#b]#body#",
+            "[*]*b*",
+            "[a]b *c*",
+            // Unclosed and empty brackets.
+            "[open *b*",
+            "[]*b*",
+            "]*b*",
+            "[a][b]*c*",
+            "*[a]b*",
+            // Word-adjacent (constrained boundary failures).
+            "a*b*c",
+            "1*2*3",
+            "*b*word",
+            // Doubled-delimiter interplay.
+            "**a* b*",
+            "*a **b** c*",
+            "``a` b`",
+            // Multi-byte characters beside markers.
+            "é*ü*é",
+            "→*b*←",
+            "«*b*»",
+            "*é*",
+            // Multi-line bodies (dot_matches_new_line).
+            "*a\nb*",
+            "**a\nb**",
+            // The constrained-monospace retry chain.
+            "`a`'",
+            "x `a`' y",
+            "`a`'`b`'",
+            r"\`a`'",
+            "`a`\"",
+            "`a`` b``",
+            // Smart quotes beside their own markers.
+            "\"`a`\"b",
+            "'`a`'.",
+            "\"`a`'",
+            // Prose full of the smart-quote subs' *first* bytes with no
+            // construct — the shape the whole-delimiter needle exists for —
+            // and the overlap traps beside it: a lone first byte directly
+            // before a real construct, and a needle occurrence split across
+            // an apostrophe and a monospace span.
+            "It's the author's own text, \"quoted\" the plain way.",
+            "''`a`'",
+            "\"\"`a`\"",
+            "it'`s`'",
+            "'`a`''`b`'",
+            // Dense soup.
+            "*a* [b*c]*d* \\*e* [f]#g# `h`' **i**",
+        ];
+
+        use crate::content::quote_subs;
+
+        for sub in quote_subs() {
+            for fixture in fixtures {
+                assert_eq!(
+                    super::find_matches(sub, fixture),
+                    reference_find_matches(sub, fixture),
+                    "candidate scan diverged for {:?}/{:?} on {fixture:?}",
+                    sub.type_,
+                    sub.scope,
+                );
+            }
         }
     }
 }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::LazyLock};
 
-use regex::{Captures, Regex, RegexBuilder, Replacer};
+use regex::{Captures, Regex, Replacer};
 
 use crate::{
     Parser, Span,
@@ -138,15 +138,50 @@ impl Replacer for SpecialCharacterReplacer<'_> {
 }
 
 /// One quoted-text recognition rule: a [`QuoteType`]/[`QuoteScope`] pairing and
-/// the [`Regex`] that recognizes it.
+/// the pattern that recognizes it.
 ///
 /// The rules are `pub(crate)` (via [`quote_subs`]) so the single-pass
 /// [`inline_builder`](crate::content::inline_builder) reuses these *exact*
 /// same patterns rather than duplicating them at its own recognition sink.
+///
+/// The pattern is compiled through `regex-automata`'s meta engine rather than
+/// the `regex` crate's own wrapper of it, because the recognition sink's
+/// candidate scan needs the one thing the wrapper does not expose: an
+/// **anchored** search at an arbitrary offset (see `find_matches` in
+/// [`inline_builder`](crate::content::inline_builder)'s quotes step). The
+/// syntax and match semantics are the `regex` crate's own — the wrapper is a
+/// thin layer over this very engine. [`source`](Self::source) keeps the
+/// pattern's text so the differential pin in that module can compile the
+/// reference `regex::Regex` these matchers replaced and compare the two
+/// match-for-match.
 pub(crate) struct QuoteSub {
     pub(crate) type_: QuoteType,
     pub(crate) scope: QuoteScope,
-    pub(crate) pattern: Regex,
+    pub(crate) pattern: regex_automata::meta::Regex,
+    /// Read only by the differential pin in the quotes step's tests; the
+    /// production matcher is [`pattern`](Self::pattern).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) source: &'static str,
+}
+
+/// Builds one [`QuoteSub`], compiling `source` with the same
+/// `dot_matches_new_line` semantics `RegexBuilder` gave every quote pattern.
+/// (The superscript and subscript patterns were built without the flag, but
+/// neither contains a `.` metacharacter, so the flag is inert for them and
+/// one shared configuration serves all twelve.)
+fn quote_sub(type_: QuoteType, scope: QuoteScope, source: &'static str) -> QuoteSub {
+    #[allow(clippy::unwrap_used)]
+    let pattern = regex_automata::meta::Regex::builder()
+        .syntax(regex_automata::util::syntax::Config::new().dot_matches_new_line(true))
+        .build(source)
+        .unwrap();
+
+    QuoteSub {
+        type_,
+        scope,
+        pattern,
+        source,
+    }
 }
 
 /// The ordered quoted-text recognition rules, shared with the single-pass
@@ -178,135 +213,82 @@ pub(crate) fn quote_subs() -> &'static [QuoteSub] {
 //   the order in which they are replaced is important.
 static QUOTE_SUBS: LazyLock<Vec<QuoteSub>> = LazyLock::new(|| {
     vec![
-        QuoteSub {
-            // **strong**
-            type_: QuoteType::Strong,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(r#"\\?(?:\[([^\[\]]+)\])?\*\*(.+?)\*\*"#)
-                .dot_matches_new_line(true)
-                .build()
-                .unwrap(),
-        },
-        QuoteSub {
-            // *strong*
-            type_: QuoteType::Strong,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?\*(\S|\S.*?\S)\*\b{end-half}"#,
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // "`double-quoted`"
-            type_: QuoteType::DoubleQuote,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?"`(\S|\S.*?\S)`"\b{end-half}"#,
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // '`single-quoted`'
-            type_: QuoteType::SingleQuote,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?'`(\S|\S.*?\S)`'\b{end-half}"#,
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // ``monospaced``
-            type_: QuoteType::Monospaced,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(r#"\\?(?:\[([^\[\]]+)\])?``(.+?)``"#)
-                .dot_matches_new_line(true)
-                .build()
-                .unwrap(),
-        },
-        QuoteSub {
-            // `monospaced`
-            type_: QuoteType::Monospaced,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:"'`}])(?:\[([^\[\]]+)\])?`(\S|\S.*?\S)`\b{end-half}"#,
-                // NB: We don't have look-ahead in Rust Regex, so we might miss some edge cases
-                // because Ruby's version matches `(?![#{CC_WORD}"'`])` which is slightly more
-                // detailed than our `\b{end-half}`.
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // __emphasis__
-            type_: QuoteType::Emphasis,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(r#"\\?(?:\[([^\[\]]+)\])?__(.+?)__"#)
-                .dot_matches_new_line(true)
-                .build()
-                .unwrap(),
-        },
-        QuoteSub {
-            // _emphasis_
-            type_: QuoteType::Emphasis,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?_(\S|\S.*?\S)_\b{end-half}"#,
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // ##mark##
-            type_: QuoteType::Mark,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(r#"\\?(?:\[([^\[\]]+)\])?##(.+?)##"#)
-                .dot_matches_new_line(true)
-                .build()
-                .unwrap(),
-        },
-        QuoteSub {
-            // #mark#
-            type_: QuoteType::Mark,
-            scope: QuoteScope::Constrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: RegexBuilder::new(
-                r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?#(\S|\S.*?\S)#\b{end-half}"#,
-            )
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap(),
-        },
-        QuoteSub {
-            // ^superscript^
-            type_: QuoteType::Superscript,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: Regex::new(r#"\\?(?:\[([^\[\]]+)\])?\^(\S+?)\^"#).unwrap(),
-        },
-        QuoteSub {
-            // ~subscript~
-            type_: QuoteType::Subscript,
-            scope: QuoteScope::Unconstrained,
-            #[allow(clippy::unwrap_used)]
-            pattern: Regex::new(r#"\\?(?:\[([^\[\]]+)\])?~(\S+?)~"#).unwrap(),
-        },
+        // **strong**
+        quote_sub(
+            QuoteType::Strong,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?\*\*(.+?)\*\*"#,
+        ),
+        // *strong*
+        quote_sub(
+            QuoteType::Strong,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?\*(\S|\S.*?\S)\*\b{end-half}"#,
+        ),
+        // "`double-quoted`"
+        quote_sub(
+            QuoteType::DoubleQuote,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?"`(\S|\S.*?\S)`"\b{end-half}"#,
+        ),
+        // '`single-quoted`'
+        quote_sub(
+            QuoteType::SingleQuote,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?'`(\S|\S.*?\S)`'\b{end-half}"#,
+        ),
+        // ``monospaced``
+        quote_sub(
+            QuoteType::Monospaced,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?``(.+?)``"#,
+        ),
+        // `monospaced`
+        //
+        // NB: We don't have look-ahead in Rust Regex, so we might miss some
+        // edge cases because Ruby's version matches `(?![#{CC_WORD}"'`])`
+        // which is slightly more detailed than our `\b{end-half}`.
+        quote_sub(
+            QuoteType::Monospaced,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:"'`}])(?:\[([^\[\]]+)\])?`(\S|\S.*?\S)`\b{end-half}"#,
+        ),
+        // __emphasis__
+        quote_sub(
+            QuoteType::Emphasis,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?__(.+?)__"#,
+        ),
+        // _emphasis_
+        quote_sub(
+            QuoteType::Emphasis,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?_(\S|\S.*?\S)_\b{end-half}"#,
+        ),
+        // ##mark##
+        quote_sub(
+            QuoteType::Mark,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?##(.+?)##"#,
+        ),
+        // #mark#
+        quote_sub(
+            QuoteType::Mark,
+            QuoteScope::Constrained,
+            r#"(^|[^\w&;:}])(?:\[([^\[\]]+)\])?#(\S|\S.*?\S)#\b{end-half}"#,
+        ),
+        // ^superscript^
+        quote_sub(
+            QuoteType::Superscript,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?\^(\S+?)\^"#,
+        ),
+        // ~subscript~
+        quote_sub(
+            QuoteType::Subscript,
+            QuoteScope::Unconstrained,
+            r#"\\?(?:\[([^\[\]]+)\])?~(\S+?)~"#,
+        ),
     ]
 });
 

--- a/parser/src/tests/inline_builder_quotes_candidate_scan.rs
+++ b/parser/src/tests/inline_builder_quotes_candidate_scan.rs
@@ -1,0 +1,171 @@
+//! Pins the quotes step's candidate scan ([`find_matches`]) against the
+//! unanchored sweep it replaced ([`reference_find_matches`]) and each sub's
+//! scan needle ([`candidate_needle`]) against its own pattern.
+//!
+//! These live here rather than in the quotes module's own tests so their
+//! lines stay out of the coverage measurement on every platform (this
+//! directory is excluded when the lcov report is generated).
+//!
+//! [`find_matches`]: crate::content::inline_builder::find_matches
+//! [`reference_find_matches`]: crate::content::inline_builder::reference_find_matches
+//! [`candidate_needle`]: crate::content::inline_builder::candidate_needle
+
+use crate::{
+    content::{
+        inline_builder::{candidate_needle, find_matches, reference_find_matches},
+        quote_subs,
+    },
+    parser::{QuoteScope, QuoteType},
+};
+
+#[test]
+fn every_quote_sub_has_a_candidate_needle() {
+    // The candidate scan hops between occurrences of each sub's own
+    // opening delimiter, so a real sub answering an empty needle would
+    // make its scan find nothing at all — and a needle that is not
+    // literally the text the pattern's own opening delimiter spells
+    // (escapes stripped) would skip real constructs. The three types no
+    // `QuoteSub` carries are the only ones allowed to answer empty,
+    // mirroring `sub_markers`'s empty answer for them.
+    for sub in quote_subs() {
+        let needle = candidate_needle(sub.type_, sub.scope);
+
+        assert!(
+            !needle.is_empty(),
+            "{:?}/{:?} has no candidate needle",
+            sub.type_,
+            sub.scope
+        );
+
+        // The needle must be the pattern's own opening delimiter: the
+        // literal run its source spells right after the optional-attrs
+        // group, with regex escapes stripped.
+        let (_, tail) = sub.source.split_once(r#"(?:\[([^\[\]]+)\])?"#).unwrap();
+        let opening = tail.replace('\\', "");
+        let needle_text = std::str::from_utf8(needle).unwrap();
+
+        assert!(
+            opening.as_bytes().starts_with(needle),
+            "{:?}/{:?}: needle {needle_text:?} is not how {tail:?} opens",
+            sub.type_,
+            sub.scope,
+        );
+    }
+
+    for type_ in [
+        QuoteType::Unquoted,
+        QuoteType::AsciiMath,
+        QuoteType::LatexMath,
+    ] {
+        for scope in [QuoteScope::Constrained, QuoteScope::Unconstrained] {
+            assert!(candidate_needle(type_, scope).is_empty(), "{type_:?}");
+        }
+    }
+}
+
+#[test]
+fn candidate_scan_matches_the_unanchored_reference() {
+    // The candidate scan must enumerate exactly the matches the
+    // unanchored sweep it replaced would have found, in the same order,
+    // with the same capture ranges. The fixtures concentrate on the
+    // shapes the scan's start enumeration has to get right: attribute
+    // lists that contain marker bytes (the one way a match starts well
+    // before the candidate that anchors it), escapes riding the prefix
+    // class, doubled and tripled delimiters, matches at either edge,
+    // multi-byte characters beside delimiters, unclosed brackets, and
+    // the constrained-monospace retry.
+    let fixtures = [
+        // Nothing to find.
+        "",
+        "plain prose with none of it",
+        // The plain shapes, at every position.
+        "*b*",
+        "a *b* c",
+        "*b* tail",
+        "head *b*",
+        "**b**",
+        "a **b** c",
+        "***b***",
+        "*a*b*",
+        "**a**b**",
+        "_i_ and __ii__",
+        "`m` and ``mm``",
+        "#h# and ##hh##",
+        "^s^ x ~t~",
+        "\"`dq`\" '`sq`'",
+        // Escapes (constrained: the backslash is the prefix char;
+        // unconstrained: its own optional group).
+        r"\*b*",
+        r"a \*b* c",
+        r"\**b**",
+        r"\[a]*b*",
+        r"[a]\*b*",
+        // Attribute lists, including marker bytes *inside* the list —
+        // the leftmost-faithfulness case.
+        "[a]*b*",
+        "x [.role]#m#",
+        "[a*b]*c*",
+        "[z#z]#A#",
+        ".[z#z]#A#",
+        "x[a#b]#body#",
+        "[*]*b*",
+        "[a]b *c*",
+        // Unclosed and empty brackets.
+        "[open *b*",
+        "[]*b*",
+        "]*b*",
+        "[a][b]*c*",
+        "*[a]b*",
+        // Word-adjacent (constrained boundary failures).
+        "a*b*c",
+        "1*2*3",
+        "*b*word",
+        // Doubled-delimiter interplay.
+        "**a* b*",
+        "*a **b** c*",
+        "``a` b`",
+        // Multi-byte characters beside markers.
+        "é*ü*é",
+        "→*b*←",
+        "«*b*»",
+        "*é*",
+        // Multi-line bodies (dot_matches_new_line).
+        "*a\nb*",
+        "**a\nb**",
+        // The constrained-monospace retry chain.
+        "`a`'",
+        "x `a`' y",
+        "`a`'`b`'",
+        r"\`a`'",
+        "`a`\"",
+        "`a`` b``",
+        // Smart quotes beside their own markers.
+        "\"`a`\"b",
+        "'`a`'.",
+        "\"`a`'",
+        // Prose full of the smart-quote subs' *first* bytes with no
+        // construct — the shape the whole-delimiter needle exists for —
+        // and the overlap traps beside it: a lone first byte directly
+        // before a real construct, and a needle occurrence split across
+        // an apostrophe and a monospace span.
+        "It's the author's own text, \"quoted\" the plain way.",
+        "''`a`'",
+        "\"\"`a`\"",
+        "it'`s`'",
+        "'`a`''`b`'",
+        // Dense soup.
+        "*a* [b*c]*d* \\*e* [f]#g# `h`' **i**",
+    ];
+
+    for sub in quote_subs() {
+        for fixture in fixtures {
+            assert_eq!(
+                find_matches(sub, fixture),
+                reference_find_matches(sub, fixture),
+                "candidate scan diverged for {:?}/{:?} on {fixture:?}",
+                sub.type_,
+                sub.scope,
+            );
+        }
+    }
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod hash;
 mod inline_builder_document_parity;
 mod inline_builder_macro_gate;
 mod inline_builder_passthrough_record_parity;
+mod inline_builder_quotes_candidate_scan;
 mod inline_builder_side_effect_parity;
 mod inline_renderer;
 mod inline_tree;


### PR DESCRIPTION
Ninth increment of the performance work tracked from [#1059's CodSpeed comparison](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following #1360–#1367.

## What changed

The quotes step matched each of its twelve substitution rules by handing the whole level string to an unanchored `captures_iter` sweep, so most of the regex engine's time went to walking the text *between* constructs. Every match of a quote pattern contains its whole opening delimiter, so `find_matches` now:

1. hops between occurrences of that **literal opening delimiter** (`**`, `` `` ``, `"` + backtick, …) with `memmem`, and
2. runs the pattern **anchored** at each position a match containing that occurrence could start at (`candidate_starts`: the delimiter itself, the character before it, and — for a delimiter adjacent to or *inside* a bracket run — the attribute list's `[` and the character before that).

An anchored attempt either matches exactly there or fails within a few bytes; the gaps are never swept by the regex engine at all. Scanning for the whole delimiter rather than its first byte matters most for the typographic-quote subs: prose is full of `'` and `"` (`it's`, `the author's`), but the quote-then-backtick byte pair almost never occurs outside a real construct — the same discrimination the unanchored engine's own literal prefilter had.

An anchored search at an arbitrary offset is the one thing the `regex` crate's wrapper does not expose, so the quote subs now compile through `regex-automata`'s meta engine directly (same engine, same syntax, same semantics). The dependency's features are pinned to exactly the set `regex` itself enables — a default-features dependency would, through feature unification, silently enable the dense-DFA engines for **every** regex in the crate and change engine selection crate-wide (measurable as one-time DFA construction plus per-parse engine swaps in unrelated steps).

## Why it's the same matcher

- `candidate_scan_matches_the_unanchored_reference` pins `find_matches` against the verbatim unanchored `captures_iter` loop it replaced (compiled from each sub's retained `source` through the `regex` crate exactly as before), match for match, capture for capture, across ~75 fixtures × 12 subs concentrating on the shapes the start enumeration has to get right: attribute lists containing marker bytes, escapes riding the prefix class, doubled/tripled delimiters, unclosed brackets, multi-byte neighbors, the constrained-monospace retry, and apostrophe-dense prose.
- `every_quote_sub_has_a_candidate_needle` ties each sub's scan needle to its own pattern's opening delimiter, so a future pattern edit cannot silently detach the two.
- The full corpus (5511 lib tests, incl. every frozen-recording differential) is green, and the five `inline_throughput` fixtures parse to byte-identical documents on this branch vs. `inline-ast`.

## Measured effect

Callgrind instruction counts per parse on the `inline_throughput` fixtures, isolated by differencing two iteration counts per binary (so one-time setup cancels), this branch vs. `inline-ast` @ 1898385:

| fixture | base | this PR | Δ |
|---|---|---|---|
| formatted_prose | 11,649,350 | 11,397,272 | **−2.2%** |
| mixed_document | 13,732,602 | 13,701,935 | −0.2% |
| macro_prose | 9,647,092 | 9,673,595 | +0.3% |
| replacement_prose | 5,971,060 | 6,058,600 | +1.5% |
| plain_prose | 1,289,141 | 1,312,711 | +1.8% |

The formatted_prose win is the unanchored sweep cost leaving the profile (`find_fwd` −175K, `find_rev` −163K per parse). The plain/replacement upticks are not algorithmic: function-level diffs show identical call counts and byte-identical output, with the deltas sitting in heap-layout-sensitive `memcpy`-under-`realloc` and a CGU inlining shift in an unrelated `captures_iter` loop — plain_prose (which contains no quote-marker byte at all, so none of this code runs there) measured +0.1% on one build of this same code and +1.8% on the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_