### PR TITLE
fix: Reserve the rebuild and fold buffers at their expected sizes

### DIFF
--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -11,6 +11,7 @@ use crate::{
     parser::{
         InlineRenderer, QuoteScope, QuoteType, RenderContext, SpecialCharacter, XrefRenderParams,
     },
+    span::HasSpan,
     strings::CowStr,
 };
 
@@ -39,7 +40,12 @@ pub(crate) fn fold_html(
     renderer: &dyn InlineRenderer,
     context: &RenderContext,
 ) -> String {
-    let mut out = String::new();
+    // Sized from the content's own source extent: rendered HTML is the
+    // source text plus markup, so the source length seeds the buffer at the
+    // plain-prose case's exact size and one growth doubling absorbs typical
+    // markup. An estimate — the string grows normally past it.
+    let source_len: usize = nodes.iter().map(|node| node.span().data().len()).sum();
+    let mut out = String::with_capacity(source_len + 16);
     fold_into_html(
         nodes,
         renderer,
@@ -410,7 +416,10 @@ fn fold_into_html(
                 // Fold the children to the body, then wrap it with the same
                 // `QuoteType`, attribute list, and id the quotes step
                 // recognized, matching Asciidoctor's own output.
-                let mut body = String::new();
+                // Sized like `fold_html`'s own buffer: the span's own
+                // source extent, which its body's text plus nested markup
+                // stays near for typical spans.
+                let mut body = String::with_capacity(styled.location.data().len() + 16);
                 fold_into_html(
                     &styled.children,
                     renderer,

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -1851,7 +1851,12 @@ fn rebuild_level<'src>(
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
-    let mut out = Vec::new();
+    // Sized for the usual shape of a rebuild: every piece re-emitted about
+    // once (a gap slice or a clone), plus each match's own `Styled` node and
+    // the extra slice its cut can leave on either side. An estimate, not a
+    // bound — a piece overlapping many ranges can emit more — but it removes
+    // the one-at-a-time growth of the common case.
+    let mut out = Vec::with_capacity(pieces.len() + 2 * matches.len());
     let mut cursor = 0usize;
 
     for m in matches {
@@ -1885,7 +1890,9 @@ fn rebuild_level<'src>(
                     }
                 }
 
-                let mut children = Vec::new();
+                // A span's body is one sliced text run in the overwhelmingly
+                // common case.
+                let mut children = Vec::with_capacity(1);
                 emit_range(nodes, pieces, body.clone(), &mut children);
 
                 let location = source_slice(pieces, construct.clone(), root);

--- a/parser/src/parser/inline_renderer.rs
+++ b/parser/src/parser/inline_renderer.rs
@@ -1435,13 +1435,17 @@ impl InlineRenderer for HtmlInlineRenderer {
 /// deliberately leaves them unescaped for a passthrough attribute list, so
 /// re-escaping here would double-escape the former and diverge on the latter.
 fn push_attribute_value(dest: &mut String, value: &str) {
-    for ch in value.chars() {
-        if ch == '"' {
-            dest.push_str("&quot;");
-        } else {
-            dest.push(ch);
-        }
+    // The overwhelmingly common value carries no `"` at all and is appended
+    // as one block copy; only a value that does pays the per-segment walk.
+    let mut rest = value;
+
+    while let Some(quote) = rest.find('"') {
+        dest.push_str(rest.get(..quote).unwrap_or_default());
+        dest.push_str("&quot;");
+        rest = rest.get(quote + 1..).unwrap_or_default();
     }
+
+    dest.push_str(rest);
 }
 
 fn wrap_body_in_html_tag(


### PR DESCRIPTION
Eleventh increment of the performance work tracked from [#1059's CodSpeed comparison](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), following #1360–#1368 and #1370.

## What changed

Caller-attributed allocation profiling on formatted_prose put the biggest remaining churn in three growth sites that all start empty and grow push by push:

- **`rebuild_level`'s output vector** — the single largest `RawVec::grow_one` source (~406K instructions/parse inclusive). Now reserved at `pieces + 2 × matches` (the usual rebuild shape: every piece re-emitted about once, plus each match's `Styled` node and the slices its cut leaves), with the per-match `children` vector reserved at its overwhelmingly common size of one.
- **The fold's output string and each `Styled` span's body string** (`wrap_body_in_html_tag` + `render_text` reserve churn, ~250K/parse inclusive). Both now start at the content's/span's own source extent. Notably, a generous 2× estimate measured **slower** on plain_prose than the growth it replaced — the oversized buffer lands in a larger allocator size class that gets split and coalesced per parse — so the estimates deliberately use the plain 1× source length and let genuinely markup-heavy content grow once past it.
- **`push_attribute_value`** appended attribute values char by char; a quote-free value (all of them, in practice) is now one block copy, with the `&quot;`-escaping walk kept for values that need it.

## Measured effect

Callgrind instructions per parse on the `inline_throughput` fixtures (marginal over two iteration counts per binary, one-time setup cancelled), vs `inline-ast` @ 3cc21a7:

| fixture | base | this PR | Δ |
|---|---|---|---|
| formatted_prose | 11,407,058 | 10,934,654 | **−4.1%** |
| mixed_document | 13,588,166 | 13,301,553 | −2.1% |
| replacement_prose | 6,046,205 | 5,959,244 | −1.4% |
| macro_prose | 9,714,653 | 9,651,052 | −0.7% |
| plain_prose | 973,900 | 983,053 | +0.9% |

Parse output is byte-identical on all five fixtures and the full suite (5513 lib tests, every frozen-recording differential included) is green. The plain_prose +0.9% sits inside the heap-layout noise band this work has repeatedly measured for byte-identical code (+0.1% to +2.5% across rebuilds); its only functional change here is the fold buffer's exact-size single allocation replacing a few growth doublings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_