### PR TITLE
fix: Freeze a forward xref in a title when an auto-id section demands it

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::LazyLock};
+use std::{collections::HashSet, fmt, sync::LazyLock};
 
 use regex::Regex;
 
@@ -13,7 +13,7 @@ use crate::{
         Content, DeferredParts, SubstitutionGroup, inline_builder::fold_reference_text,
         substitute_attributes_in_reftext,
     },
-    document::{InterpretedValue, RefType},
+    document::{InterpretedValue, RefType, title_freeze},
     inlines::InlineNode,
     internal::debug::DebugSliceReference,
     parser::{ResolvedAttributes, ResolvedReference, XrefSignifier},
@@ -270,13 +270,64 @@ impl<'src> SectionBlock<'src> {
         let mut section_title = Content::from(title_span);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
 
-        // The footnote-free rendering of the title, for the reference text and
-        // auto-generated ID.
-        let title_reftext = fold_reference_text(
-            section_title.inlines(),
-            &*parser.renderer,
-            &parser.render_context(),
-        );
+        // A fully-owned snapshot of the title's own deferred cross-references,
+        // registered below (once the section's final id is known) as a
+        // potential target for a *later* section's own demand — see
+        // `document::title_freeze` (issue #1110). `None` for the
+        // overwhelmingly common title with no embedded cross-reference at
+        // all, which this whole mechanism has nothing to do for.
+        //
+        // Built via `to_owned_title` rather than reading `section_title`'s
+        // own [`deferred_parts`](Content::deferred_parts) directly: that
+        // template is empty for any content but a *carried* title (an
+        // ordinary section heading always still has its tree to fold, so it
+        // never needs one) — `to_owned_title` is what synthesizes one from
+        // the tree, which the snapshot needs since it cannot keep the tree
+        // itself (see `title_freeze`'s own docs).
+        let recomputable_title =
+            section_title
+                .to_owned_title(parser)
+                .deferred_parts()
+                .map(|deferred| title_freeze::RecomputableTitle {
+                    block: deferred.block.to_vec(),
+                    footnote: deferred.footnote.to_vec(),
+                    template: deferred.template.to_vec(),
+                });
+
+        // Whether this section is about to auto-generate its own id: the one
+        // parse-time trigger for eagerly converting a title before the whole
+        // document — and so the complete catalog — is available, mirroring
+        // Asciidoctor's `generate_id` -> `Section#title` path. `manual_id`
+        // (below) folds in the same two sources once more, for the branch
+        // that actually assigns the id; this is computed ahead of it because
+        // it also decides *how* `title_reftext` is computed next.
+        let will_auto_generate_id = sectids && attr_or_anchor_id.is_none() && embedded_id.is_none();
+
+        // A title with no embedded cross-reference folds exactly as before:
+        // this pass and the ordinary per-content one already agree, since
+        // there is nothing left for either to resolve. A title carrying one,
+        // when this section is about to auto-generate its own id, is instead
+        // resolved *now*, against the catalog as it currently stands —
+        // recursively demanding (and permanently freezing) any *earlier*
+        // title it depends on, exactly the eager conversion Asciidoctor
+        // performs at this same point to build the id string. This section's
+        // *own* result is used only for that string (and, below, as a
+        // provisional catalog reference text) — never frozen itself; see
+        // `title_freeze`'s own "It is the target, never the demander"
+        // section. Every other title (an explicit id, or `sectids` disabled)
+        // keeps the plain unresolved-fallback fold: nothing forces its
+        // conversion this early either way.
+        let title_reftext = match will_auto_generate_id
+            .then_some(recomputable_title.as_ref())
+            .flatten()
+        {
+            Some(node) => title_freeze::resolve_now(node, parser, &mut HashSet::new()).rendered,
+            None => fold_reference_text(
+                section_title.inlines(),
+                &*parser.renderer,
+                &parser.render_context(),
+            ),
+        };
 
         // A section carrying the `bibliography` style implicitly adds that
         // style to each top-level unordered list in its body (see the
@@ -425,6 +476,35 @@ impl<'src> SectionBlock<'src> {
             // sources directly from the anchor/attrlist).
             embedded_id.map(str::to_string)
         };
+
+        // The section's effective id: `section_id` (the field, and the local
+        // variable of the same name above) only ever holds an id drawn from
+        // an *embedded* title anchor — everything else `id()`/`reference_id()`
+        // read directly from `attrlist`/`anchor` instead (see
+        // `reference_id`'s own docs) — so an id supplied *above* the heading
+        // falls back to `manual_id` here.
+        let effective_id = section_id.clone().or_else(|| manual_id.map(str::to_string));
+
+        // A section without an explicit reftext is a *recomputable*
+        // cross-reference target: another (later) section's own
+        // auto-generated id may still need to demand this one's reference
+        // text — either freezing it right away (`title_freeze::resolve_now`
+        // above already did exactly that for a demand originating *here*,
+        // against whatever earlier titles *this* section's own title
+        // references) or, lacking any demand at all, once the whole
+        // document's catalog is known, in the ordinary document-order pass
+        // (`document::title_refs`). Either way that needs this section's own
+        // deferred cross-references on hand, so register them under the id
+        // just determined — this section's own eager conversion above never
+        // freezes *itself* (see `title_freeze`'s own docs), so this always
+        // runs regardless of `will_auto_generate_id`. See
+        // `document::title_freeze` (issue #1110).
+        if !has_explicit_reftext
+            && let Some(id) = effective_id.as_deref()
+            && let Some(recomputable_title) = recomputable_title
+        {
+            title_freeze::register_recomputable_title(parser, id, recomputable_title);
+        }
 
         // Restore "normal" top-level section type if exiting a level 1
         // appendix.
@@ -1132,14 +1212,25 @@ fn generate_section_id(title: &str, parser: &Parser) -> String {
         .unwrap_or_default()
         .to_owned();
 
-    let mut gen_id = title.to_lowercase().to_owned();
+    // Real HTML tags are stripped *first*, as their own pass, via the same
+    // tag-stripper `Document::doctitle_sanitized` uses — not folded into the
+    // regex below alongside the "invalid character" alternative. A single
+    // combined regex with both alternatives is order-dependent: at a
+    // position where a run of invalid characters happens to run straight
+    // into a tag's `<` (e.g. the `][forward]</a>`-shaped text a title's own
+    // *unresolved* cross-reference rendering produces — `[forward]` is the
+    // reference's bracketed fallback, `</a>` its enclosing anchor's closing
+    // tag), the greedy `[^ \w\-.]+` alternative — which matches starting at
+    // the `]`, not the `<` — already claims the tag's `<` and `/` before the
+    // tag alternative ever gets a chance to match the *whole* tag as one
+    // unit, leaking the tag name (`a`) through into the generated id. Tags
+    // are gone before that regex ever runs, so this can no longer happen.
+    let mut gen_id = crate::content::sanitize_title(title).to_lowercase();
 
     #[allow(clippy::unwrap_used)]
     static INVALID_SECTION_ID_CHARS: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(
-            r"<[^>]+>|&lt;[^&]*&gt;|&(?:[a-z][a-z]+\d{0,2}|#\d{2,5}|#x[\da-f]{2,4});|[^ \w\-.]+",
-        )
-        .unwrap()
+        Regex::new(r"&lt;[^&]*&gt;|&(?:[a-z][a-z]+\d{0,2}|#\d{2,5}|#x[\da-f]{2,4});|[^ \w\-.]+")
+            .unwrap()
     });
 
     gen_id = INVALID_SECTION_ID_CHARS

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -454,7 +454,14 @@ impl<'src> SectionBlock<'src> {
         // assuming `manual_id`'s mere presence means ownership.
         let mut manual_id_registered = false;
 
-        let section_id = if sectids && manual_id.is_none() {
+        // Whether this section auto-generates its own id — reused below to
+        // compute `effective_id`, since which branch actually ran is exactly
+        // what decides whether `section_id` (set unconditionally from
+        // `embedded_id` in the `else` branch, duplicate or not — see that
+        // branch's own comment) is safe to treat as this section's own.
+        let is_auto_generated_id = sectids && manual_id.is_none();
+
+        let section_id = if is_auto_generated_id {
             let id = parser.generate_and_register_unique_id(
                 &proposed_base_id,
                 Some(&reftext),
@@ -498,11 +505,22 @@ impl<'src> SectionBlock<'src> {
         // won that id: a rejected duplicate must not be treated as this
         // section's own, or `title_freeze::register_recomputable_title` below
         // would replace the legitimate owner's snapshot with this section's.
-        let effective_id = section_id.clone().or_else(|| {
+        //
+        // `section_id` itself cannot answer that for the *embedded*-anchor
+        // case: `id()`/`reference_id()` deliberately reads it back
+        // unconditionally, duplicate or not (see the `else` branch above),
+        // the same way `attrlist.id()` reflects a duplicate *attribute* id
+        // regardless of registration. Reusing it here would let exactly the
+        // same rejected duplicate back in, just from the other source — so
+        // this reads `is_auto_generated_id` instead, to know which branch
+        // actually ran, rather than trying to infer ownership from its result.
+        let effective_id = if is_auto_generated_id {
+            section_id.clone()
+        } else {
             manual_id_registered
                 .then(|| manual_id.map(str::to_string))
                 .flatten()
-        });
+        };
 
         // A section without an explicit reftext is a *recomputable*
         // cross-reference target: another (later) section's own

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -321,7 +321,11 @@ impl<'src> SectionBlock<'src> {
             .then_some(recomputable_title.as_ref())
             .flatten()
         {
-            Some(node) => title_freeze::resolve_now(node, parser, &mut HashSet::new()).rendered,
+            Some(node) => {
+                title_freeze::resolve_now(node, parser, &mut HashSet::new())
+                    .0
+                    .rendered
+            }
             None => fold_reference_text(
                 section_title.inlines(),
                 &*parser.renderer,
@@ -443,6 +447,13 @@ impl<'src> SectionBlock<'src> {
             .or_else(|| embedded_reftext.clone())
             .unwrap_or_else(|| CowStr::from(title_reftext.as_str()));
 
+        // Whether a `manual_id` above was actually registered to *this*
+        // section — `false` when `register_ref` rejected it as a duplicate,
+        // in which case the id belongs to whichever section claimed it
+        // first, not this one. `effective_id` below reads this rather than
+        // assuming `manual_id`'s mere presence means ownership.
+        let mut manual_id_registered = false;
+
         let section_id = if sectids && manual_id.is_none() {
             let id = parser.generate_and_register_unique_id(
                 &proposed_base_id,
@@ -457,6 +468,7 @@ impl<'src> SectionBlock<'src> {
             if let Some(manual_id) = manual_id {
                 match parser.register_ref(manual_id, Some(&reftext), RefType::Section) {
                     Ok(()) => {
+                        manual_id_registered = true;
                         if let Some(signifier) = xref_signifier {
                             parser.set_ref_signifier(manual_id, signifier);
                         }
@@ -482,8 +494,15 @@ impl<'src> SectionBlock<'src> {
         // an *embedded* title anchor — everything else `id()`/`reference_id()`
         // read directly from `attrlist`/`anchor` instead (see
         // `reference_id`'s own docs) — so an id supplied *above* the heading
-        // falls back to `manual_id` here.
-        let effective_id = section_id.clone().or_else(|| manual_id.map(str::to_string));
+        // falls back to `manual_id` here, but only when this section actually
+        // won that id: a rejected duplicate must not be treated as this
+        // section's own, or `title_freeze::register_recomputable_title` below
+        // would replace the legitimate owner's snapshot with this section's.
+        let effective_id = section_id.clone().or_else(|| {
+            manual_id_registered
+                .then(|| manual_id.map(str::to_string))
+                .flatten()
+        });
 
         // A section without an explicit reftext is a *recomputable*
         // cross-reference target: another (later) section's own

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -326,6 +326,26 @@ pub(crate) struct OwnedTitle {
     render_attributes: Option<Box<ResolvedAttributes>>,
 }
 
+impl OwnedTitle {
+    /// Returns this snapshot's deferred cross-reference template and
+    /// segments, if it carries any — the same shape and the same accessor
+    /// name as [`Content::deferred_parts`], so a caller that only needs the
+    /// segments/template (not the borrowed inline tree a live `Content`
+    /// additionally offers) can treat either the same way. Used by
+    /// `document::title_freeze` (issue #1110's parse-time demand-driven
+    /// title freeze), which retains a section heading's own snapshot on the
+    /// [`Parser`] — which cannot itself be generic over the
+    /// source lifetime — for a *later* section's own auto-generated id to
+    /// demand.
+    pub(crate) fn deferred_parts(&self) -> Option<DeferredParts<'_>> {
+        self.deferred.as_ref().map(|d| DeferredParts {
+            block: &d.block,
+            footnote: &d.footnote,
+            template: &d.template,
+        })
+    }
+}
+
 impl<'src> Content<'src> {
     /// Constructs a `Content` from a source `Span` and a potentially-filtered
     /// view of that source text.

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -824,6 +824,23 @@ mod tests {
     }
 
     #[test]
+    fn set_reftext_on_an_entry_with_no_previous_reftext_just_installs_it() {
+        // No `previous` reftext at all — the reverse-lookup handoff has
+        // nothing to do, since there was never a stale entry pointing at
+        // `id` to begin with.
+        let mut catalog = Catalog::new();
+        catalog.register_ref("s1", None, RefType::Section).unwrap();
+
+        catalog.set_reftext("s1", "New Text".to_string());
+
+        assert_eq!(
+            catalog.get_ref("s1").unwrap().reftext,
+            Some("New Text".to_string())
+        );
+        assert_eq!(catalog.resolve_id("New Text"), Some("s1".to_string()));
+    }
+
+    #[test]
     fn set_reftext_keeps_a_duplicate_reftexts_original_owner() {
         // Two sections that happen to share a reftext: the reverse lookup
         // keeps pointing at whichever registered first, matching

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -196,6 +196,68 @@ impl Catalog {
         self.reftext_to_id.get(reftext).cloned()
     }
 
+    /// Resolves `target` to a registered same-document ID: a direct ID match
+    /// first, then a natural (reference-text) match — the two-step lookup
+    /// [`CatalogResolver`](crate::parser::CatalogResolver) performs inline,
+    /// and that the document-order title resolution passes
+    /// (`document::title_refs`, and its parse-time counterpart
+    /// `document::title_freeze`) also need, to tell whether a cross-reference
+    /// target names a *recomputable* title rather than an ordinary anchor or
+    /// an unresolved/cross-document target.
+    pub(crate) fn same_document_id(&self, target: &str) -> Option<String> {
+        if self.contains_id(target) {
+            Some(target.to_string())
+        } else {
+            self.resolve_id(target)
+        }
+    }
+
+    /// Overwrites an already-registered element's reference text.
+    ///
+    /// Used only to install a title's *frozen* reference text once computed
+    /// (`document::title_freeze`, issue #1110's parse-time demand-driven
+    /// freeze), so a plain (non-title) cross-reference to it — which, unlike
+    /// a title-to-title one, is never re-resolved against the tree — still
+    /// sees the same frozen text. A no-op if `id` is not registered.
+    ///
+    /// The reverse (reftext -> id) lookup is updated to match: when the old
+    /// reftext still points at `id` there, it is handed over to another
+    /// entry that also carries that same (duplicate) reftext, if one exists,
+    /// or removed otherwise — a natural cross-reference to the vacated text
+    /// should still resolve to whichever entry legitimately keeps it, the
+    /// same as if `id` had never claimed it first.
+    pub(crate) fn set_reftext(&mut self, id: &str, reftext: String) {
+        let Some(entry) = self.refs.get_mut(id) else {
+            return;
+        };
+        let previous = entry.reftext.replace(reftext.clone());
+
+        if let Some(previous) = previous
+            && self.reftext_to_id.get(&previous).map(String::as_str) == Some(id)
+        {
+            let other_owner = self
+                .refs
+                .iter()
+                .find(|(other_id, entry)| {
+                    other_id.as_str() != id && entry.reftext.as_deref() == Some(previous.as_str())
+                })
+                .map(|(other_id, _)| other_id.clone());
+
+            match other_owner {
+                Some(other_id) => {
+                    self.reftext_to_id.insert(previous, other_id);
+                }
+                None => {
+                    self.reftext_to_id.remove(&previous);
+                }
+            }
+        }
+
+        self.reftext_to_id
+            .entry(reftext)
+            .or_insert_with(|| id.to_string());
+    }
+
     /// Attaches an [`XrefSignifier`] to an already-registered element, so a
     /// cross-reference to it can build `full`/`short`
     /// [`xrefstyle`](crate::parser::XrefStyle) text. A no-op if `id` is not
@@ -710,6 +772,77 @@ mod tests {
         let id2 = catalog.generate_and_register_unique_id("taken", None, RefType::Section, "-");
         assert_eq!(id2, "taken-3");
         assert!(catalog.contains_id("taken-3"));
+    }
+
+    #[test]
+    fn same_document_id_matches_by_id_then_by_reftext() {
+        let mut catalog = Catalog::new();
+        catalog
+            .register_ref("later", Some("The Later Section"), RefType::Section)
+            .unwrap();
+
+        // A direct ID match wins even when it also happens to be a reftext.
+        assert_eq!(catalog.same_document_id("later"), Some("later".to_string()));
+
+        // A natural (reference-text) match is the fallback.
+        assert_eq!(
+            catalog.same_document_id("The Later Section"),
+            Some("later".to_string())
+        );
+
+        // Neither: no same-document target at all.
+        assert_eq!(catalog.same_document_id("nonexistent"), None);
+    }
+
+    #[test]
+    fn set_reftext_overwrites_and_reindexes() {
+        let mut catalog = Catalog::new();
+        catalog
+            .register_ref("s1", Some("Old Text"), RefType::Section)
+            .unwrap();
+
+        catalog.set_reftext("s1", "New Text".to_string());
+
+        assert_eq!(
+            catalog.get_ref("s1").unwrap().reftext,
+            Some("New Text".to_string())
+        );
+
+        // The reverse lookup follows the new text...
+        assert_eq!(catalog.resolve_id("New Text"), Some("s1".to_string()));
+
+        // ...and the stale reverse entry for the old text is gone, since it
+        // still pointed at this same id.
+        assert_eq!(catalog.resolve_id("Old Text"), None);
+    }
+
+    #[test]
+    fn set_reftext_is_a_no_op_for_an_unregistered_id() {
+        let mut catalog = Catalog::new();
+        catalog.set_reftext("missing", "Text".to_string());
+        assert!(!catalog.contains_id("missing"));
+    }
+
+    #[test]
+    fn set_reftext_keeps_a_duplicate_reftexts_original_owner() {
+        // Two sections that happen to share a reftext: the reverse lookup
+        // keeps pointing at whichever registered first, matching
+        // `register_ref`'s own duplicate handling. Overwriting the *first*
+        // section's reftext to something else must not drag that shared
+        // entry away from the second section, which still legitimately owns
+        // it.
+        let mut catalog = Catalog::new();
+        catalog
+            .register_ref("first", Some("Shared"), RefType::Section)
+            .unwrap();
+        catalog
+            .register_ref("second", Some("Shared"), RefType::Section)
+            .unwrap();
+
+        catalog.set_reftext("first", "Unique".to_string());
+
+        assert_eq!(catalog.resolve_id("Shared"), Some("second".to_string()));
+        assert_eq!(catalog.resolve_id("Unique"), Some("first".to_string()));
     }
 
     #[test]

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -30,6 +30,8 @@ pub use header::{Comments, Header, HeaderAttributes};
 mod revision_line;
 pub use revision_line::RevisionLine;
 
+pub(crate) mod title_freeze;
+
 mod title_refs;
 
 mod toc;

--- a/parser/src/document/title_freeze.rs
+++ b/parser/src/document/title_freeze.rs
@@ -56,6 +56,22 @@
 //! document is known, by the ordinary post-parse pass — which is also what
 //! ultimately resolves an id-generating section's own title, per the above.
 //!
+//! # A cross-document reference is never frozen
+//!
+//! A demanded title's own resolution is only actually installed as frozen
+//! when it is *safe* to — see [`resolve_now`]'s own docs. A cross-document
+//! target (`xref:other.adoc#topic[]`) can only ever be resolved by a host
+//! supplied later, explicitly, to `Document::resolve_references` — arbitrarily
+//! many times, each an independent sweep, per that method's own contract —
+//! never by this module, which only ever consults the built-in,
+//! same-document [`CatalogResolver`]. Freezing such a title anyway would
+//! permanently bake in today's local-only fallback and deny every later sweep
+//! the chance to do better. So a title reached through a cross-document
+//! segment — its own, or one embedded (transitively) in a title it demands —
+//! is resolved for this one demand and then left exactly as recomputable as
+//! it was, open to a later demand that might find the catalog (or the
+//! resolver) different next time.
+//!
 //! # Only a top-level splice, like a carried block title
 //!
 //! [`Parser`] cannot itself be generic over the source lifetime (see
@@ -146,6 +162,20 @@ impl TitleFreezeState {
     pub(crate) fn frozen_resolution(&self, id: &str) -> Option<&Resolution> {
         self.frozen.get(id)
     }
+
+    /// Whether `id` is a *recomputable* demand target at all — frozen
+    /// already, or still open to a demand — the same question
+    /// `document::title_refs::compute`'s own `id_to_node.get(target_id)`
+    /// asks of the post-parse pass's node list. `false` for a target that
+    /// resolves through the catalog perfectly well but carries no
+    /// cross-reference of its own (so was never registered here at all): its
+    /// catalog reference text is already final, and [`demand`] must not be
+    /// asked about it — asking would (correctly) report "not found" and the
+    /// caller would wrongly read that as "no reference text", discarding a
+    /// perfectly good one.
+    fn is_recomputable(&self, id: &str) -> bool {
+        self.frozen.contains_key(id) || self.recomputable.contains_key(id)
+    }
 }
 
 /// Registers `id`'s own deferred title parts as a potential demand target —
@@ -188,15 +218,34 @@ pub(crate) fn register_recomputable_title(parser: &mut Parser, id: &str, title: 
 /// [`document::title_refs`](super::title_refs)'s own sweep reads back to
 /// report them itself — the one place a warning is safe from being
 /// overwritten by the very sweep it's part of.
+///
+/// The second element of the returned pair says whether this resolution is
+/// safe to [`freeze`](demand): `false` when any segment reached — directly on
+/// `node`, or transitively through a [`demand`]ed target — carries its own
+/// [`DerivedReference`](crate::parser::DerivedReference) (a cross-document-
+/// shaped target, e.g. `xref:other.adoc#topic[]`). A parse only ever consults
+/// the built-in, same-document [`CatalogResolver`] (a host's own resolver, if
+/// any, is supplied later, explicitly, to `Document::resolve_references`,
+/// arbitrarily many times, each an independent sweep); permanently baking in
+/// today's local-only fallback for such a target would deny every later sweep
+/// the chance to resolve it properly, defeating that contract. A target this
+/// walk simply cannot find yet (same-document-shaped, not `derived`, just not
+/// registered) does *not* taint freezability — that is the ordinary, correct
+/// case issue #1110 exists for, and Asciidoctor freezes it too.
 pub(crate) fn resolve_now(
     node: &RecomputableTitle,
     parser: &mut Parser,
     in_progress: &mut HashSet<String>,
-) -> Resolution {
+) -> (Resolution, bool) {
     let mut block = node.block.clone();
     let mut footnote = node.footnote.clone();
+    let mut freezable = true;
 
     for xref in block.iter_mut().chain(footnote.iter_mut()) {
+        if xref.derived.is_some() {
+            freezable = false;
+        }
+
         let mut resolved = {
             let catalog = parser.catalog();
             CatalogResolver::new(&catalog).resolve(&ResolutionContext {
@@ -220,6 +269,7 @@ pub(crate) fn resolve_now(
         if let Some(reference) = resolved.as_mut()
             && let Some(target_id) = target_id.as_deref()
             && reference.href.strip_prefix('#') == Some(target_id)
+            && parser.title_freeze_state().is_recomputable(target_id)
         {
             // Unlike `document::title_refs::compute`, there is no
             // `resolver_chose_text` check here: the only resolver a parse can
@@ -228,7 +278,21 @@ pub(crate) fn resolve_now(
             // `Document::resolve_references` — long after parsing finishes),
             // and `CatalogResolver`'s own text is always read from this same
             // catalog entry, so it can never disagree with it.
-            reference.text = demand(target_id, parser, in_progress);
+            //
+            // `is_recomputable` above guarantees `demand` finds `target_id`
+            // either already frozen or still registered, so the only way it
+            // can still return `None` here is the cycle case — exactly
+            // mirroring `document::title_refs::compute`'s own
+            // `target_in_progress` branch, which is the one other place that
+            // explicitly blanks a reference's text to the bracketed fallback
+            // rather than leaving the catalog's already-good answer alone.
+            reference.text = match demand(target_id, parser, in_progress) {
+                Some((text, target_freezable)) => {
+                    freezable &= target_freezable;
+                    Some(text)
+                }
+                None => None,
+            };
         }
 
         xref.resolved = resolved;
@@ -238,17 +302,20 @@ pub(crate) fn resolve_now(
     let footnote_ordered = resolved_destinations(&footnote);
     let rendered = render_xref_template(&node.template, &block, &*parser.renderer);
 
-    Resolution {
-        rendered,
-        block_ordered,
-        footnote_ordered,
-    }
+    (
+        Resolution {
+            rendered,
+            block_ordered,
+            footnote_ordered,
+        },
+        freezable,
+    )
 }
 
 /// Demands `target_id`'s reference text against the catalog as it currently
-/// stands, freezing it — permanently, for every future reference, including
-/// `target_id`'s own final rendered heading — the first time it is demanded
-/// this way. See the module docs.
+/// stands. When the result is safe to (see [`resolve_now`]'s own docs), it is
+/// frozen — permanently, for every future reference, including `target_id`'s
+/// own final rendered heading. See the module docs.
 ///
 /// Returns `None` when `target_id` does not name a known recomputable title
 /// (not registered yet, or registered with an explicit reftext, in which case
@@ -256,14 +323,17 @@ pub(crate) fn resolve_now(
 /// higher up this same call chain — a cycle, broken exactly as
 /// `document::title_refs::compute` breaks one: the bracketed fallback,
 /// *without* freezing anything (the section is still being computed further
-/// up the stack, which is what freezes it once that frame returns).
+/// up the stack, which is what freezes it once that frame returns). Otherwise
+/// returns the resolved text alongside whether it was frozen, so a caller
+/// folding this text into its *own* title knows whether it, in turn, is still
+/// safe to freeze.
 fn demand(
     target_id: &str,
     parser: &mut Parser,
     in_progress: &mut HashSet<String>,
-) -> Option<String> {
+) -> Option<(String, bool)> {
     if let Some(resolution) = parser.title_freeze_state().frozen_resolution(target_id) {
-        return Some(resolution.rendered.clone());
+        return Some((resolution.rendered.clone(), true));
     }
 
     if !in_progress.insert(target_id.to_string()) {
@@ -279,15 +349,17 @@ fn demand(
 
     in_progress.remove(target_id);
 
-    result.map(|resolution| {
+    result.map(|(resolution, freezable)| {
         let rendered = resolution.rendered.clone();
 
-        parser.set_ref_reftext(target_id, rendered.clone());
-        parser
-            .title_freeze_state_mut()
-            .frozen
-            .insert(target_id.to_string(), resolution);
+        if freezable {
+            parser.set_ref_reftext(target_id, rendered.clone());
+            parser
+                .title_freeze_state_mut()
+                .frozen
+                .insert(target_id.to_string(), resolution);
+        }
 
-        rendered
+        (rendered, freezable)
     })
 }

--- a/parser/src/document/title_freeze.rs
+++ b/parser/src/document/title_freeze.rs
@@ -1,0 +1,293 @@
+//! Parse-time, demand-driven title cross-reference resolution.
+//!
+//! [`document::title_refs`](super::title_refs) resolves every title's
+//! cross-references once, in document order, against the *complete* catalog —
+//! which is correct for a title nothing forces to convert any earlier. It is
+//! not the whole story: Asciidoctor also converts a section's title *eagerly*,
+//! during parsing, whenever generating *another* section's auto-id needs this
+//! title's reference text (`Section#id` calls `generate_id`, which reads the
+//! referenced section's converted `title` when building the id string from a
+//! title that embeds a cross-reference to it).
+//!
+//! Asciidoctor memoizes a section's converted title the first time anything
+//! reads it, and never recomputes it afterward. When that first read happens
+//! *during parsing* — because some auto-generated id demanded it — a forward
+//! cross-reference embedded in the title that is not yet resolvable at that
+//! moment is frozen as its bracketed `[target]` fallback forever: not just
+//! for whoever demanded it, but for the title's own final rendering too, even
+//! once the real target is parsed moments later. See issue #1110.
+//!
+//! This module is the parse-time half of that behavior, called from
+//! [`SectionBlock::parse`](crate::blocks::SectionBlock::parse) exactly when a
+//! section is about to auto-generate its own id — the one parse-time trigger
+//! for eager conversion. [`resolve_now`] resolves and folds *that* section's
+//! own title against the catalog as it currently stands (which is also what
+//! its id gets built from), recursively [`demand`]-ing (and permanently
+//! freezing) any *earlier* title it depends on. Freezing installs a
+//! [`Resolution`] on the [`Parser`] so that:
+//!
+//! - [`document::title_refs`](super::title_refs)'s post-parse pass, which
+//!   otherwise treats every title as freely recomputable, seeds its memo from
+//!   [`Parser::frozen_title_resolution`] first and skips recomputing whatever
+//!   it finds already frozen — installing the very same rendering (and resolved
+//!   destinations) this module computed, for both the frozen section's own
+//!   heading and anyone else's reference to it.
+//! - A plain (non-title) cross-reference — resolved separately, and never
+//!   re-resolved against a title's tree the way a title-to-title one is — sees
+//!   the same frozen text too, because freezing installs it as the section's
+//!   registered catalog reference text (`Catalog::set_reftext`).
+//!
+//! # It is the *target*, never the demander, that freezes
+//!
+//! Generating a section's own auto-id is what *triggers* this module, but it
+//! is never what gets frozen: the id-generating section's own title is
+//! resolved once more, fresh, by the ordinary post-parse pass, exactly as if
+//! this module did not exist — it stays open to a target of its own, should
+//! a still-later section's id happen to demand it. Only a title reached
+//! through [`demand`] — an *earlier*, already-registered section this title
+//! embeds a cross-reference to — is ever frozen. This matches Asciidoctor:
+//! nothing about generating one's own id forces *that section's own*
+//! `Section#xreftext` to be read (only the id string is needed for that),
+//! whereas a title that itself references another section *does* need that
+//! other section's `xreftext`, and reading it is what freezes it.
+//!
+//! A title nothing ever demands this way is untouched by this module: it
+//! stays exactly as recomputable as it always was, resolved once the whole
+//! document is known, by the ordinary post-parse pass — which is also what
+//! ultimately resolves an id-generating section's own title, per the above.
+//!
+//! # Only a top-level splice, like a carried block title
+//!
+//! [`Parser`] cannot itself be generic over the source lifetime (see
+//! [`OwnedTitle`](crate::content::OwnedTitle)'s own docs for why), so the
+//! per-id state this module retains ([`RecomputableTitle`]) cannot hold a
+//! borrowed inline tree. It renders through
+//! [`render_xref_template`] instead —
+//! the same *template* rendering a block title carried across a section
+//! heading falls back to — which means a cross-reference **nested** inside
+//! another construct (`*<<tgt>>*`) keeps whatever fallback text it had at the
+//! title's own substitution time even after this module resolves it: only a
+//! **top-level** reference's rendering reflects the demand-time resolution.
+//! This is the same narrowing `fold_deferring_xrefs` documents for a carried
+//! title, accepted here for the same reason: the alternative is retaining a
+//! borrowed tree on the parser, which the crate's public API is not prepared
+//! to pay for.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    Parser,
+    content::{XrefSegment, XrefTemplatePiece, render_xref_template, resolved_destinations},
+    parser::{CatalogResolver, ReferenceResolver, ResolutionContext, ResolvedReference},
+};
+
+/// The resolved outcome of one title: its final rendering, plus the resolved
+/// destinations of its cross-references in placeholder order.
+///
+/// Shared between this module and
+/// [`document::title_refs`](super::title_refs), which is the only reason it
+/// is [`Clone`]: a frozen resolution computed here is cloned into that pass's
+/// memo, once per document, rather than recomputed.
+#[derive(Clone, Debug)]
+pub(crate) struct Resolution {
+    /// The title's final rendered form, with cross-title references
+    /// coordinated.
+    pub(crate) rendered: String,
+
+    /// The resolved destination of each title-level cross-reference, in
+    /// document order, ready for mirroring into the title tree.
+    pub(crate) block_ordered: Vec<Option<ResolvedReference>>,
+
+    /// The resolved destination of each cross-reference embedded in a
+    /// footnote the title carries, in segment order, ready for mirroring into
+    /// the title tree's footnote subtrees.
+    pub(crate) footnote_ordered: Vec<Option<ResolvedReference>>,
+}
+
+/// A fully-owned (`'static`-shaped) snapshot of a section heading's own
+/// deferred cross-references — everything [`resolve_now`] needs to resolve
+/// and fold it again later, without the borrowed inline tree
+/// [`Content::deferred_parts`](crate::content::Content::deferred_parts)
+/// itself cannot outlive.
+///
+/// Registered under the section's id as soon as it is known (whether or not
+/// this section itself ever triggers eager conversion), so a *later*
+/// section's own demand can still reach it.
+#[derive(Clone, Debug)]
+pub(crate) struct RecomputableTitle {
+    /// The title's block-level cross-references, in document order.
+    pub(crate) block: Vec<XrefSegment>,
+
+    /// The cross-references the title's footnotes carry.
+    pub(crate) footnote: Vec<XrefSegment>,
+
+    /// The deferred template this title renders from — see the module docs'
+    /// "Only a top-level splice" section.
+    pub(crate) template: Vec<XrefTemplatePiece>,
+}
+
+/// Parse-time demand-driven title state, threaded on the [`Parser`] for the
+/// life of one parse. See the module docs.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TitleFreezeState {
+    /// Every non-explicit-reftext section's own deferred title parts, keyed
+    /// by its registered id — a potential demand *target*, whether or not
+    /// anything ever actually demands it.
+    recomputable: HashMap<String, RecomputableTitle>,
+
+    /// The frozen resolution for an id that was demanded during parsing.
+    /// Once set for an id, never overwritten — that permanence is the
+    /// freeze.
+    frozen: HashMap<String, Resolution>,
+}
+
+impl TitleFreezeState {
+    /// Returns the frozen resolution for `id`, if it has one.
+    pub(crate) fn frozen_resolution(&self, id: &str) -> Option<&Resolution> {
+        self.frozen.get(id)
+    }
+}
+
+/// Registers `id`'s own deferred title parts as a potential demand target —
+/// called once the section's final id is known, for every section without an
+/// explicit reftext.
+///
+/// Unconditional: nothing can have frozen `id` yet. Freezing only ever
+/// reaches an id [`demand`] finds already registered here, and `id` itself
+/// only becomes registered — atomically, within this same
+/// [`SectionBlock::parse`](crate::blocks::SectionBlock::parse) call, with no
+/// other section's parse interleaved — a few lines after the catalog
+/// registration `Catalog::same_document_id` requires to resolve *to* it in
+/// the first place. There is consequently no window in which some other,
+/// still-parsing section could demand `id` before this call installs its
+/// snapshot.
+pub(crate) fn register_recomputable_title(parser: &mut Parser, id: &str, title: RecomputableTitle) {
+    parser
+        .title_freeze_state_mut()
+        .recomputable
+        .insert(id.to_string(), title);
+}
+
+/// Resolves and folds `node` right now, against the catalog as it currently
+/// stands, recursively [`demand`]-ing (and freezing) any earlier title it
+/// depends on. Called for the *id-generating* section's own title — the
+/// computation that decides its id string — never installed as that
+/// section's own frozen resolution (see the module docs' "It is the target,
+/// never the demander" section): only what this walk reaches *through*
+/// [`demand`] ever freezes.
+///
+/// This reports no warnings of its own for a target it cannot resolve: a
+/// `PossibleInvalidReference` warning only ever survives as part of a
+/// resolution *sweep*'s own output (`Document::replace_reference_warnings`
+/// discards every prior one whenever a new sweep runs, including the one
+/// [`Parser::parse`] itself always performs right after parsing finishes), so
+/// a warning pushed here would be silently wiped moments later. Instead, a
+/// frozen node's [`Resolution::block_ordered`]/[`Resolution::footnote_ordered`]
+/// carries a
+/// `None` for exactly the segments that never resolved, which
+/// [`document::title_refs`](super::title_refs)'s own sweep reads back to
+/// report them itself — the one place a warning is safe from being
+/// overwritten by the very sweep it's part of.
+pub(crate) fn resolve_now(
+    node: &RecomputableTitle,
+    parser: &mut Parser,
+    in_progress: &mut HashSet<String>,
+) -> Resolution {
+    let mut block = node.block.clone();
+    let mut footnote = node.footnote.clone();
+
+    for xref in block.iter_mut().chain(footnote.iter_mut()) {
+        let mut resolved = {
+            let catalog = parser.catalog();
+            CatalogResolver::new(&catalog).resolve(&ResolutionContext {
+                target: &xref.target,
+                provided_text: xref.provided_text.as_deref(),
+                derived: xref.derived.as_ref(),
+            })
+        };
+
+        // Explicit link text is used verbatim, so a target that only
+        // supplies its own reference text need not be consulted — mirroring
+        // `document::title_refs::compute`'s identical check.
+        let has_explicit_text = xref.provided_text.as_deref().is_some_and(|t| !t.is_empty());
+
+        let target_id = if has_explicit_text {
+            None
+        } else {
+            parser.catalog().same_document_id(&xref.target)
+        };
+
+        if let Some(reference) = resolved.as_mut()
+            && let Some(target_id) = target_id.as_deref()
+            && reference.href.strip_prefix('#') == Some(target_id)
+        {
+            // Unlike `document::title_refs::compute`, there is no
+            // `resolver_chose_text` check here: the only resolver a parse can
+            // ever consult is the built-in `CatalogResolver` (a host's own
+            // resolver, if any, is only ever supplied later, explicitly, to
+            // `Document::resolve_references` — long after parsing finishes),
+            // and `CatalogResolver`'s own text is always read from this same
+            // catalog entry, so it can never disagree with it.
+            reference.text = demand(target_id, parser, in_progress);
+        }
+
+        xref.resolved = resolved;
+    }
+
+    let block_ordered = resolved_destinations(&block);
+    let footnote_ordered = resolved_destinations(&footnote);
+    let rendered = render_xref_template(&node.template, &block, &*parser.renderer);
+
+    Resolution {
+        rendered,
+        block_ordered,
+        footnote_ordered,
+    }
+}
+
+/// Demands `target_id`'s reference text against the catalog as it currently
+/// stands, freezing it — permanently, for every future reference, including
+/// `target_id`'s own final rendered heading — the first time it is demanded
+/// this way. See the module docs.
+///
+/// Returns `None` when `target_id` does not name a known recomputable title
+/// (not registered yet, or registered with an explicit reftext, in which case
+/// it is not a recomputable target at all) or is already mid-resolution
+/// higher up this same call chain — a cycle, broken exactly as
+/// `document::title_refs::compute` breaks one: the bracketed fallback,
+/// *without* freezing anything (the section is still being computed further
+/// up the stack, which is what freezes it once that frame returns).
+fn demand(
+    target_id: &str,
+    parser: &mut Parser,
+    in_progress: &mut HashSet<String>,
+) -> Option<String> {
+    if let Some(resolution) = parser.title_freeze_state().frozen_resolution(target_id) {
+        return Some(resolution.rendered.clone());
+    }
+
+    if !in_progress.insert(target_id.to_string()) {
+        return None;
+    }
+
+    let snapshot = parser
+        .title_freeze_state()
+        .recomputable
+        .get(target_id)
+        .cloned();
+    let result = snapshot.map(|node| resolve_now(&node, parser, in_progress));
+
+    in_progress.remove(target_id);
+
+    result.map(|resolution| {
+        let rendered = resolution.rendered.clone();
+
+        parser.set_ref_reftext(target_id, rendered.clone());
+        parser
+            .title_freeze_state_mut()
+            .frozen
+            .insert(target_id.to_string(), resolution);
+
+        rendered
+    })
+}

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -29,37 +29,12 @@ use crate::{
         XrefSegment, XrefTemplatePiece, fold_resolved_title, render_xref_template,
         resolved_destinations,
     },
-    document::Catalog,
+    document::{Catalog, title_freeze::Resolution},
     inlines::InlineNode,
     parser::{
-        InlineRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
-        ResolvedAttributes, ResolvedReference,
+        InlineRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext, ResolvedAttributes,
     },
 };
-
-/// The resolved outcome of one title: its final rendering, plus the resolved
-/// destinations of its cross-references in placeholder order.
-///
-/// The rendering is installed into the title's rendered string; the
-/// `block_ordered` / `footnote_ordered` destinations are mirrored into the
-/// title's inline tree (see [`Content::mirror_tree_xref_resolution`]), so both
-/// views of the title agree.
-///
-/// [`Content::mirror_tree_xref_resolution`]: crate::content::Content::mirror_tree_xref_resolution
-struct Resolution {
-    /// The title's final rendered form, with cross-title references
-    /// coordinated.
-    rendered: String,
-
-    /// The resolved destination of each title-level cross-reference, in
-    /// document order, ready for mirroring into the title tree.
-    block_ordered: Vec<Option<ResolvedReference>>,
-
-    /// The resolved destination of each cross-reference embedded in a footnote
-    /// the title carries, in segment order, ready for
-    /// mirroring into the title tree's footnote subtrees.
-    footnote_ordered: Vec<Option<ResolvedReference>>,
-}
 
 /// One title carrying cross-references, captured for the resolution pass.
 struct TitleNode<'src> {
@@ -132,7 +107,51 @@ pub(crate) fn resolve_title_references<'src>(
         }
     }
 
-    let mut memo: Vec<Option<Resolution>> = (0..nodes.len()).map(|_| None).collect();
+    // A title whose reference text was already demanded (and so frozen)
+    // during parsing — see `document::title_freeze`, issue #1110 — is seeded
+    // here rather than left for `compute` to derive: `compute`'s own
+    // memo check short-circuits on a `Some` entry before it would otherwise
+    // recompute the title fresh against the now-complete catalog, so this is
+    // the one hook this pass needs to install the frozen answer everywhere
+    // that answer belongs — the title's own final rendering as much as any
+    // other reference to it.
+    let mut memo: Vec<Option<Resolution>> = nodes
+        .iter()
+        .map(|node| {
+            node.map_id
+                .as_deref()
+                .and_then(|id| parser.frozen_title_resolution(id))
+                .cloned()
+        })
+        .collect();
+
+    // A frozen node's own segments are never walked by `compute` (its memo
+    // entry short-circuits before that loop runs), so this is the one chance
+    // to report whichever of them never resolved — `document::title_freeze`
+    // deliberately reports none of its own, precisely so it lands here: a
+    // `PossibleInvalidReference` warning only survives as part of a
+    // resolution sweep's own output, and this pre-seeding happens inside one.
+    // `frozen.block_ordered`/`footnote_ordered` already say which segment
+    // never resolved (a `None` — computed once, at freeze time, against
+    // whatever the catalog knew then, and never revisited); zipped against
+    // this same node's freshly-collected segments, position for position,
+    // that becomes the same `(target, source)` pair `compute` would have
+    // reported.
+    for (node, frozen) in nodes.iter().zip(memo.iter()) {
+        let Some(frozen) = frozen else { continue };
+
+        for (segment, destination) in node
+            .block
+            .iter()
+            .zip(frozen.block_ordered.iter())
+            .chain(node.footnote.iter().zip(frozen.footnote_ordered.iter()))
+        {
+            if destination.is_none() && segment.derived.is_none() {
+                warnings.unresolved(&segment.target, node.source);
+            }
+        }
+    }
+
     let mut in_progress: Vec<bool> = vec![false; nodes.len()];
 
     for (index, node) in nodes.iter().enumerate() {
@@ -353,7 +372,7 @@ fn compute<'src>(
         // correct.
         if !has_explicit_text
             && let Some(reference) = resolved.as_mut()
-            && let Some(target_id) = lookup_id(catalog, &xref.target)
+            && let Some(target_id) = catalog.same_document_id(&xref.target)
             && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
             && reference.href.strip_prefix('#') == Some(target_id.as_str())
         {
@@ -436,16 +455,4 @@ fn compute<'src>(
         });
     }
     rendered
-}
-
-/// Resolves a cross-reference target to a catalog ID the same way
-/// [`CatalogResolver`](crate::parser::CatalogResolver) does: a direct ID match
-/// first, then a natural (reference-text) match. Only same-document IDs are
-/// returned, which is exactly the set of titles this pass can recompute.
-fn lookup_id(catalog: &Catalog, target: &str) -> Option<String> {
-    if catalog.contains_id(target) {
-        Some(target.to_string())
-    } else {
-        catalog.resolve_id(target)
-    }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -782,6 +782,12 @@ impl Parser {
         // heading.
         self.pending_block_title = None;
 
+        // Start each parse with no parse-time title-freeze state: a reused
+        // `Parser` must not let one document's frozen or recomputable titles
+        // (keyed by id, which a later document can easily reuse) leak into
+        // the next. See `document::title_freeze`.
+        self.title_freeze = TitleFreezeState::default();
+
         // Reset counter (and captioned-block) numbering for each new document.
         Arc::make_mut(&mut self.counter_values.borrow_mut()).clear();
         self.locked_counter_values.borrow_mut().clear();

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -21,7 +21,10 @@ use crate::{
     Document, HasSpan, Span,
     blocks::{SectionNumber, SectionType},
     content::{OwnedTitle, SubstitutionGroup, XrefSegment, XrefTemplatePiece},
-    document::{Attribute, Catalog, DuplicateIdError, Footnote, InterpretedValue, RefType},
+    document::{
+        Attribute, Catalog, DuplicateIdError, Footnote, InterpretedValue, RefType,
+        title_freeze::{Resolution, TitleFreezeState},
+    },
     parser::{
         AllowableValue, AttributeValue, DatetimeContext, DefaultPathResolver, DocinfoFileHandler,
         HtmlInlineRenderer, ImageFileHandler, IncludeFileHandler, InlineRenderer,
@@ -212,6 +215,10 @@ pub struct Parser {
     /// cross-references, so an embedded `<<id>>` in a carried title still
     /// resolves once the catalog is complete.
     pub(crate) pending_block_title: Option<OwnedTitle>,
+
+    /// Parse-time, demand-driven title cross-reference state — see
+    /// `document::title_freeze` (issue #1110).
+    title_freeze: TitleFreezeState,
 
     /// Live values of [counter] attributes, keyed by counter name (e.g.
     /// `index`, `example-number`, `table-number`).
@@ -578,6 +585,7 @@ impl Default for Parser {
             in_delimited_block: false,
             in_bibliography_list_item: Cell::new(false),
             pending_block_title: None,
+            title_freeze: TitleFreezeState::default(),
             counter_values: RefCell::new(Arc::new(HashMap::new())),
             locked_counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
@@ -1794,6 +1802,35 @@ impl Parser {
     /// [`register_ref`](Self::register_ref).
     pub(crate) fn set_ref_signifier(&self, id: &str, signifier: XrefSignifier) {
         self.catalog.borrow_mut().set_signifier(id, signifier);
+    }
+
+    /// Overwrites an already-registered element's reference text — see
+    /// [`Catalog::set_reftext`].
+    ///
+    /// Takes `&self` for the same reason as
+    /// [`register_ref`](Self::register_ref).
+    pub(crate) fn set_ref_reftext(&self, id: &str, reftext: String) {
+        self.catalog.borrow_mut().set_reftext(id, reftext);
+    }
+
+    /// Returns the frozen title resolution for `id`, if its reference text
+    /// was demanded — and so permanently fixed — during parsing rather than
+    /// left to the ordinary document-order pass. See
+    /// `document::title_freeze` (issue #1110).
+    pub(crate) fn frozen_title_resolution(&self, id: &str) -> Option<&Resolution> {
+        self.title_freeze.frozen_resolution(id)
+    }
+
+    /// Returns the parser's parse-time, demand-driven title state — see
+    /// `document::title_freeze` (issue #1110).
+    pub(crate) fn title_freeze_state(&self) -> &TitleFreezeState {
+        &self.title_freeze
+    }
+
+    /// Returns a mutable borrow of the parser's parse-time, demand-driven
+    /// title state — see `document::title_freeze` (issue #1110).
+    pub(crate) fn title_freeze_state_mut(&mut self) -> &mut TitleFreezeState {
+        &mut self.title_freeze
     }
 
     /// Records a referenced image in the document catalog when

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1541,6 +1541,29 @@ mod xrefs_in_titles {
         );
     }
 
+    /// The same corruption, reached through the *other* source `manual_id`
+    /// can come from: an anchor embedded in the title itself (`== Title
+    /// [[id]]`) rather than an attribute above the heading. `section_id` (the
+    /// struct field) is set from `embedded_id` unconditionally — duplicate or
+    /// not, mirroring how `id()` reads back a duplicate *attribute* id
+    /// unconditionally too — so the id-ownership check must not simply trust
+    /// it.
+    #[test]
+    fn a_duplicate_embedded_anchor_id_does_not_replace_the_original_owners_recomputable_title() {
+        let doc = Parser::default()
+            .parse("[#b]\n== B\n\n[#c]\n== C\n\n[#a]\n== <<b>>\n\n== <<c>> [[a]]\n\n== <<a>>");
+
+        let sections: Vec<_> = sections(&doc);
+
+        assert_eq!(sections[2].section_title(), r##"<a href="#b">B</a>"##);
+        assert_eq!(sections[4].section_title(), r##"<a href="#a">B</a>"##);
+
+        assert!(
+            doc.warnings()
+                .any(|w| format!("{w:?}").contains("DuplicateId"))
+        );
+    }
+
     /// A title's cross-document reference (`xref:other.adoc#topic[]`,
     /// unqualified so it needs the target's own reference text) can only ever
     /// be resolved by a host resolver supplied later, explicitly, to

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1199,9 +1199,11 @@ mod included_file_collapses_to_internal_anchor {
 /// title, plus the corners of how a title maps (or does not map) to a
 /// referenceable target.
 mod xrefs_in_titles {
+    use super::DerivedRewritingResolver;
     use crate::{
         Parser,
         blocks::{FindBlocks, IsBlock},
+        parser::{CatalogResolver, HtmlInlineRenderer},
     };
 
     /// Collects `(context, title)` for every titled block in the document, in
@@ -1508,6 +1510,101 @@ mod xrefs_in_titles {
         assert_eq!(sections[0].section_title(), r##"<a href="#b">[b]</a>"##);
         assert_eq!(sections[1].section_title(), r##"<a href="#a">[b]</a>"##);
         assert_eq!(sections[2].section_title(), r##"Ref <a href="#a">[b]</a>"##);
+    }
+
+    /// A manual id that collides with an already-registered one is rejected
+    /// (and warned about) rather than claiming the id — so a later
+    /// auto-id section's demand for that id must still reach the
+    /// *legitimate* owner's title, not the rejected duplicate's. Registering
+    /// the duplicate's own snapshot under the same id (as if it had won the
+    /// id) would silently replace the original's, corrupting both the
+    /// demand's answer and the original's own catalog reference text.
+    #[test]
+    fn a_duplicate_manual_id_does_not_replace_the_original_owners_recomputable_title() {
+        // `b` and `c` are defined *before* either `a` section, so a stray
+        // fold against a still-partial catalog is not what distinguishes
+        // `B` from `C` here — only which of the two `a` titles the demand
+        // actually reaches is.
+        let doc = Parser::default()
+            .parse("[#b]\n== B\n\n[#c]\n== C\n\n[#a]\n== <<b>>\n\n[#a]\n== <<c>>\n\n== <<a>>");
+
+        let sections: Vec<_> = sections(&doc);
+
+        // The demand reaches `a`'s own (first, legitimate) title — `<<b>>`
+        // resolved to `B` — never the duplicate's `<<c>>`.
+        assert_eq!(sections[2].section_title(), r##"<a href="#b">B</a>"##);
+        assert_eq!(sections[4].section_title(), r##"<a href="#a">B</a>"##);
+
+        assert!(
+            doc.warnings()
+                .any(|w| format!("{w:?}").contains("DuplicateId"))
+        );
+    }
+
+    /// A title's cross-document reference (`xref:other.adoc#topic[]`,
+    /// unqualified so it needs the target's own reference text) can only ever
+    /// be resolved by a host resolver supplied later, explicitly, to
+    /// `Document::resolve_references` — never by this crate's own parse-time
+    /// demand, which only ever consults the built-in, same-document
+    /// `CatalogResolver`. Freezing such a title anyway would permanently deny
+    /// that later, independent resolution sweep the chance to do better, so
+    /// it must not freeze even when an auto-id section demands it.
+    #[test]
+    fn a_title_with_a_cross_document_reference_is_never_frozen() {
+        let mut parser = Parser::default();
+        let mut doc = parser.parse_deferred("[#a]\n== <<other.adoc#topic>>\n\n== <<a>>");
+
+        // Resolve once with the built-in resolver (mirroring what `parse()`
+        // would have done automatically) — this is the moment a title with a
+        // same-document forward reference would have frozen, had `a`'s title
+        // been eligible.
+        {
+            let catalog = doc.catalog().clone();
+            let resolver = CatalogResolver::new(&catalog);
+            doc.resolve_references(&resolver, &HtmlInlineRenderer {}, &parser);
+        }
+
+        // A *different*, later resolver sweep — exactly the repeatable-
+        // resolution contract `Document::resolve_references` documents —
+        // still changes `a`'s rendering. A frozen title could not do this.
+        let resolver = DerivedRewritingResolver;
+        doc.resolve_references(&resolver, &HtmlInlineRenderer {}, &parser);
+
+        let sections: Vec<_> = sections(&doc);
+        assert_eq!(
+            sections[0].section_title(),
+            r##"<a href="/en/other.html#topic">other.html</a>"##
+        );
+    }
+
+    /// A `Parser` reused across documents must not let one document's frozen
+    /// (or merely recomputable) titles leak into the next: a later document
+    /// can easily reuse the same ids, and its own titles must be resolved
+    /// against *its own* catalog, not contaminated by a different document's
+    /// parse-time state.
+    #[test]
+    fn title_freeze_state_does_not_leak_between_reused_parses() {
+        let mut parser = Parser::default();
+
+        // First document: the auto-id middle section demands (and freezes)
+        // `s1`'s reference text against a catalog that does not yet have
+        // `forward` — the same shape as the issue's own repro.
+        let _doc1 = parser.parse("[#s1]\n== <<forward>>\n\n== <<s1>>\n\n[#forward]\n== Forward");
+
+        // Second document, parsed with the *same* `Parser`: it reuses the id
+        // `s1`, again with an embedded forward reference — but with no
+        // demanding section this time, so nothing should freeze it, and it
+        // should resolve normally, exactly like
+        // `forward_reference_in_title_resolves_without_a_demanding_section`.
+        // A leaked freeze from `_doc1` would instead show the bracketed
+        // fallback here.
+        let doc2 = parser.parse("[#s1]\n== <<forward>>\n\n[#forward]\n== Forward");
+
+        let sections: Vec<_> = sections(&doc2);
+        assert_eq!(
+            sections[0].section_title(),
+            r##"<a href="#forward">Forward</a>"##
+        );
     }
 
     fn sections<'a>(doc: &'a crate::Document<'a>) -> Vec<&'a crate::blocks::SectionBlock<'a>> {

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1361,6 +1361,167 @@ mod xrefs_in_titles {
         assert_eq!(para.title(), Some(r##"See <a href="#goal">Goal</a>"##));
     }
 
+    /// Issue #1110's own repro: a middle section's auto-generated id demands
+    /// `s1`'s reference text *during parsing*, before `forward` — the target
+    /// `s1`'s own title cross-references — is registered. Asciidoctor freezes
+    /// `s1`'s reference text at that partial-catalog answer forever, so the
+    /// forward reference stays the bracketed `[forward]` fallback even in
+    /// `s1`'s own final heading, once `forward` exists.
+    #[test]
+    fn forward_reference_in_title_freezes_when_demanded_by_an_auto_id_section() {
+        let doc =
+            Parser::default().parse("[#s1]\n== <<forward>>\n\n== <<s1>>\n\n[#forward]\n== Forward");
+
+        let sections: Vec<_> = sections(&doc);
+
+        // `s1`'s own heading stays frozen at the bracketed fallback — not
+        // resolved to `Forward`, even though `forward` is defined later in
+        // the very same document.
+        assert_eq!(
+            sections[0].section_title(),
+            r##"<a href="#forward">[forward]</a>"##
+        );
+
+        // The middle section's auto-generated id is derived from `s1`'s
+        // *frozen* reference text (`[forward]`, sanitized to `forward`), not
+        // from `s1`'s own id — the demand only ever reaches this through
+        // `s1`'s reftext, which is exactly what freezes.
+        assert_eq!(sections[1].id(), Some("_forward"));
+        assert_eq!(
+            sections[1].section_title(),
+            r##"<a href="#s1">[forward]</a>"##
+        );
+
+        assert_eq!(sections[2].section_title(), "Forward");
+    }
+
+    /// The inverse confirmation from issue #1110: without a demanding
+    /// auto-id section in between, the exact same forward reference resolves
+    /// normally, against the complete catalog, once the whole document is
+    /// parsed.
+    #[test]
+    fn forward_reference_in_title_resolves_without_a_demanding_section() {
+        let doc = Parser::default()
+            .parse("[#a]\n== See <<b>>\n\n[#b]\n== Consult https://google.com[Google]");
+
+        let sections: Vec<_> = sections(&doc);
+
+        assert_eq!(
+            sections[0].section_title(),
+            r##"See <a href="#b">Consult Google</a>"##
+        );
+    }
+
+    /// A plain (non-title) cross-reference to a frozen section sees the same
+    /// frozen text a title-to-title reference does: freezing installs it as
+    /// the section's registered catalog reference text too
+    /// (`Catalog::set_reftext`), which is what a paragraph's own reference
+    /// resolution reads.
+    #[test]
+    fn a_plain_reference_to_a_frozen_title_sees_its_frozen_text() {
+        let doc = Parser::default()
+            .parse("[#s1]\n== <<forward>>\n\n== <<s1>>\n\n[#forward]\n== Forward\n\npara <<s1>>");
+
+        let para = super::first_paragraph(&doc);
+        assert_eq!(para, r##"para <a href="#s1">[forward]</a>"##);
+    }
+
+    /// A target genuinely absent from the whole document — not merely
+    /// forward-referenced — still gets reported once, even when it is
+    /// discovered while freezing a demanded title rather than by the
+    /// ordinary post-parse pass (which never runs for a frozen title).
+    #[test]
+    fn a_target_that_never_resolves_in_a_frozen_title_is_still_a_warning() {
+        let doc = Parser::default().parse("[#s1]\n== <<nowhere>>\n\n== <<s1>>");
+
+        let sections: Vec<_> = sections(&doc);
+        assert_eq!(
+            sections[0].section_title(),
+            r##"<a href="#nowhere">[nowhere]</a>"##
+        );
+
+        assert!(
+            doc.warnings().any(|w| format!("{w:?}").contains("nowhere")),
+            "expected an unresolved-reference warning naming \"nowhere\"; warnings were: {:?}",
+            doc.warnings().collect::<Vec<_>>()
+        );
+    }
+
+    /// Two titles that reference each other, both reached through an
+    /// auto-id section's demand chain, must not deadlock or overflow the
+    /// stack: the second demand reached while the first is still being
+    /// resolved is a cycle, broken exactly like
+    /// `document::title_refs::compute` breaks one — the bracketed fallback,
+    /// without freezing the cycle partner prematurely.
+    #[test]
+    fn a_cycle_reached_through_a_demand_chain_does_not_deadlock() {
+        let doc = Parser::default().parse("[#x]\n== <<y>>\n\n[#y]\n== <<x>>\n\n== <<x>>");
+
+        let sections: Vec<_> = sections(&doc);
+
+        // `x`'s own title demands `y`'s reftext, which in turn demands `x`'s
+        // — but `x` is still mid-resolution, so `y`'s reference to it falls
+        // back to the bracketed form rather than recursing forever.
+        assert_eq!(sections[0].section_title(), r##"<a href="#y">[x]</a>"##);
+        assert_eq!(sections[1].section_title(), r##"<a href="#x">[x]</a>"##);
+    }
+
+    /// A cross-reference that supplies its own display text needs no
+    /// reference text from its target, so demanding one is skipped entirely
+    /// — mirroring `document::title_refs::compute`'s identical short-circuit.
+    /// `earlier`'s own (otherwise-demandable) forward reference is left
+    /// completely alone by the auto-id section referencing it with explicit
+    /// text, and so resolves normally, later, against the full catalog.
+    #[test]
+    fn explicit_link_text_in_a_title_never_demands_its_target() {
+        let doc = Parser::default()
+            .parse("[#earlier]\n== <<later>>\n\n== Ref <<earlier,Custom>>\n\n[#later]\n== Later");
+
+        let sections: Vec<_> = sections(&doc);
+
+        // The auto-id section's own rendering uses the explicit text
+        // verbatim.
+        assert_eq!(
+            sections[1].section_title(),
+            r##"Ref <a href="#earlier">Custom</a>"##
+        );
+
+        // `earlier` itself was never demanded, so it stayed open for the
+        // ordinary post-parse pass and resolved its own forward reference
+        // fully, rather than freezing at the bracketed fallback.
+        assert_eq!(
+            sections[0].section_title(),
+            r##"<a href="#later">Later</a>"##
+        );
+    }
+
+    /// A second, later auto-id section demanding an id an earlier one already
+    /// froze hits the frozen fast path directly, rather than re-resolving it
+    /// — both see the exact same (already-frozen) text.
+    #[test]
+    fn a_second_demand_for_an_already_frozen_id_reuses_it() {
+        let doc =
+            Parser::default().parse("[#a]\n== <<b>>\n\n== <<a>>\n\n== Ref <<a>>\n\n[#b]\n== B");
+
+        let sections: Vec<_> = sections(&doc);
+
+        assert_eq!(sections[0].section_title(), r##"<a href="#b">[b]</a>"##);
+        assert_eq!(sections[1].section_title(), r##"<a href="#a">[b]</a>"##);
+        assert_eq!(sections[2].section_title(), r##"Ref <a href="#a">[b]</a>"##);
+    }
+
+    fn sections<'a>(doc: &'a crate::Document<'a>) -> Vec<&'a crate::blocks::SectionBlock<'a>> {
+        doc.child_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     #[test]
     fn two_references_in_a_carried_title_resolve_in_order() {
         // The carried title's deferred template is synthesized from its own


### PR DESCRIPTION
## Summary

Fixes #1110.

Asciidoctor evaluates a section's title *eagerly*, during parsing, whenever generating a *later* section's auto-id needs that title's reference text (`generate_id` reads the converted `title`). It memoizes the result — including a still-unresolved forward cross-reference — forever, even once the referenced target is parsed moments later.

This crate instead resolved every title exactly once, post-parse, against the *complete* catalog (`document::title_refs`), which has no notion of "this reftext was already demanded, and frozen, at an earlier point in parsing." A forward `<<…>>` in a title therefore resolved even in cases where Asciidoctor freezes it at its bracketed `[target]` fallback.

- Adds `document::title_freeze`: a parse-time, demand-driven resolution pass. When a section is about to auto-generate its own id (`SectionBlock::parse`), its title is resolved right now, against the catalog as it currently stands — recursively demanding (and permanently freezing) any *earlier* title it references. The id-generating section's own title is never frozen by this — only a target it demands *is* (see the module's own "It is the target, never the demander" doc section) — matching Asciidoctor, where nothing about generating one's own id needs to read *that section's own* `xreftext`.
- `document::title_refs`'s post-parse pass seeds its memo from whatever got frozen this way and skips recomputing it, so both the frozen title's own final heading and any other reference to it (including a plain, non-title reference, via `Catalog::set_reftext`) stay consistent.
- Verified against the two oracle-confirmed shapes from the issue (`forward_reference_in_title_freezes_when_demanded_by_an_auto_id_section`, `forward_reference_in_title_resolves_without_a_demanding_section`), plus cycle-safety, explicit-link-text (never demands), a second demand reusing an already-frozen id, a plain-reference consistency check, and an unresolved-reference warning for a target that never resolves in a frozen title.

### Along the way

Fixed a pre-existing, independent bug in `generate_section_id`'s id-sanitizing regex that this work surfaced (needed for the auto-generated id itself to come out correct, e.g. `_forward` rather than a mangled `_forwarda`): a run of "invalid" characters immediately adjacent to an HTML tag could swallow part of the tag's `<` before the tag-matching alternative got a chance to match the whole tag, leaking the tag name through. Tags are now stripped in their own pass first (reusing the existing `sanitize_title` helper), before the remaining regex runs.

## Known limitation

The parser cannot itself be generic over the source lifetime (`Parser` is not `Parser<'src>`), so the per-id snapshot this module retains renders through the same *template* mechanism a block title carried across a section heading already falls back to. This means a cross-reference **nested** inside another construct (e.g. `*<<tgt>>*`) inside a title that gets frozen keeps its parse-time fallback text rather than reflecting the demand-time resolution — only a *top-level* reference's rendering does. This mirrors an existing, accepted narrowing elsewhere in the codebase (a carried block title) and is documented in the module's own docs.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets`
- [x] `cargo test --workspace` (5539 passed, 0 failed)
- [x] `cargo +nightly doc --no-deps --document-private-items`
- [x] `cargo llvm-cov` — new code (`document/title_freeze.rs`) at 100% line/region coverage; other touched files show only pre-existing, unrelated gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoWYsWf63wDR8oGuwS1XB5


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoWYsWf63wDR8oGuwS1XB5)_