### PR TITLE
fix: Box InlineNode's wide variants so the enum drops to 120 bytes

### DIFF
--- a/parser/src/content/inline_builder/char_replacements.rs
+++ b/parser/src/content/inline_builder/char_replacements.rs
@@ -962,7 +962,7 @@ mod tests {
         // running the macros step, to drive the recursion in isolation.)
         let loc = Span::new("(C)");
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
@@ -977,7 +977,7 @@ mod tests {
             xrefstyle: None,
             attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
             location: loc,
-        });
+        }));
 
         let out = apply_character_replacements(vec![reference], loc, &mut None);
 

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -1030,7 +1030,7 @@ mod tests {
         // per_character`] exercises a hand-built replacement.)
         let location = Span::new("image:sunset.jpg[Sunset]");
 
-        let hand_built = InlineNode::Image(Image {
+        let hand_built = InlineNode::Image(Box::new(Image {
             is_icon: false,
             target: CowStr::from("sunset.jpg"),
             restored_target_ranges: vec![],
@@ -1039,7 +1039,7 @@ mod tests {
             height: None,
             attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
             location,
-        });
+        }));
 
         // The macro-built equivalent (which carries an attribute list) is the
         // oracle: the two must fold identically.
@@ -1058,7 +1058,7 @@ mod tests {
         // target, so the fold still resolves and renders the plain path.
         let location = Span::new("image:sunset.jpg[Sunset]");
 
-        let hand_built = InlineNode::Image(Image {
+        let hand_built = InlineNode::Image(Box::new(Image {
             is_icon: false,
             target: CowStr::from("sunset.jpg"),
             restored_target_ranges: vec![3..99, 100..200],
@@ -1067,7 +1067,7 @@ mod tests {
             height: None,
             attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
             location,
-        });
+        }));
 
         let renderer = HtmlInlineRenderer {};
 
@@ -1082,7 +1082,7 @@ mod tests {
     /// `xrefstyle` formatting actually changes (design's `apply_xrefstyle`
     /// only alters output when a signifier is present).
     fn resolved_xref_with_signifier(xrefstyle: Option<XrefStyle>) -> InlineNode<'static> {
-        InlineNode::Ref(Ref {
+        InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Xref,
             link_form: None,
             target: CowStr::from("install"),
@@ -1101,7 +1101,7 @@ mod tests {
             xrefstyle,
             attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
             location: Span::new(""),
-        })
+        }))
     }
 
     #[test]

--- a/parser/src/content/inline_builder/footnotes.rs
+++ b/parser/src/content/inline_builder/footnotes.rs
@@ -559,13 +559,13 @@ fn build_footnote_node<'src>(
     if let Some(id) = id {
         if let Some(number) = parser.footnote_index_for_id(id.as_ref()) {
             // A reference to an already-defined footnote: reuse its number.
-            return Some(InlineNode::Footnote(Footnote {
+            return Some(InlineNode::Footnote(Box::new(Footnote {
                 id: Some(id),
                 number: Some(CowStr::from(number)),
                 is_reference: true,
                 children: vec![],
                 location,
-            }));
+            })));
         }
 
         return match content_match {
@@ -574,13 +574,13 @@ fn build_footnote_node<'src>(
                 let children = footnote_children(content, s, pieces, nodes);
                 let number = register_footnote_number(parser, Some(id.as_ref()), &children, root);
 
-                Some(InlineNode::Footnote(Footnote {
+                Some(InlineNode::Footnote(Box::new(Footnote {
                     id: Some(id),
                     number: Some(CowStr::from(number)),
                     is_reference: false,
                     children,
                     location,
-                }))
+                })))
             }
 
             // A reference to an id that was never defined, reported right
@@ -594,13 +594,13 @@ fn build_footnote_node<'src>(
                     crate::warnings::WarningType::InvalidFootnoteReference(id.to_string()),
                 );
 
-                Some(InlineNode::Footnote(Footnote {
+                Some(InlineNode::Footnote(Box::new(Footnote {
                     id: Some(id),
                     number: None,
                     is_reference: true,
                     children: vec![],
                     location,
-                }))
+                })))
             }
         };
     }
@@ -611,13 +611,13 @@ fn build_footnote_node<'src>(
     let children = footnote_children(content, s, pieces, nodes);
     let number = register_footnote_number(parser, None, &children, root);
 
-    Some(InlineNode::Footnote(Footnote {
+    Some(InlineNode::Footnote(Box::new(Footnote {
         id: None,
         number: Some(CowStr::from(number)),
         is_reference: false,
         children,
         location,
-    }))
+    })))
 }
 
 /// Builds one [`Footnote`](InlineNode::Footnote) node from a `footnoteref:`
@@ -698,13 +698,13 @@ fn build_footnoteref_node<'src>(
 
     if let Some(number) = parser.footnote_index_for_id(id.as_ref()) {
         // A reference to an already-defined footnote: reuse its number.
-        return Some(InlineNode::Footnote(Footnote {
+        return Some(InlineNode::Footnote(Box::new(Footnote {
             id: Some(id),
             number: Some(CowStr::from(number)),
             is_reference: true,
             children: vec![],
             location,
-        }));
+        })));
     }
 
     match content_range {
@@ -713,13 +713,13 @@ fn build_footnoteref_node<'src>(
             let children = footnote_children(content_range, s, pieces, nodes);
             let number = register_footnote_number(parser, Some(id.as_ref()), &children, root);
 
-            Some(InlineNode::Footnote(Footnote {
+            Some(InlineNode::Footnote(Box::new(Footnote {
                 id: Some(id),
                 number: Some(CowStr::from(number)),
                 is_reference: false,
                 children,
                 location,
-            }))
+            })))
         }
 
         // A reference to an id that was never defined — see the sibling site
@@ -731,13 +731,13 @@ fn build_footnoteref_node<'src>(
                 crate::warnings::WarningType::InvalidFootnoteReference(id.to_string()),
             );
 
-            Some(InlineNode::Footnote(Footnote {
+            Some(InlineNode::Footnote(Box::new(Footnote {
                 id: Some(id),
                 number: None,
                 is_reference: true,
                 children: vec![],
                 location,
-            }))
+            })))
         }
     }
 }

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -1477,7 +1477,7 @@ mod tests {
         let anchor = build_with(root, &Parser::default());
         assert_eq!(anchor.len(), 1);
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
@@ -1489,7 +1489,7 @@ mod tests {
             xrefstyle: None,
             attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
-        });
+        }));
 
         let source = "*see [[a]]* and footnote:[see [[b]]]";
         let parser = Parser::default();

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -678,7 +678,7 @@ fn build_image_node<'src>(
         (Some(CowStr::from(alt)), width, height)
     };
 
-    InlineNode::Image(Image {
+    InlineNode::Image(Box::new(Image {
         is_icon,
         target,
         restored_target_ranges,
@@ -687,7 +687,7 @@ fn build_image_node<'src>(
         height,
         attrs: attrlist,
         location,
-    })
+    }))
 }
 
 /// Rewrites this level's match string so each masked **passthrough** or
@@ -2601,14 +2601,14 @@ mod tests {
                 },
                 location: root,
             },
-            InlineNode::Stem(crate::inlines::Stem {
+            InlineNode::Stem(Box::new(crate::inlines::Stem {
                 notation: crate::inlines::StemNotation::AsciiMath,
                 value: CowStr::from("x"),
                 subs: crate::content::SubstitutionGroup::Stem,
                 source_text: None,
                 children: vec![],
                 location: root,
-            }),
+            })),
         ];
 
         for node in &restorable {
@@ -2769,7 +2769,7 @@ mod tests {
         let image = build_with(root, &Parser::default());
         assert_eq!(image.len(), 1);
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
@@ -2781,7 +2781,7 @@ mod tests {
             xrefstyle: None,
             attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
-        });
+        }));
 
         let parser = Parser::default().with_catalog_assets(true);
         apply_image_side_effects(std::slice::from_ref(&reference), &parser, root);

--- a/parser/src/content/inline_builder/macros/links.rs
+++ b/parser/src/content/inline_builder/macros/links.rs
@@ -847,7 +847,7 @@ fn build_inline_link_node<'src>(
         macro_text_children(trimmed, m.start()..end, true, nodes, pieces, root)
     };
 
-    let node = InlineNode::Ref(Ref {
+    let node = InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Link,
         link_form: Some(LinkForm::AutoOrFormal),
         target: CowStr::from(target),
@@ -859,7 +859,7 @@ fn build_inline_link_node<'src>(
         derived: None,
         xrefstyle: None,
         location,
-    });
+    }));
 
     Some(MacroMatch {
         kind: MacroMatchKind::Node {
@@ -1000,7 +1000,7 @@ fn build_angle_link_node<'src>(
         root,
     );
 
-    let node = InlineNode::Ref(Ref {
+    let node = InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Link,
         link_form: Some(LinkForm::AutoOrFormal),
         target: CowStr::from(target),
@@ -1012,7 +1012,7 @@ fn build_angle_link_node<'src>(
         derived: None,
         xrefstyle: None,
         location,
-    });
+    }));
 
     Some(MacroMatch {
         kind: MacroMatchKind::Node {
@@ -1692,7 +1692,7 @@ pub(super) fn build_link_node<'src>(
         macro_text_children(trimmed, m.start()..end, true, nodes, pieces, root)
     };
 
-    Some(InlineNode::Ref(Ref {
+    Some(InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Link,
         link_form: Some(LinkForm::Macro),
         target: CowStr::from(target),
@@ -1704,7 +1704,7 @@ pub(super) fn build_link_node<'src>(
         derived: None,
         xrefstyle: None,
         location,
-    }))
+    })))
 }
 
 /// One link display text read as an attribute list — the result
@@ -2190,7 +2190,7 @@ fn build_email_node<'src>(
     let range = address_m.start()..address_m.end();
     let location = source_slice(pieces, range.clone(), root);
 
-    InlineNode::Ref(Ref {
+    InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Link,
         link_form: Some(LinkForm::Email),
         target: CowStr::from(format!("mailto:{address}")),
@@ -2202,7 +2202,7 @@ fn build_email_node<'src>(
         derived: None,
         xrefstyle: None,
         location,
-    })
+    }))
 }
 
 /// Performs the recognition side effect a matched link needs —

--- a/parser/src/content/inline_builder/macros/mod.rs
+++ b/parser/src/content/inline_builder/macros/mod.rs
@@ -1663,7 +1663,7 @@ mod tests {
         // an `image:` macro has that macro recognized inside it.
         let root = Span::new("image:x.png[X]");
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.org"),
@@ -1678,7 +1678,7 @@ mod tests {
             xrefstyle: None,
             attrs: crate::attributes::Attrlist::empty(root.slice(0..0)),
             location: root,
-        });
+        }));
 
         let out = apply_macros(
             vec![reference],

--- a/parser/src/content/inline_builder/macros/ui.rs
+++ b/parser/src/content/inline_builder/macros/ui.rs
@@ -178,7 +178,7 @@ fn build_kbd_btn_node<'src>(
         UiKind::Button(CowStr::from(normalize_index_text(content, true)))
     };
 
-    InlineNode::Ui(Ui { kind, location })
+    InlineNode::Ui(Box::new(Ui { kind, location }))
 }
 
 /// The menu UI macro pass at a level: matches [`INLINE_MENU_MACRO`] over the
@@ -345,14 +345,14 @@ fn build_menu_node<'src>(
 
     let (submenus, item) = split_menu_items(caps.get(2).map(|m| m.as_str()));
 
-    InlineNode::Ui(Ui {
+    InlineNode::Ui(Box::new(Ui {
         kind: UiKind::Menu {
             menu,
             submenus,
             item,
         },
         location,
-    })
+    }))
 }
 
 /// Splits a menu macro's item list into its submenu path and trailing item: a

--- a/parser/src/content/inline_builder/macros/xref.rs
+++ b/parser/src/content/inline_builder/macros/xref.rs
@@ -625,7 +625,7 @@ fn build_xref_node<'src>(
 
     let location = source_slice(pieces, full.clone(), root);
 
-    InlineNode::Ref(Ref {
+    InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Xref,
         link_form: None,
         target: CowStr::from(target),
@@ -643,7 +643,7 @@ fn build_xref_node<'src>(
         xrefstyle: xrefstyle.or_else(|| document_xrefstyle(parser)),
         attrs: Attrlist::empty(location.slice(0..0)),
         location,
-    })
+    }))
 }
 
 /// Interprets the bracketed display text of an `xref:` macro, mirroring
@@ -927,7 +927,7 @@ fn build_xref_shorthand_node<'src>(
         }
     };
 
-    InlineNode::Ref(Ref {
+    InlineNode::Ref(Box::new(Ref {
         variant: RefVariant::Xref,
         link_form: None,
         target: CowStr::from(target),
@@ -943,7 +943,7 @@ fn build_xref_shorthand_node<'src>(
         xrefstyle: document_xrefstyle(parser),
         attrs: Attrlist::empty(location.slice(0..0)),
         location,
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -1071,7 +1071,7 @@ fn build_attrlisted_passthrough_node<'src>(
 
     let (id, roles, attrs) = attributes_of(attrlist_span, parser);
 
-    InlineNode::Styled(Styled {
+    InlineNode::Styled(Box::new(Styled {
         variant,
         form: SpanForm::Unconstrained,
         id,
@@ -1083,7 +1083,7 @@ fn build_attrlisted_passthrough_node<'src>(
             text: body_span.data().to_string(),
         }),
         location,
-    })
+    }))
 }
 
 /// Builds one [`Styled`] node from a verbatim, unescaped, attribute-listed
@@ -1173,7 +1173,7 @@ fn build_bare_attrlisted_passthrough_node<'src>(
 
     let (id, roles, attrs) = attributes_of(attrlist_span, parser);
 
-    InlineNode::Styled(Styled {
+    InlineNode::Styled(Box::new(Styled {
         variant,
         form: SpanForm::Unconstrained,
         id,
@@ -1185,7 +1185,7 @@ fn build_bare_attrlisted_passthrough_node<'src>(
             text: body_span.data().to_string(),
         }),
         location,
-    })
+    }))
 }
 
 /// Splits an old-behavior-eligible attrlist span into its final attrlist body
@@ -1342,7 +1342,7 @@ mod tests {
                 value: CowStr::from("+++"),
                 location,
             },
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Strong,
                 form: SpanForm::Constrained,
                 id: None,
@@ -1351,7 +1351,7 @@ mod tests {
                 children: vec![],
                 passthrough: None,
                 location,
-            }),
+            })),
             InlineNode::Text {
                 value: CowStr::from("+++"),
                 location,
@@ -2466,7 +2466,7 @@ mod tests {
                 value: CowStr::from("[attrs]+"),
                 location: source.slice(0..8),
             },
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Strong,
                 form: SpanForm::Constrained,
                 id: None,
@@ -2475,7 +2475,7 @@ mod tests {
                 children: vec![],
                 passthrough: None,
                 location: source.slice(8..9),
-            }),
+            })),
             InlineNode::Text {
                 value: CowStr::from("+"),
                 location: source.slice(9..10),
@@ -2878,7 +2878,7 @@ mod tests {
                 value: CowStr::from("+"),
                 location: source.slice(0..1),
             },
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Strong,
                 form: SpanForm::Constrained,
                 id: None,
@@ -2887,7 +2887,7 @@ mod tests {
                 children: vec![],
                 passthrough: None,
                 location: source.slice(1..2),
-            }),
+            })),
             InlineNode::Text {
                 value: CowStr::from("+"),
                 location: source.slice(2..3),

--- a/parser/src/content/inline_builder/post_replacements.rs
+++ b/parser/src/content/inline_builder/post_replacements.rs
@@ -417,7 +417,7 @@ mod tests {
         // recognized (driven directly, as above).
         let loc = Span::new("x +\ny");
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
@@ -432,7 +432,7 @@ mod tests {
             xrefstyle: None,
             attrs: Attrlist::empty(loc.slice(0..0)),
             location: loc,
-        });
+        }));
 
         let out =
             apply_post_replacements(vec![reference], loc, &Parser::default(), None, &mut None);

--- a/parser/src/content/inline_builder/quotes.rs
+++ b/parser/src/content/inline_builder/quotes.rs
@@ -2105,7 +2105,7 @@ fn rebuild_level<'src>(
                     None => (None, Vec::new(), Attrlist::empty(location.slice(0..0))),
                 };
 
-                out.push(InlineNode::Styled(Styled {
+                out.push(InlineNode::Styled(Box::new(Styled {
                     variant: *variant,
                     form: *form,
                     id,
@@ -2114,7 +2114,7 @@ fn rebuild_level<'src>(
                     children,
                     passthrough: None,
                     location,
-                }));
+                })));
             }
         }
 
@@ -2934,7 +2934,7 @@ mod tests {
         assert_eq!(styled_boundaries(&bare), None);
         assert_eq!(
             LevelContext::child_contexts(
-                &[InlineNode::Styled(bare)],
+                &[InlineNode::Styled(Box::new(bare))],
                 LevelContext::INSIDE_REF,
                 Masked::UNKNOWN
             ),
@@ -3027,7 +3027,7 @@ mod tests {
             (Some('a'), Some('a'))
         );
 
-        transparent.children = vec![InlineNode::Styled(span(StyleVariant::Strong))];
+        transparent.children = vec![InlineNode::Styled(Box::new(span(StyleVariant::Strong)))];
 
         assert_eq!(
             styled_sibling_boundaries(&transparent, Masked::UNKNOWN),
@@ -3169,7 +3169,7 @@ mod tests {
         const TAG: LevelContext = LevelContext::INSIDE_REF;
 
         fn styled(variant: StyleVariant) -> InlineNode<'static> {
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant,
                 form: SpanForm::Constrained,
                 id: None,
@@ -3178,7 +3178,7 @@ mod tests {
                 children: Vec::new(),
                 passthrough: None,
                 location: Span::new("x"),
-            })
+            }))
         }
 
         fn text(value: &'static str) -> InlineNode<'static> {
@@ -3316,7 +3316,7 @@ mod tests {
         // first one's body ends with, which is what a whole-content match
         // would read between the two.
         fn transparent(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Unquoted,
                 form: SpanForm::Constrained,
                 id: None,
@@ -3325,7 +3325,7 @@ mod tests {
                 children,
                 passthrough: None,
                 location: Span::new("x"),
-            })
+            }))
         }
 
         assert_eq!(
@@ -3592,7 +3592,7 @@ mod tests {
         );
 
         let (s, pieces) = build_match_string(
-            &[InlineNode::Styled(styled.clone())],
+            &[InlineNode::Styled(Box::new(styled.clone()))],
             Masked::known(&[identity]),
         );
 
@@ -3603,7 +3603,8 @@ mod tests {
         // The same node, *not* named by the identity, is a span that really
         // has been rendered — and presents the two characters its
         // `<span class="x">…</span>` puts beside its siblings.
-        let (s, pieces) = build_match_string(&[InlineNode::Styled(styled)], Masked::known(&[]));
+        let (s, pieces) =
+            build_match_string(&[InlineNode::Styled(Box::new(styled))], Masked::known(&[]));
 
         assert_eq!(s, format!("<{SPAN_PLACEHOLDER}>"));
         assert_eq!(pieces.len(), 1);
@@ -3646,8 +3647,10 @@ mod tests {
         // on either side of the placeholder — and the piece still covers the
         // placeholder alone, so the two belong to no node and no range a
         // caller slices moves.
-        let (s, pieces) =
-            build_match_string(&[InlineNode::Styled(styled(body()))], Masked::known(&[]));
+        let (s, pieces) = build_match_string(
+            &[InlineNode::Styled(Box::new(styled(body())))],
+            Masked::known(&[]),
+        );
 
         assert_eq!(s, format!("x{SPAN_PLACEHOLDER} "));
         assert_eq!(pieces.len(), 1);
@@ -3656,8 +3659,10 @@ mod tests {
         // Without it — every step but `macros` — the span this module cannot
         // rule out being an extraction wrapper keeps the bare placeholder,
         // byte for byte what it carried before.
-        let (s, pieces) =
-            build_match_string(&[InlineNode::Styled(styled(body()))], Masked::UNKNOWN);
+        let (s, pieces) = build_match_string(
+            &[InlineNode::Styled(Box::new(styled(body())))],
+            Masked::UNKNOWN,
+        );
 
         assert_eq!(s, SPAN_PLACEHOLDER.to_string());
         assert_eq!(pieces[0].s_start, 0);
@@ -3673,7 +3678,10 @@ mod tests {
             wrapper.location.data().len(),
         );
 
-        let (s, _) = build_match_string(&[InlineNode::Styled(wrapper)], Masked::known(&[identity]));
+        let (s, _) = build_match_string(
+            &[InlineNode::Styled(Box::new(wrapper))],
+            Masked::known(&[identity]),
+        );
 
         assert_eq!(s, SPAN_PLACEHOLDER.to_string());
     }
@@ -3696,7 +3704,7 @@ mod tests {
         };
 
         let styled = |variant| {
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant,
                 form: SpanForm::Constrained,
                 id: None,
@@ -3705,7 +3713,7 @@ mod tests {
                 children: vec![text("x")],
                 passthrough: None,
                 location: Span::new("\"`x`\""),
-            })
+            }))
         };
 
         // A `CharRef` contributes its entity, whose `&` sniffs.
@@ -4224,7 +4232,7 @@ mod tests {
         let source = Span::new("abcd");
 
         let with_children = |variant, children: Vec<InlineNode<'static>>| {
-            vec![InlineNode::Styled(Styled {
+            vec![InlineNode::Styled(Box::new(Styled {
                 variant,
                 form: SpanForm::Constrained,
                 id: None,
@@ -4233,7 +4241,7 @@ mod tests {
                 children,
                 passthrough: None,
                 location: source,
-            })]
+            }))]
         };
 
         for variant in variants {
@@ -4374,7 +4382,7 @@ mod tests {
         // splitting one clones it whole, exactly as before.
         let source = Span::new("*x*");
 
-        let nodes = vec![InlineNode::Styled(Styled {
+        let nodes = vec![InlineNode::Styled(Box::new(Styled {
             variant: StyleVariant::Strong,
             form: SpanForm::Constrained,
             id: None,
@@ -4383,7 +4391,7 @@ mod tests {
             children: vec![],
             passthrough: None,
             location: source,
-        })];
+        }))];
 
         let (_, pieces) = build_match_string(&nodes, Masked::UNKNOWN);
 

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -709,7 +709,7 @@ mod tests {
         // the step must descend into a `Styled` span's children.
         let loc = Span::new("a<b");
 
-        let styled = InlineNode::Styled(Styled {
+        let styled = InlineNode::Styled(Box::new(Styled {
             variant: StyleVariant::Strong,
             form: SpanForm::Constrained,
             id: None,
@@ -721,7 +721,7 @@ mod tests {
             }],
             passthrough: None,
             location: loc,
-        });
+        }));
 
         let out = apply_special_characters(vec![styled]);
 
@@ -744,7 +744,7 @@ mod tests {
         // A reference's display text is likewise refined in place.
         let loc = Span::new("x&y");
 
-        let reference = InlineNode::Ref(Ref {
+        let reference = InlineNode::Ref(Box::new(Ref {
             variant: RefVariant::Link,
             link_form: Some(crate::inlines::LinkForm::Macro),
             target: CowStr::from("https://example.com"),
@@ -759,7 +759,7 @@ mod tests {
             xrefstyle: None,
             attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
             location: loc,
-        });
+        }));
 
         let out = apply_special_characters(vec![reference]);
 
@@ -967,7 +967,7 @@ mod tests {
         };
 
         let out = classify_unescaped_specials(vec![
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Strong,
                 form: SpanForm::Constrained,
                 id: None,
@@ -976,8 +976,8 @@ mod tests {
                 children: child(),
                 passthrough: None,
                 location: loc,
-            }),
-            InlineNode::Ref(Ref {
+            })),
+            InlineNode::Ref(Box::new(Ref {
                 variant: RefVariant::Link,
                 link_form: Some(crate::inlines::LinkForm::Macro),
                 target: CowStr::from("https://example.com"),
@@ -989,20 +989,20 @@ mod tests {
                 xrefstyle: None,
                 attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
                 location: loc,
-            }),
+            })),
             InlineNode::Anchor(Anchor {
                 id: CowStr::from("id"),
                 reftext: Some(child()),
                 is_bibliography: false,
                 location: loc,
             }),
-            InlineNode::Footnote(Footnote {
+            InlineNode::Footnote(Box::new(Footnote {
                 id: None,
                 number: Some(CowStr::from("1")),
                 is_reference: false,
                 children: child(),
                 location: loc,
-            }),
+            })),
         ]);
 
         assert_eq!(out.len(), 4);

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -282,7 +282,7 @@ fn build_stem_node<'src>(
 
     let (value, source) = stem_expression_value(&emitted, notation, &subs, parser);
 
-    Some(InlineNode::Stem(Stem {
+    Some(InlineNode::Stem(Box::new(Stem {
         notation,
         // The body's own nodes, kept rather than folded away: an embedded
         // passthrough is its own extraction entry, and `value` alone gives a
@@ -294,7 +294,7 @@ fn build_stem_node<'src>(
         value: CowStr::from(value),
         subs,
         location,
-    }))
+    })))
 }
 
 /// Computes a [`Stem`](InlineNode::Stem) node's `value` from the expression
@@ -389,7 +389,7 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{InlineNode, Stem, StemNotation},
+        inlines::{InlineNode, StemNotation},
         parser::HtmlInlineRenderer,
     };
 
@@ -397,13 +397,9 @@ mod tests {
     /// with the given `value`.
     fn assert_stem(node: &InlineNode<'_>, notation: StemNotation, value: &str) {
         match node {
-            InlineNode::Stem(Stem {
-                notation: n,
-                value: v,
-                ..
-            }) => {
-                assert_eq!(*n, notation, "notation");
-                assert_eq!(v.as_ref(), value, "value");
+            InlineNode::Stem(stem) => {
+                assert_eq!(stem.notation, notation, "notation");
+                assert_eq!(stem.value.as_ref(), value, "value");
             }
 
             other => panic!("expected Stem({notation:?}, {value:?}), got {other:?}"),

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -80,25 +80,32 @@ pub enum InlineNode<'src> {
     },
 
     // ─── ASG parent nodes ─────────────────────────────────────────────
+    //
+    // The wide payloads here (and among the extensions below) are boxed so
+    // the enum stays small: nearly every node in a real document is a
+    // `Text`/`CharRef` leaf, and the builder moves whole node vectors
+    // through each substitution step's rebuild, so element size is paid on
+    // every step. The boxed structs are a small minority of nodes and each
+    // box is allocated once at construction, then moves as one pointer.
     /// A formatted span (strong, emphasis, code, mark, and crate extensions).
     /// ASG: `inlineSpan`.
-    Styled(Styled<'src>),
+    Styled(Box<Styled<'src>>),
 
     /// A link or cross-reference. ASG: `inlineRef`.
-    Ref(Ref<'src>),
+    Ref(Box<Ref<'src>>),
 
     // ─── crate extensions (no ASG inline node yet) ────────────────────
     /// An inline image (`image:target[…]`).
-    Image(Image<'src>),
+    Image(Box<Image<'src>>),
 
     /// A footnote (`footnote:[…]` or `footnote:id[…]`).
-    Footnote(Footnote<'src>),
+    Footnote(Box<Footnote<'src>>),
 
     /// An inline anchor (`[[id]]` or `anchor:id[reftext]`).
     Anchor(Anchor<'src>),
 
     /// A UI macro: `kbd:`, `btn:`, or `menu:`.
-    Ui(Ui<'src>),
+    Ui(Box<Ui<'src>>),
 
     /// An index term (`((term))`, `(((primary, secondary)))`,
     /// `indexterm:[…]`, or `indexterm2:[…]`).
@@ -108,7 +115,7 @@ pub enum InlineNode<'src> {
     Callout(Callout<'src>),
 
     /// Inline STEM content (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`).
-    Stem(Stem<'src>),
+    Stem(Box<Stem<'src>>),
 
     /// An explicit line break (a trailing `+` at the end of a line).
     LineBreak {
@@ -116,6 +123,12 @@ pub enum InlineNode<'src> {
         location: Span<'src>,
     },
 }
+
+// The size the boxing above buys, pinned: the builder pipeline moves whole
+// node vectors through each substitution step's rebuild, so a widened enum
+// is a per-step cost on every node in the document. A variant that pushes
+// past this bound should be boxed instead.
+const _: () = assert!(std::mem::size_of::<InlineNode<'_>>() <= 128);
 
 impl<'src> HasSpan<'src> for InlineNode<'src> {
     fn span(&self) -> Span<'src> {
@@ -168,7 +181,7 @@ mod tests {
                 origin: RawOrigin::Substitution,
                 location,
             },
-            InlineNode::Styled(Styled {
+            InlineNode::Styled(Box::new(Styled {
                 variant: StyleVariant::Strong,
                 form: SpanForm::Constrained,
                 id: None,
@@ -177,8 +190,8 @@ mod tests {
                 children: vec![],
                 passthrough: None,
                 location,
-            }),
-            InlineNode::Ref(Ref {
+            })),
+            InlineNode::Ref(Box::new(Ref {
                 variant: RefVariant::Link,
                 link_form: Some(crate::inlines::LinkForm::Macro),
                 target: CowStr::from("https://example.com"),
@@ -190,8 +203,8 @@ mod tests {
                 xrefstyle: None,
                 attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 location,
-            }),
-            InlineNode::Image(Image {
+            })),
+            InlineNode::Image(Box::new(Image {
                 is_icon: false,
                 target: CowStr::from("photo.png"),
                 restored_target_ranges: vec![],
@@ -200,24 +213,24 @@ mod tests {
                 height: None,
                 attrs: crate::attributes::Attrlist::empty(location.slice(0..0)),
                 location,
-            }),
-            InlineNode::Footnote(Footnote {
+            })),
+            InlineNode::Footnote(Box::new(Footnote {
                 id: None,
                 number: Some(CowStr::from("1")),
                 is_reference: false,
                 children: vec![],
                 location,
-            }),
+            })),
             InlineNode::Anchor(Anchor {
                 id: CowStr::from("intro"),
                 reftext: None,
                 is_bibliography: false,
                 location,
             }),
-            InlineNode::Ui(Ui {
+            InlineNode::Ui(Box::new(Ui {
                 kind: UiKind::Button(CowStr::from("Save")),
                 location,
-            }),
+            })),
             InlineNode::IndexTerm(IndexTerm {
                 terms: vec![CowStr::from("term")],
                 children: vec![],
@@ -229,14 +242,14 @@ mod tests {
                 guard: CalloutGuard::LineComment(CowStr::from("# ")),
                 location,
             }),
-            InlineNode::Stem(Stem {
+            InlineNode::Stem(Box::new(Stem {
                 notation: StemNotation::AsciiMath,
                 value: CowStr::from("x^2"),
                 subs: crate::content::SubstitutionGroup::Stem,
                 source_text: None,
                 children: vec![],
                 location,
-            }),
+            })),
             InlineNode::LineBreak { location },
         ]
     }

--- a/parser/src/tests/inline_tree.rs
+++ b/parser/src/tests/inline_tree.rs
@@ -921,7 +921,7 @@ fn collect_footnote_refs<'a>(doc: &'a Document<'a>) -> Vec<Ref<'a>> {
 
                 InlineNode::Ref(reference) => {
                     if in_footnote {
-                        out.push(reference.clone());
+                        out.push((**reference).clone());
                     }
 
                     walk(&reference.children, in_footnote, out);
@@ -992,7 +992,7 @@ fn collect_refs<'a>(doc: &'a Document<'a>) -> Vec<Ref<'a>> {
         for node in nodes {
             match node {
                 InlineNode::Ref(reference) => {
-                    out.push(reference.clone());
+                    out.push((**reference).clone());
                     walk(&reference.children, out);
                 }
 
@@ -1300,7 +1300,7 @@ fn collect_section_title_refs<'a>(doc: &'a Document<'a>) -> Vec<Ref<'a>> {
         for node in nodes {
             match node {
                 InlineNode::Ref(reference) => {
-                    out.push(reference.clone());
+                    out.push((**reference).clone());
                     refs_in(&reference.children, out);
                 }
 
@@ -1521,7 +1521,7 @@ fn first_footnote<'a>(doc: &'a Document<'a>) -> Footnote<'a> {
     fn find<'a>(nodes: &[InlineNode<'a>]) -> Option<Footnote<'a>> {
         for node in nodes {
             let found = match node {
-                InlineNode::Footnote(footnote) => Some(footnote.clone()),
+                InlineNode::Footnote(footnote) => Some((**footnote).clone()),
                 InlineNode::Styled(styled) => find(&styled.children),
                 InlineNode::Ref(reference) => find(&reference.children),
                 _ => None,
@@ -1555,7 +1555,7 @@ fn refs_in<'a>(nodes: &[InlineNode<'a>]) -> Vec<crate::inlines::Ref<'a>> {
         for node in nodes {
             match node {
                 InlineNode::Ref(reference) => {
-                    out.push(reference.clone());
+                    out.push((**reference).clone());
                     walk(&reference.children, out);
                 }
 
@@ -1643,7 +1643,7 @@ fn footnote_reference_keeps_an_empty_subtree() {
         })
         .flat_map(|simple| simple.content().inlines().to_vec())
         .filter_map(|node| match node {
-            InlineNode::Footnote(footnote) => Some(footnote),
+            InlineNode::Footnote(footnote) => Some(*footnote),
             _ => None,
         })
         .collect();
@@ -1988,7 +1988,7 @@ fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
 
 /// A cross-reference node, unresolved.
 fn unresolved_xref() -> InlineNode<'static> {
-    crate::inlines::InlineNode::Ref(crate::inlines::Ref {
+    crate::inlines::InlineNode::Ref(Box::new(crate::inlines::Ref {
         variant: RefVariant::Xref,
         link_form: None,
         target: "tgt".into(),
@@ -2000,23 +2000,23 @@ fn unresolved_xref() -> InlineNode<'static> {
         xrefstyle: None,
         attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
         location: Span::new(""),
-    })
+    }))
 }
 
 /// A defining footnote node holding `children`.
 fn defining_footnote(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
-    InlineNode::Footnote(crate::inlines::Footnote {
+    InlineNode::Footnote(Box::new(crate::inlines::Footnote {
         id: None,
         number: Some("1".into()),
         is_reference: false,
         children,
         location: Span::new(""),
-    })
+    }))
 }
 
 /// A link node holding `children` as its display text.
 fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
-    InlineNode::Ref(crate::inlines::Ref {
+    InlineNode::Ref(Box::new(crate::inlines::Ref {
         variant: RefVariant::Link,
         link_form: Some(crate::inlines::LinkForm::Macro),
         target: "https://example.org".into(),
@@ -2028,12 +2028,12 @@ fn link_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         xrefstyle: None,
         attrs: crate::attributes::Attrlist::empty(Span::new("").slice(0..0)),
         location: Span::new(""),
-    })
+    }))
 }
 
 /// A strong span holding `children`.
 fn strong_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
-    InlineNode::Styled(crate::inlines::Styled {
+    InlineNode::Styled(Box::new(crate::inlines::Styled {
         variant: StyleVariant::Strong,
         form: SpanForm::Constrained,
         id: None,
@@ -2042,7 +2042,7 @@ fn strong_over(children: Vec<InlineNode<'static>>) -> InlineNode<'static> {
         children,
         passthrough: None,
         location: Span::new(""),
-    })
+    }))
 }
 
 /// A `Content` carrying `inlines` as its inline tree.


### PR DESCRIPTION
## What this does

`InlineNode` was **384 bytes** — the size of its widest inline variant (`Ref` at 384; `Styled` and `Image` at 280) — while the leaves that make up nearly every node in a real document (`Text`, `CharRef`: a 24-byte `CowStr` plus a 40-byte `Span`) carry 64 bytes of payload. Every node vector the builder moves through a substitution step's rebuild, every `emit_range` push, every growth realloc, and every `TakenNodes` slot paid the widest variant's freight; allocator + memcpy/memmove traffic still accounted for **22–26% of a parse** after the churn-reduction increments (#1381–#1383).

The six wide variants — `Styled`, `Ref`, `Image`, `Footnote`, `Ui`, `Stem` — now **box their payloads**, bringing the enum to **120 bytes** (bounded by the `Raw` variant), pinned by a const assertion at ≤128 so a future variant that outgrows the bound gets boxed rather than silently re-widening every node.

The trade is one heap allocation per *wide* node at construction. Those are a small minority of nodes, and — because the owning rebuilds of #1381/#1382 already *move* rather than clone them — each box then travels through every later rebuild as one pointer instead of a 384-byte copy.

## API impact

This is the public-enum shape change discussed on the branch: variants become `Styled(Box<Styled>)` etc. Destructuring patterns are untouched (`InlineNode::Styled(styled)` still matches; the binding is a `Box`, deref-transparent for field reads and method calls), construction sites gain a `Box::new`, and the handful of sites that move or clone the inner struct deref through the box — the whole crate-wide fallout is +149/−132 lines across 16 files, all mechanical. Doing this pre-landing keeps it out of semver history.

## Why it's correct

Purely representational: no recognition, ordering, or rendering logic changes. The full suite (5,525 lib tests — golden recordings, every differential pin) passes unchanged, and parse output is **byte-identical** on all five profiling fixtures.

## Measured effect

Callgrind instructions/parse (same marginal-cost methodology as previous increments) — every fixture improves:

| fixture | before (#1383 tip) | after | Δ |
|---|---:|---:|---:|
| replacement_prose | 3,566,620 | 3,384,287 | **−5.1%** |
| macro_prose | 8,144,405 | 7,820,853 | **−4.0%** |
| mixed_document | 10,806,935 | 10,412,635 | **−3.6%** |
| plain_prose | 957,012 | 932,175 | **−2.6%** |
| formatted_prose | 7,440,774 | 7,288,672 | **−2.0%** |

(Instruction counts understate this change: 3× fewer bytes per node also means better cache behavior on real hardware than in callgrind's model.)

## Preflight

- `cargo +nightly fmt --all -- --check` ✅
- `cargo clippy -p asciidoc-parser --all-targets` ✅
- `cargo test --workspace` ✅ (5,525 lib tests)
- `cargo +nightly doc --no-deps --document-private-items` ✅
- Diff coverage: every added line in `parser/src` covered ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_