### PR TITLE
feat: Add blanket Rc<T> impls for the file-handler traits

### DIFF
--- a/parser/src/parser/docinfo_file_handler.rs
+++ b/parser/src/parser/docinfo_file_handler.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use crate::Parser;
 
@@ -45,4 +45,68 @@ pub trait DocinfoFileHandler: Debug {
         file_name: &str,
         parser: &Parser,
     ) -> Option<String>;
+}
+
+/// An `Rc<T>` wrapping any `DocinfoFileHandler` (including an unsized
+/// `Rc<dyn DocinfoFileHandler>`) is itself a `DocinfoFileHandler`, delegating
+/// to the wrapped handler.
+///
+/// See the analogous impl on
+/// [`IncludeFileHandler`](crate::parser::IncludeFileHandler) for why this is
+/// useful: it lets a handler already held behind an `Rc` be passed straight to
+/// [`Parser::with_docinfo_file_handler`], whose `Sized` bound a trait object
+/// cannot otherwise satisfy.
+///
+/// [`Parser::with_docinfo_file_handler`]: crate::Parser::with_docinfo_file_handler
+impl<T: DocinfoFileHandler + ?Sized> DocinfoFileHandler for Rc<T> {
+    fn resolve_docinfo(
+        &self,
+        docinfodir: Option<&str>,
+        file_name: &str,
+        parser: &Parser,
+    ) -> Option<String> {
+        (**self).resolve_docinfo(docinfodir, file_name, parser)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::DocinfoFileHandler;
+    use crate::{Parser, SafeMode, document::DocinfoLocation};
+
+    // The blanket `impl<T: DocinfoFileHandler + ?Sized> DocinfoFileHandler for
+    // Rc<T>` above lets `Rc<dyn DocinfoFileHandler>` be handed straight to
+    // `Parser::with_docinfo_file_handler` -- no delegating newtype required.
+    #[test]
+    fn rc_dyn_docinfo_file_handler_resolves_through_the_parser() {
+        #[derive(Debug)]
+        struct Fixed;
+
+        impl DocinfoFileHandler for Fixed {
+            fn resolve_docinfo(
+                &self,
+                _docinfodir: Option<&str>,
+                file_name: &str,
+                _parser: &Parser,
+            ) -> Option<String> {
+                (file_name == "docinfo.html").then(|| "<meta name=\"via-rc\">".to_owned())
+            }
+        }
+
+        let handler: Rc<dyn DocinfoFileHandler> = Rc::new(Fixed);
+
+        // Docinfo is resolved below `Secure`; `Server` also exercises the
+        // safe-mode lock's own docinfo handling.
+        let head = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("mydoc.adoc")
+            .with_docinfo_file_handler(handler)
+            .parse("= Doc\n:docinfo: shared-head\n\nBody.")
+            .docinfo(DocinfoLocation::Head)
+            .to_string();
+
+        assert_eq!(head, "<meta name=\"via-rc\">");
+    }
 }

--- a/parser/src/parser/image_file_handler.rs
+++ b/parser/src/parser/image_file_handler.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use crate::parser::RenderContext;
 
@@ -37,4 +37,67 @@ pub trait ImageFileHandler: Debug {
     /// is not readable), return `None`; the image will then fall back to
     /// rendering an ordinary web path.
     fn resolve_image(&self, target: &str, context: &RenderContext) -> Option<Vec<u8>>;
+}
+
+/// An `Rc<T>` wrapping any `ImageFileHandler` (including an unsized `Rc<dyn
+/// ImageFileHandler>`) is itself an `ImageFileHandler`, delegating to the
+/// wrapped handler.
+///
+/// See the analogous impl on
+/// [`IncludeFileHandler`](crate::parser::IncludeFileHandler) for why this is
+/// useful: it lets a handler already held behind an `Rc` be passed straight to
+/// [`Parser::with_image_file_handler`], whose `Sized` bound a trait object
+/// cannot otherwise satisfy.
+///
+/// [`Parser::with_image_file_handler`]: crate::Parser::with_image_file_handler
+impl<T: ImageFileHandler + ?Sized> ImageFileHandler for Rc<T> {
+    fn resolve_image(&self, target: &str, context: &RenderContext) -> Option<Vec<u8>> {
+        (**self).resolve_image(target, context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::ImageFileHandler;
+    use crate::{
+        Parser, SafeMode,
+        parser::{ModificationContext, RenderContext},
+        tests::prelude::rendered_paragraphs,
+    };
+
+    // The blanket `impl<T: ImageFileHandler + ?Sized> ImageFileHandler for
+    // Rc<T>` above lets `Rc<dyn ImageFileHandler>` be handed straight to
+    // `Parser::with_image_file_handler` -- no delegating newtype required.
+    #[test]
+    fn rc_dyn_image_file_handler_resolves_through_the_parser() {
+        #[derive(Debug)]
+        struct Fixed;
+
+        impl ImageFileHandler for Fixed {
+            fn resolve_image(&self, target: &str, _context: &RenderContext) -> Option<Vec<u8>> {
+                (target == "circle.png").then(|| b"fake-bytes".to_vec())
+            }
+        }
+
+        let handler: Rc<dyn ImageFileHandler> = Rc::new(Fixed);
+
+        // Below `Secure`, with `data-uri` set, the default HTML renderer
+        // embeds the image bytes -- read through the registered
+        // `ImageFileHandler` -- as a `data:` URI.
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("data-uri", true, ModificationContext::Anywhere)
+            .with_image_file_handler(handler)
+            .parse("image:circle.png[Tiger]");
+
+        let paragraphs = rendered_paragraphs(&doc);
+        assert!(
+            paragraphs
+                .first()
+                .is_some_and(|p| p.contains("data:image/png;base64,ZmFrZS1ieXRlcw==")),
+            "{paragraphs:?}"
+        );
+    }
 }

--- a/parser/src/parser/include_file_handler.rs
+++ b/parser/src/parser/include_file_handler.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use crate::{Parser, attributes::Attrlist};
 
@@ -83,6 +83,31 @@ pub trait IncludeFileHandler: Debug {
         attrlist: &Attrlist<'src>,
         parser: &Parser,
     ) -> IncludeResolution;
+}
+
+/// An `Rc<T>` wrapping any `IncludeFileHandler` (including an unsized
+/// `Rc<dyn IncludeFileHandler>`) is itself an `IncludeFileHandler`, delegating
+/// to the wrapped handler.
+///
+/// This lets a caller who already holds a handler behind an `Rc` — for example
+/// to share one handler across several [`Parser`]s, or to store it as a trait
+/// object alongside other state — hand that `Rc` straight to
+/// [`Parser::with_include_file_handler`] without writing a delegating newtype
+/// first, since [`Parser::with_include_file_handler`] requires a `Sized`
+/// argument and there is otherwise no way to satisfy that bound with a trait
+/// object.
+///
+/// [`Parser::with_include_file_handler`]: crate::Parser::with_include_file_handler
+impl<T: IncludeFileHandler + ?Sized> IncludeFileHandler for Rc<T> {
+    fn resolve_target<'src>(
+        &self,
+        source: Option<&str>,
+        target: &str,
+        attrlist: &Attrlist<'src>,
+        parser: &Parser,
+    ) -> IncludeResolution {
+        (**self).resolve_target(source, target, attrlist, parser)
+    }
 }
 
 /// The outcome of an [`IncludeFileHandler::resolve_target`] call: either the
@@ -206,7 +231,10 @@ impl From<&str> for IncludeContent {
 
 #[cfg(test)]
 mod tests {
-    use super::{IncludeContent, IncludeResolution};
+    use std::rc::Rc;
+
+    use super::{IncludeContent, IncludeFileHandler, IncludeResolution};
+    use crate::{Parser, SafeMode, attributes::Attrlist, tests::prelude::rendered_paragraphs};
 
     #[test]
     fn resolution_from_include_content_is_found() {
@@ -240,5 +268,40 @@ mod tests {
         let from_str: IncludeContent = "Content.".into();
         assert_eq!(from_str, IncludeContent::new("Content."));
         assert!(!from_str.encoding_handled());
+    }
+
+    // The blanket `impl<T: IncludeFileHandler + ?Sized> IncludeFileHandler for
+    // Rc<T>` above lets `Rc<dyn IncludeFileHandler>` be handed straight to
+    // `Parser::with_include_file_handler` -- no delegating newtype required.
+    #[test]
+    fn rc_dyn_include_file_handler_resolves_through_the_parser() {
+        #[derive(Debug)]
+        struct Fixed;
+
+        impl IncludeFileHandler for Fixed {
+            fn resolve_target<'src>(
+                &self,
+                _source: Option<&str>,
+                _target: &str,
+                _attrlist: &Attrlist<'src>,
+                _parser: &Parser,
+            ) -> IncludeResolution {
+                IncludeResolution::Found(IncludeContent::new(
+                    "Included via an Rc-wrapped trait object.",
+                ))
+            }
+        }
+
+        let handler: Rc<dyn IncludeFileHandler> = Rc::new(Fixed);
+
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Unsafe)
+            .with_include_file_handler(handler)
+            .parse("include::anything.adoc[]");
+
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["Included via an Rc-wrapped trait object.".to_string()]
+        );
     }
 }

--- a/parser/src/parser/svg_file_handler.rs
+++ b/parser/src/parser/svg_file_handler.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, rc::Rc};
 
 use crate::parser::RenderContext;
 
@@ -37,4 +37,64 @@ pub trait SvgFileHandler: Debug {
     /// If a `Some` result is provided, it is a typical Rust [`String`] and
     /// therefore must be encoded as UTF-8.
     fn resolve_svg(&self, target: &str, context: &RenderContext) -> Option<String>;
+}
+
+/// An `Rc<T>` wrapping any `SvgFileHandler` (including an unsized `Rc<dyn
+/// SvgFileHandler>`) is itself an `SvgFileHandler`, delegating to the wrapped
+/// handler.
+///
+/// See the analogous impl on
+/// [`IncludeFileHandler`](crate::parser::IncludeFileHandler) for why this is
+/// useful: it lets a handler already held behind an `Rc` be passed straight to
+/// [`Parser::with_svg_file_handler`], whose `Sized` bound a trait object
+/// cannot otherwise satisfy.
+///
+/// [`Parser::with_svg_file_handler`]: crate::Parser::with_svg_file_handler
+impl<T: SvgFileHandler + ?Sized> SvgFileHandler for Rc<T> {
+    fn resolve_svg(&self, target: &str, context: &RenderContext) -> Option<String> {
+        (**self).resolve_svg(target, context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::SvgFileHandler;
+    use crate::{Parser, SafeMode, parser::RenderContext, tests::prelude::rendered_paragraphs};
+
+    const SAMPLE_SVG: &str = concat!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 500 500\">",
+        "<circle cx=\"250\" cy=\"250\" r=\"200\"/></svg>",
+    );
+
+    // The blanket `impl<T: SvgFileHandler + ?Sized> SvgFileHandler for Rc<T>`
+    // above lets `Rc<dyn SvgFileHandler>` be handed straight to
+    // `Parser::with_svg_file_handler` -- no delegating newtype required.
+    #[test]
+    fn rc_dyn_svg_file_handler_resolves_through_the_parser() {
+        #[derive(Debug)]
+        struct Fixed;
+
+        impl SvgFileHandler for Fixed {
+            fn resolve_svg(&self, target: &str, _context: &RenderContext) -> Option<String> {
+                (target == "sample.svg").then(|| SAMPLE_SVG.to_owned())
+            }
+        }
+
+        let handler: Rc<dyn SvgFileHandler> = Rc::new(Fixed);
+
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_svg_file_handler(handler)
+            .parse("image:sample.svg[opts=inline]");
+
+        let paragraphs = rendered_paragraphs(&doc);
+        assert!(
+            paragraphs
+                .first()
+                .is_some_and(|p| p.contains("<circle cx=\"250\" cy=\"250\" r=\"200\"/>")),
+            "{paragraphs:?}"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1390.

## Summary

`asciidoc-html5`'s `Options` needs to store a caller-supplied file handler behind an `Rc` — `Options` is `Clone` and its `apply()` may seed more than one `Parser` from the same handler (e.g. `load_deferred`'s returned `Parser`) — but `Parser::with_include_file_handler` (and its docinfo/SVG/image counterparts) require a `Sized` handler and wrap it in their own `Rc`. With no blanket impl of these traits for `Rc<dyn Trait>`, and the orphan rules blocking a downstream crate from adding one, `asciidoc-html5` had to write a local delegating newtype per trait just to satisfy the `Sized` bound (see asciidoc-rs/asciidoc-html5#338).

This adds, for each of the four handler traits:

```rust
impl<T: IncludeFileHandler + ?Sized> IncludeFileHandler for Rc<T> {
    fn resolve_target<'src>(
        &self,
        source: Option<&str>,
        target: &str,
        attrlist: &Attrlist<'src>,
        parser: &Parser,
    ) -> IncludeResolution {
        (**self).resolve_target(source, target, attrlist, parser)
    }
}
```

(and the analogous impl for `DocinfoFileHandler`, `SvgFileHandler`, and `ImageFileHandler`, added for consistency even though `asciidoc-html5` doesn't consume that last one yet). With these in place, `Rc<dyn IncludeFileHandler>` (etc.) satisfies the trait directly and can be handed straight to `Parser::with_include_file_handler`, with no delegating newtype required downstream.

This is purely additive — a new blanket impl, no changes to existing signatures or behavior.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p asciidoc-parser --all-targets` (clean, including under `#[deny(clippy::indexing_slicing)]`)
- [x] `cargo test --workspace` (5548 passed, 0 failed, 68 ignored, unchanged; + 6 doctests)
- [x] `cargo +nightly doc --no-deps --document-private-items` (clean, no broken intra-doc links)
- [x] `cargo llvm-cov -p asciidoc-parser --lib` — all four touched files (`docinfo_file_handler.rs`, `image_file_handler.rs`, `include_file_handler.rs`, `svg_file_handler.rs`) at 100% line/region/function coverage
- [x] Added one test per trait: constructs an `Rc<dyn Trait>` from a fixture handler and hands it straight to the corresponding `Parser::with_*_handler`, verifying it resolves through a real parse — this is the exact usage the blanket impl is meant to unlock, and wouldn't compile without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai5fb62NCY9np6nzJrckGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai5fb62NCY9np6nzJrckGu)_