### PR TITLE
fix: Gate the macro families' needle sweeps behind one digram scan

### DIFF
--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -3,8 +3,8 @@
 //! item.
 
 use super::{
-    LevelStrings, MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
-    image::range_is_verbatim_or_synthesized, rebuild_macro_level, shifted_level,
+    ANCHOR_DIGRAMS, LevelSniff, MacroMatch, MacroMatchKind, emit_range_unescaping_brackets,
+    image::range_is_verbatim_or_synthesized, rebuild_macro_level,
 };
 use crate::{
     Parser, Span,
@@ -214,24 +214,15 @@ pub(super) fn anchor_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: see
-    // `biblio_anchor_level`'s own copy of this comment.
-    if single_text_value(&nodes).is_some_and(|value| !anchor_prefilter(value)) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter: an anchor needs either the shorthand `[[` opener or the
     // `anchor:` macro prefix. The `[` characters are not special, so a
-    // shorthand reaches the macros step with its `[[` intact.
-    if !anchor_prefilter(s) {
+    // shorthand reaches the macros step with its `[[` intact. The digram
+    // gate fronts the exact needle sweep.
+    if digrams & ANCHOR_DIGRAMS == 0 || !anchor_prefilter(s) {
         return nodes;
     }
 
@@ -242,7 +233,7 @@ pub(super) fn anchor_macros_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -7,8 +7,8 @@ use std::borrow::Cow;
 #[allow(unused_imports)]
 use super::super::quotes::build_match_string;
 use super::{
-    LevelStrings, MacroMatch, MacroMatchKind, links::restore_masked_passthroughs,
-    rebuild_macro_level, shifted_level,
+    IMAGE_DIGRAMS, LevelSniff, MacroMatch, MacroMatchKind, links::restore_masked_passthroughs,
+    rebuild_macro_level,
 };
 use crate::{
     Parser, Span,
@@ -20,9 +20,7 @@ use crate::{
         INLINE_IMAGE_MACRO, basename,
         inline_builder::{
             fold::{fold_html, fold_stem, render_text},
-            quotes::{
-                LevelContext, Piece, charref_entity, single_text_value, source_slice, text_slice,
-            },
+            quotes::{LevelContext, Piece, charref_entity, source_slice, text_slice},
             special_chars::Masked,
         },
         normalize_text_lf_escaped_bracket,
@@ -50,22 +48,14 @@ pub(super) fn image_macros_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !image_macro_prefilter(value)) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let entry = shifted_level(level, &nodes, ctx, masked);
+    let (shared_s, shared_pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's `found_macroish`: an image
-    // or icon macro needs its name prefix and an opening bracket.
-    if !image_macro_prefilter(&entry.0) {
+    // or icon macro needs its name prefix and an opening bracket. The digram
+    // gate fronts the exact needle sweep.
+    if digrams & IMAGE_DIGRAMS == 0 || !image_macro_prefilter(shared_s) {
         return nodes;
     }
 
@@ -75,11 +65,11 @@ pub(super) fn image_macros_level<'src>(
     // needs that. The widening rewrites the pair, so the (rare) level that
     // needs it works on its own copy and the shared slot stays as built.
     let widened;
-    let (s, pieces) = if has_restorable_piece(&entry.1, &nodes) {
-        widened = widen_masked_pieces(entry.0.clone(), entry.1.clone(), &nodes);
+    let (s, pieces) = if has_restorable_piece(shared_pieces, &nodes) {
+        widened = widen_masked_pieces(shared_s.to_owned(), shared_pieces.to_vec(), &nodes);
         (widened.0.as_str(), widened.1.as_slice())
     } else {
-        (entry.0.as_str(), entry.1.as_slice())
+        (shared_s, shared_pieces)
     };
 
     let matches = find_image_matches(s, pieces, root, parser, &nodes);
@@ -89,7 +79,7 @@ pub(super) fn image_macros_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -1,7 +1,7 @@
 //! Index-term recognition (`((term))`, `(((primary, secondary)))`,
 //! `indexterm:[…]`, `indexterm2:[…]`).
 
-use super::{LevelStrings, MacroMatch, MacroMatchKind, rebuild_macro_level, shifted_level};
+use super::{INDEXTERM_DIGRAMS, LevelSniff, MacroMatch, MacroMatchKind, rebuild_macro_level};
 // Referenced by the doc comments below, whose offset arithmetic mirrors this
 // rewrite (see [`shown_term_range`]); the code performs it structurally
 // rather than calling it.
@@ -13,9 +13,7 @@ use crate::{
     content::{
         INLINE_INDEXTERM,
         inline_builder::{
-            quotes::{
-                LevelContext, Piece, SPAN_PLACEHOLDER, emit_range, single_text_value, source_slice,
-            },
+            quotes::{LevelContext, Piece, SPAN_PLACEHOLDER, emit_range, source_slice},
             special_chars::Masked,
         },
     },
@@ -43,27 +41,15 @@ pub(super) fn indexterm_macros_level<'src>(
     parser: &Parser,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !indexterm_prefilter(value)) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a shorthand needs a
     // `((` … `))` pair (its parens are not special, so they reach the macros
     // step intact), and a macro form needs a `:[` and `dexterm` (matching both
     // `indexterm:` and `indexterm2:`).
-    if !indexterm_prefilter(s) {
+    if digrams & INDEXTERM_DIGRAMS == 0 || !indexterm_prefilter(s) {
         return nodes;
     }
 
@@ -92,7 +78,7 @@ pub(super) fn indexterm_macros_level<'src>(
     let macro_matches = matches.into_iter().map(|m| m.macro_match).collect();
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, macro_matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -10,9 +10,10 @@ use super::super::quotes::build_match_string;
 #[allow(unused_imports)]
 use super::computed_value_children;
 use super::{
-    ComputedSpecials, LevelStrings, MacroMatch, MacroMatchKind,
+    ComputedSpecials, INLINE_LINK_DIGRAMS, LINK_MACRO_DIGRAMS, LevelSniff, MacroMatch,
+    MacroMatchKind,
     image::{Tokened, range_is_restorable, range_is_verbatim, restorable_body, tokened_bracket},
-    macro_text_children, rebuild_macro_level, restored_value_children, shifted_level,
+    macro_text_children, rebuild_macro_level, restored_value_children,
 };
 use crate::{
     Parser, Span,
@@ -201,25 +202,14 @@ pub(super) fn inline_link_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !value.contains("://")) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's guard: an auto-link needs a
-    // `://` scheme separator somewhere in the level.
-    if !s.contains("://") {
+    // `://` scheme separator somewhere in the level. The digram gate fronts
+    // the exact needle sweep.
+    if digrams & INLINE_LINK_DIGRAMS == 0 || !s.contains("://") {
         return nodes;
     }
 
@@ -230,7 +220,7 @@ pub(super) fn inline_link_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 
@@ -989,25 +979,13 @@ pub(super) fn link_macro_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !link_macro_prefilter(value)) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's guard: a link/mailto macro
     // needs its prefix and an opening bracket.
-    if !link_macro_prefilter(s) {
+    if digrams & LINK_MACRO_DIGRAMS == 0 || !link_macro_prefilter(s) {
         return nodes;
     }
 
@@ -1018,7 +996,7 @@ pub(super) fn link_macro_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 
@@ -1889,21 +1867,17 @@ pub(super) fn email_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
+    // check below can run against that directly. (A one-byte needle: memchr
+    // is already the fused scan, so this family takes no digram class.)
     if single_text_value(&nodes).is_some_and(|value| !value.contains('@')) {
         return nodes;
     }
 
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, _digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter mirroring the string step's own `text.contains('@')`
     // guard.
@@ -1918,7 +1892,7 @@ pub(super) fn email_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -342,7 +342,7 @@ fn apply_macro_families<'src>(
     // One shifted match string for the whole level, shared across every
     // family's turn below (see [`shifted_level`]): a family fills it lazily,
     // and a family that rebuilds the level clears it.
-    let mut level: Option<LevelStrings> = None;
+    let mut level = LevelSniff::default();
 
     // The UI macros run before image/icon and only under `experimental`,
     // mirroring the string step's order and gate.
@@ -389,7 +389,7 @@ fn apply_macro_families<'src>(
             {
                 // The term's children are their own level, with their own
                 // slot.
-                let mut term_level: Option<LevelStrings> = None;
+                let mut term_level = LevelSniff::default();
 
                 index_term.children = apply_reference_families(
                     std::mem::take(&mut index_term.children),
@@ -407,7 +407,7 @@ fn apply_macro_families<'src>(
         // presents to this level's match string are its body's own outer
         // characters — so refining its children above can change what this
         // level's string holds. Rebuild it on the next family's turn.
-        level = None;
+        level.invalidate();
     }
 
     apply_reference_families(nodes, root, parser, ctx, masked, specials, &mut level)
@@ -438,7 +438,7 @@ fn apply_reference_families<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
     // Auto-links and formal-URL links (`INLINE_LINK`) run after the index-term
     // pass and before the `link:`/`mailto:` macro.
@@ -470,22 +470,123 @@ fn apply_reference_families<'src>(
 /// family's turn rebuilds it lazily.
 pub(super) type LevelStrings = (String, Vec<Piece>);
 
-/// Fills `level` if it is empty — the one shared build — and hands back the
-/// entry. The string a family's cheap needle prefilter then reads is the
-/// *shifted* one (it carries the enclosing construct's boundary characters),
-/// which can only make the prefilter more permissive than the unshifted read
-/// the families took before sharing: the real matcher, which always ran over
-/// the shifted string, still decides.
-pub(super) fn shifted_level<'a>(
-    level: &'a mut Option<LevelStrings>,
-    nodes: &[InlineNode<'_>],
-    ctx: LevelContext,
-    masked: Masked<'_>,
-) -> &'a LevelStrings {
-    level.get_or_insert_with(|| {
-        let (s, pieces) = build_match_string(nodes, masked);
-        ctx.shift(s, pieces)
-    })
+/// The digram bit for one adjacent byte pair — the single source both the
+/// family classes below and [`digram_mask`]'s per-pair classification are
+/// built from. Each family's class holds the **first two bytes** of every
+/// needle its exact prefilter looks for, so a needle's presence always
+/// implies its family's bit: the digram gate can only be more permissive
+/// than the `contains` sweep it fronts, and the exact sweep still confirms.
+/// `every_family_needle_carries_its_digram` (in the tests below) pins each
+/// spelled needle to its class.
+const fn digram_bit(a: u8, b: u8) -> u32 {
+    match (a, b) {
+        (b'[', b'[') => 1 << 0,
+        (b'r', b':') => 1 << 1,
+        (b'e', b':') => 1 << 2,
+        (b'n', b':') => 1 << 3,
+        (b'(', b'(') => 1 << 4,
+        (b':', b'[') => 1 << 5,
+        (b'k', b':') => 1 << 6,
+        (b'o', b':') => 1 << 7,
+        (b':', b'/') => 1 << 8,
+        (b'f', b':') => 1 << 9,
+        (b'&', b'l') => 1 << 10,
+        (b'd', b':') => 1 << 11,
+        (b'u', b':') => 1 << 12,
+
+        _ => 0,
+    }
+}
+
+/// Whether `b` closes any digram in [`digram_bit`]'s table — the scan's
+/// per-byte fast path. Every digram was chosen to end in one of these five
+/// characters, all uncommon in prose, so the two-byte classification only
+/// runs at the few positions that could close one.
+const fn closes_digram(b: u8) -> bool {
+    matches!(b, b':' | b'[' | b'(' | b'/' | b'l')
+}
+
+/// The digram classes present anywhere in `s`: one fused pass, standing in
+/// for every family's own needle sweep over the same bytes.
+fn digram_mask(s: &str) -> u32 {
+    let bytes = s.as_bytes();
+    let mut mask = 0u32;
+
+    for (a, b) in bytes.iter().zip(bytes.iter().skip(1)) {
+        if closes_digram(*b) {
+            mask |= digram_bit(*a, *b);
+        }
+    }
+
+    mask
+}
+
+/// Anchors: `[[`, and `anchor:`'s `r:` tail.
+pub(super) const ANCHOR_DIGRAMS: u32 = digram_bit(b'[', b'[') | digram_bit(b'r', b':');
+
+/// Image/icon macros: `image:`'s `e:` and `icon:`'s `n:` tails.
+pub(super) const IMAGE_DIGRAMS: u32 = digram_bit(b'e', b':') | digram_bit(b'n', b':');
+
+/// Index terms: the `((` shorthand and the `indexterm:[`/`indexterm2:[`
+/// macro forms' `:[`.
+pub(super) const INDEXTERM_DIGRAMS: u32 = digram_bit(b'(', b'(') | digram_bit(b':', b'[');
+
+/// The `link:`/`mailto:` macro: `link:`'s `k:` and `mailto:`'s `o:` tails.
+pub(super) const LINK_MACRO_DIGRAMS: u32 = digram_bit(b'k', b':') | digram_bit(b'o', b':');
+
+/// Auto-links: the `://` scheme separator.
+pub(super) const INLINE_LINK_DIGRAMS: u32 = digram_bit(b':', b'/');
+
+/// Cross-references: `xref:`'s `f:` tail and the shorthand's escaped
+/// `&lt;&lt;` opener.
+pub(super) const XREF_DIGRAMS: u32 = digram_bit(b'f', b':') | digram_bit(b'&', b'l');
+
+/// Keyboard/button macros: `kbd:`'s `d:` and `btn:`'s `n:` tails.
+pub(super) const KBD_BTN_DIGRAMS: u32 = digram_bit(b'd', b':') | digram_bit(b'n', b':');
+
+/// The menu macro: `menu:`'s `u:` tail.
+pub(super) const MENU_DIGRAMS: u32 = digram_bit(b'u', b':');
+
+/// The families' shared per-level sniff state: the one shifted match-string
+/// build ([`LevelStrings`]) with its [`digram_mask`], computed at most once
+/// per level, however many families ask.
+///
+/// The string a family reads is the *shifted* one (it carries the enclosing
+/// construct's boundary characters), which can only make its prefilter more
+/// permissive than the unshifted read the families took before sharing: the
+/// real matcher, which always ran over the shifted string, still decides.
+#[derive(Default)]
+pub(super) struct LevelSniff {
+    /// The shared shifted build and its digram mask.
+    strings: Option<(LevelStrings, u32)>,
+}
+
+impl LevelSniff {
+    /// Fills the shared build if it is empty and hands back the entry with
+    /// its digram mask; a family tests its class against the mask before
+    /// paying for its exact needle sweep.
+    pub(super) fn shifted(
+        &mut self,
+        nodes: &[InlineNode<'_>],
+        ctx: LevelContext,
+        masked: Masked<'_>,
+    ) -> (&str, &[Piece], u32) {
+        let ((s, pieces), digrams) = self.strings.get_or_insert_with(|| {
+            let (s, pieces) = build_match_string(nodes, masked);
+            let shifted = ctx.shift(s, pieces);
+            let digrams = digram_mask(&shifted.0);
+            (shifted, digrams)
+        });
+
+        (s.as_str(), pieces.as_slice(), *digrams)
+    }
+
+    /// Clears everything the sniff holds; called by a family that rebuilt
+    /// the level (and after the visible-index-term walk, whose child
+    /// refinement can change a transparent term's boundary characters).
+    pub(super) fn invalidate(&mut self) {
+        self.strings = None;
+    }
 }
 
 /// The single entry point for
@@ -1758,5 +1859,37 @@ mod tests {
                 WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn every_family_needle_carries_its_digram() {
+        // The digram gate fronts each family's exact needle sweep, so every
+        // needle a family's prefilter looks for must carry at least one byte
+        // pair of that family's class — otherwise the gate would silently
+        // disable the construct. Each needle is spelled here as its family's
+        // prefilter spells it.
+        use super::{
+            ANCHOR_DIGRAMS, IMAGE_DIGRAMS, INDEXTERM_DIGRAMS, INLINE_LINK_DIGRAMS, KBD_BTN_DIGRAMS,
+            LINK_MACRO_DIGRAMS, MENU_DIGRAMS, XREF_DIGRAMS, digram_mask,
+        };
+
+        for (family, class, needles) in [
+            ("anchors", ANCHOR_DIGRAMS, &["[[", "anchor:"][..]),
+            ("image", IMAGE_DIGRAMS, &["image:", "icon:"][..]),
+            ("indexterm", INDEXTERM_DIGRAMS, &["((", ":["][..]),
+            ("link macro", LINK_MACRO_DIGRAMS, &["link:", "mailto:"][..]),
+            ("inline link", INLINE_LINK_DIGRAMS, &["://"][..]),
+            ("xref", XREF_DIGRAMS, &["xref:", "&lt;&lt;"][..]),
+            ("kbd/btn", KBD_BTN_DIGRAMS, &["kbd:", "btn:"][..]),
+            ("menu", MENU_DIGRAMS, &["menu:"][..]),
+        ] {
+            for needle in needles {
+                assert_ne!(
+                    digram_mask(needle) & class,
+                    0,
+                    "{family}: needle {needle:?} carries no byte pair of its class"
+                );
+            }
+        }
     }
 }

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -1,15 +1,15 @@
 //! UI macro recognition (`kbd:[…]`, `btn:[…]`, `menu:…[…]`).
 
 use super::{
-    LevelStrings, MacroMatch, MacroMatchKind, image::range_has_no_opaque_piece,
-    rebuild_macro_level, shifted_level,
+    KBD_BTN_DIGRAMS, LevelSniff, MENU_DIGRAMS, MacroMatch, MacroMatchKind,
+    image::range_has_no_opaque_piece, rebuild_macro_level,
 };
 use crate::{
     Span,
     content::{
         INLINE_KBD_BTN_MACRO, INLINE_MENU_MACRO,
         inline_builder::{
-            quotes::{LevelContext, Piece, single_text_value, source_slice, text_slice},
+            quotes::{LevelContext, Piece, source_slice, text_slice},
             special_chars::Masked,
         },
         normalize_index_text, split_kbd_keys,
@@ -44,23 +44,11 @@ pub(super) fn kbd_btn_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !kbd_btn_prefilter(value)) {
-        return nodes;
-    }
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
-
-    if !kbd_btn_prefilter(s) {
+    if digrams & KBD_BTN_DIGRAMS == 0 || !kbd_btn_prefilter(s) {
         return nodes;
     }
 
@@ -71,7 +59,7 @@ pub(super) fn kbd_btn_macros_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 
@@ -228,21 +216,11 @@ pub(super) fn menu_macros_level<'src>(
     root: Span<'src>,
     ctx: LevelContext,
     masked: Masked<'_>,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: see
-    // `kbd_btn_macros_level`'s own copy of this comment.
-    if single_text_value(&nodes).is_some_and(|value| !menu_prefilter(value)) {
-        return nodes;
-    }
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
-
-    if !menu_prefilter(s) {
+    if digrams & MENU_DIGRAMS == 0 || !menu_prefilter(s) {
         return nodes;
     }
 
@@ -253,7 +231,7 @@ pub(super) fn menu_macros_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -10,10 +10,10 @@ use super::super::quotes::build_match_string;
 #[allow(unused_imports)]
 use super::computed_value_children;
 use super::{
-    ComputedSpecials, LevelStrings, MacroMatch, MacroMatchKind,
+    ComputedSpecials, LevelSniff, MacroMatch, MacroMatchKind, XREF_DIGRAMS,
     image::{range_has_no_opaque_piece, range_is_substitution_restorable},
     links::restore_masked_passthroughs,
-    macro_text_children, rebuild_macro_level, restored_value_children, shifted_level, tokened_text,
+    macro_text_children, rebuild_macro_level, restored_value_children, tokened_text,
     untranslated_value,
 };
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
     content::{
         INLINE_XREF, document_xrefstyle,
         inline_builder::{
-            quotes::{LevelContext, Piece, single_text_value, source_slice},
+            quotes::{LevelContext, Piece, source_slice},
             special_chars::Masked,
         },
         xref_target::{
@@ -114,21 +114,9 @@ pub(super) fn xref_macros_level<'src>(
     ctx: LevelContext,
     masked: Masked<'_>,
     specials: ComputedSpecials,
-    level: &mut Option<LevelStrings>,
+    level: &mut LevelSniff,
 ) -> Vec<InlineNode<'src>> {
-    // Cheap pre-filter, taken *before* the match string is materialized: a
-    // single, unsplit `Text` node's match string is its own value, so the
-    // check below can run against that directly. A level already split by
-    // an earlier step falls back to the build, exactly as before.
-    if single_text_value(&nodes).is_some_and(|value| !xref_prefilter(value)) {
-        return nodes;
-    }
-
-    // The level's shared shifted match string (see `shifted_level`).
-    let (s, pieces) = {
-        let entry = shifted_level(level, &nodes, ctx, masked);
-        (entry.0.as_str(), entry.1.as_slice())
-    };
+    let (s, pieces, digrams) = level.shifted(&nodes, ctx, masked);
 
     // Cheap pre-filter: both the `xref:` macro form and the `<<id>>` shorthand
     // (seen here as `&lt;&lt;id&gt;&gt;`, since specials run before macros) are
@@ -136,7 +124,7 @@ pub(super) fn xref_macros_level<'src>(
     // shorthand's `&lt;&lt;` opener, mirroring the string step's
     // `text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:"))`
     // guard.
-    if !xref_prefilter(s) {
+    if digrams & XREF_DIGRAMS == 0 || !xref_prefilter(s) {
         return nodes;
     }
 
@@ -147,7 +135,7 @@ pub(super) fn xref_macros_level<'src>(
     }
 
     let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
-    *level = None;
+    level.invalidate();
     rebuilt
 }
 


### PR DESCRIPTION
Fourteenth increment of the performance work tracked from [#1059's CodSpeed comparison](https://github.com/asciidoc-rs/asciidoc-parser/pull/1059#issuecomment-5159336459), building directly on #1373's shared per-level slot.

## What changed

Even with the match string shared (#1373), each macro family still swept it for its own needles (`image:`, `icon:`, `link:`, `mailto:`, `xref:`, `&lt;&lt;`, `[[`, `anchor:`, `((`, `:[`, `://`, …) — a level inside the macros step paid ~a dozen substring searches over the same bytes, ~750K instructions/parse on formatted_prose by caller-attributed profiling.

The shared slot now computes **one digram mask** alongside the build: a single pass classifying adjacent byte pairs into per-family classes. Design points:

- **Conservative by construction**: each family's class holds a byte pair that *every one* of its needles contains, so needle-present always implies class-present; a family whose class is absent skips its sweep outright, and one whose class is present still runs the exact `contains` check — recognition is unchanged. `every_family_needle_carries_its_digram` pins each spelled needle to its class.
- **Digrams chosen for prose rarity**: the needles' letter-colon tails (`e:`, `k:`, `r:`, `f:`, …) and the structural openers (`[[`, `((`, `:[`, `:/`, `&l`) rather than their common prefixes (`im`, `li`, `ma` — measured as weak filters in an earlier draft of this change). All chosen pairs end in one of five prose-rare bytes (`:` `[` `(` `/` `l`), giving the scan a cheap per-byte fast path.
- The bare-email family keeps its one-byte `@` memchr sniff, which is already the fused form.

## Measured effect

Callgrind instructions per parse on the `inline_throughput` fixtures (marginal over two iteration counts per binary), vs `inline-ast` @ b7024e2:

| fixture | base | this PR | Δ |
|---|---|---|---|
| formatted_prose | 9,914,193 | 9,580,637 | **−3.4%** |
| mixed_document | 12,292,209 | 12,139,148 | −1.2% |
| replacement_prose | 4,116,305 | 4,101,425 | −0.4% |
| plain_prose | 983,367 | 985,858 | +0.25% |
| macro_prose | 9,300,631 | 9,387,018 | +0.9% |

macro_prose is the one fixture dense enough in real constructs that every gate legitimately opens, leaving the scan itself as overhead; that +0.9% (and plain's +0.25%) sit inside the ±1–2.5% heap-layout noise band this work has repeatedly measured on byte-identical code, while the net across the suite is ~−415K instructions/parse. Parse output is byte-identical on all five fixtures; the full suite (5515 lib tests) is green, and every added line is covered under CI's exact coverage configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_