### PR TITLE
fix: Slim RawOrigin and box the remaining wide InlineNode variants

### DIFF
--- a/parser/src/content/inline_builder/callouts.rs
+++ b/parser/src/content/inline_builder/callouts.rs
@@ -292,11 +292,11 @@ fn rebuild_callout_level<'src>(
                     None => CalloutGuard::LineComment(CowStr::Borrowed("")),
                 };
 
-                out.push(InlineNode::Callout(Callout {
+                out.push(InlineNode::Callout(Box::new(Callout {
                     number: CowStr::from(number.clone()),
                     guard,
                     location: source_slice(pieces, m.full.clone(), root),
-                }));
+                })));
 
                 cursor = m.full.end;
             }
@@ -448,7 +448,7 @@ mod tests {
         nodes
             .iter()
             .filter_map(|n| match n {
-                InlineNode::Callout(callout) => Some(callout),
+                InlineNode::Callout(callout) => Some(&**callout),
                 _ => None,
             })
             .collect()

--- a/parser/src/content/inline_builder/fold.rs
+++ b/parser/src/content/inline_builder/fold.rs
@@ -886,7 +886,9 @@ mod tests {
     };
     use crate::{
         Parser, Span,
-        inlines::{CharRef, Image, InlineNode, RawForm, RawOrigin, Ref, RefVariant},
+        inlines::{
+            CharRef, Image, InlineNode, PassthroughOrigin, RawForm, RawOrigin, Ref, RefVariant,
+        },
         parser::{
             HtmlInlineRenderer, ModificationContext, ResolvedReference, XrefSignifier, XrefStyle,
         },
@@ -990,10 +992,10 @@ mod tests {
         let raw = InlineNode::Raw {
             value: CowStr::from(location.data()),
             form: RawForm::AsIs,
-            origin: RawOrigin::Passthrough {
+            origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: crate::content::SubstitutionGroup::None,
                 source_text: None,
-            },
+            })),
             location,
         };
 

--- a/parser/src/content/inline_builder/macros/anchors.rs
+++ b/parser/src/content/inline_builder/macros/anchors.rs
@@ -172,7 +172,7 @@ pub(super) fn biblio_anchor_level<'src>(
 
     let location = source_slice(&pieces, full.clone(), root);
 
-    let mut out = vec![InlineNode::Anchor(Anchor {
+    let mut out = vec![InlineNode::Anchor(Box::new(Anchor {
         id,
         reftext: Some(vec![InlineNode::Text {
             value: reftext,
@@ -180,7 +180,7 @@ pub(super) fn biblio_anchor_level<'src>(
         }]),
         is_bibliography: true,
         location,
-    })];
+    }))];
 
     // The bracketed label pushed into the flow. Its brackets are
     // the match's own outer `[` and `]` (the very characters the triple bracket
@@ -397,12 +397,12 @@ fn build_anchor_node<'src>(
         )
     });
 
-    Some(InlineNode::Anchor(Anchor {
+    Some(InlineNode::Anchor(Box::new(Anchor {
         id,
         reftext,
         is_bibliography: false,
         location,
-    }))
+    })))
 }
 
 /// Builds an inline anchor's `reftext` — a single [`Text`](InlineNode::Text)

--- a/parser/src/content/inline_builder/macros/image.rs
+++ b/parser/src/content/inline_builder/macros/image.rs
@@ -1245,7 +1245,10 @@ mod tests {
             build, char_replacements::apply_character_replacements, macros::apply_macros,
             special_chars::Masked,
         },
-        inlines::{CharRef, Image, InlineNode, RawForm, RawOrigin, SpanForm, StyleVariant},
+        inlines::{
+            CharRef, Image, InlineNode, PassthroughOrigin, RawForm, RawOrigin, SpanForm,
+            StyleVariant,
+        },
         parser::{DefaultPathResolver, HtmlInlineRenderer},
         strings::CowStr,
     };
@@ -2595,10 +2598,10 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from("raw"),
                 form: RawForm::AsIs,
-                origin: RawOrigin::Passthrough {
+                origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                     subs: crate::content::SubstitutionGroup::None,
                     source_text: None,
-                },
+                })),
                 location: root,
             },
             InlineNode::Stem(Box::new(crate::inlines::Stem {

--- a/parser/src/content/inline_builder/macros/indexterm.rs
+++ b/parser/src/content/inline_builder/macros/indexterm.rs
@@ -618,24 +618,24 @@ fn build_indexterm_macro_match<'src>(
         };
 
         (
-            InlineNode::IndexTerm(IndexTerm {
+            InlineNode::IndexTerm(Box::new(IndexTerm {
                 terms,
                 children,
                 visible: true,
                 location,
-            }),
+            })),
             rendered_nonempty,
         )
     } else {
         // A concealed term renders nothing, so it is always recognized; its
         // argument (which never reaches the flow) is not reconstructed.
         (
-            InlineNode::IndexTerm(IndexTerm {
+            InlineNode::IndexTerm(Box::new(IndexTerm {
                 terms: vec![],
                 children: vec![],
                 visible: false,
                 location,
-            }),
+            })),
             false,
         )
     };
@@ -807,12 +807,12 @@ fn push_indexterm_shorthand_matches<'src>(
             .computed
             .map_or_else(Vec::new, |term| vec![CowStr::from(term)]);
 
-        let node = InlineNode::IndexTerm(IndexTerm {
+        let node = InlineNode::IndexTerm(Box::new(IndexTerm {
             terms,
             children: shown.children,
             visible: true,
             location: source_slice(pieces, term_full.clone(), root),
-        });
+        }));
 
         matches.push(RecognizedIndexterm {
             macro_match: MacroMatch {
@@ -865,22 +865,22 @@ fn push_indexterm_shorthand_matches<'src>(
         let rendered_nonempty = before || after || shown_nonempty;
 
         (
-            InlineNode::IndexTerm(IndexTerm {
+            InlineNode::IndexTerm(Box::new(IndexTerm {
                 terms,
                 children: shown.children,
                 visible: true,
                 location,
-            }),
+            })),
             rendered_nonempty,
         )
     } else {
         (
-            InlineNode::IndexTerm(IndexTerm {
+            InlineNode::IndexTerm(Box::new(IndexTerm {
                 terms: vec![],
                 children: vec![],
                 visible: false,
                 location,
-            }),
+            })),
             false,
         )
     };

--- a/parser/src/content/inline_builder/mod.rs
+++ b/parser/src/content/inline_builder/mod.rs
@@ -768,7 +768,7 @@ mod tests {
     use crate::{
         Parser, Span,
         content::inline_builder::fold_html,
-        inlines::{InlineNode, RawOrigin},
+        inlines::{InlineNode, PassthroughOrigin, RawOrigin},
         parser::{HtmlInlineRenderer, ModificationContext},
         strings::CowStr,
     };
@@ -819,31 +819,31 @@ mod tests {
             vec![
                 (
                     "+++<b>x</b>+++",
-                    vec![RawOrigin::Passthrough {
+                    vec![RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                         subs: crate::content::SubstitutionGroup::None,
-                        source_text: None
-                    }]
+                        source_text: None,
+                    }))]
                 ),
                 (
                     "++a < b++",
-                    vec![RawOrigin::Passthrough {
+                    vec![RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                         subs: crate::content::SubstitutionGroup::Verbatim,
-                        source_text: None
-                    }]
+                        source_text: None,
+                    }))]
                 ),
                 (
                     "$$<i>$$",
-                    vec![RawOrigin::Passthrough {
+                    vec![RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                         subs: crate::content::SubstitutionGroup::Verbatim,
-                        source_text: None
-                    }]
+                        source_text: None,
+                    }))]
                 ),
                 (
                     "pass:[<b>]",
-                    vec![RawOrigin::Passthrough {
+                    vec![RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                         subs: crate::content::SubstitutionGroup::None,
-                        source_text: None
-                    }]
+                        source_text: None,
+                    }))]
                 ),
             ]
         );

--- a/parser/src/content/inline_builder/passthrough_step.rs
+++ b/parser/src/content/inline_builder/passthrough_step.rs
@@ -12,7 +12,10 @@ use super::{
 use crate::{
     Parser, Span,
     content::{INLINE_PASS, INLINE_PASS_MACRO, SubstitutionGroup},
-    inlines::{InlineNode, PassthroughWrapper, RawForm, RawOrigin, SpanForm, StyleVariant, Styled},
+    inlines::{
+        InlineNode, PassthroughOrigin, PassthroughWrapper, RawForm, RawOrigin, SpanForm,
+        StyleVariant, Styled,
+    },
     strings::CowStr,
 };
 
@@ -693,10 +696,10 @@ fn build_bare_unconstrained_match<'src>(
                 // already-extracted construct, that body with each inner
                 // node's own fold bytes spliced in — matching what
                 // Asciidoctor's own restore produces there too).
-                origin: RawOrigin::Passthrough {
+                origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                     subs: SubstitutionGroup::Verbatim,
                     source_text: None,
-                },
+                })),
                 location,
             }),
         },
@@ -837,10 +840,10 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::AsIs,
-            origin: RawOrigin::Passthrough {
+            origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: SubstitutionGroup::None,
                 source_text: None,
-            },
+            })),
             location,
         };
     }
@@ -858,10 +861,10 @@ fn build_passthrough_node<'src>(
         return InlineNode::Raw {
             value: CowStr::from(content.data()),
             form: RawForm::Escaped,
-            origin: RawOrigin::Passthrough {
+            origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: SubstitutionGroup::Verbatim,
                 source_text: None,
-            },
+            })),
             location,
         };
     }
@@ -967,7 +970,7 @@ fn build_passthrough_node<'src>(
     InlineNode::Raw {
         value,
         form: RawForm::AsIs,
-        origin: RawOrigin::Passthrough { subs, source_text },
+        origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin { subs, source_text })),
         location,
     }
 }
@@ -1057,14 +1060,14 @@ fn build_attrlisted_passthrough_node<'src>(
             // passthrough, whose `Styled` wrapper is what the extraction pass
             // records as one entry; the group here is the body's own, read off
             // the delimiters exactly as the unprefixed forms above read theirs.
-            origin: RawOrigin::Passthrough {
+            origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: if form == RawForm::AsIs {
                     SubstitutionGroup::None
                 } else {
                     SubstitutionGroup::Verbatim
                 },
                 source_text: None,
-            },
+            })),
             location: body_span,
         }]
     };
@@ -1163,10 +1166,10 @@ fn build_bare_attrlisted_passthrough_node<'src>(
         vec![InlineNode::Raw {
             value: CowStr::from(body_span.data()),
             form: RawForm::Escaped,
-            origin: RawOrigin::Passthrough {
+            origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: SubstitutionGroup::Verbatim,
                 source_text: None,
-            },
+            })),
             location: body_span,
         }]
     };

--- a/parser/src/content/inline_builder/special_chars.rs
+++ b/parser/src/content/inline_builder/special_chars.rs
@@ -604,8 +604,8 @@ mod tests {
         Span,
         content::{Content, SubstitutionStep},
         inlines::{
-            Anchor, CharRef, Footnote, InlineNode, RawForm, RawOrigin, Ref, RefVariant, SpanForm,
-            StyleVariant, Styled,
+            Anchor, CharRef, Footnote, InlineNode, PassthroughOrigin, RawForm, RawOrigin, Ref,
+            RefVariant, SpanForm, StyleVariant, Styled,
         },
         parser::HtmlInlineRenderer,
         strings::CowStr,
@@ -990,12 +990,12 @@ mod tests {
                 attrs: crate::attributes::Attrlist::empty(loc.slice(0..0)),
                 location: loc,
             })),
-            InlineNode::Anchor(Anchor {
+            InlineNode::Anchor(Box::new(Anchor {
                 id: CowStr::from("id"),
                 reftext: Some(child()),
                 is_bibliography: false,
                 location: loc,
-            }),
+            })),
             InlineNode::Footnote(Box::new(Footnote {
                 id: None,
                 number: Some(CowStr::from("1")),
@@ -1046,10 +1046,10 @@ mod tests {
             InlineNode::Raw {
                 value: CowStr::from(location.data()),
                 form: RawForm::AsIs,
-                origin: RawOrigin::Passthrough {
+                origin: RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                     subs: crate::content::SubstitutionGroup::None,
                     source_text: None,
-                },
+                })),
                 location,
             },
         ]);

--- a/parser/src/content/inline_builder/stem_step.rs
+++ b/parser/src/content/inline_builder/stem_step.rs
@@ -767,7 +767,7 @@ mod tests {
         // embeds a passthrough — the case the field exists for, since an
         // embedded passthrough is its own extraction entry and folding it into
         // `value` left a walk no way to reach it.
-        use crate::inlines::{InlineNode, RawOrigin};
+        use crate::inlines::{InlineNode, PassthroughOrigin, RawOrigin};
 
         // A flat body: one `Text` run, and `value` says the same thing.
         let nodes = build_src(Span::new("stem:[x^2]"));
@@ -795,10 +795,10 @@ mod tests {
         assert_eq!(value.as_ref(), "<b>");
         assert_eq!(
             *origin,
-            RawOrigin::Passthrough {
+            RawOrigin::Passthrough(Box::new(PassthroughOrigin {
                 subs: crate::content::SubstitutionGroup::None,
                 source_text: None,
-            }
+            }))
         );
 
         // The rendering is unchanged by keeping them — this increment moves no

--- a/parser/src/content/inline_builder/test_support.rs
+++ b/parser/src/content/inline_builder/test_support.rs
@@ -10,7 +10,9 @@
 use super::{build, quotes::apply_quotes, special_chars::apply_special_characters};
 use crate::{
     HasSpan, Parser, Span,
-    inlines::{CharRef, InlineNode, RawOrigin, Ref, RefVariant, SpanForm, StyleVariant},
+    inlines::{
+        CharRef, InlineNode, PassthroughOrigin, RawOrigin, Ref, RefVariant, SpanForm, StyleVariant,
+    },
     parser::HtmlInlineRenderer,
     strings::CowStr,
 };
@@ -166,10 +168,10 @@ pub(super) fn assert_raw<'src>(node: &InlineNode<'src>, value: &str) -> Span<'sr
 /// [`RawForm`](crate::inlines::RawForm) beside it. The two deliberately
 /// disagree for the bare `+…+` form, which is `Verbatim` but folds `AsIs`.
 pub(super) fn passthrough(subs: crate::content::SubstitutionGroup) -> RawOrigin {
-    RawOrigin::Passthrough {
+    RawOrigin::Passthrough(Box::new(PassthroughOrigin {
         subs,
         source_text: None,
-    }
+    }))
 }
 
 pub(super) fn assert_raw_form(

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -98,7 +98,7 @@ fn collect_from_tree(nodes: &[InlineNode<'_>], out: &mut Vec<Passthrough>) {
         match node {
             InlineNode::Raw {
                 value,
-                origin: RawOrigin::Passthrough { subs, source_text },
+                origin: RawOrigin::Passthrough(origin),
                 ..
             } => {
                 out.push(Passthrough {
@@ -108,10 +108,11 @@ fn collect_from_tree(nodes: &[InlineNode<'_>], out: &mut Vec<Passthrough>) {
                     // what the enclosing level's `Raw` leaf carries.
                     // `source_text` is the input that produced it, and is
                     // `None` wherever the group changed nothing.
-                    text: source_text
+                    text: origin
+                        .source_text
                         .clone()
                         .unwrap_or_else(|| value.as_ref().to_string()),
-                    subs: subs.clone(),
+                    subs: origin.subs.clone(),
                 });
             }
 

--- a/parser/src/inlines/inline_node.rs
+++ b/parser/src/inlines/inline_node.rs
@@ -102,17 +102,17 @@ pub enum InlineNode<'src> {
     Footnote(Box<Footnote<'src>>),
 
     /// An inline anchor (`[[id]]` or `anchor:id[reftext]`).
-    Anchor(Anchor<'src>),
+    Anchor(Box<Anchor<'src>>),
 
     /// A UI macro: `kbd:`, `btn:`, or `menu:`.
     Ui(Box<Ui<'src>>),
 
     /// An index term (`((term))`, `(((primary, secondary)))`,
     /// `indexterm:[…]`, or `indexterm2:[…]`).
-    IndexTerm(IndexTerm<'src>),
+    IndexTerm(Box<IndexTerm<'src>>),
 
     /// A callout number in verbatim content (`<1>`, `<.>`).
-    Callout(Callout<'src>),
+    Callout(Box<Callout<'src>>),
 
     /// Inline STEM content (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`).
     Stem(Box<Stem<'src>>),
@@ -128,7 +128,7 @@ pub enum InlineNode<'src> {
 // node vectors through each substitution step's rebuild, so a widened enum
 // is a per-step cost on every node in the document. A variant that pushes
 // past this bound should be boxed instead.
-const _: () = assert!(std::mem::size_of::<InlineNode<'_>>() <= 128);
+const _: () = assert!(std::mem::size_of::<InlineNode<'_>>() <= 80);
 
 impl<'src> HasSpan<'src> for InlineNode<'src> {
     fn span(&self) -> Span<'src> {
@@ -221,27 +221,27 @@ mod tests {
                 children: vec![],
                 location,
             })),
-            InlineNode::Anchor(Anchor {
+            InlineNode::Anchor(Box::new(Anchor {
                 id: CowStr::from("intro"),
                 reftext: None,
                 is_bibliography: false,
                 location,
-            }),
+            })),
             InlineNode::Ui(Box::new(Ui {
                 kind: UiKind::Button(CowStr::from("Save")),
                 location,
             })),
-            InlineNode::IndexTerm(IndexTerm {
+            InlineNode::IndexTerm(Box::new(IndexTerm {
                 terms: vec![CowStr::from("term")],
                 children: vec![],
                 visible: false,
                 location,
-            }),
-            InlineNode::Callout(Callout {
+            })),
+            InlineNode::Callout(Box::new(Callout {
                 number: CowStr::from("1"),
                 guard: CalloutGuard::LineComment(CowStr::from("# ")),
                 location,
-            }),
+            })),
             InlineNode::Stem(Box::new(Stem {
                 notation: StemNotation::AsciiMath,
                 value: CowStr::from("x^2"),
@@ -352,42 +352,18 @@ mod tests {
 /// extraction pass resolved for it, which nothing else in the tree records: the
 /// substitution group its body is restored under, and — for the one form whose
 /// [`value`](InlineNode::Raw) is *not* the author's own bytes — that body. See
-/// the variant's own documentation.
+/// [`PassthroughOrigin`].
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum RawOrigin {
     /// An explicit passthrough the extraction pass pulled out before any step
     /// ran: `+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, or an inline STEM body.
     ///
     /// The author asked for this text to be off limits.
-    Passthrough {
-        /// The substitution group this body is restored under, as the
-        /// extraction pass resolved it — `None` for `+++…+++` and a bare
-        /// `pass:[…]`, `Verbatim` for `++…++` and `$$…$$`, and whatever list a
-        /// `pass:c,q[…]` spelled out.
-        ///
-        /// [`RawForm`] is the *fold's* two-valued view of this: a group that
-        /// applies nothing renders [`AsIs`](RawForm::AsIs), one that applies
-        /// special characters and nothing else renders
-        /// [`Escaped`](RawForm::Escaped). The two agree for every group the
-        /// fold can carry out by itself, and the group says more than the fold
-        /// needs precisely so that a consumer asking *what the author wrote*
-        /// does not have to infer it back from what the fold did.
-        subs: SubstitutionGroup,
-
-        /// The author's body **before** its group was applied, when
-        /// [`value`](InlineNode::Raw) is not it.
-        ///
-        /// For every form the fold can restore by itself, `value` *is* the
-        /// author's body and this is `None`. The exception is a `pass:` macro
-        /// carrying an explicit substitution list (`pass:c,q[…]`): rendering an
-        /// arbitrary group means building the body's own tree under that group,
-        /// which needs a `Parser`, and a fold takes a renderer and a
-        /// [`RenderContext`](crate::parser::RenderContext) instead — so that
-        /// body is rendered at **build** time and `value` holds the result.
-        /// Recording the input beside it is what keeps the author's own text
-        /// answerable from the tree.
-        source_text: Option<String>,
-    },
+    ///
+    /// The payload is boxed for the same reason [`InlineNode`]'s wide variants
+    /// are: a `Raw` node's origin rides inside every such node through every
+    /// rebuild, and the passthrough facts are both wide and rare.
+    Passthrough(Box<PassthroughOrigin>),
 
     /// Raw output a substitution produced **in place**, with no extraction
     /// involved: a literal `<`, `>`, or `&` from an expanded attribute value
@@ -395,6 +371,40 @@ pub enum RawOrigin {
     /// ran), a special an effective order never escaped, or a slice of an
     /// entity's own bytes.
     Substitution,
+}
+
+/// The two facts the extraction pass resolved for a
+/// [`Passthrough`](RawOrigin::Passthrough)-origin [`Raw`](InlineNode::Raw)
+/// node, which nothing else in the tree records.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PassthroughOrigin {
+    /// The substitution group this body is restored under, as the
+    /// extraction pass resolved it — `None` for `+++…+++` and a bare
+    /// `pass:[…]`, `Verbatim` for `++…++` and `$$…$$`, and whatever list a
+    /// `pass:c,q[…]` spelled out.
+    ///
+    /// [`RawForm`] is the *fold's* two-valued view of this: a group that
+    /// applies nothing renders [`AsIs`](RawForm::AsIs), one that applies
+    /// special characters and nothing else renders
+    /// [`Escaped`](RawForm::Escaped). The two agree for every group the
+    /// fold can carry out by itself, and the group says more than the fold
+    /// needs precisely so that a consumer asking *what the author wrote*
+    /// does not have to infer it back from what the fold did.
+    pub subs: SubstitutionGroup,
+
+    /// The author's body **before** its group was applied, when
+    /// [`value`](InlineNode::Raw) is not it.
+    ///
+    /// For every form the fold can restore by itself, `value` *is* the
+    /// author's body and this is `None`. The exception is a `pass:` macro
+    /// carrying an explicit substitution list (`pass:c,q[…]`): rendering an
+    /// arbitrary group means building the body's own tree under that group,
+    /// which needs a `Parser`, and a fold takes a renderer and a
+    /// [`RenderContext`](crate::parser::RenderContext) instead — so that
+    /// body is rendered at **build** time and `value` holds the result.
+    /// Recording the input beside it is what keeps the author's own text
+    /// answerable from the tree.
+    pub source_text: Option<String>,
 }
 
 /// How a [`Raw`](InlineNode::Raw) node's value reaches the output.

--- a/parser/src/inlines/mod.rs
+++ b/parser/src/inlines/mod.rs
@@ -42,7 +42,7 @@ mod index_term;
 pub use index_term::IndexTerm;
 
 mod inline_node;
-pub use inline_node::{InlineNode, RawForm, RawOrigin};
+pub use inline_node::{InlineNode, PassthroughOrigin, RawForm, RawOrigin};
 
 mod ref_node;
 pub use ref_node::{LinkForm, Ref, RefVariant};


### PR DESCRIPTION
## What

Follow-up to #1384, finishing the node-size work: `InlineNode` drops from **120 to 80 bytes**, and the compile-time ceiling tightens from ≤128 to ≤80.

Two moves, both the same mechanism #1384 established:

1. **`RawOrigin` 48 → 8 bytes.** The enum's `Passthrough` variant carried a `SubstitutionGroup` (24 bytes) and an `Option<String>` (24 bytes) inline, so *every* `Raw` node — including the majority whose origin is just `Substitution` — paid 48 bytes for facts only passthroughs have. That payload now lives behind a box as the new `PassthroughOrigin` struct. This alone takes the `Raw` variant, the enum's previous ceiling, from 120 to 80 bytes.

2. **Box the three remaining wide payloads** — `Anchor` (96 bytes), `IndexTerm` (96), and `Callout` (88) — exactly as #1384 boxed the other six. Without this, `Anchor`/`IndexTerm` at 104 would have become the new ceiling and capped the win at 120 → 104.

## Why

The builder moves whole node vectors through every substitution step's rebuild, so element size is a per-step cost on every node in the document. All four affected node kinds are rare in real documents (a passthrough origin, an anchor, an index term, a callout), so the extra box allocation is paid almost never, while every node move gets one-third cheaper.

## Measurements

Marginal instructions/parse (callgrind, two-point iteration diff) vs the #1384 build:

| Fixture | Δ |
|---|---|
| formatted_prose | −1.3% |
| replacement_prose | −0.9% |
| mixed_document | −0.3% |
| plain_prose | −0.2% |
| macro_prose | +0.2% (inside the documented ±1–2.5% noise band) |

Parse trees are **byte-identical** on all five differential fixtures.

## Verification

- `cargo test --workspace`: 5,531 tests green
- clippy `--all-targets`, nightly fmt, and nightly doc (private items) all clean
- Diff coverage: every changed file's missed-region and missed-line counts are identical to the `inline-ast` baseline
- `const _: () = assert!(size_of::<InlineNode>() <= 80)` pins the new ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ5Kkkg67wUYqyu3dYLevR)_