### PR TITLE
fix: Share one match string across the macro families at a level

### DIFF
--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -3,8 +3,8 @@
 //! item.
 
 use super::{
-    MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
-    image::range_is_verbatim_or_synthesized, rebuild_macro_level,
+    LevelStrings, MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
+    image::range_is_verbatim_or_synthesized, rebuild_macro_level, shifted_level,
 };
 use crate::{
     Parser, Span,
@@ -214,6 +214,7 @@ pub(super) fn anchor_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: see
     // `biblio_anchor_level`'s own copy of this comment.
@@ -221,27 +222,28 @@ pub(super) fn anchor_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
     // `anchor:` macro prefix. The `[` characters are not special, so a
     // shorthand reaches the macros step with its `[[` intact.
-    if !anchor_prefilter(&s) {
+    if !anchor_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_anchor_matches(&nodes, &s, &pieces, root);
+    let matches = find_anchor_matches(&nodes, s, pieces, root);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every recognized inline anchor at this level — both spellings — as a

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2,7 +2,14 @@
 
 use std::borrow::Cow;
 
-use super::{MacroMatch, MacroMatchKind, links::restore_masked_passthroughs, rebuild_macro_level};
+// Referenced by the doc comments below; the code itself reaches the level's
+// match string through [`shifted_level`]'s shared slot now.
+#[allow(unused_imports)]
+use super::super::quotes::build_match_string;
+use super::{
+    LevelStrings, MacroMatch, MacroMatchKind, links::restore_masked_passthroughs,
+    rebuild_macro_level, shifted_level,
+};
 use crate::{
     Parser, Span,
     attributes::{
@@ -14,8 +21,7 @@ use crate::{
         inline_builder::{
             fold::{fold_html, fold_stem, render_text},
             quotes::{
-                LevelContext, Piece, build_match_string, charref_entity, single_text_value,
-                source_slice, text_slice,
+                LevelContext, Piece, charref_entity, single_text_value, source_slice, text_slice,
             },
             special_chars::Masked,
         },
@@ -44,6 +50,7 @@ pub(super) fn image_macros_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -53,32 +60,37 @@ pub(super) fn image_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let entry = shifted_level(level, &nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's `found_macroish`: an image
     // or icon macro needs its name prefix and an opening bracket.
-    if !image_macro_prefilter(&s) {
+    if !image_macro_prefilter(&entry.0) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    // …and with each masked passthrough's or STEM expression's placeholder
+    // …with each masked passthrough's or STEM expression's placeholder
     // widened into the three-byte token [`INLINE_IMAGE_MACRO`]'s target class
     // needs to match it — see `widen_masked_pieces` for why this family alone
-    // needs that.
-    let (s, pieces) = widen_masked_pieces(s, pieces, &nodes);
+    // needs that. The widening rewrites the pair, so the (rare) level that
+    // needs it works on its own copy and the shared slot stays as built.
+    let widened;
+    let (s, pieces) = if has_restorable_piece(&entry.1, &nodes) {
+        widened = widen_masked_pieces(entry.0.clone(), entry.1.clone(), &nodes);
+        (widened.0.as_str(), widened.1.as_slice())
+    } else {
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
-    let matches = find_image_matches(&s, &pieces, root, parser, &nodes);
+    let matches = find_image_matches(s, pieces, root, parser, &nodes);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every image/icon macro at this level, skipping any whose match crosses
@@ -713,18 +725,17 @@ fn build_image_node<'src>(
 /// `\u{96}`, a digit, `\u{97}` can begin or end an image match, whose ends
 /// are the literal macro name and `]`). The numbering is per level and
 /// exists only to keep tokens distinct across this level's own placeholders.
+fn has_restorable_piece(pieces: &[Piece], nodes: &[InlineNode<'_>]) -> bool {
+    pieces
+        .iter()
+        .any(|piece| nodes.get(piece.node_index).is_some_and(node_is_restorable))
+}
+
 fn widen_masked_pieces(
     s: String,
     pieces: Vec<Piece>,
     nodes: &[InlineNode<'_>],
 ) -> (String, Vec<Piece>) {
-    if !pieces
-        .iter()
-        .any(|piece| nodes.get(piece.node_index).is_some_and(node_is_restorable))
-    {
-        return (s, pieces);
-    }
-
     let mut out = String::with_capacity(s.len() + 8);
     let mut out_pieces = Vec::with_capacity(pieces.len());
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1,7 +1,7 @@
 //! Index-term recognition (`((term))`, `(((primary, secondary)))`,
 //! `indexterm:[…]`, `indexterm2:[…]`).
 
-use super::{MacroMatch, MacroMatchKind, rebuild_macro_level};
+use super::{LevelStrings, MacroMatch, MacroMatchKind, rebuild_macro_level, shifted_level};
 // Referenced by the doc comments below, whose offset arithmetic mirrors this
 // rewrite (see [`shown_term_range`]); the code performs it structurally
 // rather than calling it.
@@ -14,8 +14,7 @@ use crate::{
         INLINE_INDEXTERM,
         inline_builder::{
             quotes::{
-                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, emit_range,
-                single_text_value, source_slice,
+                LevelContext, Piece, SPAN_PLACEHOLDER, emit_range, single_text_value, source_slice,
             },
             special_chars::Masked,
         },
@@ -44,6 +43,7 @@ pub(super) fn indexterm_macros_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -53,22 +53,21 @@ pub(super) fn indexterm_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter mirroring the string step's guard: a shorthand needs a
     // `((` … `))` pair (its parens are not special, so they reach the macros
     // step intact), and a macro form needs a `:[` and `dexterm` (matching both
     // `indexterm:` and `indexterm2:`).
-    if !indexterm_prefilter(&s) {
+    if !indexterm_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_indexterm_matches(&s, &nodes, &pieces, root, parser);
+    let matches = find_indexterm_matches(s, &nodes, pieces, root, parser);
 
     if matches.is_empty() {
         return nodes;
@@ -92,7 +91,9 @@ pub(super) fn indexterm_macros_level<'src>(
 
     let macro_matches = matches.into_iter().map(|m| m.macro_match).collect();
 
-    rebuild_macro_level(&nodes, &pieces, &s, macro_matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, macro_matches);
+    *level = None;
+    rebuilt
 }
 
 /// A recognized index-term match, plus the two facts

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -3,12 +3,16 @@
 // Referenced by the doc comments below, whose own rebuild is the one this
 // family reaches through `restored_value_children`; the code no longer calls
 // it directly.
+// Referenced by the doc comments below; the code itself reaches the level's
+// match string through [`shifted_level`]'s shared slot now.
+#[allow(unused_imports)]
+use super::super::quotes::build_match_string;
 #[allow(unused_imports)]
 use super::computed_value_children;
 use super::{
-    ComputedSpecials, MacroMatch, MacroMatchKind,
+    ComputedSpecials, LevelStrings, MacroMatch, MacroMatchKind,
     image::{Tokened, range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
-    macro_text_children, rebuild_macro_level, restored_value_children,
+    macro_text_children, rebuild_macro_level, restored_value_children, shifted_level,
 };
 use crate::{
     Parser, Span,
@@ -20,10 +24,7 @@ use crate::{
         INLINE_EMAIL, INLINE_LINK, INLINE_LINK_MACRO, NormalizedCaps, URI_SNIFF,
         encode_uri_component, extract_attributes_from_text,
         inline_builder::{
-            quotes::{
-                LevelContext, Piece, SPAN_PLACEHOLDER, build_match_string, single_text_value,
-                source_slice,
-            },
+            quotes::{LevelContext, Piece, SPAN_PLACEHOLDER, single_text_value, source_slice},
             special_chars::Masked,
         },
     },
@@ -200,6 +201,7 @@ pub(super) fn inline_link_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -209,7 +211,11 @@ pub(super) fn inline_link_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter mirroring the string step's guard: an auto-link needs a
     // `://` scheme separator somewhere in the level.
@@ -217,18 +223,15 @@ pub(super) fn inline_link_level<'src>(
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_inline_link_matches(&nodes, &s, &pieces, root, parser, specials);
+    let matches = find_inline_link_matches(&nodes, s, pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every recognized auto-link / formal-URL / angle-bracketed link at this
@@ -986,6 +989,7 @@ pub(super) fn link_macro_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -995,26 +999,27 @@ pub(super) fn link_macro_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter mirroring the string step's guard: a link/mailto macro
     // needs its prefix and an opening bracket.
-    if !link_macro_prefilter(&s) {
+    if !link_macro_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_link_macro_matches(&nodes, &s, &pieces, root, parser, specials);
+    let matches = find_link_macro_matches(&nodes, s, pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every recognized `link:`/`mailto:` macro at this level, skipping any
@@ -1884,6 +1889,7 @@ pub(super) fn email_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -1893,7 +1899,11 @@ pub(super) fn email_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter mirroring the string step's own `text.contains('@')`
     // guard.
@@ -1901,18 +1911,15 @@ pub(super) fn email_level<'src>(
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_email_matches(&nodes, &s, &pieces, root);
+    let matches = find_email_matches(&nodes, s, pieces, root);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every recognized bare e-mail address at this level, honoring the

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -16,8 +16,8 @@ use xref::xref_macros_level;
 
 use super::{
     quotes::{
-        LevelContext, Piece, charref_entity, emit_range, single_text_value, source_slice,
-        special_entity, text_slice,
+        LevelContext, Piece, build_match_string, charref_entity, emit_range, single_text_value,
+        source_slice, special_entity, text_slice,
     },
     special_chars::{Masked, unescaped_value_children},
 };
@@ -146,7 +146,7 @@ pub(super) enum ComputedSpecials {
 /// [`range_has_no_opaque_piece`](image::range_has_no_opaque_piece)). A
 /// **restored entity** (`&copy;`, `&#8217;` — an author-written entity the
 /// replacements step un-escaped) rides on that same gate, since
-/// [`build_match_string`](super::quotes::build_match_string) gives it its own
+/// [`build_match_string`] gives it its own
 /// bytes too; it needs no per-family work, so it is admitted for the
 /// index-term, anchor and STEM families as well, and a footnote's text — which
 /// is structured children rather than a sliced value — carries either leaf as
@@ -263,7 +263,7 @@ pub(crate) fn level_may_have_macros(value: &str) -> bool {
 ///
 /// The same two families read the character a construct written *beside* a
 /// rendered span presents, which
-/// [`build_match_string`](super::quotes::build_match_string) writes around
+/// [`build_match_string`] writes around
 /// that span's own placeholder — the two outer characters of its markup, or,
 /// for a span rendering to its **body** and nothing else, that body's own two
 /// outer characters. Either one it can write only for a span really
@@ -339,20 +339,25 @@ fn apply_macro_families<'src>(
         }
     }
 
+    // One shifted match string for the whole level, shared across every
+    // family's turn below (see [`shifted_level`]): a family fills it lazily,
+    // and a family that rebuilds the level clears it.
+    let mut level: Option<LevelStrings> = None;
+
     // The UI macros run before image/icon and only under `experimental`,
     // mirroring the string step's order and gate.
     let nodes = if parser.is_attribute_set("experimental") {
-        let nodes = kbd_btn_macros_level(nodes, root, ctx, masked);
-        menu_macros_level(nodes, root, ctx, masked)
+        let nodes = kbd_btn_macros_level(nodes, root, ctx, masked, &mut level);
+        menu_macros_level(nodes, root, ctx, masked, &mut level)
     } else {
         nodes
     };
 
-    let nodes = image_macros_level(nodes, root, parser, ctx, masked);
+    let nodes = image_macros_level(nodes, root, parser, ctx, masked, &mut level);
 
     // Index terms (`((term))`, `(((primary, secondary)))`, `indexterm:[…]`,
     // `indexterm2:[…]`) run after image/icon and before the link families.
-    let mut nodes = indexterm_macros_level(nodes, root, parser, ctx, masked);
+    let mut nodes = indexterm_macros_level(nodes, root, parser, ctx, masked, &mut level);
 
     // A **visible** term's shown text is not a boundary the later families
     // stop at — it is ordinary flow content, and
@@ -382,6 +387,10 @@ fn apply_macro_families<'src>(
             if let InlineNode::IndexTerm(index_term) = node
                 && !index_term.children.is_empty()
             {
+                // The term's children are their own level, with their own
+                // slot.
+                let mut term_level: Option<LevelStrings> = None;
+
                 index_term.children = apply_reference_families(
                     std::mem::take(&mut index_term.children),
                     root,
@@ -389,12 +398,19 @@ fn apply_macro_families<'src>(
                     inner,
                     masked,
                     specials,
+                    &mut term_level,
                 );
             }
         }
+
+        // A visible term is *transparent* — the boundary characters it
+        // presents to this level's match string are its body's own outer
+        // characters — so refining its children above can change what this
+        // level's string holds. Rebuild it on the next family's turn.
+        level = None;
     }
 
-    apply_reference_families(nodes, root, parser, ctx, masked, specials)
+    apply_reference_families(nodes, root, parser, ctx, masked, specials, &mut level)
 
     // Footnotes are **not** handled here. Every other family's recognition is
     // order-independent (no cross-node side effect), so it is safe for them to
@@ -422,28 +438,54 @@ fn apply_reference_families<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro.
-    let nodes = inline_link_level(nodes, root, parser, ctx, masked, specials);
+    let nodes = inline_link_level(nodes, root, parser, ctx, masked, specials, level);
 
     // The `link:`/`mailto:` macro runs after the auto-link pass.
-    let nodes = link_macro_level(nodes, root, parser, ctx, masked, specials);
+    let nodes = link_macro_level(nodes, root, parser, ctx, masked, specials, level);
 
     // A bare e-mail address (`doc@example.org`) runs after both URL-link
     // families and before the anchor pass — so an address that is really the
     // tail of a URL, or a `mailto:` macro's own target, is already inside an
     // opaque node and is not re-recognized.
-    let nodes = email_level(nodes, root, ctx, masked);
+    let nodes = email_level(nodes, root, ctx, masked, level);
 
     // Inline anchors (`[[id]]`, `anchor:id[…]`) run after the link families and
     // before cross-references. (The bibliography-anchor pass — a `^`-anchored
     // `[[[id]]]`, recognized only inside a bibliography list item — runs
     // first, in [`apply_macros`], outside this recursion.)
-    let nodes = anchor_macros_level(nodes, root, ctx, masked);
+    let nodes = anchor_macros_level(nodes, root, ctx, masked, level);
 
     // Cross-references (`xref:id[…]`) run after the anchor pass.
-    xref_macros_level(nodes, root, parser, ctx, masked, specials)
+    xref_macros_level(nodes, root, parser, ctx, masked, specials, level)
+}
+
+/// A level's **shifted** match string and [`Piece`] map — one
+/// [`build_match_string`]-plus-[`shift`](LevelContext::shift) result, held so
+/// the family passes at one level can share a single build rather than each
+/// repeating it. A family that rebuilds the level clears the slot; the next
+/// family's turn rebuilds it lazily.
+pub(super) type LevelStrings = (String, Vec<Piece>);
+
+/// Fills `level` if it is empty — the one shared build — and hands back the
+/// entry. The string a family's cheap needle prefilter then reads is the
+/// *shifted* one (it carries the enclosing construct's boundary characters),
+/// which can only make the prefilter more permissive than the unshifted read
+/// the families took before sharing: the real matcher, which always ran over
+/// the shifted string, still decides.
+pub(super) fn shifted_level<'a>(
+    level: &'a mut Option<LevelStrings>,
+    nodes: &[InlineNode<'_>],
+    ctx: LevelContext,
+    masked: Masked<'_>,
+) -> &'a LevelStrings {
+    level.get_or_insert_with(|| {
+        let (s, pieces) = build_match_string(nodes, masked);
+        ctx.shift(s, pieces)
+    })
 }
 
 /// The single entry point for
@@ -746,7 +788,7 @@ pub(in crate::content::inline_builder) fn emit_range_unescaping_brackets<'src>(
 /// earlier-recognized macro node — has no such body: its markup exists only
 /// when the tree is folded. There is still nothing to restore *into bytes*,
 /// but there is something to carry: the **node**. So this tokens every atomic
-/// piece [`build_match_string`](super::quotes::build_match_string) stands in
+/// piece [`build_match_string`] stands in
 /// as one placeholder, whatever kind it is, and the caller splices each node
 /// back through [`restored_value_children`].
 ///
@@ -787,7 +829,7 @@ pub(super) fn tokened_text<'src>(
 
         // The pieces that become a token are the **opaque** ones — atomic, and
         // not one of the three [`CharRef`](InlineNode::CharRef) leaves
-        // [`build_match_string`](super::quotes::build_match_string) gives real
+        // [`build_match_string`] gives real
         // bytes to. Every other piece contributes its own bytes as it stands,
         // and the caller's own rebuild
         // ([`computed_value_children`]) already knows how to unwind them.
@@ -1003,7 +1045,7 @@ pub(super) fn computed_value_children<'src>(
 /// for any part of it).
 ///
 /// The rebuild applies the same trichotomy to a string:
-/// [`build_match_string`](super::quotes::build_match_string) gives an escaped
+/// [`build_match_string`] gives an escaped
 /// special its canonical entity and a *restored* entity its own bytes, while a
 /// [`Text`](InlineNode::Text) node holds **logical** text the fold escapes. So
 /// the two classes come apart here — the special becomes the character it
@@ -1038,7 +1080,7 @@ pub(super) fn computed_value_children<'src>(
 /// [`Replacement`](CharRef::Replacement)'s numeric one. A *literal* `&` (an
 /// attribute expansion splicing one in after the escaping step) is a
 /// [`Raw`](InlineNode::Raw) leaf, which
-/// [`build_match_string`](super::quotes::build_match_string) stands in as an
+/// [`build_match_string`] stands in as an
 /// opaque placeholder carrying no `&` at all — so it never reaches a computed
 /// value as bytes. The branch is pinned by a direct unit test rather than by
 /// the corpus.

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -1,15 +1,15 @@
 //! UI macro recognition (`kbd:[…]`, `btn:[…]`, `menu:…[…]`).
 
-use super::{MacroMatch, MacroMatchKind, image::range_has_no_opaque_piece, rebuild_macro_level};
+use super::{
+    LevelStrings, MacroMatch, MacroMatchKind, image::range_has_no_opaque_piece,
+    rebuild_macro_level, shifted_level,
+};
 use crate::{
     Span,
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
         inline_builder::{
-            quotes::{
-                LevelContext, Piece, build_match_string, single_text_value, source_slice,
-                text_slice,
-            },
+            quotes::{LevelContext, Piece, single_text_value, source_slice, text_slice},
             special_chars::Masked,
         },
         normalize_index_text, split_kbd_keys,
@@ -44,6 +44,7 @@ pub(super) fn kbd_btn_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -53,24 +54,25 @@ pub(super) fn kbd_btn_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
-    if !kbd_btn_prefilter(&s) {
+    if !kbd_btn_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_kbd_btn_matches(&nodes, &s, &pieces, root);
+    let matches = find_kbd_btn_matches(&nodes, s, pieces, root);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every keyboard/button macro at this level, skipping any whose match
@@ -226,6 +228,7 @@ pub(super) fn menu_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: see
     // `kbd_btn_macros_level`'s own copy of this comment.
@@ -233,24 +236,25 @@ pub(super) fn menu_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
-    if !menu_prefilter(&s) {
+    if !menu_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_menu_matches(&nodes, &s, &pieces, root);
+    let matches = find_menu_matches(&nodes, s, pieces, root);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// Finds every menu macro at this level, skipping any whose match crosses an

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -3,13 +3,17 @@
 // Referenced by the doc comments below, whose own rebuild is the one this
 // family reaches through `restored_value_children`; the code no longer calls
 // it directly.
+// Referenced by the doc comments below; the code itself reaches the level's
+// match string through [`shifted_level`]'s shared slot now.
+#[allow(unused_imports)]
+use super::super::quotes::build_match_string;
 #[allow(unused_imports)]
 use super::computed_value_children;
 use super::{
-    ComputedSpecials, MacroMatch, MacroMatchKind,
+    ComputedSpecials, LevelStrings, MacroMatch, MacroMatchKind,
     image::{range_has_no_opaque_piece, range_is_substitution_restorable},
     links::restore_masked_passthroughs,
-    macro_text_children, rebuild_macro_level, restored_value_children, tokened_text,
+    macro_text_children, rebuild_macro_level, restored_value_children, shifted_level, tokened_text,
     untranslated_value,
 };
 use crate::{
@@ -21,7 +25,7 @@ use crate::{
     content::{
         INLINE_XREF, document_xrefstyle,
         inline_builder::{
-            quotes::{LevelContext, Piece, build_match_string, single_text_value, source_slice},
+            quotes::{LevelContext, Piece, single_text_value, source_slice},
             special_chars::Masked,
         },
         xref_target::{
@@ -110,6 +114,7 @@ pub(super) fn xref_macros_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
@@ -119,7 +124,11 @@ pub(super) fn xref_macros_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, masked);
+    // The level's shared shifted match string (see `shifted_level`).
+    let (s, pieces) = {
+        let entry = shifted_level(level, &nodes, ctx, masked);
+        (entry.0.as_str(), entry.1.as_slice())
+    };
 
     // Cheap pre-filter: both the `xref:` macro form and the `<<id>>` shorthand
     // (seen here as `&lt;&lt;id&gt;&gt;`, since specials run before macros) are
@@ -127,22 +136,19 @@ pub(super) fn xref_macros_level<'src>(
     // shorthand's `&lt;&lt;` opener, mirroring the string step's
     // `text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:"))`
     // guard.
-    if !xref_prefilter(&s) {
+    if !xref_prefilter(s) {
         return nodes;
     }
 
-    // Matched over the level wrapped in the boundary character its enclosing
-    // construct presents, with the level's own pieces moved into that string's
-    // coordinates — see `apply_macro_families`'s own doc comment.
-    let (s, pieces) = ctx.shift(s, pieces);
-
-    let matches = find_xref_matches(&nodes, &s, &pieces, root, parser, specials);
+    let matches = find_xref_matches(&nodes, s, pieces, root, parser, specials);
 
     if matches.is_empty() {
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    *level = None;
+    rebuilt
 }
 
 /// A shorthand whose id holds rendered inline markup is not a valid

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -788,6 +788,7 @@ fn apply_quote_sub<'src>(
 }
 
 /// One leaf/opaque node's placement in a level's reconstructed match string.
+#[derive(Clone)]
 pub(super) struct Piece {
     /// Index of the node in the level's node vector.
     pub(super) node_index: usize,


### PR DESCRIPTION
Thirteenth increment of the performance work tracked from [#1059's CodSpeed comparison](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459). Independent of #1372 (different step, different files); the two compose.

## What changed

Caller-attributed profiling showed that every macro family's level pass — image, index terms, the three link spellings, anchors, cross-references, and the experimental UI macros — opened by building **its own copy** of the level's match string (`build_match_string`) and shifting it into the enclosing construct's boundary coordinates (`ctx.shift`). A level that passes the step's trigger gate paid for up to nine identical builds; on formatted_prose those repeats were ~1.1M of 10.9M instructions/parse.

The families now share **one shifted build per level**, through the same lazily-filled, cleared-on-rebuild slot pattern the quote subs already use (#1367):

- `apply_macro_families` owns an `Option<LevelStrings>` slot; each family fills it on first need (`shifted_level`) and clears it when it rebuilds the level.
- The visible-index-term walk also clears it: a transparent term's boundary characters are read from the very children that walk refines.
- The one family that rewrites the pair — image, when a masked passthrough's placeholder needs widening — detects that (rare) case up front and works on its own copy, leaving the shared slot as built.
- A family's cheap needle prefilter now reads the *shifted* string. That is strictly more permissive than the unshifted read it took before (the shift only prepends boundary characters), and the real matcher — which always ran over the shifted string — still decides, so recognition is unchanged. All shared-path prefilters are `contains`-style; the one position-anchored prefilter in this step (`biblio_anchor_level`'s `starts_with`) stays on its own unshared build.

## Measured effect

Callgrind instructions per parse on the `inline_throughput` fixtures (marginal over two iteration counts per binary), vs `inline-ast` @ 133b731:

| fixture | base | this PR | Δ |
|---|---|---|---|
| replacement_prose | 5,959,244 | 5,147,770 | **−13.6%** |
| formatted_prose | 10,934,654 | 9,901,273 | **−9.5%** |
| mixed_document | 13,301,553 | 12,537,540 | −5.7% |
| macro_prose | 9,714,653 | 9,308,607 | −4.2% |
| plain_prose | 983,053 | 981,844 | −0.1% |

Parse output is byte-identical on all five fixtures; the full suite (5513 lib tests, every frozen-recording differential included) is green, and every added line is covered under CI's exact coverage configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_