### PR TITLE
fix: Skip whole substitution steps through one fused trigger scan

### DIFF
--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -386,6 +386,7 @@ mod post_replacements;
 mod quotes;
 mod special_chars;
 mod stem_step;
+mod trigger_scan;
 
 #[cfg(test)]
 pub(crate) mod snapshot;
@@ -413,6 +414,11 @@ use special_chars::{
     masked_locations,
 };
 use stem_step::apply_stem;
+#[cfg(test)]
+pub(crate) use trigger_scan::{
+    ATTRIBUTE_TRIGGERS, MACRO_TRIGGERS, PASSTHROUGH_TRIGGERS, POST_REPLACEMENT_TRIGGERS,
+    QUOTE_TRIGGERS, REPLACEMENT_TRIGGERS, SPECIAL_TRIGGERS, STEM_TRIGGERS, trigger_mask,
+};
 
 use crate::{
     Parser, Span,
@@ -541,16 +547,32 @@ pub(crate) fn build_for_group<'src>(
 
     let mut nodes = vec![InlineNode::Text { value, location }];
 
+    // The fused per-step gate: while the tree is still a single `Text` node,
+    // one shared scan of its bytes (see [`trigger_scan`]) answers every
+    // step's own lone-text sniff at once, and a step whose trigger bytes are
+    // absent is skipped without being called at all. Every step that *does*
+    // run invalidates the scan, so a step that transforms the tree can never
+    // leave a stale answer behind (see [`trigger_scan::LoneTextSniff`] for
+    // when a rescan is actually needed); everything after it proceeds
+    // exactly as before.
+    let mut sniff = trigger_scan::LoneTextSniff::default();
+
     // Passthroughs are extracted before every other step (mirroring
     // `Passthroughs::extract_from`'s own gate), so their content is
     // never touched by specialcharacters, quotes, replacements, or macros.
     if steps.contains(&SubstitutionStep::Macros) || group == &SubstitutionGroup::Header {
-        nodes = apply_passthroughs(nodes, location, parser);
+        if sniff.may(&nodes, trigger_scan::PASSTHROUGH_TRIGGERS) {
+            nodes = apply_passthroughs(nodes, location, parser);
+            sniff.invalidate();
+        }
 
         // Inline STEM is an implicit passthrough too, extracted last
         // (mirroring `Passthroughs::extract_from`'s own ordering) so a
         // passthrough placeholder nested inside a STEM expression survives.
-        nodes = apply_stem(nodes, location, parser);
+        if sniff.may(&nodes, trigger_scan::STEM_TRIGGERS) {
+            nodes = apply_stem(nodes, location, parser);
+            sniff.invalidate();
+        }
     }
 
     // What the extraction pass masked, recorded — as it must be — *before* any
@@ -569,6 +591,26 @@ pub(crate) fn build_for_group<'src>(
     let masked = masked_locations(&nodes);
 
     for (position, step) in steps.iter().enumerate() {
+        // The fused gate's per-step answer. `Callouts` takes no class here:
+        // it runs only in the Verbatim group's order and keeps its own sniff.
+        let triggers = match step {
+            SubstitutionStep::SpecialCharacters => Some(trigger_scan::SPECIAL_TRIGGERS),
+            SubstitutionStep::Quotes => Some(trigger_scan::QUOTE_TRIGGERS),
+            SubstitutionStep::AttributeReferences => Some(trigger_scan::ATTRIBUTE_TRIGGERS),
+            SubstitutionStep::CharacterReplacements => Some(trigger_scan::REPLACEMENT_TRIGGERS),
+            SubstitutionStep::Macros => Some(trigger_scan::MACRO_TRIGGERS),
+            SubstitutionStep::PostReplacement => Some(trigger_scan::POST_REPLACEMENT_TRIGGERS),
+            SubstitutionStep::Callouts => None,
+        };
+
+        if let Some(triggers) = triggers
+            && !sniff.may(&nodes, triggers)
+        {
+            continue;
+        }
+
+        sniff.invalidate();
+
         nodes = match step {
             SubstitutionStep::SpecialCharacters => {
                 // Applied to this step's own *position* in the order:
@@ -659,7 +701,9 @@ pub(crate) fn build_for_group<'src>(
     // `Raw` leaf here rather than the `Text` run the fold would escape. This
     // runs last, after the group's own steps, so every transducer still sees
     // the specials as ordinary text.
-    if !steps.contains(&SubstitutionStep::SpecialCharacters) {
+    if !steps.contains(&SubstitutionStep::SpecialCharacters)
+        && sniff.may(&nodes, trigger_scan::SPECIAL_TRIGGERS)
+    {
         nodes = classify_unescaped_specials(nodes);
     }
 

--- a/parser/src/content/inline_builder/trigger_scan.rs
+++ b/parser/src/content/inline_builder/trigger_scan.rs
@@ -1,0 +1,184 @@
+//! One fused trigger scan for the whole substitution pipeline.
+//!
+//! Nearly every step opens with its own cheap sniff over a lone
+//! [`Text`](InlineNode::Text) node's value — quotes' marker mask, the macros
+//! step's trigger-byte gate, the attribute step's `{` probe, and so on. For
+//! the overwhelmingly common content shape (a plain paragraph that no step
+//! touches), that means walking the same bytes once per step just to conclude
+//! "nothing here" each time.
+//!
+//! [`LoneTextSniff`] collapses those walks into **one** pass: [`trigger_mask`]
+//! classifies each byte into the union of every step's
+//! trigger bytes, ORing the classes together, and
+//! [`build_for_group`](super::build_for_group) then skips a step's whole call
+//! when the mask holds none of that step's bytes. The gate fires only while
+//! the tree is a single `Text` node — the one shape whose match string *is*
+//! its value — and every step that does run invalidates the cached mask (see
+//! [`LoneTextSniff`] for when a rescan is really needed), so a step that
+//! transforms the tree can never leave a stale answer behind and every later
+//! step runs normally.
+//!
+//! Each step's class here must stay **conservative** against that step's own
+//! sniff: it may name more bytes than the step needs, never fewer. A byte the
+//! class over-names costs one redundant step call (the step's own sniff then
+//! declines); a byte it under-named would silently disable a construct. The
+//! per-step reasoning lives on each constant below, and
+//! `crate::tests::inline_builder_trigger_scan` pins every class against its
+//! step's own recognizers, so a future needle cannot drift out of its class
+//! unnoticed.
+
+use crate::{inlines::InlineNode, strings::CowStr};
+
+/// The passthrough-extraction pass. Union of its two phases' own sniffs: the
+/// macro/doubled forms (`++`, `$$`, and `pass:`/`ss:`) and the bare or
+/// attrlisted single-`+` form, whose `-]` needle carries the `]` here.
+pub(crate) const PASSTHROUGH_TRIGGERS: u32 = bit(b'+') | bit(b'$') | bit(b':') | bit(b']');
+
+/// Inline STEM extraction: every spelling its sniff admits (`stem:`,
+/// `asciimath:`, `latexmath:`) requires the colon.
+pub(crate) const STEM_TRIGGERS: u32 = bit(b':');
+
+/// The specialcharacters step (and the end-of-group
+/// [`classify_unescaped_specials`](super::special_chars::classify_unescaped_specials)
+/// sweep): the three characters it escapes or classifies.
+pub(crate) const SPECIAL_TRIGGERS: u32 = bit(b'<') | bit(b'>') | bit(b'&');
+
+/// The quotes step: the eight `sub_markers` characters (see that function in
+/// the quotes module). Every quote sub requires *all* of its own markers, so
+/// a value holding none of the eight can satisfy no sub at all.
+pub(crate) const QUOTE_TRIGGERS: u32 =
+    bit(b'*') | bit(b'"') | bit(b'\'') | bit(b'`') | bit(b'_') | bit(b'#') | bit(b'^') | bit(b'~');
+
+/// The attribute-references step: a reference or counter directive is always
+/// spelled `{…}`.
+pub(crate) const ATTRIBUTE_TRIGGERS: u32 = bit(b'{');
+
+/// The character-replacements step: one byte from each alternative of its own
+/// sniff (`[&']|--|\.\.\.|\([CRT]M?\)` — see
+/// [`maybe_has_replacements`](crate::content::maybe_has_replacements)).
+pub(crate) const REPLACEMENT_TRIGGERS: u32 =
+    bit(b'&') | bit(b'\'') | bit(b'-') | bit(b'.') | bit(b'(');
+
+/// The macros step: the same five bytes as
+/// [`level_may_have_macros`](super::macros::level_may_have_macros), which
+/// documents why they cover every macro family. The footnotes pass rides on
+/// this same gate: its constructs (`footnote:[…]`, `footnoteref:[…]`) always
+/// carry the colon.
+pub(crate) const MACRO_TRIGGERS: u32 = bit(b':') | bit(b'[') | bit(b'(') | bit(b'@') | bit(b'&');
+
+/// The post-replacements step: a hard break needs the ` +` marker — except
+/// under the `hardbreaks` option, where every `\n` becomes one, which is why
+/// the newline is in this class rather than only `+`.
+pub(crate) const POST_REPLACEMENT_TRIGGERS: u32 = bit(b'+') | bit(b'\n');
+
+/// The bit for one trigger byte — the single source both the step classes
+/// above and [`trigger_mask`]'s per-byte classification are built from. A
+/// byte outside every class answers `0`; the classification is per **byte**,
+/// which cannot miss a trigger inside a multi-byte character since every
+/// trigger byte is ASCII and never occurs in a multi-byte character's
+/// encoding.
+const fn bit(b: u8) -> u32 {
+    match b {
+        b'+' => 1 << 0,
+        b'$' => 1 << 1,
+        b':' => 1 << 2,
+        b']' => 1 << 3,
+        b'<' => 1 << 4,
+        b'>' => 1 << 5,
+        b'&' => 1 << 6,
+        b'*' => 1 << 7,
+        b'"' => 1 << 8,
+        b'\'' => 1 << 9,
+        b'`' => 1 << 10,
+        b'_' => 1 << 11,
+        b'#' => 1 << 12,
+        b'^' => 1 << 13,
+        b'~' => 1 << 14,
+        b'{' => 1 << 15,
+        b'-' => 1 << 16,
+        b'.' => 1 << 17,
+        b'(' => 1 << 18,
+        b'[' => 1 << 19,
+        b'@' => 1 << 20,
+        b'\n' => 1 << 21,
+
+        _ => 0,
+    }
+}
+
+/// The fused scan itself: the trigger classes present anywhere in `value`.
+pub(crate) fn trigger_mask(value: &str) -> u32 {
+    let mut mask = 0u32;
+
+    for b in value.bytes() {
+        mask |= bit(b);
+    }
+
+    mask
+}
+
+/// The one-pass replacement for each step's own lone-`Text` sniff, cached
+/// across the step loop.
+///
+/// [`may`](Self::may) answers whether a step whose trigger class is
+/// `triggers` could possibly act on `nodes`: `false` only when the tree is a
+/// single `Text` node whose value holds none of the class's bytes — the
+/// caller then skips the step's call entirely. Any other tree shape answers
+/// `true`, leaving the decision to the step's own machinery.
+///
+/// The cached mask is reused on two grounds, each sound on its own:
+///
+/// - **Freshness** — no step has run since the scan
+///   ([`invalidate`](Self::invalidate) is called after every step that does),
+///   so the node the mask describes is untouched, whatever its [`CowStr`]
+///   variant.
+/// - **A matching borrowed identity** — a [`Borrowed`](CowStr::Borrowed)
+///   value's bytes live in the source, which outlives the whole build, so the
+///   same address and length can only ever name the same bytes again. An
+///   *owned* value earns no such key: a step can free it and the allocator can
+///   hand its address, at the same length, to a different replacement value
+///   (and an inlined value's address is just its slot in the node vector) —
+///   those rescan once a step has run, which only ever happens on a level that
+///   carries trigger bytes anyway.
+#[derive(Default)]
+pub(crate) struct LoneTextSniff {
+    /// The address/length identity of the **borrowed** lone value `mask`
+    /// describes; `None` when the last scanned value was not borrowed.
+    borrowed_key: Option<(usize, usize)>,
+
+    /// [`trigger_mask`] of the last-scanned lone value.
+    mask: u32,
+
+    /// Whether no step has run since `mask` was computed.
+    fresh: bool,
+}
+
+impl LoneTextSniff {
+    pub(crate) fn may(&mut self, nodes: &[InlineNode<'_>], triggers: u32) -> bool {
+        let [InlineNode::Text { value, .. }] = nodes else {
+            return true;
+        };
+
+        let borrowed_key = match value {
+            CowStr::Borrowed(text) => Some((text.as_ptr() as usize, text.len())),
+            _ => None,
+        };
+
+        let reusable = self.fresh || (borrowed_key.is_some() && borrowed_key == self.borrowed_key);
+
+        if !reusable {
+            self.mask = trigger_mask(value.as_ref());
+            self.borrowed_key = borrowed_key;
+        }
+
+        self.fresh = true;
+        self.mask & triggers != 0
+    }
+
+    /// Records that a step ran, whether or not it changed the tree; the next
+    /// [`may`](Self::may) then rescans unless the value's borrowed identity
+    /// vouches for the cached mask.
+    pub(crate) fn invalidate(&mut self) {
+        self.fresh = false;
+    }
+}

--- a/parser/src/tests/inline_builder_trigger_scan.rs
+++ b/parser/src/tests/inline_builder_trigger_scan.rs
@@ -1,0 +1,118 @@
+//! Pins the fused trigger scan's per-step byte classes (see
+//! `content::inline_builder::trigger_scan`) against each step's own
+//! recognizers, so a future needle cannot silently fall outside its step's
+//! class and have a construct skipped for a lone-text level.
+//!
+//! Each class must be **conservative**: whenever a step's own sniff could
+//! answer `true`, the value must carry at least one byte of that step's
+//! class. The pins below spell every sniff's alternatives out as minimal
+//! trigger strings — over-naming a byte costs one redundant call, but a
+//! trigger string whose bytes all fall outside its class would disable the
+//! construct, which is what these catch.
+
+use crate::content::{
+    inline_builder::{
+        ATTRIBUTE_TRIGGERS, MACRO_TRIGGERS, PASSTHROUGH_TRIGGERS, POST_REPLACEMENT_TRIGGERS,
+        QUOTE_TRIGGERS, REPLACEMENT_TRIGGERS, SPECIAL_TRIGGERS, STEM_TRIGGERS,
+        level_may_have_macros, trigger_mask,
+    },
+    maybe_has_replacements,
+};
+
+/// Asserts that every one of `triggers` opens `class`.
+fn assert_all_open(class: u32, triggers: &[&str], step: &str) {
+    for trigger in triggers {
+        assert_ne!(
+            trigger_mask(trigger) & class,
+            0,
+            "{step}: trigger {trigger:?} carries no byte of its step's class"
+        );
+    }
+}
+
+#[test]
+fn every_step_sniff_trigger_opens_its_class() {
+    // Passthrough extraction: both internal phases' needles (`++`, `$$`,
+    // `ss:` — the tail shared by `pass:` and `subs:`-attributed forms — and
+    // the bare/attrlisted single-`+` phase's `+` and `-]`).
+    assert_all_open(
+        PASSTHROUGH_TRIGGERS,
+        &["++", "$$", "ss:", "+", "-]"],
+        "passthroughs",
+    );
+
+    // Inline STEM: every macro spelling its sniff admits.
+    assert_all_open(
+        STEM_TRIGGERS,
+        &["stem:", "asciimath:", "latexmath:"],
+        "stem",
+    );
+
+    // Specialcharacters (and the end-of-group unescaped-specials sweep).
+    assert_all_open(SPECIAL_TRIGGERS, &["<", ">", "&"], "specialcharacters");
+
+    // Quotes: a minimal construct of every quote sub. Each sub requires all
+    // of its own markers, so one byte per construct in the class suffices.
+    assert_all_open(
+        QUOTE_TRIGGERS,
+        &[
+            "**b**", "*b*", "\"`b`\"", "'`b`'", "``b``", "`b`", "__b__", "_b_", "##b##", "#b#",
+            "^b^", "~b~",
+        ],
+        "quotes",
+    );
+
+    // Attribute references and counter directives.
+    assert_all_open(ATTRIBUTE_TRIGGERS, &["{attr}", "{counter:n}"], "attributes");
+
+    // Character replacements: one trigger per alternative of the step's own
+    // sniff pattern, pinned exhaustively against it below.
+    assert_all_open(
+        REPLACEMENT_TRIGGERS,
+        &["&amp;", "'", "--", "...", "(C)", "(R)", "(TM)"],
+        "replacements",
+    );
+
+    // Macros (the footnotes pass rides on the same gate; both of its
+    // spellings carry the colon).
+    assert_all_open(
+        MACRO_TRIGGERS,
+        &["footnote:[x]", "footnoteref:[x,id]"],
+        "macros",
+    );
+
+    // Post-replacements: the ` +` break marker, and — under the `hardbreaks`
+    // option, where no `+` is needed — the newline every break then rides on.
+    assert_all_open(
+        POST_REPLACEMENT_TRIGGERS,
+        &["a +", "\n"],
+        "post-replacements",
+    );
+}
+
+#[test]
+fn single_byte_sniffs_are_covered_exhaustively() {
+    // For the two steps whose own sniff is reachable from here, check every
+    // single-character value: wherever the step's sniff already answers
+    // `true`, the fused class must too. (Multi-character alternatives are
+    // pinned as whole trigger strings above.)
+    for b in 0u8..=127 {
+        let s = (b as char).to_string();
+
+        if level_may_have_macros(&s) {
+            assert_ne!(
+                trigger_mask(&s) & MACRO_TRIGGERS,
+                0,
+                "macros: byte {b:#04x} opens the step's own gate but not its class"
+            );
+        }
+
+        if maybe_has_replacements(&s) {
+            assert_ne!(
+                trigger_mask(&s) & REPLACEMENT_TRIGGERS,
+                0,
+                "replacements: byte {b:#04x} opens the step's own sniff but not its class"
+            );
+        }
+    }
+}

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod inline_builder_macro_gate;
 mod inline_builder_passthrough_record_parity;
 mod inline_builder_quotes_candidate_scan;
 mod inline_builder_side_effect_parity;
+mod inline_builder_trigger_scan;
 mod inline_renderer;
 mod inline_tree;
 mod origin;


### PR DESCRIPTION
Tenth increment of the performance work tracked from [#1059's CodSpeed comparison](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following #1360–#1368.

## What changed

Nearly every substitution step opens with its own cheap sniff over a lone `Text` node's value — quotes' marker mask, the macros step's trigger-byte gate (#1365), the attribute step's `{` probe, post-replacements' `+` probe, and so on. For the overwhelmingly common content shape (a plain paragraph no step touches), that means walking the same bytes once per step just to conclude "nothing here" each time — plus each step's call overhead on top.

`build_for_group` now runs **one fused trigger scan** (new `trigger_scan` module): a single pass classifies the lone value's bytes into the union of every step's trigger classes, and a step whose class has no byte present is skipped without being called at all — passthrough/STEM extraction, specialcharacters, quotes, attributes, replacements, macros+footnotes, post-replacements, and the end-of-group unescaped-specials sweep are all gated. (`Callouts` keeps its own sniff; it only runs in the Verbatim order.)

Soundness has two legs:

- **Conservative classes.** Each step's class may over-name bytes (costing one redundant call that the step's own sniff then declines) but never under-name them. The per-step reasoning is documented on each constant — including the two non-obvious ones: post-replacements includes `\n` because the `hardbreaks` option breaks without any `+`, and the footnotes pass rides the macros class because both of its spellings carry the colon. `tests/inline_builder_trigger_scan` pins every class against its step's own recognizers (exhaustively per byte where the sniff is callable, per trigger string for multi-byte needles), so a future needle can't drift out of its class unnoticed.
- **Sound cache invalidation.** The gate fires only while the tree is a single `Text` node, and every step that runs invalidates the scan. A rescan is skipped only when nothing ran since the scan, or when the value is `CowStr::Borrowed` with a matching address/length — borrowed bytes live in the source, which outlives the build, so that identity can never name different bytes. An owned value gets no identity key at all: a step can free it and the allocator can reuse its address at the same length for the replacement value.

## Measured effect

Callgrind instructions per parse on the `inline_throughput` fixtures (marginal over two iteration counts per binary, one-time setup cancelled), vs `inline-ast` @ 9b4a3a8:

| fixture | base | this PR | Δ |
|---|---|---|---|
| plain_prose | 1,312,711 | 973,900 | **−25.8%** |
| mixed_document | 13,701,935 | 13,588,166 | −0.8% |
| replacement_prose | 6,058,600 | 6,046,205 | −0.2% |
| formatted_prose | 11,397,272 | 11,407,058 | +0.1% |
| macro_prose | 9,673,595 | 9,714,653 | +0.4% |

Parse output is byte-identical on all five fixtures, and the full suite (5513 lib tests, every frozen-recording differential included) is green. As a side effect, the steps an untriggered document never runs also never compile their `LazyLock` regexes, dropping the first parse's one-time cost by a further ~21M instructions when nothing needs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_