### PR TITLE
fix: Share the root level's match string across step families

### DIFF
--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -2,7 +2,7 @@
 
 use super::{
     quotes::{
-        LevelContext, Piece, TakenNodes, build_match_string, emit_range_from,
+        LevelContext, LevelStrings, Piece, TakenNodes, build_match_string, emit_range_from,
         level_may_have_replacements, source_slice,
     },
     special_chars::Masked,
@@ -37,8 +37,9 @@ use crate::{
 pub(super) fn apply_character_replacements<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
-    apply_replacements_recursive(nodes, root, LevelContext::ROOT)
+    apply_replacements_recursive(nodes, root, LevelContext::ROOT, level)
 }
 
 /// Applies every [`character_replacements`] rule to `nodes`, descending into
@@ -61,6 +62,7 @@ fn apply_replacements_recursive<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     ctx: LevelContext,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // A level with no parent node to descend into — the common leaf-only
     // case — skips the walk over its nodes entirely. The descent mutates
@@ -78,13 +80,18 @@ fn apply_replacements_recursive<'src>(
                 InlineNode::Styled(styled) => {
                     let inner = LevelContext::inside_styled(styled, ctx);
                     let children = std::mem::take(&mut styled.children);
-                    styled.children = apply_replacements_recursive(children, root, inner);
+                    styled.children =
+                        apply_replacements_recursive(children, root, inner, &mut None);
                 }
 
                 InlineNode::Ref(reference) => {
                     let children = std::mem::take(&mut reference.children);
-                    reference.children =
-                        apply_replacements_recursive(children, root, LevelContext::INSIDE_REF);
+                    reference.children = apply_replacements_recursive(
+                        children,
+                        root,
+                        LevelContext::INSIDE_REF,
+                        &mut None,
+                    );
                 }
 
                 _ => {}
@@ -103,9 +110,16 @@ fn apply_replacements_recursive<'src>(
     }
 
     // The match string is a pure function of the level's node list, so one
-    // build here serves every rule that leaves the level unchanged — the
-    // common outcome by far.
-    let level = build_match_string(&nodes, Masked::UNKNOWN);
+    // build serves every rule that leaves the level unchanged — the common
+    // outcome by far. The root call reuses whatever an earlier step family
+    // left in the shared slot (built under the same `Masked::UNKNOWN`; the
+    // child descent above cannot change it, since a span contributes only
+    // its placeholder and fixed boundary characters there), and each pass
+    // below hands the slot back whatever still describes the nodes it
+    // returns.
+    let level = shared
+        .take()
+        .unwrap_or_else(|| build_match_string(&nodes, Masked::UNKNOWN));
 
     // A haystack with no backslash anywhere — real prose, almost always —
     // takes the fused pass: every rule matched against this one string, one
@@ -114,9 +128,9 @@ fn apply_replacements_recursive<'src>(
     // touch, but the sequenced strings differ), so those levels keep the
     // rule-at-a-time pass whose semantics the escapes were specified against.
     if ctx.haystack(&level.0).0.contains('\\') {
-        sequential_replacement_rules(nodes, level, root, ctx)
+        sequential_replacement_rules(nodes, level, root, ctx, shared)
     } else {
-        fused_replacement_rules(nodes, &level, root, ctx)
+        fused_replacement_rules(nodes, level, root, ctx, shared)
     }
 }
 
@@ -136,11 +150,12 @@ fn apply_replacements_recursive<'src>(
 /// passes against each other across the rule list's interaction shapes.
 fn fused_replacement_rules<'src>(
     nodes: Vec<InlineNode<'src>>,
-    level: &(String, Vec<Piece>),
+    level: LevelStrings,
     root: Span<'src>,
     ctx: LevelContext,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
-    let (s, pieces) = level;
+    let (s, pieces) = &level;
     let (haystack, prefix) = ctx.haystack(s);
 
     let mut merged: Vec<ReplacementMatch> = Vec::new();
@@ -166,6 +181,8 @@ fn fused_replacement_rules<'src>(
     }
 
     if merged.is_empty() {
+        // Nothing changed: the level strings still describe `nodes`.
+        *shared = Some(level);
         return nodes;
     }
 
@@ -193,9 +210,10 @@ fn fused_replacement_rules<'src>(
 /// the fused pass against.
 fn sequential_replacement_rules<'src>(
     mut nodes: Vec<InlineNode<'src>>,
-    mut level: (String, Vec<Piece>),
+    mut level: LevelStrings,
     root: Span<'src>,
     ctx: LevelContext,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Only a rule that actually matched something invalidates the level's
     // match string, by rebuilding the level (which takes it by value — see
@@ -206,6 +224,9 @@ fn sequential_replacement_rules<'src>(
             level = build_match_string(&nodes, Masked::UNKNOWN);
         }
     }
+
+    // Whether any rule matched or not, `level` describes the nodes returned.
+    *shared = Some(level);
 
     nodes
 }
@@ -958,7 +979,7 @@ mod tests {
             location: loc,
         });
 
-        let out = apply_character_replacements(vec![reference], loc);
+        let out = apply_character_replacements(vec![reference], loc, &mut None);
 
         assert_eq!(out.len(), 1);
 
@@ -1132,8 +1153,15 @@ mod tests {
                 "fixture {source:?} belongs to the sequential-only path"
             );
 
-            let fused = fused_replacement_rules(nodes.clone(), &level, root, LevelContext::ROOT);
-            let sequential = sequential_replacement_rules(nodes, level, root, LevelContext::ROOT);
+            let fused = fused_replacement_rules(
+                nodes.clone(),
+                level.clone(),
+                root,
+                LevelContext::ROOT,
+                &mut None,
+            );
+            let sequential =
+                sequential_replacement_rules(nodes, level, root, LevelContext::ROOT, &mut None);
 
             assert_eq!(
                 fused, sequential,

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -3,7 +3,9 @@
 use super::{
     fold_deferring_xrefs,
     macros::{emit_range_unescaping_brackets, image::range_has_no_opaque_piece},
-    quotes::{Piece, build_match_string, single_text_value, source_slice, text_slice},
+    quotes::{
+        LevelStrings, Piece, build_match_string, single_text_value, source_slice, text_slice,
+    },
     special_chars::Masked,
 };
 use crate::{
@@ -54,6 +56,7 @@ pub(super) fn apply_footnotes<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // A subtree with no `"tnote"` substring anywhere — the overwhelmingly
     // common case — has nothing for this pass to do, so return it completely
@@ -69,11 +72,17 @@ pub(super) fn apply_footnotes<'src>(
     // the rebuild entirely when there is nothing to find keeps every other
     // family's nodes byte- *and* representation-identical to what
     // `apply_macros` produced.
-    if !subtree_might_have_footnote(&nodes) {
+    if !subtree_might_have_footnote(&nodes, Some(shared)) {
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+    // The root call reuses whatever an earlier step family left in the
+    // shared slot (built under the same `Masked::UNKNOWN`); the rebuild
+    // below replaces the level, so the slot is emptied by the `take`. A
+    // recursive call reaches here with an empty local slot and builds.
+    let (s, pieces) = shared
+        .take()
+        .unwrap_or_else(|| build_match_string(&nodes, Masked::UNKNOWN));
 
     // Cheap pre-filter mirroring the string step's `found_macroish &&
     // text.contains("tnote")`: both `footnote:` and the deprecated
@@ -99,7 +108,10 @@ pub(super) fn apply_footnotes<'src>(
 /// [`Text`](InlineNode::Text) pieces the way a per-node substring check
 /// could) but allocates no [`InlineNode`], letting a subtree with nothing to
 /// find come back from `apply_footnotes` completely unchanged.
-fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
+fn subtree_might_have_footnote(
+    nodes: &[InlineNode<'_>],
+    level: Option<&mut Option<LevelStrings>>,
+) -> bool {
     // Cheap pre-filter, taken *before* the match string is materialized: a
     // lone `Text` node has no `Styled`/`Ref`/`IndexTerm` child to recurse
     // into either, so this level's own value is the whole answer for it —
@@ -109,16 +121,32 @@ fn subtree_might_have_footnote(nodes: &[InlineNode<'_>]) -> bool {
         return value.contains("tnote");
     }
 
-    let (s, _) = build_match_string(nodes, Masked::UNKNOWN);
+    // The root call reads the level strings an earlier step family left in
+    // the shared slot rather than rebuilding them — and fills an empty slot
+    // with the build it makes, which [`apply_footnotes`] then takes rather
+    // than building the same strings again. Child levels build their own,
+    // read-only.
+    let built;
+    let s = match level {
+        Some(slot) => {
+            &slot
+                .get_or_insert_with(|| build_match_string(nodes, Masked::UNKNOWN))
+                .0
+        }
+        None => {
+            built = build_match_string(nodes, Masked::UNKNOWN);
+            &built.0
+        }
+    };
 
     if s.contains("tnote") {
         return true;
     }
 
     nodes.iter().any(|node| match node {
-        InlineNode::Styled(styled) => subtree_might_have_footnote(&styled.children),
-        InlineNode::Ref(reference) => subtree_might_have_footnote(&reference.children),
-        InlineNode::IndexTerm(index_term) => subtree_might_have_footnote(&index_term.children),
+        InlineNode::Styled(styled) => subtree_might_have_footnote(&styled.children, None),
+        InlineNode::Ref(reference) => subtree_might_have_footnote(&reference.children, None),
+        InlineNode::IndexTerm(term) => subtree_might_have_footnote(&term.children, None),
         _ => false,
     })
 }
@@ -241,12 +269,13 @@ fn emit_range_recursing_footnotes<'src>(
         if piece.atomic {
             match node.clone() {
                 InlineNode::Styled(mut styled) => {
-                    styled.children = apply_footnotes(styled.children, root, parser);
+                    styled.children = apply_footnotes(styled.children, root, parser, &mut None);
                     out.push(InlineNode::Styled(styled));
                 }
 
                 InlineNode::Ref(mut reference) => {
-                    reference.children = apply_footnotes(reference.children, root, parser);
+                    reference.children =
+                        apply_footnotes(reference.children, root, parser, &mut None);
                     out.push(InlineNode::Ref(reference));
                 }
 
@@ -261,7 +290,8 @@ fn emit_range_recursing_footnotes<'src>(
                 // so a `footnote:[…]` written there never reaches this
                 // footnote pass either.
                 InlineNode::IndexTerm(mut index_term) => {
-                    index_term.children = apply_footnotes(index_term.children, root, parser);
+                    index_term.children =
+                        apply_footnotes(index_term.children, root, parser, &mut None);
                     out.push(InlineNode::IndexTerm(index_term));
                 }
 

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -2681,7 +2681,7 @@ mod tests {
     /// quotes, character replacements) — the state the macros step consumes —
     /// so a test can drive [`apply_macros`] directly.
     fn build_through_special_and_replacements(source: Span<'_>) -> Vec<InlineNode<'_>> {
-        apply_character_replacements(build_through_quotes(source), source)
+        apply_character_replacements(build_through_quotes(source), source, &mut None)
     }
 
     // ---- `apply_image_side_effects` ----------------------------------------

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -557,6 +557,16 @@ pub(crate) fn build_for_group<'src>(
     // exactly as before.
     let mut sniff = trigger_scan::LoneTextSniff::default();
 
+    // The root level's reconstructed match string, shared across the step
+    // families that build it the same way (under `Masked::UNKNOWN`) — the
+    // quotes step, character replacements, footnotes, and post-replacements
+    // each reuse whatever the previous family left valid instead of
+    // rebuilding it for an unchanged level. Each family that takes the slot
+    // maintains it honestly (a rebuild empties or refreshes it); a step that
+    // does not take it clears it in its own arm below. `LevelStrings`
+    // documents the contract.
+    let mut root_level: Option<quotes::LevelStrings> = None;
+
     // Passthroughs are extracted before every other step (mirroring
     // `Passthroughs::extract_from`'s own gate), so their content is
     // never touched by specialcharacters, quotes, replacements, or macros.
@@ -625,10 +635,11 @@ pub(crate) fn build_for_group<'src>(
                     flatten_prior_markup(nodes, &masked, &*parser.renderer, parser)
                 };
 
+                root_level = None;
                 apply_special_characters(nodes)
             }
 
-            SubstitutionStep::Quotes => apply_quotes(nodes, location, parser),
+            SubstitutionStep::Quotes => apply_quotes(nodes, location, parser, &mut root_level),
 
             // In the *normal* effective order (specialcharacters → quotes →
             // attributes → replacements → macros), by this
@@ -652,11 +663,12 @@ pub(crate) fn build_for_group<'src>(
                     SplicedSpecials::Verbatim
                 };
 
+                root_level = None;
                 apply_attribute_references(nodes, location, parser, specials)
             }
 
             SubstitutionStep::CharacterReplacements => {
-                apply_character_replacements(nodes, location)
+                apply_character_replacements(nodes, location, &mut root_level)
             }
 
             SubstitutionStep::Macros => {
@@ -685,14 +697,22 @@ pub(crate) fn build_for_group<'src>(
                 // comment for why this cannot be folded into `apply_macros`
                 // as an ordinary level pass.
                 let nodes = apply_macros(nodes, location, parser, Masked::known(&masked), specials);
-                apply_footnotes(nodes, location, parser)
+
+                // The macros step builds its strings under `Masked::known`
+                // and keeps its own cache (`LevelSniff`), so the shared slot
+                // is stale by construction here.
+                root_level = None;
+                apply_footnotes(nodes, location, parser, &mut root_level)
             }
 
             SubstitutionStep::PostReplacement => {
-                apply_post_replacements(nodes, location, parser, attrlist)
+                apply_post_replacements(nodes, location, parser, attrlist, &mut root_level)
             }
 
-            SubstitutionStep::Callouts => apply_callouts(nodes, location, parser, attrlist),
+            SubstitutionStep::Callouts => {
+                root_level = None;
+                apply_callouts(nodes, location, parser, attrlist)
+            }
         };
     }
 

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -1,7 +1,9 @@
 //! The post-replacements substitution step (hard line breaks).
 
 use super::{
-    quotes::{Piece, build_match_string, emit_range, single_text_value, source_slice},
+    quotes::{
+        LevelStrings, Piece, build_match_string, emit_range, single_text_value, source_slice,
+    },
     special_chars::Masked,
 };
 use crate::{
@@ -21,8 +23,9 @@ pub(super) fn apply_post_replacements<'src>(
     root: Span<'src>,
     parser: &Parser,
     attrlist: Option<&Attrlist<'src>>,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
-    apply_level(nodes, root, parser, attrlist, true)
+    apply_level(nodes, root, parser, attrlist, true, shared)
 }
 
 /// A break needs a `+`, and — off the root level, where an end-of-level
@@ -45,6 +48,7 @@ fn apply_level<'src>(
     parser: &Parser,
     attrlist: Option<&Attrlist<'src>>,
     is_root: bool,
+    shared: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     // Descend into spans/refs first, recognizing a break inside a nested
     // span before this level's own pass runs. A nested level is never the
@@ -64,12 +68,14 @@ fn apply_level<'src>(
             match node {
                 InlineNode::Styled(styled) => {
                     let children = std::mem::take(&mut styled.children);
-                    styled.children = apply_level(children, root, parser, attrlist, false);
+                    styled.children =
+                        apply_level(children, root, parser, attrlist, false, &mut None);
                 }
 
                 InlineNode::Ref(reference) => {
                     let children = std::mem::take(&mut reference.children);
-                    reference.children = apply_level(children, root, parser, attrlist, false);
+                    reference.children =
+                        apply_level(children, root, parser, attrlist, false, &mut None);
                 }
 
                 _ => {}
@@ -80,6 +86,8 @@ fn apply_level<'src>(
     if parser.is_attribute_set("hardbreaks-option")
         || attrlist.is_some_and(|attrlist| attrlist.has_option("hardbreaks"))
     {
+        // The hardbreak rebuild replaces the level.
+        *shared = None;
         return apply_hardbreaks(nodes, root);
     }
 
@@ -90,13 +98,21 @@ fn apply_level<'src>(
         return nodes;
     }
 
-    let (s, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
+    // The root call reuses whatever an earlier step family left in the
+    // shared slot (built under the same `Masked::UNKNOWN`; the child descent
+    // above cannot change it, since a span contributes only its placeholder
+    // and fixed boundary characters there); the no-match paths below hand it
+    // back, and a rebuild leaves it empty.
+    let (s, pieces) = shared
+        .take()
+        .unwrap_or_else(|| build_match_string(&nodes, Masked::UNKNOWN));
 
     // A break needs a `+`, and — off the root level, where an end-of-level
     // match is discarded below — a `\n` for the pattern's `$` to anchor
     // against. At the root, the guard is on a `+` alone, since the whole
     // content's own haystack is checked there.
     if !level_prefilter(&s, is_root) {
+        *shared = Some((s, pieces));
         return nodes;
     }
 
@@ -131,6 +147,7 @@ fn apply_level<'src>(
         .collect();
 
     if breaks.is_empty() {
+        *shared = Some((s, pieces));
         return nodes;
     }
 
@@ -417,7 +434,8 @@ mod tests {
             location: loc,
         });
 
-        let out = apply_post_replacements(vec![reference], loc, &Parser::default(), None);
+        let out =
+            apply_post_replacements(vec![reference], loc, &Parser::default(), None, &mut None);
 
         match &out[0] {
             InlineNode::Ref(reference) => {

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -636,10 +636,10 @@ pub(super) fn apply_quotes<'src>(
     nodes: Vec<InlineNode<'src>>,
     root: Span<'src>,
     parser: &Parser,
+    level: &mut Option<LevelStrings>,
 ) -> Vec<InlineNode<'src>> {
     let mut nodes = nodes;
     let mut cached_mask: Option<(usize, usize, u8)> = None;
-    let mut level: Option<LevelStrings> = None;
 
     for sub in quote_subs() {
         if let Some(value) = single_text_value(&nodes) {
@@ -667,23 +667,19 @@ pub(super) fn apply_quotes<'src>(
             }
         }
 
-        apply_quote_sub(
-            sub,
-            &mut nodes,
-            root,
-            parser,
-            LevelContext::ROOT,
-            &mut level,
-        );
+        apply_quote_sub(sub, &mut nodes, root, parser, LevelContext::ROOT, level);
     }
 
     nodes
 }
 
 /// A level's reconstructed match string and its [`Piece`] map — one
-/// [`build_match_string`] result, held so a rule loop can reuse it across
-/// rules while nothing has changed the level it describes.
-type LevelStrings = (String, Vec<Piece>);
+/// [`build_match_string`] result (under [`Masked::UNKNOWN`]), held so a rule
+/// loop — or, for the **root** level, the whole run of step families that
+/// build under that same mask (see `build_for_group`'s shared slot) — can
+/// reuse it while nothing has changed the level it describes. Whoever
+/// changes the level it describes empties (or refreshes) the slot.
+pub(super) type LevelStrings = (String, Vec<Piece>);
 
 /// The bit [`marker_mask`] records the presence of `marker` under, or `0` for
 /// a character that is not one of the eight [`sub_markers`] characters (which

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -4193,6 +4193,85 @@ mod tests {
     }
 
     #[test]
+    fn a_spans_contribution_under_an_unknown_mask_ignores_its_children() {
+        // The invariant the shared root-level slot rests on (see
+        // `build_for_group`): under [`Masked::UNKNOWN`] — the mask every
+        // family that takes the slot builds with — a [`Styled`] span of
+        // *every* variant contributes only its placeholder and, for the two
+        // smart-quote variants, the fixed `&`/`;` its rendering always
+        // presents. The child-reading probe
+        // (`probe_styled_sibling_boundaries` / the transparent fallback) sits
+        // behind the identity-mask guard and is unreachable here, so a
+        // descent that rewrites a span's children cannot change the parent
+        // level's match string — which is what lets a family reuse the slot
+        // across its own child descent, and lets one family hand it to the
+        // next.
+        use super::{Masked, build_match_string};
+        use crate::inlines::Styled;
+
+        let variants = [
+            StyleVariant::Strong,
+            StyleVariant::Emphasis,
+            StyleVariant::Code,
+            StyleVariant::Mark,
+            StyleVariant::Superscript,
+            StyleVariant::Subscript,
+            StyleVariant::DoubleQuote,
+            StyleVariant::SingleQuote,
+            StyleVariant::Unquoted,
+        ];
+
+        let source = Span::new("abcd");
+
+        let with_children = |variant, children: Vec<InlineNode<'static>>| {
+            vec![InlineNode::Styled(Styled {
+                variant,
+                form: SpanForm::Constrained,
+                id: None,
+                roles: vec![],
+                attrs: crate::attributes::Attrlist::empty(source.slice(0..0)),
+                children,
+                passthrough: None,
+                location: source,
+            })]
+        };
+
+        for variant in variants {
+            // Two child lists whose outer characters differ in every way the
+            // probe could read them: different letters, and a child list
+            // that is empty outright.
+            let a = with_children(
+                variant,
+                vec![InlineNode::Text {
+                    value: CowStr::from("xy"),
+                    location: source,
+                }],
+            );
+            let b = with_children(
+                variant,
+                vec![InlineNode::Text {
+                    value: CowStr::from("qr"),
+                    location: source,
+                }],
+            );
+            let c = with_children(variant, vec![]);
+
+            let s_a = build_match_string(&a, Masked::UNKNOWN).0;
+            let s_b = build_match_string(&b, Masked::UNKNOWN).0;
+            let s_c = build_match_string(&c, Masked::UNKNOWN).0;
+
+            assert_eq!(
+                s_a, s_b,
+                "{variant:?}'s contribution read its children's bytes"
+            );
+            assert_eq!(
+                s_a, s_c,
+                "{variant:?}'s contribution read its children's shape"
+            );
+        }
+    }
+
+    #[test]
     fn an_owning_supply_moves_each_node_out_at_most_once() {
         // `TakenNodes` hands each node out whole exactly once — the contract
         // an owning rebuild relies on (its emitted ranges are disjoint, so a

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -50,7 +50,12 @@ pub(super) fn build_through_special(source: Span<'_>) -> Vec<InlineNode<'_>> {
 /// Builds the tree **through the quotes step**, for the quotes-stage
 /// differential (see [`build_through_special`]).
 pub(super) fn build_through_quotes(source: Span<'_>) -> Vec<InlineNode<'_>> {
-    apply_quotes(build_through_special(source), source, &Parser::default())
+    apply_quotes(
+        build_through_special(source),
+        source,
+        &Parser::default(),
+        &mut None,
+    )
 }
 
 /// Asserts that `node` is a [`Text`](InlineNode::Text) whose `value`


### PR DESCRIPTION
## What this does

Third step of the churn-reduction program (#1381, #1382). The step families that reconstruct the level match string the same way — under `Masked::UNKNOWN`: **quotes, character replacements, footnotes, and post-replacements** — now share one root-level `LevelStrings` slot, owned by `build_for_group`, instead of each rebuilding the same string for an unchanged level. The per-family rebuilds of the root string were the largest remaining `build_match_string` pool on the profiling fixtures (~770k instructions/parse spread across the families on formatted_prose at the time it was measured).

The slot's contract lives on the `LevelStrings` alias: *whoever changes the level it describes empties (or refreshes) it.*

- The quotes step's existing internal slot is lifted out unchanged, invalidation discipline and all.
- Character replacements take-or-build at the root and hand back whatever still describes the nodes they return — the sequential pass hands back the string it just rebuilt, so a later family reuses even a post-rewrite string.
- The footnote sniff **fills** an empty slot with the build it makes, which `apply_footnotes` then takes rather than building the same strings twice (this pairs the family's two root builds into one even though the macros step clears the slot just before it).
- Post-replacements hand the slot back on their no-match paths.
- A family that does not take the slot — special characters, attribute references, macros (which builds under `Masked::known` and keeps its own `LevelSniff` cache), callouts — clears it in its own dispatch arm.
- Child levels are untouched: each recursion carries a fresh local slot exactly as before.

## Why it's correct

Sharing across families is sound for the same reason each family's own internal reuse already was: the string is a pure function of the level's node list under a fixed mask, and a child descent cannot change it — under `Masked::UNKNOWN` a span contributes only its placeholder and fixed boundary characters, whatever happens to its children. The full suite (5524 lib tests: golden recordings, the fused-vs-sequential pin, every family's differential corpus) passes, and parse output is **byte-identical** on all five profiling fixtures.

## Measured effect

Callgrind instructions/parse (same marginal-cost methodology as previous increments):

| fixture | before (#1382 tip) | after | Δ |
|---|---:|---:|---:|
| replacement_prose | 3,699,820 | 3,566,620 | **−3.6%** |
| formatted_prose | 7,541,455 | 7,440,774 | **−1.3%** |
| macro_prose | 8,197,200 | 8,144,405 | −0.6% |
| mixed_document | 10,869,193 | 10,806,935 | −0.6% |
| plain_prose | 951,054 | 957,012 | +0.6%* |

\* Within the documented codegen-layout noise band (see #1381's control experiment).

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5524 lib tests)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- Diff coverage: every added line in `parser/src` covered ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_