### PR TITLE
fix: Move nodes out of a quote rebuild instead of cloning them

### DIFF
--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -4226,9 +4226,12 @@ mod tests {
 
         // An emission over a taken supply emits nothing rather than a
         // duplicate — the guard the whole-node path keeps for the shape the
-        // disjointness argument rules out.
+        // disjointness argument rules out. The same holds for a *partial*
+        // overlap (the entity-splitting read), whose peek also comes back
+        // empty.
         let mut out = Vec::new();
         emit_range_from(&mut supply, &pieces, 0..s.len(), &mut out);
+        emit_range_from(&mut supply, &pieces, 0..(s.len() - 1), &mut out);
         assert!(out.is_empty());
     }
 

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -872,7 +872,7 @@ fn match_level<'src>(
         return false;
     }
 
-    let rebuilt = rebuild_level(nodes, pieces, s, &matches, root, parser);
+    let rebuilt = rebuild_level(std::mem::take(nodes), pieces, s, &matches, root, parser);
 
     *level = None;
     *nodes = rebuilt;
@@ -2040,13 +2040,18 @@ fn classify_match(
 /// original nodes; each match becomes kept prefix/literal text plus (for a
 /// wrap) a [`Styled`] span over the mapped-back body nodes.
 fn rebuild_level<'src>(
-    nodes: &[InlineNode<'src>],
+    nodes: Vec<InlineNode<'src>>,
     pieces: &[Piece],
     s: &str,
     matches: &[QuoteMatch],
     root: Span<'src>,
     parser: &Parser,
 ) -> Vec<InlineNode<'src>> {
+    // The level is taken by value: the caller replaces it with the rebuilt
+    // vector, so each node re-emitted whole is **moved** out rather than
+    // deep-cloned and then dropped with the old vector (see [`NodeSupply`]).
+    let mut supply = TakenNodes::new(nodes);
+
     // Sized for the usual shape of a rebuild: every piece re-emitted about
     // once (a gap slice or a clone), plus each match's own `Styled` node and
     // the extra slice its cut can leave on either side. An estimate, not a
@@ -2060,8 +2065,13 @@ fn rebuild_level<'src>(
             QuoteMatchKind::Unescape => {
                 // Emit the gap, then drop the leading backslash and keep the
                 // remainder as literal text.
-                emit_range(nodes, pieces, cursor..m.full.start, &mut out);
-                emit_range(nodes, pieces, (m.full.start + 1)..m.full.end, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..m.full.start, &mut out);
+                emit_range_from(
+                    &mut supply,
+                    pieces,
+                    (m.full.start + 1)..m.full.end,
+                    &mut out,
+                );
             }
 
             QuoteMatchKind::Wrap {
@@ -2076,20 +2086,20 @@ fn rebuild_level<'src>(
                     // Ordinary case: the gap runs all the way to the construct,
                     // absorbing any boundary prefix into one contiguous run of
                     // kept text.
-                    None => emit_range(nodes, pieces, cursor..construct.start, &mut out),
+                    None => emit_range_from(&mut supply, pieces, cursor..construct.start, &mut out),
 
                     // Escaped-with-attributes: the gap stops at the backslash,
                     // then the `[a]` literal (skipping the backslash) is kept.
                     Some(literal) => {
-                        emit_range(nodes, pieces, cursor..m.full.start, &mut out);
-                        emit_range(nodes, pieces, literal.clone(), &mut out);
+                        emit_range_from(&mut supply, pieces, cursor..m.full.start, &mut out);
+                        emit_range_from(&mut supply, pieces, literal.clone(), &mut out);
                     }
                 }
 
                 // A span's body is one sliced text run in the overwhelmingly
                 // common case.
                 let mut children = Vec::with_capacity(1);
-                emit_range(nodes, pieces, body.clone(), &mut children);
+                emit_range_from(&mut supply, pieces, body.clone(), &mut children);
 
                 let location = source_slice(pieces, construct.clone(), root);
 
@@ -2117,7 +2127,7 @@ fn rebuild_level<'src>(
 
     // Emit the trailing gap.
     if cursor < s.len() {
-        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+        emit_range_from(&mut supply, pieces, cursor..s.len(), &mut out);
     }
 
     out
@@ -2235,6 +2245,67 @@ pub(super) fn emit_range<'src>(
     range: std::ops::Range<usize>,
     out: &mut Vec<InlineNode<'src>>,
 ) {
+    emit_range_from(&mut &*nodes, pieces, range, out);
+}
+
+/// A rebuild's supply of the level's existing nodes — how [`emit_range_from`]
+/// reads a node it re-emits.
+///
+/// A borrowed slice is the ordinary supply: each whole-node emission clones,
+/// and the caller keeps its level. [`TakenNodes`] is the owning one: a
+/// rebuild that *replaces* the level it reads from — as every rule-loop
+/// rebuild does, dropping the old vector the moment the new one exists — can
+/// hand its nodes over and have each whole-node emission **move** the node
+/// out instead of deep-cloning a subtree it is about to drop anyway.
+pub(super) trait NodeSupply<'src> {
+    /// A shared view of the node at `index`, for the reads that never
+    /// re-emit it whole (slicing a text run, splitting an entity).
+    fn peek(&self, index: usize) -> Option<&InlineNode<'src>>;
+
+    /// The node at `index`, to re-emit whole. Sound for an owning supply
+    /// exactly because the ranges one rebuild emits are disjoint, so a piece
+    /// wholly inside one of them can be wholly inside no other — each node
+    /// is asked for whole at most once.
+    fn whole(&mut self, index: usize) -> Option<InlineNode<'src>>;
+}
+
+impl<'src> NodeSupply<'src> for &[InlineNode<'src>] {
+    fn peek(&self, index: usize) -> Option<&InlineNode<'src>> {
+        self.get(index)
+    }
+
+    fn whole(&mut self, index: usize) -> Option<InlineNode<'src>> {
+        self.get(index).cloned()
+    }
+}
+
+/// The owning [`NodeSupply`]: a level's nodes, each moved out at most once.
+pub(super) struct TakenNodes<'src>(Vec<Option<InlineNode<'src>>>);
+
+impl<'src> TakenNodes<'src> {
+    pub(super) fn new(nodes: Vec<InlineNode<'src>>) -> Self {
+        Self(nodes.into_iter().map(Some).collect())
+    }
+}
+
+impl<'src> NodeSupply<'src> for TakenNodes<'src> {
+    fn peek(&self, index: usize) -> Option<&InlineNode<'src>> {
+        self.0.get(index).and_then(Option::as_ref)
+    }
+
+    fn whole(&mut self, index: usize) -> Option<InlineNode<'src>> {
+        self.0.get_mut(index).and_then(Option::take)
+    }
+}
+
+/// [`emit_range`] over any [`NodeSupply`] — the shared implementation behind
+/// the borrowed wrapper above and the owning rebuilds.
+pub(super) fn emit_range_from<'src, S: NodeSupply<'src>>(
+    supply: &mut S,
+    pieces: &[Piece],
+    range: std::ops::Range<usize>,
+    out: &mut Vec<InlineNode<'src>>,
+) {
     // An empty range (e.g. a macro whose node consumes its whole match, so the
     // kept-suffix range is zero-width) emits nothing — never a spurious empty
     // `Text` node sliced from a piece the range merely touches.
@@ -2251,17 +2322,19 @@ pub(super) fn emit_range<'src>(
             continue;
         }
 
-        let Some(node) = nodes.get(piece.node_index) else {
-            continue;
-        };
-
         if piece.atomic {
             // An atomic piece falling wholly inside the range is emitted as
             // its own node, which is the overwhelmingly common case.
             if p_start >= range.start && p_end <= range.end {
-                out.push(node.clone());
+                if let Some(node) = supply.whole(piece.node_index) {
+                    out.push(node);
+                }
                 continue;
             }
+
+            let Some(node) = supply.peek(piece.node_index) else {
+                continue;
+            };
 
             // A boundary that *splits* one is answerable for exactly the
             // leaves [`charref_entity`] names — the three
@@ -2310,7 +2383,7 @@ pub(super) fn emit_range<'src>(
         let lo = range.start.max(p_start) - p_start;
         let hi = range.end.min(p_end) - p_start;
 
-        if let InlineNode::Text { value, location } = node {
+        if let Some(InlineNode::Text { value, location }) = supply.peek(piece.node_index) {
             if piece.synthesized {
                 // No `'src` slice exists for these bytes: slice the node's
                 // *value* instead, keeping the whole original `location` as
@@ -4121,6 +4194,42 @@ mod tests {
         assert_eq!(s_to_src(&pieces, 14, Bias::Start), 110);
         assert_eq!(s_to_src(&pieces, 14, Bias::End), 110);
         assert_eq!(s_to_src(&pieces, 16, Bias::Start), 112);
+    }
+
+    #[test]
+    fn an_owning_supply_moves_each_node_out_at_most_once() {
+        // `TakenNodes` hands each node out whole exactly once — the contract
+        // an owning rebuild relies on (its emitted ranges are disjoint, so a
+        // second whole-emission of the same piece cannot happen; if it ever
+        // did, the second ask comes back empty rather than duplicating a
+        // node). `peek` keeps answering for a node not yet moved, and stops
+        // for one that was.
+        use super::{
+            super::{special_chars::apply_special_characters, test_support::seed},
+            Masked, NodeSupply, TakenNodes, build_match_string, emit_range_from,
+        };
+
+        // One `CharRef::Special` leaf: an atomic piece, so re-emitting its
+        // whole range goes through `whole` rather than the slicing reads.
+        let source = Span::new("&");
+        let nodes = apply_special_characters(seed(source));
+
+        let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+
+        let mut supply = TakenNodes::new(nodes);
+
+        assert!(supply.peek(0).is_some());
+        assert!(supply.whole(0).is_some());
+        assert!(supply.whole(0).is_none());
+        assert!(supply.peek(0).is_none());
+        assert!(supply.whole(1).is_none());
+
+        // An emission over a taken supply emits nothing rather than a
+        // duplicate — the guard the whole-node path keeps for the shape the
+        // disjointness argument rules out.
+        let mut out = Vec::new();
+        emit_range_from(&mut supply, &pieces, 0..s.len(), &mut out);
+        assert!(out.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What this does

First increment of the allocator/tree-churn program. `rebuild_level` re-emitted every untouched node of a level by **deep clone** — whole `Styled` subtrees included — and then dropped the originals with the old vector the moment the rebuilt one replaced it. On formatted_prose that clone-then-drop churn under `match_level` was ~440k instructions/parse (318k in `InlineNode::clone` plus the matching `drop_in_place` traffic), paid once per matching quote sub.

`emit_range`'s body moves to `emit_range_from`, generic over a **`NodeSupply`**:

- the borrowed slice supply preserves today's behavior for every other caller — `emit_range` stays as its wrapper, signature unchanged, so the 40+ call sites across the other families are untouched;
- the new owning **`TakenNodes`** supply hands each node out whole at most once, *moving* it instead of cloning. `rebuild_level` now takes the level by value (`match_level` `std::mem::take`s the vector it is about to replace), so each whole-node re-emission is a move.

## Why it's correct

- **The move is sound** because the ranges one rebuild emits are disjoint (a gap ends where a construct starts, a body sits inside its construct, an unescape skips only its backslash, and the cursor only advances), so an atomic piece wholly inside one emitted range can be wholly inside no other — each node is asked for whole at most once. The splitting reads (an entity cut into `Raw` halves, a text run's slices) go through the supply's shared `peek` and never move a node; a placeholder piece is a single character, so no range boundary can cut one.
- A new unit test pins the at-most-once contract, the empty re-emission over a taken supply on the whole-node path, and the same guard on the entity-split path.
- The full suite (5523 lib tests: golden recordings, all differential corpora) passes, and parse output is **byte-identical** on all five profiling fixtures.

## Measured effect

Callgrind instructions/parse (same marginal-cost methodology as previous increments):

| fixture | before (#1380 tip) | after | Δ |
|---|---:|---:|---:|
| formatted_prose | 7,892,750 | 7,527,060 | **−4.6%** |
| mixed_document | 11,001,345 | 10,965,924 | −0.3% |
| plain_prose | 949,741 | 954,884 | +0.5% |
| replacement_prose | 3,666,785 | 3,697,517 | +0.8% |
| macro_prose | 8,290,018 | 8,521,217 | +2.8%* |

\* **The macro_prose delta is codegen-layout noise, verified experimentally**: the per-function breakdown puts this build's macro_prose changes at quotes −87k / alloc −4k (the change's own effect) against +341k inside *unmodified* `regex_automata` internals, and a control build of the **unchanged base** plus one provably inert edit (an uncalled `#[inline(never)]` function in quotes.rs) moves macro_prose by **+3.7%** — more than this PR does. macro_prose's marginal is currently hyper-sensitive to CGU partitioning around quotes.rs; this PR's delta there is indistinguishable from zero. formatted's −4.6% is the change's real effect (concentrated in alloc/mem −207k with regex flat).

## Follow-up

The other families' rebuilds (macros, footnotes, char-replacements, attribute refs) still use the borrowed wrapper; converting them to the owning supply is mechanical follow-up work with the machinery this PR adds.

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5523 lib tests)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- Diff coverage: every added line in `parser/src` covered ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_