### PR TITLE
fix: Move nodes out of the macro and replacement rebuilds too

### DIFF
--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -2,8 +2,8 @@
 
 use super::{
     quotes::{
-        LevelContext, Piece, build_match_string, emit_range, level_may_have_replacements,
-        source_slice,
+        LevelContext, Piece, TakenNodes, build_match_string, emit_range_from,
+        level_may_have_replacements, source_slice,
     },
     special_chars::Masked,
 };
@@ -182,7 +182,7 @@ fn fused_replacement_rules<'src>(
     // each needs at least two characters, and a context is one — so `merged`
     // being non-empty means `matches` is too, and the rebuild below always
     // has work.
-    rebuild_replacements(&nodes, pieces, s, &matches, root)
+    rebuild_replacements(nodes, pieces, s, &matches, root)
 }
 
 /// Every [`character_replacements`] rule applied to the level in list order,
@@ -197,11 +197,12 @@ fn sequential_replacement_rules<'src>(
     root: Span<'src>,
     ctx: LevelContext,
 ) -> Vec<InlineNode<'src>> {
-    // Only a rule that actually replaced something invalidates the level's
-    // match string, by handing back the rebuilt level.
+    // Only a rule that actually matched something invalidates the level's
+    // match string, by rebuilding the level (which takes it by value — see
+    // [`rebuild_replacements`]) and re-deriving the string.
     for repl in character_replacements() {
-        if let Some(rebuilt) = replace_level(repl, &nodes, &level, root, ctx) {
-            nodes = rebuilt;
+        if let Some(matches) = replace_level(repl, &level, ctx) {
+            nodes = rebuild_replacements(nodes, &level.1, &level.0, &matches, root);
             level = build_match_string(&nodes, Masked::UNKNOWN);
         }
     }
@@ -302,14 +303,12 @@ enum ReplacementKind {
 /// So once true for a level, the sniff cannot go false again for the rest of
 /// that level's rule loop, and re-taking it on every rule's own turn would
 /// only ever confirm what the caller already established.
-fn replace_level<'src>(
+fn replace_level(
     repl: &CharacterReplacement,
-    nodes: &[InlineNode<'src>],
     level: &(String, Vec<Piece>),
-    root: Span<'src>,
     ctx: LevelContext,
-) -> Option<Vec<InlineNode<'src>>> {
-    let (s, pieces) = level;
+) -> Option<Vec<ReplacementMatch>> {
+    let (s, _) = level;
 
     // The rule runs over the level wrapped in its enclosing construct's own
     // boundary characters, and every offset it reports is mapped back into the
@@ -330,7 +329,7 @@ fn replace_level<'src>(
         return None;
     }
 
-    Some(rebuild_replacements(nodes, pieces, s, &matches, root))
+    Some(matches)
 }
 
 /// Finds every non-overlapping match of `repl` in the escaped match string
@@ -522,12 +521,20 @@ fn reference_find_replacement_matches(
 /// gap keeps its original nodes; each match becomes its kept literal text plus
 /// the replacement leaf.
 fn rebuild_replacements<'src>(
-    nodes: &[InlineNode<'src>],
+    nodes: Vec<InlineNode<'src>>,
     pieces: &[Piece],
     s: &str,
     matches: &[ReplacementMatch],
     root: Span<'src>,
 ) -> Vec<InlineNode<'src>> {
+    // The level is taken by value: both callers replace it with the rebuilt
+    // vector, so each node re-emitted whole is **moved** out rather than
+    // deep-cloned and then dropped with the old vector — the same owning
+    // rebuild the quotes and macro steps take, on the same disjointness
+    // argument (every gap runs from the monotone cursor forward). See
+    // [`NodeSupply`](super::quotes::NodeSupply).
+    let mut supply = TakenNodes::new(nodes);
+
     let mut out = Vec::new();
     let mut cursor = 0usize;
 
@@ -535,8 +542,8 @@ fn rebuild_replacements<'src>(
         match &m.kind {
             ReplacementKind::Unescape { backslash } => {
                 // Keep the whole match with the single backslash dropped.
-                emit_range(nodes, pieces, cursor..*backslash, &mut out);
-                emit_range(nodes, pieces, (*backslash + 1)..m.full.end, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..*backslash, &mut out);
+                emit_range_from(&mut supply, pieces, (*backslash + 1)..m.full.end, &mut out);
                 cursor = m.full.end;
             }
 
@@ -546,7 +553,7 @@ fn rebuild_replacements<'src>(
                 // `consumed.end`, so a kept trailing letter
                 // (the second letter of a `w'w` apostrophe) is
                 // absorbed by the next gap.
-                emit_range(nodes, pieces, cursor..consumed.start, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..consumed.start, &mut out);
 
                 out.push(InlineNode::CharRef {
                     value: CharRef::Replacement(value),
@@ -559,7 +566,7 @@ fn rebuild_replacements<'src>(
             ReplacementKind::Entity { name } => {
                 // The entity is emitted as written (`&copy;`); its `&`/`;` come
                 // from the pattern, its name from the level's escaped text.
-                emit_range(nodes, pieces, cursor..m.full.start, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..m.full.start, &mut out);
 
                 let entity = format!("&{};", &s[name.clone()]);
 
@@ -574,7 +581,7 @@ fn rebuild_replacements<'src>(
     }
 
     if cursor < s.len() {
-        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+        emit_range_from(&mut supply, pieces, cursor..s.len(), &mut out);
     }
 
     out

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -232,7 +232,7 @@ pub(super) fn anchor_macros_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -78,7 +78,7 @@ pub(super) fn image_macros_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -77,7 +77,7 @@ pub(super) fn indexterm_macros_level<'src>(
 
     let macro_matches = matches.into_iter().map(|m| m.macro_match).collect();
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, macro_matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, macro_matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -219,7 +219,7 @@ pub(super) fn inline_link_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }
@@ -1165,7 +1165,7 @@ pub(super) fn link_macro_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }
@@ -2061,7 +2061,7 @@ pub(super) fn email_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -16,8 +16,8 @@ use xref::xref_macros_level;
 
 use super::{
     quotes::{
-        LevelContext, Piece, build_match_string, charref_entity, emit_range, single_text_value,
-        source_slice, special_entity, text_slice,
+        LevelContext, Piece, TakenNodes, build_match_string, charref_entity, emit_range,
+        emit_range_from, single_text_value, source_slice, special_entity, text_slice,
     },
     special_chars::{Masked, unescaped_value_children},
 };
@@ -693,11 +693,20 @@ pub(super) enum MacroMatchKind<'src> {
 /// macro families, which differ only in how they produce the [`MacroMatch`]
 /// list.
 pub(super) fn rebuild_macro_level<'src>(
-    nodes: &[InlineNode<'src>],
+    nodes: Vec<InlineNode<'src>>,
     pieces: &[Piece],
     s: &str,
     matches: Vec<MacroMatch<'src>>,
 ) -> Vec<InlineNode<'src>> {
+    // The level is taken by value: every caller replaces it with the rebuilt
+    // vector, so each node re-emitted whole is **moved** out rather than
+    // deep-cloned and then dropped with the old vector — the same owning
+    // rebuild the quotes step takes, on the same disjointness argument (a
+    // gap ends where a node's consumed range starts, a kept suffix starts
+    // where it ends, an unescape skips only its backslash, and the cursor
+    // only advances). See [`NodeSupply`](super::quotes::NodeSupply).
+    let mut supply = TakenNodes::new(nodes);
+
     let mut out = Vec::new();
     let mut cursor = 0usize;
 
@@ -707,17 +716,17 @@ pub(super) fn rebuild_macro_level<'src>(
         match kind {
             MacroMatchKind::Unescape { backslash } => {
                 // Keep the whole match with the single backslash dropped.
-                emit_range(nodes, pieces, cursor..backslash, &mut out);
-                emit_range(nodes, pieces, (backslash + 1)..full.end, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..backslash, &mut out);
+                emit_range_from(&mut supply, pieces, (backslash + 1)..full.end, &mut out);
             }
 
             MacroMatchKind::Node { consumed, node } => {
                 // The gap runs to the node, absorbing any kept boundary prefix;
                 // the node replaces `consumed`; any stripped trailing
                 // punctuation after it is kept as literal.
-                emit_range(nodes, pieces, cursor..consumed.start, &mut out);
+                emit_range_from(&mut supply, pieces, cursor..consumed.start, &mut out);
                 out.push(*node);
-                emit_range(nodes, pieces, consumed.end..full.end, &mut out);
+                emit_range_from(&mut supply, pieces, consumed.end..full.end, &mut out);
             }
         }
 
@@ -725,7 +734,7 @@ pub(super) fn rebuild_macro_level<'src>(
     }
 
     if cursor < s.len() {
-        emit_range(nodes, pieces, cursor..s.len(), &mut out);
+        emit_range_from(&mut supply, pieces, cursor..s.len(), &mut out);
     }
 
     out

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -58,7 +58,7 @@ pub(super) fn kbd_btn_macros_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }
@@ -230,7 +230,7 @@ pub(super) fn menu_macros_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -134,7 +134,7 @@ pub(super) fn xref_macros_level<'src>(
         return nodes;
     }
 
-    let rebuilt = rebuild_macro_level(&nodes, pieces, s, matches);
+    let rebuilt = rebuild_macro_level(nodes, pieces, s, matches);
     level.invalidate();
     rebuilt
 }

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -221,7 +221,7 @@ fn apply_pass_macro_level<'src>(
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    rebuild_macro_level(nodes, &pieces, &s, matches)
 }
 
 /// Mirrors `Passthroughs::extract_from`'s own guard for `INLINE_PASS`.
@@ -260,7 +260,7 @@ fn apply_bare_attrlisted_pass_level<'src>(
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    rebuild_macro_level(nodes, &pieces, &s, matches)
 }
 
 /// Finds every passthrough at this level.

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -166,7 +166,7 @@ pub(super) fn apply_stem<'src>(
         return nodes;
     }
 
-    rebuild_macro_level(&nodes, &pieces, &s, matches)
+    rebuild_macro_level(nodes, &pieces, &s, matches)
 }
 
 /// Finds every STEM macro at this level — both the bare form and one


### PR DESCRIPTION
## What this does

Second step of the owning-rebuild conversion (#1381 introduced the `NodeSupply` machinery and converted the quotes step). The shared **`rebuild_macro_level`** — every macro family's rebuild — and **`rebuild_replacements`** now take the level by value and *move* each whole-node re-emission out of it via `TakenNodes`, rather than deep-cloning nodes into the new vector and dropping the originals with the old one. This was the remaining `InlineNode::clone` pool: ~180k instructions/parse on mixed_document, ~120k on macro_prose.

- Every `rebuild_macro_level` caller (all twelve, across the macro families, passthrough, and stem steps) already owned its level and returned the rebuilt vector — handing the vector over is the compiler-checked no-op it looks like.
- The sequential replacements path is restructured so ownership only changes hands when a rule matched: `replace_level` now returns the rule's **matches** (its find half), and `sequential_replacement_rules` performs the owning rebuild itself, keeping the untouched level on the no-match turn exactly as before.

## Why it's correct

- The disjointness argument is the quotes rebuild's, verbatim: every gap runs from the monotone cursor forward, a node's consumed range and its kept prefix/suffix never overlap, and an unescape skips only its backslash — so an atomic piece wholly inside one emitted range can be wholly inside no other, which is precisely `TakenNodes`' at-most-once contract (pinned by #1381's unit test).
- The full suite (5524 lib tests — golden recordings, the fused-vs-sequential replacements pin, every macro family's differential corpus) passes, and parse output is **byte-identical** on all five profiling fixtures.

## Measured effect

Callgrind instructions/parse (same marginal-cost methodology as previous increments):

| fixture | before (#1381 tip) | after | Δ |
|---|---:|---:|---:|
| macro_prose | 8,521,217 | 8,197,200 | **−3.8%** |
| mixed_document | 10,965,924 | 10,869,193 | **−0.9%** |
| plain_prose | 954,884 | 951,054 | −0.4% |
| replacement_prose | 3,697,517 | 3,699,820 | +0.1% |
| formatted_prose | 7,527,060 | 7,541,455 | +0.2% |

(The macro_prose figure also confirms #1381's layout-noise diagnosis: with this build the fixture sits *below* the pre-#1381 reading, recovering the wobble and the real clone win together.)

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5524 lib tests)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- Diff coverage: every added line in `parser/src` covered ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_